### PR TITLE
Add "cluster pull" command

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -32,6 +32,18 @@ func setupClusterCommand() *cobra.Command {
 		},
 	}
 
+	pullCommand := &cobra.Command{
+		Use:   "pull",
+		Short: "Pulls down the most recent version of the images",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := cluster.DockerComposePull()
+			if err != nil {
+				return errors.Wrap(err, "pulling down the images failed")
+			}
+			return nil
+		},
+	}
+
 	shellInitCommand := &cobra.Command{
 		Use:   "shellinit",
 		Short: "Initiate environment variables",
@@ -53,6 +65,7 @@ func setupClusterCommand() *cobra.Command {
 	cmd.AddCommand(
 		upCommand,
 		downCommand,
+		pullCommand,
 		shellInitCommand)
 	return cmd
 }

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -32,13 +32,13 @@ func setupClusterCommand() *cobra.Command {
 		},
 	}
 
-	pullCommand := &cobra.Command{
-		Use:   "pull",
-		Short: "Pulls down the most recent version of the images",
+	updateCommand := &cobra.Command{
+		Use:   "update",
+		Short: "Updates the cluster to the most recent versions.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := cluster.DockerComposePull()
+			err := cluster.Update()
 			if err != nil {
-				return errors.Wrap(err, "pulling down the images failed")
+				return errors.Wrap(err, "failed updating the cluster images")
 			}
 			return nil
 		},
@@ -65,7 +65,7 @@ func setupClusterCommand() *cobra.Command {
 	cmd.AddCommand(
 		upCommand,
 		downCommand,
-		pullCommand,
+		updateCommand,
 		shellInitCommand)
 	return cmd
 }

--- a/internal/cluster/boot.go
+++ b/internal/cluster/boot.go
@@ -64,6 +64,11 @@ func TearDown() error {
 	return nil
 }
 
+// Update pulls down the most recent versions of the Docker images
+func Update() error {
+	return dockerComposePull()
+}
+
 func dockerComposeBuild() error {
 	clusterDir, err := install.ClusterDir()
 	if err != nil {
@@ -84,8 +89,7 @@ func dockerComposeBuild() error {
 	return nil
 }
 
-// DockerComposePull pulls down the most recent versions of the Docker images
-func DockerComposePull() error {
+func dockerComposePull() error {
 	clusterDir, err := install.ClusterDir()
 	if err != nil {
 		return errors.Wrap(err, "locating cluster directory failed")

--- a/internal/cluster/boot.go
+++ b/internal/cluster/boot.go
@@ -66,7 +66,11 @@ func TearDown() error {
 
 // Update pulls down the most recent versions of the Docker images
 func Update() error {
-	return dockerComposePull()
+	err := dockerComposePull()
+	if err != nil {
+		return errors.Wrap(err, "updating docker images failed")
+	}
+	return nil
 }
 
 func dockerComposeBuild() error {

--- a/internal/cluster/boot.go
+++ b/internal/cluster/boot.go
@@ -84,6 +84,26 @@ func dockerComposeBuild() error {
 	return nil
 }
 
+func DockerComposePull() error {
+	clusterDir, err := install.ClusterDir()
+	if err != nil {
+		return errors.Wrap(err, "locating cluster directory failed")
+	}
+
+	args := []string{
+		"-f", filepath.Join(clusterDir, "snapshot.yml"),
+		"pull",
+	}
+	cmd := exec.Command("docker-compose", args...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	err = cmd.Run()
+	if err != nil {
+		return errors.Wrap(err, "running command failed")
+	}
+	return nil
+}
+
 func dockerComposeUp() error {
 	clusterDir, err := install.ClusterDir()
 	if err != nil {

--- a/internal/cluster/boot.go
+++ b/internal/cluster/boot.go
@@ -84,6 +84,7 @@ func dockerComposeBuild() error {
 	return nil
 }
 
+// DockerComposePull pulls down the most recent versions of the Docker images
 func DockerComposePull() error {
 	clusterDir, err := install.ClusterDir()
 	if err != nil {


### PR DESCRIPTION
Often it is useful to get the most recent version of the images. For this the most recent images must be pulled. I initially added it to the bootUp command directly but realised this could become annoying as sometimes starting a cluster could take much longer. Instead I made it a manual command.