### PR TITLE
Remove details

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,7 @@ These tests allow you to exercise any Ingest Node Pipelines defined by your pack
 
 These tests allow you to test a package's ability to ingest data end-to-end. 
 
-These tests will spin up an Elasticsearch node, a Kibana instance, a Package Registry, an Elastic Agent, and — depending on the package — an instance of the integration service for the package being tested. Then the tests will enroll the Agent with Fleet, configure a policy via Ingest Manager APIs, and assign the policy to the enrolled Agent. Once the Agent has received the policy, the tests will wait for the Agent to collect the appropriate data from the integration service and ingest it into the appropriate data stream in Elasticsearch.
-
-For details on how to configure system tests for a package, see the [HOWTO guide](docs/howto/system_testing.md).
+For details on how to configure amd run system tests, see the [HOWTO guide](docs/howto/system_testing.md).
 
 _Context: package_
 


### PR DESCRIPTION
I decided to remove the details about what system tests do from the README for two reasons:
- to make this section consistent with the section on pipeline tests, and
- since the details are covered in the HOWTO guide already
