### PR TITLE
Test stack commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,16 @@ lint:
 gomod:
 	go mod tidy
 
+test-stack-command:
+	elastic-package stack up -d
+	eval "$(elastic-package stack shellinit)"
+	curl -f ${ELASTIC_PACKAGE_KIBANA_HOST}/login | grep kbn-injected-metadata >/dev/null # healthcheck
+	elastic-package stack down
+
+test: test-stack-command
+
 check-git-clean:
 	git update-index --really-refresh
 	git diff-index --quiet HEAD
 
-check: build format lint gomod check-git-clean
+check: build format lint gomod test check-git-clean

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,7 @@ gomod:
 	go mod tidy
 
 test-stack-command:
-	elastic-package stack up -d
-	eval "$(elastic-package stack shellinit)"
-	curl -f ${ELASTIC_PACKAGE_KIBANA_HOST}/login | grep kbn-injected-metadata >/dev/null # healthcheck
-	elastic-package stack down
+	./scripts/test-stack-command.sh
 
 test: test-stack-command
 

--- a/scripts/test-stack-command.sh
+++ b/scripts/test-stack-command.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+elastic-package stack up -d
+
+eval "$(elastic-package stack shellinit)"
+curl -f ${ELASTIC_PACKAGE_KIBANA_HOST}/login | grep kbn-injected-metadata >/dev/null # healthcheck
+
+elastic-package stack down


### PR DESCRIPTION
This PR introduces smoke tests for `elastic-package stack` commands to make sure it can download and boot up relevant images.