### PR TITLE
Update dependency on package-spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/aymerick/raymond v2.0.2+incompatible
 	github.com/elastic/go-elasticsearch/v7 v7.9.0
-	github.com/elastic/package-spec/code/go v0.0.0-20200915131953-4f033cadc785
+	github.com/elastic/package-spec/code/go v0.0.0-20200918073701-d669841b7963
 	github.com/go-git/go-billy/v5 v5.0.0
 	github.com/go-git/go-git/v5 v5.1.0
 	github.com/google/go-github/v32 v32.1.0

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,6 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/elastic/go-elasticsearch/v7 v7.9.0 h1:UEau+a1MiiE/F+UrDj60kqIHFWdzU1M2y/YtBU2NC2M=
 github.com/elastic/go-elasticsearch/v7 v7.9.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
-github.com/elastic/package-spec/code/go v0.0.0-20200915131953-4f033cadc785 h1:ttXQE7Apam44cnRwqDRbvOGAsWHzJfhM8OVDgnFzb3k=
-github.com/elastic/package-spec/code/go v0.0.0-20200915131953-4f033cadc785/go.mod h1:SuwqJxWP/DP1OiyXaYToOM6J3n8VswrVoswLsWX+NLo=
 github.com/elastic/package-spec/code/go v0.0.0-20200918073701-d669841b7963 h1:1HSGJbZoM2Hn1utGedrTZ/L4ycNGi8vJ3BDLApEE9qI=
 github.com/elastic/package-spec/code/go v0.0.0-20200918073701-d669841b7963/go.mod h1:SuwqJxWP/DP1OiyXaYToOM6J3n8VswrVoswLsWX+NLo=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/elastic/go-elasticsearch/v7 v7.9.0 h1:UEau+a1MiiE/F+UrDj60kqIHFWdzU1M
 github.com/elastic/go-elasticsearch/v7 v7.9.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/package-spec/code/go v0.0.0-20200915131953-4f033cadc785 h1:ttXQE7Apam44cnRwqDRbvOGAsWHzJfhM8OVDgnFzb3k=
 github.com/elastic/package-spec/code/go v0.0.0-20200915131953-4f033cadc785/go.mod h1:SuwqJxWP/DP1OiyXaYToOM6J3n8VswrVoswLsWX+NLo=
+github.com/elastic/package-spec/code/go v0.0.0-20200918073701-d669841b7963 h1:1HSGJbZoM2Hn1utGedrTZ/L4ycNGi8vJ3BDLApEE9qI=
+github.com/elastic/package-spec/code/go v0.0.0-20200918073701-d669841b7963/go.mod h1:SuwqJxWP/DP1OiyXaYToOM6J3n8VswrVoswLsWX+NLo=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION
Update dependency on package-spec to enable two-character datasets name.

For the purpose of https://github.com/elastic/integrations/pull/245