### PR TITLE
Bumping up packge-spec dependency to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/AlecAivazis/survey/v2 v2.1.0
 	github.com/Masterminds/semver v1.5.0
-	github.com/elastic/package-spec/code/go v0.0.0-20200817183209-596ecfdacb29
+	github.com/elastic/package-spec/code/go v0.0.0-20200817225106-d939a82ed059
 	github.com/go-git/go-billy/v5 v5.0.0
 	github.com/go-git/go-git/v5 v5.1.0
 	github.com/google/go-github/v32 v32.1.0

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/elastic/package-spec/code/go v0.0.0-20200817183209-596ecfdacb29 h1:1oUCvmbg9x99cIYbVpYBL/GkYerh8khS45IhUvf5okA=
-github.com/elastic/package-spec/code/go v0.0.0-20200817183209-596ecfdacb29/go.mod h1:Nwrtk7MkomLee1bKTTLFHXaWQwn0A4OlPDa1xTebFDo=
+github.com/elastic/package-spec/code/go v0.0.0-20200817225106-d939a82ed059 h1:5DT7pudPKQOVmECtQTwpNiOkMSzDJcqQOIwbBlsFhC8=
+github.com/elastic/package-spec/code/go v0.0.0-20200817225106-d939a82ed059/go.mod h1:Nwrtk7MkomLee1bKTTLFHXaWQwn0A4OlPDa1xTebFDo=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=


### PR DESCRIPTION
Bumps up `github.com/elastic/package-spec/code/go` dependency to latest version.