### PR TITLE
Fix Kibana Fleet URL

### DIFF
--- a/internal/install/static_kibana_config_yml.go
+++ b/internal/install/static_kibana_config_yml.go
@@ -17,7 +17,7 @@ xpack.ingestManager.enabled: true
 xpack.ingestManager.registryUrl: "http://package-registry:8080"
 xpack.ingestManager.fleet.enabled: true
 xpack.ingestManager.fleet.elasticsearch.host: "http://elasticsearch:9200"
-xpack.ingestManager.fleet.kibana.host: "http://localhost:5601"
+xpack.ingestManager.fleet.kibana.host: "http://kibana:5601"
 xpack.ingestManager.fleet.tlsCheckDisabled: true
 
 xpack.encryptedSavedObjects.encryptionKey: "12345678901234567890123456789012"


### PR DESCRIPTION
This PR fixes the Kibana Fleet URL in the `kibana.config.yml` file used by the Kibana Docker container that's booted up by `elastic-package stack up`. This URL value is passed to the Elastic Agent container so the hostname in the URL needs to be `kibana` and not `localhost`.