### PR TITLE
Fix: missing build tag in version file

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	// BuildTime is the build time of the binary (set externally with ldflags).
-	BuildTime string
+	BuildTime = "unknown"
 
 	// CommitHash is the Git hash of the branch, used for version purposes (set externally with ldflags).
 	CommitHash = "undefined"
@@ -15,8 +15,8 @@ var (
 
 // BuildTimeFormatted method returns the build time preserving the RFC3339 format.
 func BuildTimeFormatted() string {
-	if BuildTime == "" {
-		return "unknown"
+	if BuildTime == "unknown" {
+		return BuildTime
 	}
 
 	seconds, err := strconv.ParseInt(BuildTime, 10, 64)


### PR DESCRIPTION
 I just spotted that the build tag in the `~/.elastic-package/version is missing if built without any flags.