### PR TITLE
Support flat and extended manifest files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,5 @@ require (
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73 // indirect
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	golang.org/x/sys v0.0.0-20200915084602-288bc346aa39 // indirect
-	golang.org/x/tools v0.0.0-20201007032633-0806396f153e // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,8 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/aymerick/raymond v2.0.2+incompatible
 	github.com/elastic/go-elasticsearch/v7 v7.9.0
-	github.com/elastic/package-spec/code/go v0.0.0-20200930145841-f3a4262e317f
+	github.com/elastic/go-ucfg v0.8.3
+	github.com/elastic/package-spec/code/go v0.0.0-20201006155108-bc98b6baa952
 	github.com/go-git/go-billy/v5 v5.0.0
 	github.com/go-git/go-git/v5 v5.1.0
 	github.com/google/go-github/v32 v32.1.0
@@ -24,5 +25,6 @@ require (
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73 // indirect
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	golang.org/x/sys v0.0.0-20200915084602-288bc346aa39 // indirect
+	golang.org/x/tools v0.0.0-20201007032633-0806396f153e // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/go.sum
+++ b/go.sum
@@ -292,7 +292,6 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -484,8 +483,6 @@ golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d h1:W07d4xkoAUSNOkOzdzXCdFGxT7o2rW4q8M34tB2i//k=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.0.0-20201007032633-0806396f153e h1:FJA2W4BQfMGZ+CD/tiAc39HXecuRsJl3EuczaSUu/Yk=
-golang.org/x/tools v0.0.0-20201007032633-0806396f153e/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,10 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/elastic/go-elasticsearch/v7 v7.9.0 h1:UEau+a1MiiE/F+UrDj60kqIHFWdzU1M2y/YtBU2NC2M=
 github.com/elastic/go-elasticsearch/v7 v7.9.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
-github.com/elastic/package-spec/code/go v0.0.0-20200930145841-f3a4262e317f h1:5b/Ikpf5PqbFY7OtHeEFjDuePBwl2WzmKn2vn2H3HfI=
-github.com/elastic/package-spec/code/go v0.0.0-20200930145841-f3a4262e317f/go.mod h1:Kz0t9hcE0vmayVhw1sYTtIt7fsVwBElVpEhOI3GswBw=
+github.com/elastic/go-ucfg v0.8.3 h1:leywnFjzr2QneZZWhE6uWd+QN/UpP0sdJRHYyuFvkeo=
+github.com/elastic/go-ucfg v0.8.3/go.mod h1:iaiY0NBIYeasNgycLyTvhJftQlQEUO2hpF+FX0JKxzo=
+github.com/elastic/package-spec/code/go v0.0.0-20201006155108-bc98b6baa952 h1:J64rogGIC1NRWlmgPfIqQ2wsbrfMoHlrt6HO8nvRjhM=
+github.com/elastic/package-spec/code/go v0.0.0-20201006155108-bc98b6baa952/go.mod h1:3W6uyBFCE4/NPcVPb+ZuoLJTMLu8BCTc+PRFDutSvfE=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -480,9 +482,10 @@ golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.0.0-20200825202427-b303f430e36d h1:W07d4xkoAUSNOkOzdzXCdFGxT7o2rW4q8M34tB2i//k=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.0.0-20200929223013-bf155c11ec6f h1:7+Nz9MyPqt2qMCTvNiRy1G0zYfkB7UCa+ayT6uVvbyI=
-golang.org/x/tools v0.0.0-20200929223013-bf155c11ec6f/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.0.0-20201007032633-0806396f153e h1:FJA2W4BQfMGZ+CD/tiAc39HXecuRsJl3EuczaSUu/Yk=
+golang.org/x/tools v0.0.0-20201007032633-0806396f153e/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/kibana/ingestmanager/client_policies.go
+++ b/internal/kibana/ingestmanager/client_policies.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
+	"github.com/elastic/elastic-package/internal/packages"
 )
 
 // Policy represents an Ingest Manager policy.
@@ -66,8 +68,8 @@ func (c *Client) DeletePolicy(p Policy) error {
 // data stream level, encapsulating the data type of the
 // variable and it's value.
 type Var struct {
-	Value interface{} `json:"value"`
-	Type  string      `json:"type"`
+	Value packages.VarValue `json:"value"`
+	Type  string            `json:"type"`
 }
 
 // Vars is a collection of variables either at the package or

--- a/internal/kibana/ingestmanager/client_policies.go
+++ b/internal/kibana/ingestmanager/client_policies.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-
-	"github.com/elastic/elastic-package/internal/packages"
 )
 
 // Policy represents an Ingest Manager policy.
@@ -68,8 +66,8 @@ func (c *Client) DeletePolicy(p Policy) error {
 // data stream level, encapsulating the data type of the
 // variable and it's value.
 type Var struct {
-	Value packages.VarValue `json:"value"`
-	Type  string            `json:"type"`
+	Value interface{} `json:"value"`
+	Type  string      `json:"type"`
 }
 
 // Vars is a collection of variables either at the package or

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -18,18 +18,18 @@ const (
 	// PackageManifestFile is the name of the package's main manifest file.
 	PackageManifestFile = "manifest.yml"
 
-	// DataStreamManifestFile is the name of the dataStream's manifest file.
+	// DataStreamManifestFile is the name of the data stream's manifest file.
 	DataStreamManifestFile = "manifest.yml"
 )
 
-// VarValue represents a variable value as defined in a package or dataStream
+// VarValue represents a Variable value as defined in a package or data stream
 // manifest file.
 type VarValue struct {
 	scalar string
 	list   []string
 }
 
-// UnmarshalYAML knows how to parse a variable value from a package or dataStream
+// UnmarshalYAML knows how to parse a Variable value from a package or data stream
 // manifest file into a VarValue.
 func (vv *VarValue) UnmarshalYAML(value *yaml.Node) error {
 	switch value.Kind {
@@ -41,7 +41,7 @@ func (vv *VarValue) UnmarshalYAML(value *yaml.Node) error {
 			vv.list[idx] = content.Value
 		}
 	default:
-		return errors.New("unknown variable value")
+		return errors.New("unknown Variable value")
 	}
 	return nil
 }
@@ -57,19 +57,22 @@ func (vv VarValue) MarshalJSON() ([]byte, error) {
 	return nil, nil
 }
 
-type variable struct {
+// Variable is an instance of configuration variable (named, typed).
+type Variable struct {
 	Name    string   `json:"name"`
 	Type    string   `json:"type"`
 	Default VarValue `json:"default"`
 }
 
-type input struct {
+// Input is a single input configuration.
+type Input struct {
 	Type string     `json:"type"`
-	Vars []variable `json:"vars"`
+	Vars []Variable `json:"vars"`
 }
 
-type policyTemplate struct {
-	Inputs []input `json:"inputs"`
+// PolicyTemplate is a configuration of inputs responsible for collecting log or metric data.
+type PolicyTemplate struct {
+	Inputs []Input `json:"inputs"`
 }
 
 // PackageManifest represents the basic structure of a package's manifest
@@ -78,10 +81,10 @@ type PackageManifest struct {
 	Title           string           `json:"title"`
 	Type            string           `json:"type"`
 	Version         string           `json:"version"`
-	PolicyTemplates []policyTemplate `json:"policy_templates" yaml:"policy_templates"`
+	PolicyTemplates []PolicyTemplate `json:"policy_templates" yaml:"policy_templates"`
 }
 
-// DataStreamManifest represents the structure of a dataStream's manifest
+// DataStreamManifest represents the structure of a data stream's manifest
 type DataStreamManifest struct {
 	Name          string `json:"name"`
 	Title         string `json:"title"`
@@ -90,8 +93,8 @@ type DataStreamManifest struct {
 		IngestPipelineName string `json:"ingest_pipeline.name"`
 	} `json:"elasticsearch"`
 	Streams []struct {
-		Input string     `json:"input"`
-		Vars  []variable `json:"vars"`
+		Input string     `json:"Input"`
+		Vars  []Variable `json:"vars"`
 	} `json:"streams"`
 }
 
@@ -124,7 +127,7 @@ func FindPackageRoot() (string, bool, error) {
 	return "", false, nil
 }
 
-// FindDataStreamRootForPath finds and returns the path to the root folder of a dataStream.
+// FindDataStreamRootForPath finds and returns the path to the root folder of a data stream.
 func FindDataStreamRootForPath(workDir string) (string, bool, error) {
 	dir := workDir
 	for dir != "." {
@@ -180,7 +183,7 @@ func ReadDataStreamManifest(path string) (*DataStreamManifest, error) {
 	return &m, nil
 }
 
-func (pt *policyTemplate) FindInputByType(inputType string) *input {
+func (pt *PolicyTemplate) FindInputByType(inputType string) *Input {
 	for _, input := range pt.Inputs {
 		if input.Type == inputType {
 			return &input

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -25,18 +25,20 @@ const (
 // VarValue represents a variable value as defined in a package or data stream
 // manifest file.
 type VarValue struct {
-	scalar string
-	list   []string
+	scalar interface{}
+	list   []interface{}
 }
 
 // Unpack knows how to parse a variable value from a package or data stream
 // manifest file into a VarValue.
-func (vv *VarValue) Unpack(cfg *ucfg.Config) error {
-	if cfg.IsArray() {
-		return cfg.Unpack(&vv.list)
-	}
-	if !cfg.IsDict() { // is scalar as dict is not supported
-		return cfg.Unpack(&vv.scalar)
+func (vv *VarValue) Unpack(value interface{}) error {
+	switch u := value.(type) {
+	case []interface{}:
+		vv.list = u
+		return nil
+	default:
+		vv.scalar = u
+		return nil
 	}
 	return errors.New("unknown variable value")
 }
@@ -44,7 +46,7 @@ func (vv *VarValue) Unpack(cfg *ucfg.Config) error {
 // MarshalJSON knows how to serialize a VarValue into the appropriate
 // JSON data type and value.
 func (vv VarValue) MarshalJSON() ([]byte, error) {
-	if vv.scalar != "" {
+	if vv.scalar != nil {
 		return json.Marshal(vv.scalar)
 	} else if vv.list != nil {
 		return json.Marshal(vv.list)

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -86,14 +86,16 @@ type PackageManifest struct {
 
 // DataStreamManifest represents the structure of a data stream's manifest
 type DataStreamManifest struct {
-	Name          string `json:"name"`
-	Title         string `json:"title"`
-	Type          string `json:"type"`
+	Name          string `json:"name" yaml:"name"`
+	Title         string `json:"title" yaml:"title"`
+	Type          string `json:"type" yaml:"type"`
 	Elasticsearch *struct {
-		IngestPipelineName string `json:"ingest_pipeline.name"`
+		IngestPipeline *struct {
+			Name string `json:"name"`
+		} `json:"ingest_pipeline"`
 	} `json:"elasticsearch"`
 	Streams []struct {
-		Input string     `json:"Input"`
+		Input string     `json:"input"`
 		Vars  []Variable `json:"vars"`
 	} `json:"streams"`
 }
@@ -166,7 +168,7 @@ func ReadPackageManifest(path string) (*PackageManifest, error) {
 	return &m, nil
 }
 
-// ReadDataStreamManifest reads and parses the given data streammanifest file.
+// ReadDataStreamManifest reads and parses the given data stream manifest file.
 func ReadDataStreamManifest(path string) (*DataStreamManifest, error) {
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -176,7 +178,7 @@ func ReadDataStreamManifest(path string) (*DataStreamManifest, error) {
 	var m DataStreamManifest
 	err = yaml.Unmarshal(content, &m)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unmarshalling data streammanifest failed (path: %s)", path)
+		return nil, errors.Wrapf(err, "unmarshalling data stream manifest failed (path: %s)", path)
 	}
 
 	m.Name = filepath.Base(filepath.Dir(path))

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -149,6 +149,7 @@ func ReadDataStreamManifest(path string) (*DataStreamManifest, error) {
 	return &m, nil
 }
 
+// FindInputByType returns the input for the provided type.
 func (pt *PolicyTemplate) FindInputByType(inputType string) *Input {
 	for _, input := range pt.Inputs {
 		if input.Type == inputType {

--- a/internal/testrunner/runners/pipeline/ingest_pipeline.go
+++ b/internal/testrunner/runners/pipeline/ingest_pipeline.go
@@ -75,9 +75,9 @@ func installIngestPipelines(esClient *elasticsearch.Client, dataStreamPath strin
 	return mainPipeline, jsonPipelines, nil
 }
 
-func getPipelineNameOrDefault(dataStreamManifest *packages.DataStreamManifest) string {
-	if dataStreamManifest.Elasticsearch != nil && dataStreamManifest.Elasticsearch.IngestPipelineName != "" {
-		return dataStreamManifest.Elasticsearch.IngestPipelineName
+func getPipelineNameOrDefault(dsm *packages.DataStreamManifest) string {
+	if dsm.Elasticsearch != nil && dsm.Elasticsearch.IngestPipeline != nil && dsm.Elasticsearch.IngestPipeline.Name != "" {
+		return dsm.Elasticsearch.IngestPipeline.Name
 	}
 	return defaultPipelineName
 }

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -186,7 +186,7 @@ func (r *runner) run() error {
 	}
 
 	// Assign policy to agent
-	logger.Info("assigning package data streamto agent...")
+	logger.Info("assigning package data stream to agent...")
 	if err := im.AssignPolicyToAgent(agent, *policy); err != nil {
 		return errors.Wrap(err, "could not assign policy to agent")
 	}

--- a/internal/testrunner/runners/system/test_config.go
+++ b/internal/testrunner/runners/system/test_config.go
@@ -13,15 +13,16 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
+	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/testrunner/runners/system/servicedeployer"
 )
 
 const configFileName = "config.yml"
 
 type testConfig struct {
-	Vars       map[string]interface{} `yaml:"vars"`
+	Vars       map[string]packages.VarValue `yaml:"vars"`
 	DataStream struct {
-		Vars map[string]interface{} `yaml:"vars"`
+		Vars map[string]packages.VarValue `yaml:"vars"`
 	} `yaml:"data_stream"`
 }
 

--- a/internal/testrunner/runners/system/test_config.go
+++ b/internal/testrunner/runners/system/test_config.go
@@ -22,10 +22,10 @@ import (
 const configFileName = "config.yml"
 
 type testConfig struct {
-	Vars       map[string]packages.VarValue `yaml:"vars"`
+	Vars       map[string]packages.VarValue `config:"vars"`
 	DataStream struct {
-		Vars map[string]packages.VarValue `yaml:"vars"`
-	} `yaml:"data_stream"`
+		Vars map[string]packages.VarValue `config:"vars"`
+	} `config:"data_stream"`
 }
 
 func newConfig(systemTestFolderPath string, ctxt servicedeployer.ServiceContext) (*testConfig, error) {

--- a/internal/testrunner/runners/system/test_config.go
+++ b/internal/testrunner/runners/system/test_config.go
@@ -13,16 +13,15 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
-	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/testrunner/runners/system/servicedeployer"
 )
 
 const configFileName = "config.yml"
 
 type testConfig struct {
-	Vars       map[string]packages.VarValue `yaml:"vars"`
+	Vars       map[string]interface{} `yaml:"vars"`
 	DataStream struct {
-		Vars map[string]packages.VarValue `yaml:"vars"`
+		Vars map[string]interface{} `yaml:"vars"`
 	} `yaml:"data_stream"`
 }
 

--- a/internal/testrunner/runners/system/test_config.go
+++ b/internal/testrunner/runners/system/test_config.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/aymerick/raymond"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v3"
+
+	"github.com/elastic/go-ucfg"
+	"github.com/elastic/go-ucfg/yaml"
 
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/testrunner/runners/system/servicedeployer"
@@ -43,10 +45,14 @@ func newConfig(systemTestFolderPath string, ctxt servicedeployer.ServiceContext)
 	}
 
 	var c testConfig
-	if err := yaml.Unmarshal(data, &c); err != nil {
-		return nil, errors.Wrapf(err, "unable to parse system test configuration file: %s", configFilePath)
+	cfg, err := yaml.NewConfig(data, ucfg.PathSep("."))
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to load system test configuration file: %s", configFilePath)
 	}
 
+	if err := cfg.Unpack(&c); err != nil {
+		return nil, errors.Wrapf(err, "unable to unpack system test configuration file: %s", configFilePath)
+	}
 	return &c, nil
 }
 


### PR DESCRIPTION
Issue: https://github.com/elastic/package-spec/issues/55

Changes introduced in the PR:
* use ucfg to support both flat and extended manifest files
* fix visibility of manifest related structures (all visible)
* replace `VarValue` (scalar/list) with `interface{}`
* fix comments in multiple places (mainly: `dataStream`)