### PR TITLE
Improve command logging

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -18,9 +18,13 @@ func setupBuildCommand() *cobra.Command {
 }
 
 func buildCommandAction(cmd *cobra.Command, args []string) error {
+	cmd.Println("Build the package")
+
 	err := builder.BuildPackage()
 	if err != nil {
 		return errors.Wrap(err, "building package failed")
 	}
+
+	cmd.Println("Done")
 	return nil
 }

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -21,6 +21,8 @@ func setupFormatCommand() *cobra.Command {
 }
 
 func formatCommandAction(cmd *cobra.Command, args []string) error {
+	cmd.Println("Format the package")
+
 	packageRoot, found, err := packages.FindPackageRoot()
 	if err != nil {
 		return errors.Wrap(err, "locating package root failed")
@@ -38,5 +40,7 @@ func formatCommandAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.Wrapf(err, "formatting the integration failed (path: %s, failFast: %t)", packageRoot, ff)
 	}
+
+	cmd.Println("Done")
 	return nil
 }

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -19,6 +19,8 @@ func setupLintCommand() *cobra.Command {
 }
 
 func lintCommandAction(cmd *cobra.Command, args []string) error {
+	cmd.Println("Lint the package")
+
 	packageRootPath, found, err := packages.FindPackageRoot()
 	if !found {
 		return errors.New("package root not found")
@@ -27,5 +29,11 @@ func lintCommandAction(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "locating package root failed")
 	}
 
-	return validator.ValidateFromPath(packageRootPath)
+	err = validator.ValidateFromPath(packageRootPath)
+	if err != nil {
+		return errors.Wrap(err, "linting package failed")
+	}
+
+	cmd.Println("Done")
+	return nil
 }

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -25,6 +25,8 @@ func setupPromoteCommand() *cobra.Command {
 }
 
 func promoteCommandAction(cmd *cobra.Command, args []string) error {
+	cmd.Println("Promote packages")
+
 	// Setup GitHub
 	err := github.EnsureAuthConfigured()
 	if err != nil {
@@ -109,6 +111,8 @@ func promoteCommandAction(cmd *cobra.Command, args []string) error {
 		return errors.Wrapf(err, "opening PR with removed packages failed (head: %s, base: %s)", newDestinationStage, destinationStage)
 	}
 	cmd.Println("Pull request with removed packages:", url)
+
+	cmd.Println("Done")
 	return nil
 }
 

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -13,8 +13,10 @@ import (
 func setupStackCommand() *cobra.Command {
 	upCommand := &cobra.Command{
 		Use:   "up",
-		Short: "Boot up the testing stack",
+		Short: "Boot up the stack",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.Println("Boot up the Elastic stack")
+
 			daemonMode, err := cmd.Flags().GetBool(cobraext.DaemonModeFlagName)
 			if err != nil {
 				return cobraext.FlagParsingError(err, cobraext.DaemonModeFlagName)
@@ -29,6 +31,8 @@ func setupStackCommand() *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "booting up the stack failed")
 			}
+
+			cmd.Println("Done")
 			return nil
 		},
 	}
@@ -37,20 +41,26 @@ func setupStackCommand() *cobra.Command {
 
 	downCommand := &cobra.Command{
 		Use:   "down",
-		Short: "Take down the testing stack",
+		Short: "Take down the stack",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.Println("Take down the Elastic stack")
+
 			err := stack.TearDown()
 			if err != nil {
 				return errors.Wrap(err, "tearing down the stack failed")
 			}
+
+			cmd.Println("Done")
 			return nil
 		},
 	}
 
 	updateCommand := &cobra.Command{
 		Use:   "update",
-		Short: "Updates the stack to the most recent versions.",
+		Short: "Update the stack to the most recent versions",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.Println("Update the Elastic stack")
+
 			stackVersion, err := cmd.Flags().GetString(cobraext.StackVersionFlagName)
 			if err != nil {
 				return cobraext.FlagParsingError(err, cobraext.StackVersionFlagName)
@@ -60,6 +70,8 @@ func setupStackCommand() *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "failed updating the stack images")
 			}
+
+			cmd.Println("Done")
 			return nil
 		},
 	}
@@ -67,7 +79,7 @@ func setupStackCommand() *cobra.Command {
 
 	shellInitCommand := &cobra.Command{
 		Use:   "shellinit",
-		Short: "Initiate environment variables",
+		Short: "Export environment variables",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			shell, err := stack.ShellInit()
 			if err != nil {
@@ -80,8 +92,8 @@ func setupStackCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "stack",
-		Short: "Manage the testing environment",
-		Long:  "Use stack command to boot up and take down the local testing stack.",
+		Short: "Manage the Elastic stack",
+		Long:  "Use stack command to boot up and take down the local Elastic stack.",
 	}
 	cmd.AddCommand(
 		upCommand,

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -21,9 +21,12 @@ func setupTestCommand() *cobra.Command {
 		Short: "Run test suite for the package",
 		Long:  "Use test runners to verify if the package collects logs and metrics properly.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.Println("Run test suite for the package")
+
 			if len(args) > 0 {
 				return fmt.Errorf("unsupported test type: %s", args[0])
 			}
+
 			return cobraext.ComposeCommandActions(cmd, args, testTypeCmdActions...)
 		}}
 
@@ -38,7 +41,7 @@ func setupTestCommand() *cobra.Command {
 		testTypeCmd := &cobra.Command{
 			Use:   string(testType),
 			Short: fmt.Sprintf("Run %s tests", testType),
-			Long:  fmt.Sprintf("Run %s tests for a package", testType),
+			Long:  fmt.Sprintf("Run %s tests for the package", testType),
 			RunE:  action,
 		}
 
@@ -50,6 +53,8 @@ func setupTestCommand() *cobra.Command {
 
 func testTypeCommandActionFactory(testType testrunner.TestType) cobraext.CommandAction {
 	return func(cmd *cobra.Command, args []string) error {
+		cmd.Printf("Run %s tests for the package\n", testType)
+
 		failOnMissing, err := cmd.Flags().GetBool(cobraext.FailOnMissingFlagName)
 		if err != nil {
 			return cobraext.FlagParsingError(err, cobraext.FailOnMissingFlagName)
@@ -97,6 +102,8 @@ func testTypeCommandActionFactory(testType testrunner.TestType) cobraext.Command
 				return errors.Wrapf(err, "error running package %s tests", testType)
 			}
 		}
+
+		cmd.Println("Done")
 		return nil
 	}
 }

--- a/internal/builder/packages.go
+++ b/internal/builder/packages.go
@@ -1,7 +1,6 @@
 package builder
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -53,8 +52,6 @@ func FindBuildPackagesDirectory() (string, bool, error) {
 }
 
 func buildPackage(sourcePath string) error {
-	fmt.Printf("Building package: %s\n", sourcePath)
-
 	buildDir, found, err := FindBuildPackagesDirectory()
 	if err != nil {
 		return errors.Wrap(err, "locating build directory failed")


### PR DESCRIPTION
This PR improves the command logging. I played a bit with the tool and as a user running `elastic-package check` I don't what's going on behind the scenes, which subcommands failed and which succeeded.

After changes:

```
$ elastic-package check
Format the package
Done
Lint the package
Error: checking package failed: linting package failed: found 1 validation error:
   1. item [_dev] is not allowed in folder [/Users/marcin.tojek/go/src/github.com/elastic/integrations/packages/nginx/dataset/access]
```

If you have other ideas, I'm happy to adjust this PR to make the tool easier to operate.