### PR TITLE
Remove setting that's no longer needed

### DIFF
--- a/internal/install/static_kibana_config_yml.go
+++ b/internal/install/static_kibana_config_yml.go
@@ -20,8 +20,5 @@ xpack.fleet.agents.elasticsearch.host: "http://elasticsearch:9200"
 xpack.fleet.agents.kibana.host: "http://kibana:5601"
 xpack.fleet.agents.tlsCheckDisabled: true
 
-# TODO: Remove once https://github.com/elastic/kibana/issues/77613 is resolved.
-xpack.fleet.agents.pollingRequestTimeout: 60000
-
 xpack.encryptedSavedObjects.encryptionKey: "12345678901234567890123456789012"
 `


### PR DESCRIPTION
Now that elastic/kibana#77613 has been resolved, we can get rid of the workaround added in #111.