### PR TITLE
Add paragraph about GitHub authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ Run the `help` command and see available actions:
 elastic-package help
 ```
 
+## GitHub Authorization
+
+The `promote` subcommand requires access to the GitHub API to open pull requests or check authorized account data.
+The tool uses the GitHub token to authorize user's call to API. The token can be stored in the `~/.elastic/github.token`
+file or passed via the `GITHUB_TOKEN` environment variable.
+
+Here are the instructions on how to create your own personal access token (PAT):
+https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
+
+Make sure you have access to public repositories (to open pull requests) and to user data (check authorized account data).
+
 ## Development
 
 Even though the project is "go-gettable", there is the `Makefile` present, which can be used to build, format or vendor


### PR DESCRIPTION
This PR adds paragraph about the Github token for `promote` subcommand.