### PR TITLE
[System test runner] Assign to the deployed service context

### DIFF
--- a/internal/testrunner/runners/system/servicedeployer/compose.go
+++ b/internal/testrunner/runners/system/servicedeployer/compose.go
@@ -87,7 +87,7 @@ func (r *DockerComposeServiceDeployer) SetUp(ctxt ServiceContext) (DeployedServi
 		return nil, errors.Wrap(err, "could not create STDOUT file")
 	}
 	service.stdout = outFile
-	ctxt.STDOUT = agentLogsFolder + stdoutFileName
+	service.ctxt.STDOUT = agentLogsFolder + stdoutFileName
 
 	service.stderrFilePath = filepath.Join(localLogsFolder, stderrFileName)
 	logger.Debugf("creating temp file %s to hold service container %s STDERR", service.stderrFilePath, serviceContainer)
@@ -96,7 +96,7 @@ func (r *DockerComposeServiceDeployer) SetUp(ctxt ServiceContext) (DeployedServi
 		return nil, errors.Wrap(err, "could not create STDERR file")
 	}
 	service.stderr = errFile
-	ctxt.STDERR = agentLogsFolder + stderrFileName
+	service.ctxt.STDERR = agentLogsFolder + stderrFileName
 
 	logger.Debugf("redirecting service container %s STDOUT and STDERR to temp files", serviceContainer)
 	cmd := exec.Command("docker", "attach", "--no-stdin", serviceContainer)


### PR DESCRIPTION
This PR fixes a subtle bug where we were setting the `STDOUT` and `STDERR` fields on the context passed in to a `ServiceDeployer`'s `SetUp` method. Instead we should be setting these on the context of the `DeployedService` returned from this method.