### PR TITLE
Rename cluster to stack

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,7 @@ func RootCmd() *cobra.Command {
 	rootCmd.AddCommand(
 		setupBuildCommand(),
 		setupCheckCommand(),
-		setupClusterCommand(),
+		setupStackCommand(),
 		setupFormatCommand(),
 		setupLintCommand(),
 		setupPromoteCommand(),

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -4,23 +4,23 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/elastic/elastic-package/internal/cluster"
 	"github.com/elastic/elastic-package/internal/cobraext"
+	"github.com/elastic/elastic-package/internal/stack"
 )
 
-func setupClusterCommand() *cobra.Command {
+func setupStackCommand() *cobra.Command {
 	upCommand := &cobra.Command{
 		Use:   "up",
-		Short: "Boot up the testing cluster",
+		Short: "Boot up the testing stack",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			daemonMode, err := cmd.Flags().GetBool(cobraext.DaemonModeFlagName)
 			if err != nil {
 				return cobraext.FlagParsingError(err, cobraext.DaemonModeFlagName)
 			}
 
-			err = cluster.BootUp(daemonMode)
+			err = stack.BootUp(daemonMode)
 			if err != nil {
-				return errors.Wrap(err, "booting up the cluster failed")
+				return errors.Wrap(err, "booting up the stack failed")
 			}
 			return nil
 		},
@@ -29,11 +29,11 @@ func setupClusterCommand() *cobra.Command {
 
 	downCommand := &cobra.Command{
 		Use:   "down",
-		Short: "Take down the testing cluster",
+		Short: "Take down the testing stack",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := cluster.TearDown()
+			err := stack.TearDown()
 			if err != nil {
-				return errors.Wrap(err, "tearing down the cluster failed")
+				return errors.Wrap(err, "tearing down the stack failed")
 			}
 			return nil
 		},
@@ -41,11 +41,11 @@ func setupClusterCommand() *cobra.Command {
 
 	updateCommand := &cobra.Command{
 		Use:   "update",
-		Short: "Updates the cluster to the most recent versions.",
+		Short: "Updates the stack to the most recent versions.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := cluster.Update()
+			err := stack.Update()
 			if err != nil {
-				return errors.Wrap(err, "failed updating the cluster images")
+				return errors.Wrap(err, "failed updating the stack images")
 			}
 			return nil
 		},
@@ -55,7 +55,7 @@ func setupClusterCommand() *cobra.Command {
 		Use:   "shellinit",
 		Short: "Initiate environment variables",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			shell, err := cluster.ShellInit()
+			shell, err := stack.ShellInit()
 			if err != nil {
 				return errors.Wrap(err, "shellinit failed")
 			}
@@ -65,9 +65,9 @@ func setupClusterCommand() *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "cluster",
+		Use:   "stack",
 		Short: "Manage the testing environment",
-		Long:  "Use cluster command to boot up and take down the local testing cluster.",
+		Long:  "Use stack command to boot up and take down the local testing stack.",
 	}
 	cmd.AddCommand(
 		upCommand,

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -11,13 +11,13 @@ import (
 
 const (
 	elasticPackageDir = ".elastic-package"
-	clusterDir        = "cluster"
+	stackDir          = "stack"
 	packagesDir       = "development"
 )
 
 const versionFilename = "version"
 
-// EnsureInstalled method installs once static resources for the testing Docker cluster.
+// EnsureInstalled method installs once static resources for the testing Docker stack.
 func EnsureInstalled() error {
 	elasticPackagePath, err := configurationDir()
 	if err != nil {
@@ -39,7 +39,7 @@ func EnsureInstalled() error {
 		return errors.Wrap(err, "writing version file failed")
 	}
 
-	err = writeClusterResources(elasticPackagePath)
+	err = writeStackResources(elasticPackagePath)
 	if err != nil {
 		return errors.Wrap(err, "writing static resources failed")
 	}
@@ -48,22 +48,22 @@ func EnsureInstalled() error {
 	return nil
 }
 
-// ClusterDir method returns the cluster directory (see: clusterDir).
-func ClusterDir() (string, error) {
+// StackDir method returns the stack directory (see: stackDir).
+func StackDir() (string, error) {
 	configurationDir, err := configurationDir()
 	if err != nil {
 		return "", errors.Wrap(err, "locating configuration directory failed")
 	}
-	return filepath.Join(configurationDir, clusterDir), nil
+	return filepath.Join(configurationDir, stackDir), nil
 }
 
-// ClusterPackagesDir method returns the cluster packages directory used for package development.
-func ClusterPackagesDir() (string, error) {
-	clusterDir, err := ClusterDir()
+// StackPackagesDir method returns the stack packages directory used for package development.
+func StackPackagesDir() (string, error) {
+	stackDir, err := StackDir()
 	if err != nil {
-		return "", errors.Wrap(err, "locating cluster directory failed")
+		return "", errors.Wrap(err, "locating stack directory failed")
 	}
-	return filepath.Join(clusterDir, packagesDir), nil
+	return filepath.Join(stackDir, packagesDir), nil
 }
 
 func configurationDir() (string, error) {
@@ -98,18 +98,18 @@ func createElasticPackageDirectory(elasticPackagePath string) error {
 	return nil
 }
 
-func writeClusterResources(elasticPackagePath string) error {
-	clusterPath := filepath.Join(elasticPackagePath, clusterDir)
-	packagesPath := filepath.Join(clusterPath, packagesDir)
+func writeStackResources(elasticPackagePath string) error {
+	stackPath := filepath.Join(elasticPackagePath, stackDir)
+	packagesPath := filepath.Join(stackPath, packagesDir)
 	err := os.MkdirAll(packagesPath, 0755)
 	if err != nil {
 		return errors.Wrapf(err, "creating directory failed (path: %s)", elasticPackagePath)
 	}
 
-	err = writeStaticResource(err, filepath.Join(clusterPath, "kibana.config.yml"), kibanaConfigYml)
-	err = writeStaticResource(err, filepath.Join(clusterPath, "snapshot.yml"), snapshotYml)
-	err = writeStaticResource(err, filepath.Join(clusterPath, "package-registry.config.yml"), packageRegistryConfigYml)
-	err = writeStaticResource(err, filepath.Join(clusterPath, "Dockerfile.package-registry"), packageRegistryDockerfile)
+	err = writeStaticResource(err, filepath.Join(stackPath, "kibana.config.yml"), kibanaConfigYml)
+	err = writeStaticResource(err, filepath.Join(stackPath, "snapshot.yml"), snapshotYml)
+	err = writeStaticResource(err, filepath.Join(stackPath, "package-registry.config.yml"), packageRegistryConfigYml)
+	err = writeStaticResource(err, filepath.Join(stackPath, "Dockerfile.package-registry"), packageRegistryDockerfile)
 	if err != nil {
 		return errors.Wrap(err, "writing static resource failed")
 	}

--- a/internal/install/static_package_registry_dockerfile.go
+++ b/internal/install/static_package_registry_dockerfile.go
@@ -2,6 +2,6 @@ package install
 
 const packageRegistryDockerfile = `FROM docker.elastic.co/package-registry/distribution:snapshot
 
-COPY ${CLUSTER_DIR}/package-registry.config.yml /package-registry/config.yml
-COPY ${CLUSTER_DIR}/development/ /packages/development
+COPY ${STACK_DIR}/package-registry.config.yml /package-registry/config.yml
+COPY ${STACK_DIR}/development/ /packages/development
 `

--- a/internal/stack/boot.go
+++ b/internal/stack/boot.go
@@ -1,11 +1,12 @@
-package cluster
+package stack
 
 import (
 	"fmt"
-	"github.com/elastic/elastic-package/internal/files"
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/elastic/elastic-package/internal/files"
 
 	"github.com/pkg/errors"
 
@@ -13,26 +14,26 @@ import (
 	"github.com/elastic/elastic-package/internal/install"
 )
 
-// BootUp method boots up the testing cluster.
+// BootUp method boots up the testing stack.
 func BootUp(daemonMode bool) error {
 	buildPackagesPath, found, err := builder.FindBuildPackagesDirectory()
 	if err != nil {
 		return errors.Wrap(err, "finding build packages directory failed")
 	}
 
-	clusterPackagesDir, err := install.ClusterPackagesDir()
+	stackPackagesDir, err := install.StackPackagesDir()
 	if err != nil {
-		return errors.Wrap(err, "locating cluster packages directory failed")
+		return errors.Wrap(err, "locating stack packages directory failed")
 	}
 
-	err = files.ClearDir(clusterPackagesDir)
+	err = files.ClearDir(stackPackagesDir)
 	if err != nil {
 		return errors.Wrap(err, "clearing package contents failed")
 	}
 
 	if found {
 		fmt.Printf("Custom build packages directory found: %s\n", buildPackagesPath)
-		err = files.CopyAll(buildPackagesPath, clusterPackagesDir)
+		err = files.CopyAll(buildPackagesPath, stackPackagesDir)
 		if err != nil {
 			return errors.Wrap(err, "copying package contents failed")
 		}
@@ -55,7 +56,7 @@ func BootUp(daemonMode bool) error {
 	return nil
 }
 
-// TearDown method takes down the testing cluster.
+// TearDown method takes down the testing stack.
 func TearDown() error {
 	err := dockerComposeDown()
 	if err != nil {
@@ -74,13 +75,13 @@ func Update() error {
 }
 
 func dockerComposeBuild() error {
-	clusterDir, err := install.ClusterDir()
+	stackDir, err := install.StackDir()
 	if err != nil {
-		return errors.Wrap(err, "locating cluster directory failed")
+		return errors.Wrap(err, "locating stack directory failed")
 	}
 
 	args := []string{
-		"-f", filepath.Join(clusterDir, "snapshot.yml"),
+		"-f", filepath.Join(stackDir, "snapshot.yml"),
 		"build", "package-registry",
 	}
 	cmd := exec.Command("docker-compose", args...)
@@ -94,13 +95,13 @@ func dockerComposeBuild() error {
 }
 
 func dockerComposePull() error {
-	clusterDir, err := install.ClusterDir()
+	stackDir, err := install.StackDir()
 	if err != nil {
-		return errors.Wrap(err, "locating cluster directory failed")
+		return errors.Wrap(err, "locating stack directory failed")
 	}
 
 	args := []string{
-		"-f", filepath.Join(clusterDir, "snapshot.yml"),
+		"-f", filepath.Join(stackDir, "snapshot.yml"),
 		"pull",
 	}
 	cmd := exec.Command("docker-compose", args...)
@@ -114,13 +115,13 @@ func dockerComposePull() error {
 }
 
 func dockerComposeUp(daemonMode bool) error {
-	clusterDir, err := install.ClusterDir()
+	stackDir, err := install.StackDir()
 	if err != nil {
-		return errors.Wrap(err, "locating cluster directory failed")
+		return errors.Wrap(err, "locating stack directory failed")
 	}
 
 	args := []string{
-		"-f", filepath.Join(clusterDir, "snapshot.yml"),
+		"-f", filepath.Join(stackDir, "snapshot.yml"),
 		"up",
 	}
 
@@ -139,14 +140,14 @@ func dockerComposeUp(daemonMode bool) error {
 }
 
 func dockerComposeDown() error {
-	clusterDir, err := install.ClusterDir()
+	stackDir, err := install.StackDir()
 	if err != nil {
-		return errors.Wrap(err, "locating cluster directory failed")
+		return errors.Wrap(err, "locating stack directory failed")
 	}
 
 	cmd := exec.Command("docker-compose",
-		"-f", filepath.Join(clusterDir, "snapshot.yml"),
-		"--project-directory", clusterDir,
+		"-f", filepath.Join(stackDir, "snapshot.yml"),
+		"--project-directory", stackDir,
 		"down")
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout

--- a/internal/stack/shellinit.go
+++ b/internal/stack/shellinit.go
@@ -1,4 +1,4 @@
-package cluster
+package stack
 
 import (
 	"fmt"
@@ -25,12 +25,12 @@ type kibanaConfiguration struct {
 
 // ShellInit method exposes environment variables that can be used for testing purposes.
 func ShellInit() (string, error) {
-	clusterDir, err := install.ClusterDir()
+	stackDir, err := install.StackDir()
 	if err != nil {
-		return "", errors.Wrap(err, "location cluster directory failed")
+		return "", errors.Wrap(err, "locating stack directory failed")
 	}
 
-	kibanaConfigurationPath := filepath.Join(clusterDir, "kibana.config.yml")
+	kibanaConfigurationPath := filepath.Join(stackDir, "kibana.config.yml")
 	body, err := ioutil.ReadFile(kibanaConfigurationPath)
 	if err != nil {
 		return "", errors.Wrap(err, "reading Kibana configuration file failed")


### PR DESCRIPTION
This PR renames the `cluster` subcommand to `stack`. For consistency, it all renames all identifiers in code that use "cluster" to use "stack" instead.

Ref: https://github.com/elastic/elastic-package/issues/57#issuecomment-676825292.