### PR TITLE
Sort imports using goimports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,7 @@ build:
 
 format:
 	gofmt -s -w .
-
-imports:
+	
 	go get -u golang.org/x/tools/cmd/goimports
 	goimports -local github.com/elastic/elastic-package/ -w .
 
@@ -29,4 +28,4 @@ check-git-clean:
 	git update-index --really-refresh
 	git diff-index --quiet HEAD
 
-check: build format imports lint licenser gomod test check-git-clean
+check: build format lint licenser gomod test check-git-clean

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ build:
 format:
 	gofmt -s -w .
 
+imports:
+	go get -u golang.org/x/tools/cmd/goimports
+	goimports -local github.com/elastic/elastic-package/ -w .
+
 lint:
 	go get -u golang.org/x/lint/golint
 	go list ./... | xargs -n 1 golint -set_exit_status
@@ -25,4 +29,4 @@ check-git-clean:
 	git update-index --really-refresh
 	git diff-index --quiet HEAD
 
-check: build format lint licenser gomod test check-git-clean
+check: build format imports lint licenser gomod test check-git-clean

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,6 @@ build:
 	    github.com/elastic/elastic-package
 
 format:
-	gofmt -s -w .
-	
 	go get -u golang.org/x/tools/cmd/goimports
 	goimports -local github.com/elastic/elastic-package/ -w .
 

--- a/go.sum
+++ b/go.sum
@@ -343,6 +343,7 @@ golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/internal/elasticsearch/client.go
+++ b/internal/elasticsearch/client.go
@@ -10,8 +10,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/elastic/elastic-package/internal/stack"
 	"github.com/elastic/go-elasticsearch/v7"
+
+	"github.com/elastic/elastic-package/internal/stack"
 )
 
 // Client method creates new instance of the Elasticsearch client.

--- a/internal/formatter/yaml_formatter.go
+++ b/internal/formatter/yaml_formatter.go
@@ -6,6 +6,7 @@ package formatter
 
 import (
 	"bytes"
+
 	"gopkg.in/yaml.v3"
 
 	"github.com/pkg/errors"

--- a/internal/github/auth.go
+++ b/internal/github/auth.go
@@ -6,11 +6,12 @@ package github
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 const (

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -6,6 +6,7 @@ package github
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 
 	"github.com/google/go-github/v32/github"

--- a/internal/testrunner/runners/pipeline/ingest_pipeline.go
+++ b/internal/testrunner/runners/pipeline/ingest_pipeline.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"io/ioutil"
 	"log"
 	"path/filepath"
@@ -17,6 +16,7 @@ import (
 	"time"
 
 	"github.com/elastic/go-elasticsearch/v7"
+	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 


### PR DESCRIPTION
This PR introduces `goimports` to keep the Go imports sorted. 