### PR TITLE
Use tiny image (125B only!) for is_ready service

### DIFF
--- a/internal/install/static_snapshot_yml.go
+++ b/internal/install/static_snapshot_yml.go
@@ -49,7 +49,7 @@ services:
       - "127.0.0.1:8080:8080"
 
   is_ready:
-    image: alpine:3.7
+    image: tianon/true
     depends_on:
       kibana:
         condition: service_healthy


### PR DESCRIPTION
This PR switches the images from `alpine` to `tianon/true` for the `is_ready` service, as the `tianon/true` image is much smaller (125 bytes) compared to the `alpine` image (~4 MB). Thanks @mtojek for finding and suggesting the `tianon/true` image: https://github.com/elastic/elastic-package/pull/71#discussion_r474580842.