### PR TITLE
Disable ingest pipeline from formatting

### DIFF
--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -24,6 +24,9 @@ func Format(packageRoot string, failFast bool) error {
 			return err
 		}
 
+		if info.IsDir() && info.Name() == "ingest_pipeline" {
+			return filepath.SkipDir
+		}
 		if info.IsDir() {
 			return nil
 		}


### PR DESCRIPTION
This PR ignores `ingest_pipeline` directory from formatting sources.

Issue: https://github.com/elastic/elastic-package/issues/66