### PR TITLE
Implement lint subcommand

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/elastic/package-spec/code/go/pkg/validator"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/elastic/elastic-package/internal/packages"
 )
 
 func setupLintCommand() *cobra.Command {
@@ -18,9 +19,12 @@ func setupLintCommand() *cobra.Command {
 }
 
 func lintCommandAction(cmd *cobra.Command, args []string) error {
-	packageRootPath, err := os.Getwd()
+	packageRootPath, found, err := packages.FindPackageRoot()
+	if !found {
+		return errors.New("package root not found")
+	}
 	if err != nil {
-		return err
+		return errors.Wrap(err, "locating package root failed")
 	}
 
 	return validator.ValidateFromPath(packageRootPath)

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -10,8 +10,8 @@ import (
 func setupLintCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lint",
-		Short: "Lint the integration",
-		Long:  "Use lint command to lint the integration files.",
+		Short: "Lint the package",
+		Long:  "Use lint command to lint the package files.",
 		RunE:  lintCommandAction,
 	}
 	return cmd

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -12,6 +12,7 @@ func setupLintCommand() *cobra.Command {
 		Short: "Lint the package",
 		Long:  "Use lint command to lint the package files.",
 		RunE:  lintCommandAction,
+		SilenceUsage: true,
 	}
 	return cmd
 }

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/elastic/package-spec/code/go/pkg/validator"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 func setupLintCommand() *cobra.Command {

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -10,10 +10,9 @@ import (
 func setupLintCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lint",
-		Short: "Lint the package",
-		Long:  "Use lint command to lint the package files.",
+		Short: "Lint the integration",
+		Long:  "Use lint command to lint the integration files.",
 		RunE:  lintCommandAction,
-		SilenceUsage: true,
 	}
 	return cmd
 }

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"fmt"
-
+	"github.com/elastic/package-spec/code/go/pkg/validator"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 func setupLintCommand() *cobra.Command {
@@ -17,6 +17,10 @@ func setupLintCommand() *cobra.Command {
 }
 
 func lintCommandAction(cmd *cobra.Command, args []string) error {
-	fmt.Println("lint is not implemented yet.")
-	return nil
+	packageRootPath, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	return validator.ValidateFromPath(packageRootPath)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,8 +7,9 @@ import (
 // RootCmd creates and returns root cmd for elastic-package
 func RootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:   "elastic-package",
-		Short: "elastic-package - Command line tool for developing Elastic packages",
+		Use:          "elastic-package",
+		Short:        "elastic-package - Command line tool for developing Elastic Integrations",
+		SilenceUsage: true,
 	}
 	rootCmd.AddCommand(
 		setupCheckCommand(),

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/elastic/elastic-package
 go 1.14
 
 require (
+	github.com/elastic/package-spec/code/go v0.0.0-00010101000000-000000000000
 	github.com/magefile/mage v1.10.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/elastic/elastic-package
 go 1.14
 
 require (
-	github.com/elastic/package-spec/code/go v0.0.0-00010101000000-000000000000
+	github.com/elastic/package-spec/code/go v0.0.0-20200810171555-6ef68460ff03
 	github.com/magefile/mage v1.10.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=
-github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -21,6 +19,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/elastic/package-spec/code/go v0.0.0-20200810171555-6ef68460ff03 h1:4wlW4y0RwcIdJJWkM5Z+/JaXdMiF2TRfEnmzyzSpiKo=
+github.com/elastic/package-spec/code/go v0.0.0-20200810171555-6ef68460ff03/go.mod h1:RuVj8bHJnrrW6GTuhSDzKn7Kwbc2pipOjzhWStKO+RI=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=
+github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -14,6 +16,8 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -62,6 +66,7 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -73,6 +78,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084 h1:sofwID9zm4tzrgykg80hfFph1mryUeLRsUfoocVVmRY=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rakyll/statik v0.1.7 h1:OF3QCZUuyPxuGEP7B4ypUa7sB/iHtqOTDYZXGM8KOdQ=
+github.com/rakyll/statik v0.1.7/go.mod h1:AlZONWzMtEnMs7W4e/1LURLiI49pIMmp6V9Unghqrcc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -87,8 +94,11 @@ github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb6
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
@@ -141,4 +151,6 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -9,14 +9,17 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// PackageManifestFile is the name of the package's main manifest file.
 const PackageManifestFile = "manifest.yml"
 
-type packageManifest struct {
+// PackageManifest represents the basic structure of a package's manifest
+type PackageManifest struct {
 	Name    string `json:"name"`
 	Type    string `json:"type"`
 	Version string `json:"version"`
 }
 
+// FindPackageRoot finds and returns the path to the root folder of a package.
 func FindPackageRoot() (string, bool, error) {
 	workDir, err := os.Getwd()
 	if err != nil {
@@ -45,13 +48,14 @@ func FindPackageRoot() (string, bool, error) {
 	return "", false, nil
 }
 
-func ReadPackageManifest(path string) (*packageManifest, error) {
+// ReadPackageManifest reads and parses the given package manifest file.
+func ReadPackageManifest(path string) (*PackageManifest, error) {
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "reading file body failed (path: %s)", path)
 	}
 
-	var m packageManifest
+	var m PackageManifest
 	err = yaml.Unmarshal(content, &m)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unmarshalling package manifest failed (path: %s)", path)

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -1,0 +1,68 @@
+package packages
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+const PackageManifestFile = "manifest.yml"
+
+type packageManifest struct {
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Version string `json:"version"`
+}
+
+func FindPackageRoot() (string, bool, error) {
+	workDir, err := os.Getwd()
+	if err != nil {
+		return "", false, errors.Wrap(err, "locating working directory failed")
+	}
+
+	dir := workDir
+	for dir != "." {
+		path := filepath.Join(dir, PackageManifestFile)
+		fileInfo, err := os.Stat(path)
+		if err == nil && !fileInfo.IsDir() {
+			ok, err := isPackageManifest(path)
+			if err != nil {
+				return "", false, errors.Wrapf(err, "verifying manifest file failed (path: %s)", path)
+			}
+			if ok {
+				return dir, true, nil
+			}
+		}
+
+		if dir == "/" {
+			break
+		}
+		dir = filepath.Dir(dir)
+	}
+	return "", false, nil
+}
+
+func ReadPackageManifest(path string) (*packageManifest, error) {
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "reading file body failed (path: %s)", path)
+	}
+
+	var m packageManifest
+	err = yaml.Unmarshal(content, &m)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unmarshalling package manifest failed (path: %s)", path)
+	}
+	return &m, nil
+}
+
+func isPackageManifest(path string) (bool, error) {
+	m, err := ReadPackageManifest(path)
+	if err != nil {
+		return false, errors.Wrapf(err, "reading package manifest failed (path: %s)", path)
+	}
+	return m.Type == "integration" && m.Version != "", nil // TODO add support for other package types
+}


### PR DESCRIPTION
This PR implements the `elastic-package lint` command.

Depends on https://github.com/elastic/package-spec/pull/12.
Resolves #5. 