### PR TITLE
Fix: SERVICE_LOGS points to agent path

### DIFF
--- a/internal/testrunner/runners/system/servicedeployer/context.go
+++ b/internal/testrunner/runners/system/servicedeployer/context.go
@@ -40,7 +40,7 @@ type ServiceContext struct {
 func (sc *ServiceContext) Aliases() map[string]interface{} {
 	return map[string]interface{}{
 		serviceLogsDirEnv: func() interface{} {
-			return sc.Logs.Folder.Local
+			return sc.Logs.Folder.Agent
 		},
 	}
 }


### PR DESCRIPTION
This PR fixes issue with invalid path defined in config.

Found in: https://github.com/elastic/elastic-package/pull/111

<img width="625" alt="Zrzut ekranu 2020-09-21 o 11 47 18" src="https://user-images.githubusercontent.com/14044910/93753302-3b1a4b80-fc00-11ea-989f-e0bbbed4f27b.png">
