### PR TITLE
Rename ingest_manager to fleet

### DIFF
--- a/internal/kibana/ingestmanager/client.go
+++ b/internal/kibana/ingestmanager/client.go
@@ -26,7 +26,7 @@ type Client struct {
 // NewClient returns a new Ingest Manager API client.
 func NewClient(baseURL, username, password string) (*Client, error) {
 	return &Client{
-		baseURL + "/api/ingest_manager",
+		baseURL + "/api/fleet",
 		username,
 		password,
 	}, nil

--- a/internal/kibana/ingestmanager/client_agents.go
+++ b/internal/kibana/ingestmanager/client_agents.go
@@ -22,7 +22,7 @@ type Agent struct {
 
 // ListAgents returns the list of agents enrolled with Fleet.
 func (c *Client) ListAgents() ([]Agent, error) {
-	statusCode, respBody, err := c.get("fleet/agents")
+	statusCode, respBody, err := c.get("agents")
 	if err != nil {
 		return nil, errors.Wrap(err, "could not list agents")
 	}
@@ -46,7 +46,7 @@ func (c *Client) ListAgents() ([]Agent, error) {
 func (c *Client) AssignPolicyToAgent(a Agent, p Policy) error {
 	reqBody := `{ "policy_id": "` + p.ID + `" }`
 
-	path := fmt.Sprintf("fleet/agents/%s/reassign", a.ID)
+	path := fmt.Sprintf("agents/%s/reassign", a.ID)
 	statusCode, respBody, err := c.put(path, []byte(reqBody))
 	if err != nil {
 		return errors.Wrap(err, "could not assign policy to agent")
@@ -64,7 +64,7 @@ func (c *Client) AssignPolicyToAgent(a Agent, p Policy) error {
 }
 
 func (c *Client) waitUntilPolicyAssigned(p Policy) error {
-	path := fmt.Sprintf("fleet/agent-status?policyId=%s", p.ID)
+	path := fmt.Sprintf("agent-status?policyId=%s", p.ID)
 
 	var assigned bool
 	for !assigned {


### PR DESCRIPTION
This PR renames `/api/ingest_manager` to `/api/fleet`.

Issue: https://github.com/elastic/kibana/pull/79193