### PR TITLE
Add cluster run command

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -12,13 +12,18 @@ func setupClusterCommand() *cobra.Command {
 		Use:   "up",
 		Short: "Boot up the testing cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := cluster.BootUp()
+			d, err := cmd.Flags().GetBool("d")
+			if err != nil {
+				return err
+			}
+			err = cluster.BootUp(d)
 			if err != nil {
 				return errors.Wrap(err, "booting up the cluster failed")
 			}
 			return nil
 		},
 	}
+	upCommand.Flags().Bool("d", false, "Run cluster as daemon")
 
 	runCommand := &cobra.Command{
 		Use:   "run",

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -20,6 +20,18 @@ func setupClusterCommand() *cobra.Command {
 		},
 	}
 
+	runCommand := &cobra.Command{
+		Use:   "run",
+		Short: "Run the testing cluster",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := cluster.Run()
+			if err != nil {
+				return errors.Wrap(err, "running the cluster failed")
+			}
+			return nil
+		},
+	}
+
 	downCommand := &cobra.Command{
 		Use:   "down",
 		Short: "Take down the testing cluster",
@@ -52,6 +64,7 @@ func setupClusterCommand() *cobra.Command {
 	}
 	cmd.AddCommand(
 		upCommand,
+		runCommand,
 		downCommand,
 		shellInitCommand)
 	return cmd

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -23,7 +23,7 @@ func setupClusterCommand() *cobra.Command {
 			return nil
 		},
 	}
-	upCommand.Flags().Bool("d", false, "Run cluster as daemon")
+	upCommand.Flags().BoolP("daemon","d", false, "Run cluster as daemon")
 
 	downCommand := &cobra.Command{
 		Use:   "down",

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -25,18 +25,6 @@ func setupClusterCommand() *cobra.Command {
 	}
 	upCommand.Flags().Bool("d", false, "Run cluster as daemon")
 
-	runCommand := &cobra.Command{
-		Use:   "run",
-		Short: "Run the testing cluster",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			err := cluster.Run()
-			if err != nil {
-				return errors.Wrap(err, "running the cluster failed")
-			}
-			return nil
-		},
-	}
-
 	downCommand := &cobra.Command{
 		Use:   "down",
 		Short: "Take down the testing cluster",
@@ -69,7 +57,6 @@ func setupClusterCommand() *cobra.Command {
 	}
 	cmd.AddCommand(
 		upCommand,
-		runCommand,
 		downCommand,
 		shellInitCommand)
 	return cmd

--- a/internal/cluster/boot.go
+++ b/internal/cluster/boot.go
@@ -55,48 +55,6 @@ func BootUp(d bool) error {
 	return nil
 }
 
-// Run method runs the cluster and shows the logs.
-func Run() error {
-	buildPackagesPath, found, err := builder.FindBuildPackagesDirectory()
-	if err != nil {
-		return errors.Wrap(err, "finding build packages directory failed")
-	}
-
-	clusterPackagesDir, err := install.ClusterPackagesDir()
-	if err != nil {
-		return errors.Wrap(err, "locating cluster packages directory failed")
-	}
-
-	err = files.ClearDir(clusterPackagesDir)
-	if err != nil {
-		return errors.Wrap(err, "clearing package contents failed")
-	}
-
-	if found {
-		fmt.Printf("Custom build packages directory found: %s\n", buildPackagesPath)
-		err = files.CopyAll(buildPackagesPath, clusterPackagesDir)
-		if err != nil {
-			return errors.Wrap(err, "copying package contents failed")
-		}
-	}
-
-	err = dockerComposeBuild()
-	if err != nil {
-		return errors.Wrap(err, "building docker images failed")
-	}
-
-	err = dockerComposeDown()
-	if err != nil {
-		return errors.Wrap(err, "stopping docker containers failed")
-	}
-
-	err = dockerComposeUp()
-	if err != nil {
-		return errors.Wrap(err, "running docker containers failed")
-	}
-	return nil
-}
-
 // TearDown method takes down the testing cluster.
 func TearDown() error {
 	err := dockerComposeDown()
@@ -154,14 +112,10 @@ func dockerComposeUp(d bool) error {
 
 	args := []string{
 		"-f", filepath.Join(clusterDir, "snapshot.yml"),
-<<<<<<< HEAD
 		"up", "--force-recreate", "--remove-orphans", "--build",
-=======
-		"up",
 	}
 	if d {
 		args = append(args, "-d")
->>>>>>> 09dcb9e... push some code changes
 	}
 	cmd := exec.Command("docker-compose", args...)
 	cmd.Stderr = os.Stderr

--- a/internal/cluster/boot.go
+++ b/internal/cluster/boot.go
@@ -48,9 +48,51 @@ func BootUp() error {
 		return errors.Wrap(err, "stopping docker containers failed")
 	}
 
-	err = dockerComposeUp()
+	err = dockerComposeUpD()
 	if err != nil {
 		return errors.Wrap(err, "running docker-compose failed")
+	}
+	return nil
+}
+
+// Run method runs the cluster and shows the logs.
+func Run() error {
+	buildPackagesPath, found, err := builder.FindBuildPackagesDirectory()
+	if err != nil {
+		return errors.Wrap(err, "finding build packages directory failed")
+	}
+
+	clusterPackagesDir, err := install.ClusterPackagesDir()
+	if err != nil {
+		return errors.Wrap(err, "locating cluster packages directory failed")
+	}
+
+	err = files.ClearDir(clusterPackagesDir)
+	if err != nil {
+		return errors.Wrap(err, "clearing package contents failed")
+	}
+
+	if found {
+		fmt.Printf("Custom build packages directory found: %s\n", buildPackagesPath)
+		err = files.CopyAll(buildPackagesPath, clusterPackagesDir)
+		if err != nil {
+			return errors.Wrap(err, "copying package contents failed")
+		}
+	}
+
+	err = dockerComposeBuild()
+	if err != nil {
+		return errors.Wrap(err, "building docker images failed")
+	}
+
+	err = dockerComposeDown()
+	if err != nil {
+		return errors.Wrap(err, "stopping docker containers failed")
+	}
+
+	err = dockerComposeUp()
+	if err != nil {
+		return errors.Wrap(err, "running docker containers failed")
 	}
 	return nil
 }
@@ -84,7 +126,7 @@ func dockerComposeBuild() error {
 	return nil
 }
 
-func dockerComposeUp() error {
+func dockerComposeUpD() error {
 	clusterDir, err := install.ClusterDir()
 	if err != nil {
 		return errors.Wrap(err, "locating cluster directory failed")
@@ -93,6 +135,26 @@ func dockerComposeUp() error {
 	args := []string{
 		"-f", filepath.Join(clusterDir, "snapshot.yml"),
 		"up", "-d",
+	}
+	cmd := exec.Command("docker-compose", args...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	err = cmd.Run()
+	if err != nil {
+		return errors.Wrap(err, "running command failed")
+	}
+	return nil
+}
+
+func dockerComposeUp() error {
+	clusterDir, err := install.ClusterDir()
+	if err != nil {
+		return errors.Wrap(err, "locating cluster directory failed")
+	}
+
+	args := []string{
+		"-f", filepath.Join(clusterDir, "snapshot.yml"),
+		"up", "--force-recreate", "--remove-orphans", "--build",
 	}
 	cmd := exec.Command("docker-compose", args...)
 	cmd.Stderr = os.Stderr

--- a/internal/cluster/boot.go
+++ b/internal/cluster/boot.go
@@ -14,7 +14,7 @@ import (
 )
 
 // BootUp method boots up the testing cluster.
-func BootUp() error {
+func BootUp(d bool) error {
 	buildPackagesPath, found, err := builder.FindBuildPackagesDirectory()
 	if err != nil {
 		return errors.Wrap(err, "finding build packages directory failed")
@@ -48,7 +48,7 @@ func BootUp() error {
 		return errors.Wrap(err, "stopping docker containers failed")
 	}
 
-	err = dockerComposeUpD()
+	err = dockerComposeUp(d)
 	if err != nil {
 		return errors.Wrap(err, "running docker-compose failed")
 	}
@@ -146,7 +146,7 @@ func dockerComposeUpD() error {
 	return nil
 }
 
-func dockerComposeUp() error {
+func dockerComposeUp(d bool) error {
 	clusterDir, err := install.ClusterDir()
 	if err != nil {
 		return errors.Wrap(err, "locating cluster directory failed")
@@ -154,7 +154,14 @@ func dockerComposeUp() error {
 
 	args := []string{
 		"-f", filepath.Join(clusterDir, "snapshot.yml"),
+<<<<<<< HEAD
 		"up", "--force-recreate", "--remove-orphans", "--build",
+=======
+		"up",
+	}
+	if d {
+		args = append(args, "-d")
+>>>>>>> 09dcb9e... push some code changes
 	}
 	cmd := exec.Command("docker-compose", args...)
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
This adds the command to spin up the cluster but have the logs exposed. The reason is that when I spin up the cluster, I always want to see the logs and not having it run in the background to debug potential issues.

I am opening this as draft to have a discussion on this first and it seems on shutdown it somehow gets stuck. Also naming wise users will aks what is the difference between up and run (one background, one not). Lets see what others think.