### PR TITLE
Expect service deployment related files in _dev/deploy

### DIFF
--- a/internal/testrunner/runners/system/servicedeployer/factory.go
+++ b/internal/testrunner/runners/system/servicedeployer/factory.go
@@ -7,7 +7,7 @@ package servicedeployer
 import (
 	"errors"
 	"os"
-	"path"
+	"path/filepath"
 )
 
 var (
@@ -19,10 +19,10 @@ var (
 // Factory chooses the appropriate service runner for the given package, depending
 // on service configuration files defined in the package.
 func Factory(packageRootPath string) (ServiceDeployer, error) {
-	packageDevPath := path.Join(packageRootPath, "_dev")
+	packageDevPath := filepath.Join(packageRootPath, "_dev")
 
 	// Is the service defined using a docker compose configuration file?
-	dockerComposeYMLPath := path.Join(packageDevPath, "docker-compose.yml")
+	dockerComposeYMLPath := filepath.Join(packageDevPath, "deploy", "docker-compose.yml")
 	if _, err := os.Stat(dockerComposeYMLPath); err == nil {
 		return NewDockerComposeServiceDeployer(dockerComposeYMLPath)
 	}


### PR DESCRIPTION
According to the package spec, files related to a package's services' deployment should be under the `<package_root>/_dev/deploy` folder:

https://github.com/elastic/package-spec/blob/4f033cadc78579d2c0d5c019728bb02b75196fdb/versions/1/_dev/spec.yml#L4

This PR adjusts the system test runner code to match the package spec.