### PR TITLE
First tear down service, then clean data stream

### DIFF
--- a/internal/kibana/ingestmanager/client_agents.go
+++ b/internal/kibana/ingestmanager/client_agents.go
@@ -54,6 +54,7 @@ func (c *Client) AssignPolicyToAgent(a Agent, p Policy) error {
 		return fmt.Errorf("could not assign policy to agent; API status code = %d; response body = %s", statusCode, respBody)
 	}
 
+	// TODO make sure the policy has been propagated to agents.
 	return nil
 
 }

--- a/internal/kibana/ingestmanager/client_agents.go
+++ b/internal/kibana/ingestmanager/client_agents.go
@@ -7,6 +7,9 @@ package ingestmanager
 import (
 	"encoding/json"
 	"fmt"
+	"time"
+
+	"github.com/elastic/elastic-package/internal/logger"
 
 	"github.com/pkg/errors"
 )
@@ -37,7 +40,6 @@ func (c *Client) ListAgents() ([]Agent, error) {
 	}
 
 	return resp.List, nil
-
 }
 
 // AssignPolicyToAgent assigns the given Policy to the given Agent.
@@ -51,10 +53,47 @@ func (c *Client) AssignPolicyToAgent(a Agent, p Policy) error {
 	}
 
 	if statusCode != 200 {
-		return fmt.Errorf("could not assign policy to agent; API status code = %d; response body = %s", statusCode, respBody)
+		return fmt.Errorf("could not assign policy to agent; API status code = %d; response body = %s", statusCode, string(respBody))
 	}
 
-	// TODO make sure the policy has been propagated to agents.
+	err = c.waitUntilPolicyAssigned(p)
+	if err != nil {
+		return errors.Wrap(err, "error occurred while waiting for the policy to be assigned to all agents")
+	}
 	return nil
+}
 
+func (c *Client) waitUntilPolicyAssigned(p Policy) error {
+	path := fmt.Sprintf("fleet/agent-status?=%s", p.ID)
+
+	var assigned bool
+	for !assigned {
+		statusCode, respBody, err := c.get(path)
+		if err != nil {
+			return errors.Wrapf(err, "could not check agent status; API status code = %d; policy ID = %s; response body = %s", statusCode, p.ID, string(respBody))
+		}
+
+		var resp struct {
+			Results struct {
+				Online int `json:"online"`
+				Total  int `json:"total"`
+			} `json:"results"`
+		}
+
+		if err := json.Unmarshal(respBody, &resp); err != nil {
+			return errors.Wrap(err, "could not convert agent status (response) to JSON")
+		}
+
+		if resp.Results.Total == 0 {
+			return fmt.Errorf("no agent is available")
+		}
+
+		if resp.Results.Total == resp.Results.Online {
+			assigned = true
+		}
+
+		logger.Debugf("Wait until the policy (ID: %s) is assigned to all agents...", p.ID)
+		time.Sleep(2 * time.Second)
+	}
+	return nil
 }

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -238,9 +238,17 @@ func (r *runner) run() error {
 }
 
 func (r *runner) tearDown() {
-	r.resetAgentPolicyHandler()
-	r.shutdownServiceHandler()
-	r.wipeDataStreamHandler()
+	if r.resetAgentPolicyHandler != nil {
+		r.resetAgentPolicyHandler()
+	}
+
+	if r.shutdownServiceHandler != nil {
+		r.shutdownServiceHandler()
+	}
+
+	if r.wipeDataStreamHandler != nil {
+		r.wipeDataStreamHandler()
+	}
 }
 
 func getStackSettingsFromEnv() stackSettings {

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -40,8 +40,8 @@ type runner struct {
 
 	// Execution order of following handlers is defined in runner.tearDown() method.
 	resetAgentPolicyHandler func()
-	shutdownServiceHandler func()
-	wipeDataStreamHandler func()
+	shutdownServiceHandler  func()
+	wipeDataStreamHandler   func()
 }
 
 type stackSettings struct {
@@ -58,10 +58,10 @@ type stackSettings struct {
 // Run runs the system tests defined under the given folder
 func Run(options testrunner.TestOptions) error {
 	r := runner{
-		testFolder: options.TestFolder,
+		testFolder:      options.TestFolder,
 		packageRootPath: options.PackageRootPath,
-		stackSettings: getStackSettingsFromEnv(),
-		esClient: options.ESClient,
+		stackSettings:   getStackSettingsFromEnv(),
+		esClient:        options.ESClient,
 	}
 	defer r.tearDown()
 	return r.run()


### PR DESCRIPTION
Closes #104 

Few words about the solution: we can't depend on stacked defers as we need to follow this order (during shutdown):

1. Reassign the original agent policy.
2. Take down the service.
3. Clean up the data stream.

If we execute it in order:

1. Reassign the original agent policy.
2. Clean up the data stream.
3. Take down the service.

... some old metrics may be left in the ES.