### PR TITLE
Fleshing out README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ to specify a different version, including SNAPSHOT versions.
 _Context: global_
 
 
+### `elastic-package test`
+
+Use this command to run tests on a package. Currently, the only type of test that is supported are Pipeline Tests.
+
+#### Pipeline Tests
+
+These tests allow you to exercise any Ingest Node Pipelines defined by your packages.
+
+_Context: package_
+
 ### `elastic-package version`
 
 Use this command to print the version of `elastic-package` that you have installed. This is

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Currently, `elastic-package` only supports packages of type [Elastic Integration
 Download and build the latest master of `elastic-package` binary:
 
 ```bash
+git clone https://github.com/elastic/elastic-package.git
+make build
+```
+
+Alternatively, you may use `go get` but you will not be able to use the `elastic-package version` command.
+
+```bash
 go get github.com/elastic/elastic-package
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,11 @@ _Context: package_
 
 ### `elastic-package promote`
 
-Use this command to promote a package to the Snapshot Package Registry.
+Use this command to promote packages from one stage of the Package Registry to another.
 
-_Context: package_
+:warning: This command is intended primarily for use by administrators. 
+
+_Context: global_
 
 #### GitHub authorization
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ file or passed via the `GITHUB_TOKEN` environment variable.
 Here are the instructions on how to create your own personal access token (PAT):
 https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
 
-Make sure you have access to public repositories (to open pull requests) and to user data (check authorized account data).
+Make sure you have enabled the following scopes:
+* `public_repo` — to open pull requests on GitHub repositories.
+* `read:user` and `user:email` — to read your user profile information from GitHub in order to populate pull requests appropriately.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ elastic-package help
 
 `elastic-package` current offers the commands listed below. 
 
-Some commands have a global context, meaning that they can be run from anywhere and they will have the 
-same result. Other commands have a package context; these must be run from anywhere under a package's
+Some commands have a _global context_, meaning that they can be run from anywhere and they will have the 
+same result. Other commands have a _package context_; these must be run from anywhere under a package's
 root folder and they will operate on the contents of that package.
 
 For more details on a specific command, run `elastic-package help <command>`.

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ _Context: global_
 
 ### `elastic-package build`
 
-Use this command to build a package. TODO: what is the purpose of building a package — when would
-a package developer want/need to run this command?
+Use this command to build a package. Built packages are stored in the `build/` folder located at the root folder of the local Git repository checkout that contains your package folder.
+
+Built packages are served up by the Elastic Package Registry running locally (see `elastic-package stack`). They can also be published to the `package-storage` repository.
 
 _Context: package_
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ elastic-package help
 
 `elastic-package` currently offers the commands listed below. 
 
-Some commands have a _global context_, meaning that they can be run from anywhere and they will have the 
-same result. Other commands have a _package context_; these must be run from anywhere under a package's
+Some commands have a _global context_, meaning that they can be executed from anywhere and they will have the 
+same result. Other commands have a _package context_; these must be executed from somewhere under a package's
 root folder and they will operate on the contents of that package.
 
 For more details on a specific command, run `elastic-package help <command>`.

--- a/README.md
+++ b/README.md
@@ -50,12 +50,6 @@ description of what each command does.
 
 _Context: global_
 
-### `elastic-package version`
-
-Use this command to print the version of `elastic-package` that you have installed. This is
-especially useful when reporting bugs.
-
-_Context: global_
 
 ### `elastic-package build`
 
@@ -64,17 +58,6 @@ a package developer want/need to run this command?
 
 _Context: package_
 
-### `elastic-package lint`
-
-Use this command to validate the contents of a package.
-
-_Context: package_
-
-### `elastic-package format`
-
-Use this command to format the contents of a package.
-
-_Context: package_
 
 ### `elastic-package check`
 
@@ -82,12 +65,21 @@ Use this command to run the `format`, `lint`, and `build` commands all at once, 
 
 _Context: package_
 
-### `elastic-package stack`
 
-Use this command to spin up a Docker-based Elastic Stack consisting of Elasticsearch, Kibana, and 
-the Package Registry.
+### `elastic-package format`
 
-_Context: global_
+Use this command to format the contents of a package.
+
+_Context: package_
+
+
+### `elastic-package lint`
+
+Use this command to validate the contents of a package using the 
+[package specification](https://github.com/elastic/package-spec).
+
+_Context: package_
+
 
 ### `elastic-package promote`
 
@@ -107,6 +99,23 @@ https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-a
 Make sure you have enabled the following scopes:
 * `public_repo` — to open pull requests on GitHub repositories.
 * `read:user` and `user:email` — to read your user profile information from GitHub in order to populate pull requests appropriately.
+
+
+### `elastic-package stack`
+
+Use this command to spin up a Docker-based Elastic Stack consisting of Elasticsearch, Kibana, and 
+the Package Registry.
+
+_Context: global_
+
+
+### `elastic-package version`
+
+Use this command to print the version of `elastic-package` that you have installed. This is
+especially useful when reporting bugs.
+
+_Context: global_
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Make sure you have enabled the following scopes:
 ### `elastic-package stack`
 
 Use this command to spin up a Docker-based Elastic Stack consisting of Elasticsearch, Kibana, and 
-the Package Registry.
+the Package Registry. By default the latest released version of the stack is spun up but it is possible
+to specify a different version, including SNAPSHOT versions.
 
 _Context: global_
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,9 @@
 # elastic-package
 
-`elastic-package` is a command line tool, written in Go, used for developing Elastic packages.
+`elastic-package` is a command line tool, written in Go, used for developing Elastic packages. It can help you lint, format, 
+test, build, and promote your packages. Learn about each of these and other features in [_Commands_](#commands) below.
 
-## Features
-
-`elastic-package` can help you lint, format, test, and build your packages. Learn about each
-of these features in _Commands_ below.
-
-## Supported package types
-
-* [Elastic Integrations](https://github.com/elastic/integrations)
+Currently, `elastic-package` only supports packages of type [Elastic Integrations](https://github.com/elastic/integrations).
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # elastic-package
 
-The elastic-package is a command line tool, written in Go, used for developing Elastic packages.
-
-*For experimental use only*
+`elastic-package` is a command line tool, written in Go, used for developing Elastic packages.
 
 ## Features
 
-TODO
+`elastic-package` can help you lint, format, test, and build your packages. Learn about each
+of these features in _Commands_ below.
 
 ## Supported package types
 
@@ -24,18 +23,80 @@ Change directory to the package under development. Note: an integration is a spe
 
 ```bash
 cd integrations
-cd package/my-integration
+cd package/my-package
 ```
 
-Run the `help` command and see available actions:
+Run the `help` command and see available commands:
 
 ```bash
 elastic-package help
 ```
 
-## GitHub authorization
+## Commands
 
-The `promote` subcommand requires access to the GitHub API to open pull requests or check authorized account data.
+`elastic-package` current offers the commands listed below. 
+
+Some commands have a global context, meaning that they can be run from anywhere and they will have the 
+same result. Other commands have a package context; these must be run from anywhere under a package's
+root folder and they will operate on the contents of that package.
+
+For more details on a specific command, run `elastic-package help <command>`.
+
+### `elastic-package help`
+
+Use this command to get a listing of all commands available under `elastic-package` and a brief
+description of what each command does.
+
+_Context: global_
+
+### `elastic-package version`
+
+Use this command to print the version of `elastic-package` that you have installed. This is
+especially useful when reporting bugs.
+
+_Context: global_
+
+### `elastic-package build`
+
+Use this command to build a package. TODO: what is the purpose of building a package — when would
+a package developer want/need to run this command?
+
+_Context: package_
+
+### `elastic-package lint`
+
+Use this command to validate the contents of a package.
+
+_Context: package_
+
+### `elastic-package format`
+
+Use this command to format the contents of a package.
+
+_Context: package_
+
+### `elastic-package check`
+
+Use this command to run the `format`, `lint`, and `build` all at once, in that order.
+
+_Context: package_
+
+### `elastic-package stack`
+
+Use this command to spin up a Docker-based Elastic Stack consisting of Elasticsearch, Kibana, and 
+the Package Registry.
+
+_Context: global_
+
+### `elastic-package promote`
+
+Use this command to promote a package to the Snapshot Package Registry.
+
+_Context: package_
+
+#### GitHub authorization
+
+The `promote` command requires access to the GitHub API to open pull requests or check authorized account data.
 The tool uses the GitHub token to authorize user's call to API. The token can be stored in the `~/.elastic/github.token`
 file or passed via the `GITHUB_TOKEN` environment variable.
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ _Context: package_
 
 ### `elastic-package check`
 
-Use this command to run the `format`, `lint`, and `build` all at once, in that order.
+Use this command to run the `format`, `lint`, and `build` commands all at once, in that order.
 
 _Context: package_
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ elastic-package help
 
 ## Commands
 
-`elastic-package` current offers the commands listed below. 
+`elastic-package` currently offers the commands listed below. 
 
 Some commands have a _global context_, meaning that they can be run from anywhere and they will have the 
 same result. Other commands have a _package context_; these must be run from anywhere under a package's


### PR DESCRIPTION
This PR fleshes out the README by adding a list of supported commands under `elastic-package` and short descriptions for each.

Preview of rendered README: https://github.com/ycombinator/elastic-package/blob/readme/README.md.

Resolves partially #75. 