### PR TITLE
Fixing typo: missing query param name

### DIFF
--- a/internal/kibana/ingestmanager/client_agents.go
+++ b/internal/kibana/ingestmanager/client_agents.go
@@ -64,7 +64,7 @@ func (c *Client) AssignPolicyToAgent(a Agent, p Policy) error {
 }
 
 func (c *Client) waitUntilPolicyAssigned(p Policy) error {
-	path := fmt.Sprintf("fleet/agent-status?=%s", p.ID)
+	path := fmt.Sprintf("fleet/agent-status?policyId=%s", p.ID)
 
 	var assigned bool
 	for !assigned {


### PR DESCRIPTION
Follow up to #117.

This PR fixes a minor typo.