### PR TITLE
Fix: push only two branches

### DIFF
--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -92,7 +92,7 @@ func promoteCommandAction(cmd *cobra.Command, args []string) error {
 	}
 
 	// Push changes
-	err = promote.PushChanges(githubUser, repository)
+	err = promote.PushChanges(githubUser, repository, newSourceStage, newDestinationStage)
 	if err != nil {
 		return errors.Wrapf(err, "pushing changes failed")
 	}

--- a/internal/promote/storage.go
+++ b/internal/promote/storage.go
@@ -385,8 +385,8 @@ func PushChanges(user string, r *git.Repository, newSourceStage, newDestinationS
 	err = r.Push(&git.PushOptions{
 		RemoteName: user,
 		RefSpecs: []config.RefSpec{
-			config.RefSpec(fmt.Sprintf("refs/heads/%s:refs/heads:%s", newSourceStage, newSourceStage)),
-			config.RefSpec(fmt.Sprintf("refs/heads/%s:refs/heads:%s", newDestinationStage, newDestinationStage)),
+			config.RefSpec(fmt.Sprintf("refs/heads/%s:refs/heads/%s", newSourceStage, newSourceStage)),
+			config.RefSpec(fmt.Sprintf("refs/heads/%s:refs/heads/%s", newDestinationStage, newDestinationStage)),
 		},
 		Auth: &http.BasicAuth{
 			Username: user,

--- a/internal/promote/storage.go
+++ b/internal/promote/storage.go
@@ -105,7 +105,12 @@ func CloneRepository(user, stage string) (*git.Repository, error) {
 
 	err = r.Fetch(&git.FetchOptions{
 		RemoteName: remoteName,
-		RefSpecs:   []config.RefSpec{"refs/*:refs/*", "HEAD:refs/heads/HEAD"},
+		RefSpecs: []config.RefSpec{
+			"HEAD:refs/heads/HEAD",
+			"refs/heads/snapshot:refs/heads/snapshot",
+			"refs/heads/staging:refs/heads/staging",
+			"refs/heads/production:refs/heads/production",
+		},
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "fetch remote branches failed")
@@ -371,7 +376,7 @@ func RemovePackages(r *git.Repository, sourceStage string, packages PackageVersi
 }
 
 // PushChanges method pushes all branches to the remote repository.
-func PushChanges(user string, r *git.Repository) error {
+func PushChanges(user string, r *git.Repository, newSourceStage, newDestinationStage string) error {
 	authToken, err := github.AuthToken()
 	if err != nil {
 		return errors.Wrap(err, "reading auth token failed")
@@ -379,6 +384,10 @@ func PushChanges(user string, r *git.Repository) error {
 
 	err = r.Push(&git.PushOptions{
 		RemoteName: user,
+		RefSpecs: []config.RefSpec{
+			config.RefSpec(fmt.Sprintf("refs/heads/%s:refs/heads:%s", newSourceStage, newSourceStage)),
+			config.RefSpec(fmt.Sprintf("refs/heads/%s:refs/heads:%s", newDestinationStage, newDestinationStage)),
+		},
 		Auth: &http.BasicAuth{
 			Username: user,
 			Password: authToken,

--- a/internal/promote/storage.go
+++ b/internal/promote/storage.go
@@ -375,7 +375,7 @@ func RemovePackages(r *git.Repository, sourceStage string, packages PackageVersi
 	return newSourceStage, nil
 }
 
-// PushChanges method pushes all branches to the remote repository.
+// PushChanges method pushes branches to the remote repository.
 func PushChanges(user string, r *git.Repository, newSourceStage, newDestinationStage string) error {
 	authToken, err := github.AuthToken()
 	if err != nil {


### PR DESCRIPTION
This PR adjusts refs used by the elastic-package and prevents syncing all branches.