### PR TITLE
Use 7.9 as default environment

### DIFF
--- a/internal/install/static_snapshot_yml.go
+++ b/internal/install/static_snapshot_yml.go
@@ -3,7 +3,7 @@ package install
 const snapshotYml = `version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.0-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "-u", "elastic:changeme", "http://127.0.0.1:9200/"]
       retries: 300
@@ -22,7 +22,7 @@ services:
       - "127.0.0.1:9200:9200"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.9.0-SNAPSHOT
     depends_on:
       elasticsearch:
         condition: service_healthy


### PR DESCRIPTION
As for the snapshot registry currently 7.9 is used as default environment, I think this should also be the default environment spinned up here. Long term it would be nice if the version could be passed in as param.