### PR TITLE
Use 7.9.0 stable for the cluster

### DIFF
--- a/internal/install/static_snapshot_yml.go
+++ b/internal/install/static_snapshot_yml.go
@@ -3,7 +3,7 @@ package install
 const snapshotYml = `version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.0-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.0
     healthcheck:
       test: ["CMD", "curl", "-f", "-u", "elastic:changeme", "http://127.0.0.1:9200/"]
       retries: 300
@@ -22,7 +22,7 @@ services:
       - "127.0.0.1:9200:9200"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.9.0-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.9.0
     depends_on:
       elasticsearch:
         condition: service_healthy


### PR DESCRIPTION
Now that 7.9.0 is out, it should be used for the cluster.