### PR TITLE
Adding fake is_ready service to block on kibana health

### DIFF
--- a/internal/install/static_snapshot_yml.go
+++ b/internal/install/static_snapshot_yml.go
@@ -47,4 +47,10 @@ services:
       interval: 1s
     ports:
       - "127.0.0.1:8080:8080"
+
+  is_ready:
+    image: alpine:3.7
+    depends_on:
+      kibana:
+        condition: service_healthy
 `


### PR DESCRIPTION
This PR adds a fake `is_ready` service that depends on the `kibana` service being up and healthy. This ensures that `elastic cluster up` does not return until all stack/cluster services are actually up and healthy.

Resolves #55.