### PR TITLE
Fix: skip last empty line

### DIFF
--- a/internal/testrunner/runners/pipeline/test_case.go
+++ b/internal/testrunner/runners/pipeline/test_case.go
@@ -95,13 +95,17 @@ func readRawInputEntries(inputData []byte, c testConfig) ([]string, error) {
 		} else {
 			body = line
 		}
+
 		inputDataEntries = append(inputDataEntries, body)
 	}
 	err := scanner.Err()
 	if err != nil {
 		return nil, errors.Wrap(err, "reading raw input test file failed")
 	}
-	inputDataEntries = append(inputDataEntries, builder.String())
 
+	lastEntry := builder.String()
+	if len(lastEntry) > 0 {
+		inputDataEntries = append(inputDataEntries, lastEntry)
+	}
 	return inputDataEntries, nil
 }

--- a/test/packages/nginx/data_stream/access/_dev/test/pipeline/test-access-single.log
+++ b/test/packages/nginx/data_stream/access/_dev/test/pipeline/test-access-single.log
@@ -1,0 +1,1 @@
+127.0.0.1 - - [07/Dec/2016:11:04:37 +0100] "GET /test1 HTTP/1.1" 404 571 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36"

--- a/test/packages/nginx/data_stream/access/_dev/test/pipeline/test-access-single.log-expected.json
+++ b/test/packages/nginx/data_stream/access/_dev/test/pipeline/test-access-single.log-expected.json
@@ -1,0 +1,39 @@
+{
+    "expected": [
+        {
+            "nginx": {
+                "access": {
+                    "remote_ip_list": [
+                        "127.0.0.1"
+                    ],
+                    "time": "07/Dec/2016:11:04:37 +0100"
+                }
+            },
+            "http": {
+                "request": {
+                    "method": "GET"
+                },
+                "version": "1.1",
+                "response": {
+                    "body": {
+                        "bytes": 571
+                    },
+                    "status_code": 404
+                }
+            },
+            "source": {
+                "address": "127.0.0.1",
+                "ip": "127.0.0.1"
+            },
+            "error": {
+                "message": "field [@timestamp] doesn't exist"
+            },
+            "user_agent": {
+                "original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36"
+            },
+            "url": {
+                "original": "/test1"
+            }
+        }
+    ]
+}

--- a/test/packages/nginx/data_stream/error/_dev/test/pipeline/test-error-raw.log-expected.json
+++ b/test/packages/nginx/data_stream/error/_dev/test/pipeline/test-error-raw.log-expected.json
@@ -95,12 +95,6 @@
             "error": {
                 "message": "field [@timestamp] doesn't exist"
             }
-        },
-        {
-            "message": "",
-            "error": {
-                "message": "Provided Grok expressions do not match field value: []"
-            }
         }
     ]
 }

--- a/test/packages/nginx/data_stream/ingress_controller/_dev/test/pipeline/test-ingest-raw.log-expected.json
+++ b/test/packages/nginx/data_stream/ingress_controller/_dev/test/pipeline/test-ingest-raw.log-expected.json
@@ -1128,12 +1128,6 @@
             "url": {
                 "original": "/v2/some"
             }
-        },
-        {
-            "message": "",
-            "error": {
-                "message": "Provided Grok expressions do not match field value: []"
-            }
         }
     ]
 }


### PR DESCRIPTION
This PR fixes the issue with empty message passed to the Simulate API in Kibana. Empty lines shouldn't be passed.

Issue: https://github.com/elastic/integrations/pull/304