### PR TITLE
Refactoring: extracting out docker compose API

### DIFF
--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -18,11 +18,8 @@ type Project struct {
 func NewProject(name string, paths ...string) (*Project, error) {
 	for _, path := range paths {
 		info, err := os.Stat(path)
-		if err != nil && os.IsNotExist(err) {
-			return nil, errors.Wrapf(err, "could not find Docker Compose configuration file: %s", path)
-		}
 		if err != nil {
-			return nil, errors.Wrapf(err, "error finding Docker Compose configuration file: %s", path)
+			return nil, errors.Wrapf(err, "could not find Docker Compose configuration file: %s", path)
 		}
 
 		if info.IsDir() {

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -14,6 +14,12 @@ type Project struct {
 	composeFilePaths []string
 }
 
+type CommandOptions struct {
+	Env       []string
+	ExtraArgs []string
+	Services  []string
+}
+
 // NewProject creates a new Docker Compose project given a sequence of Docker Compose configuration files.
 func NewProject(name string, paths ...string) (*Project, error) {
 	for _, path := range paths {
@@ -36,13 +42,13 @@ func NewProject(name string, paths ...string) (*Project, error) {
 }
 
 // Up brings up a Docker Compose project.
-func (p *Project) Up(extraArgs, env []string, services ...string) error {
+func (p *Project) Up(opts CommandOptions) error {
 	args := p.baseArgs()
 	args = append(args, "up")
-	args = append(args, extraArgs...)
-	args = append(args, services...)
+	args = append(args, opts.ExtraArgs...)
+	args = append(args, opts.Services...)
 
-	if err := runDockerComposeCmd(args, env); err != nil {
+	if err := runDockerComposeCmd(args, opts.Env); err != nil {
 		return errors.Wrap(err, "running Docker Compose up command failed")
 	}
 
@@ -50,12 +56,12 @@ func (p *Project) Up(extraArgs, env []string, services ...string) error {
 }
 
 // Down tears down a Docker Compose project.
-func (p *Project) Down(extraArgs, env []string) error {
+func (p *Project) Down(opts CommandOptions) error {
 	args := p.baseArgs()
 	args = append(args, "down")
-	args = append(args, extraArgs...)
+	args = append(args, opts.ExtraArgs...)
 
-	if err := runDockerComposeCmd(args, env); err != nil {
+	if err := runDockerComposeCmd(args, opts.Env); err != nil {
 		return errors.Wrap(err, "running Docker Compose down command failed")
 	}
 
@@ -63,13 +69,13 @@ func (p *Project) Down(extraArgs, env []string) error {
 }
 
 // Build builds a Docker Compose project.
-func (p *Project) Build(extraArgs, env []string, services ...string) error {
+func (p *Project) Build(opts CommandOptions) error {
 	args := p.baseArgs()
 	args = append(args, "build")
-	args = append(args, extraArgs...)
-	args = append(args, services...)
+	args = append(args, opts.ExtraArgs...)
+	args = append(args, opts.Services...)
 
-	if err := runDockerComposeCmd(args, env); err != nil {
+	if err := runDockerComposeCmd(args, opts.Env); err != nil {
 		return errors.Wrap(err, "running Docker Compose build command failed")
 	}
 
@@ -77,13 +83,13 @@ func (p *Project) Build(extraArgs, env []string, services ...string) error {
 }
 
 // Pull pulls down images for a Docker Compose project.
-func (p *Project) Pull(extraArgs, env []string, services ...string) error {
+func (p *Project) Pull(opts CommandOptions) error {
 	args := p.baseArgs()
 	args = append(args, "pull")
-	args = append(args, extraArgs...)
-	args = append(args, services...)
+	args = append(args, opts.ExtraArgs...)
+	args = append(args, opts.Services...)
 
-	if err := runDockerComposeCmd(args, env); err != nil {
+	if err := runDockerComposeCmd(args, opts.Env); err != nil {
 		return errors.Wrap(err, "running Docker Compose pull command failed")
 	}
 

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package compose
 
 import (

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -10,8 +10,8 @@ import (
 
 // Project represents a Docker Compose project.
 type Project struct {
-	name  string
-	paths []string
+	name             string
+	composeFilePaths []string
 }
 
 // NewProject creates a new Docker Compose project given a sequence of Docker Compose configuration files.
@@ -95,7 +95,7 @@ func (p *Project) Pull(extraArgs, env []string, services ...string) error {
 
 func (p *Project) baseArgs() []string {
 	var args []string
-	for _, path := range p.paths {
+	for _, path := range p.composeFilePaths {
 		args = append(args, "-f", path)
 	}
 

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -1,0 +1,112 @@
+package compose
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/pkg/errors"
+)
+
+type Project struct {
+	name  string
+	paths []string
+}
+
+// NewProject creates a new Docker Compose project given a sequence of Docker Compose configuration files.
+func NewProject(name string, paths ...string) (*Project, error) {
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if err != nil && os.IsNotExist(err) {
+			return nil, errors.Wrapf(err, "could not find docker-compose configuration file: %s", path)
+		}
+		if err != nil {
+			return nil, errors.Wrapf(err, "error finding docker-compose configuration file: %s", path)
+		}
+
+		if info.IsDir() {
+			return nil, fmt.Errorf("expected docker-compose configuration file (%s) to be a file, not a folder", path)
+		}
+	}
+
+	c := Project{
+		name,
+		paths,
+	}
+
+	return &c, nil
+}
+
+// Up brings up a Docker Compose project.
+func (p *Project) Up(extraArgs, env []string, services ...string) error {
+	args := p.baseArgs()
+	args = append(args, "up")
+	args = append(args, extraArgs...)
+	args = append(args, services...)
+
+	if err := runDockerComposeCmd(args, env); err != nil {
+		return errors.Wrap(err, "running docker-compose up command failed")
+	}
+
+	return nil
+}
+
+// Down tears down a Docker Compose project.
+func (p *Project) Down(extraArgs, env []string) error {
+	args := p.baseArgs()
+	args = append(args, "down")
+	args = append(args, extraArgs...)
+
+	if err := runDockerComposeCmd(args, env); err != nil {
+		return errors.Wrap(err, "running docker-compose down command failed")
+	}
+
+	return nil
+}
+
+// Build builds a Docker Compose project.
+func (p *Project) Build(extraArgs, env []string, services ...string) error {
+	args := p.baseArgs()
+	args = append(args, "build")
+	args = append(args, extraArgs...)
+	args = append(args, services...)
+
+	if err := runDockerComposeCmd(args, env); err != nil {
+		return errors.Wrap(err, "running docker-compose build command failed")
+	}
+
+	return nil
+}
+
+// Pull pulls down images for a Docker Compose project.
+func (p *Project) Pull(extraArgs, env []string, services ...string) error {
+	args := p.baseArgs()
+	args = append(args, "pull")
+	args = append(args, extraArgs...)
+	args = append(args, services...)
+
+	if err := runDockerComposeCmd(args, env); err != nil {
+		return errors.Wrap(err, "running docker-compose pull command failed")
+	}
+
+	return nil
+}
+
+func (p *Project) baseArgs() []string {
+	var args []string
+	for _, path := range p.paths {
+		args = append(args, "-f", path)
+	}
+
+	args = append(args, "-p", p.name)
+	return args
+}
+
+func runDockerComposeCmd(args, env []string) error {
+	cmd := exec.Command("docker-compose", args...)
+	cmd.Env = append(os.Environ(), env...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+
+	return cmd.Run()
+}

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Project represents a Docker Compose project.
 type Project struct {
 	name  string
 	paths []string

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -14,6 +14,8 @@ type Project struct {
 	composeFilePaths []string
 }
 
+// CommandOptions encapsulates the environment variables, extra arguments, and Docker Compose services
+// that can be passed to each Docker Compose command.
 type CommandOptions struct {
 	Env       []string
 	ExtraArgs []string

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -19,14 +19,14 @@ func NewProject(name string, paths ...string) (*Project, error) {
 	for _, path := range paths {
 		info, err := os.Stat(path)
 		if err != nil && os.IsNotExist(err) {
-			return nil, errors.Wrapf(err, "could not find docker-compose configuration file: %s", path)
+			return nil, errors.Wrapf(err, "could not find Docker Compose configuration file: %s", path)
 		}
 		if err != nil {
-			return nil, errors.Wrapf(err, "error finding docker-compose configuration file: %s", path)
+			return nil, errors.Wrapf(err, "error finding Docker Compose configuration file: %s", path)
 		}
 
 		if info.IsDir() {
-			return nil, fmt.Errorf("expected docker-compose configuration file (%s) to be a file, not a folder", path)
+			return nil, fmt.Errorf("expected Docker Compose configuration file (%s) to be a file, not a folder", path)
 		}
 	}
 
@@ -46,7 +46,7 @@ func (p *Project) Up(extraArgs, env []string, services ...string) error {
 	args = append(args, services...)
 
 	if err := runDockerComposeCmd(args, env); err != nil {
-		return errors.Wrap(err, "running docker-compose up command failed")
+		return errors.Wrap(err, "running Docker Compose up command failed")
 	}
 
 	return nil
@@ -59,7 +59,7 @@ func (p *Project) Down(extraArgs, env []string) error {
 	args = append(args, extraArgs...)
 
 	if err := runDockerComposeCmd(args, env); err != nil {
-		return errors.Wrap(err, "running docker-compose down command failed")
+		return errors.Wrap(err, "running Docker Compose down command failed")
 	}
 
 	return nil
@@ -73,7 +73,7 @@ func (p *Project) Build(extraArgs, env []string, services ...string) error {
 	args = append(args, services...)
 
 	if err := runDockerComposeCmd(args, env); err != nil {
-		return errors.Wrap(err, "running docker-compose build command failed")
+		return errors.Wrap(err, "running Docker Compose build command failed")
 	}
 
 	return nil
@@ -87,7 +87,7 @@ func (p *Project) Pull(extraArgs, env []string, services ...string) error {
 	args = append(args, services...)
 
 	if err := runDockerComposeCmd(args, env); err != nil {
-		return errors.Wrap(err, "running docker-compose pull command failed")
+		return errors.Wrap(err, "running Docker Compose pull command failed")
 	}
 
 	return nil

--- a/internal/stack/boot.go
+++ b/internal/stack/boot.go
@@ -24,7 +24,7 @@ type BootOptions struct {
 	Services []string
 }
 
-const DockerComposeProjectName = "elastic-package-stack"
+const dockerComposeProjectName = "elastic-package-stack"
 
 // BootUp method boots up the testing stack.
 func BootUp(options BootOptions) error {
@@ -94,7 +94,7 @@ func dockerComposeBuild(options BootOptions) error {
 
 	services := withIsReadyServices(withDependentServices(options.Services))
 
-	c, err := compose.NewProject(DockerComposeProjectName, filepath.Join(stackDir, "snapshot.yml"))
+	c, err := compose.NewProject(dockerComposeProjectName, filepath.Join(stackDir, "snapshot.yml"))
 	if err != nil {
 		return errors.Wrap(err, "could not create docker compose project")
 	}
@@ -115,7 +115,7 @@ func dockerComposePull(options BootOptions) error {
 
 	services := withIsReadyServices(withDependentServices(options.Services))
 
-	c, err := compose.NewProject(DockerComposeProjectName, filepath.Join(stackDir, "snapshot.yml"))
+	c, err := compose.NewProject(dockerComposeProjectName, filepath.Join(stackDir, "snapshot.yml"))
 	if err != nil {
 		return errors.Wrap(err, "could not create docker compose project")
 	}
@@ -136,7 +136,7 @@ func dockerComposeUp(options BootOptions) error {
 
 	services := withIsReadyServices(withDependentServices(options.Services))
 
-	c, err := compose.NewProject(DockerComposeProjectName, filepath.Join(stackDir, "snapshot.yml"))
+	c, err := compose.NewProject(dockerComposeProjectName, filepath.Join(stackDir, "snapshot.yml"))
 	if err != nil {
 		return errors.Wrap(err, "could not create docker compose project")
 	}
@@ -160,7 +160,7 @@ func dockerComposeDown() error {
 		return errors.Wrap(err, "locating stack directory failed")
 	}
 
-	c, err := compose.NewProject(DockerComposeProjectName, filepath.Join(stackDir, "snapshot.yml"))
+	c, err := compose.NewProject(dockerComposeProjectName, filepath.Join(stackDir, "snapshot.yml"))
 	if err != nil {
 		return errors.Wrap(err, "could not create docker compose project")
 	}


### PR DESCRIPTION
While working on https://github.com/elastic/elastic-package/pull/64 as well as thinking about https://github.com/elastic/elastic-package/issues/8, I realized it might be better to extract the Docker Compose Golang API out of the `stack` package. This PR does that.