### PR TITLE
Fix waiting for agent policy reassignment

### DIFF
--- a/internal/install/static_kibana_config_yml.go
+++ b/internal/install/static_kibana_config_yml.go
@@ -19,9 +19,5 @@ xpack.fleet.agents.enabled: true
 xpack.fleet.agents.elasticsearch.host: "http://elasticsearch:9200"
 xpack.fleet.agents.kibana.host: "http://kibana:5601"
 xpack.fleet.agents.tlsCheckDisabled: true
-
-# TODO: Remove once https://github.com/elastic/kibana/issues/77613 is resolved.
-xpack.fleet.agents.pollingRequestTimeout: 60000
-
 xpack.encryptedSavedObjects.encryptionKey: "12345678901234567890123456789012"
 `

--- a/internal/kibana/ingestmanager/client_agents.go
+++ b/internal/kibana/ingestmanager/client_agents.go
@@ -69,14 +69,14 @@ func (c *Client) getTotalAgentForPolicy(p Policy) (int, error) {
 	path := fmt.Sprintf("agents?kuery=%s", kuery)
 	statusCode, respBody, err := c.get(path)
 	if err != nil {
-		return -1, errors.Wrapf(err, "could not check agent status; API status code = %d; policy ID = %s; response body = %s", statusCode, p.ID, string(respBody))
+		return 0, errors.Wrapf(err, "could not check agent status; API status code = %d; policy ID = %s; response body = %s", statusCode, p.ID, string(respBody))
 	}
 	var resp struct {
 		Total int `json:"total"`
 	}
 
 	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return -1, errors.Wrap(err, "could not convert agent list (response) to JSON")
+		return 0, errors.Wrap(err, "could not convert agent list (response) to JSON")
 	}
 
 	return resp.Total, nil
@@ -105,7 +105,7 @@ func (c *Client) waitUntilPolicyAssigned(p Policy) error {
 		}
 
 		if err := json.Unmarshal(respBody, &resp); err != nil {
-			return errors.Wrap(err, "could not convert agent lost (response) to JSON")
+			return errors.Wrap(err, "could not convert agent list (response) to JSON")
 		}
 
 		if resp.Total == totalAgents {

--- a/internal/kibana/ingestmanager/client_agents.go
+++ b/internal/kibana/ingestmanager/client_agents.go
@@ -7,6 +7,7 @@ package ingestmanager
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/elastic/elastic-package/internal/logger"
@@ -63,32 +64,51 @@ func (c *Client) AssignPolicyToAgent(a Agent, p Policy) error {
 	return nil
 }
 
+func (c *Client) getTotalAgentForPolicy(p Policy) (int, error) {
+	kuery := url.QueryEscape(fmt.Sprintf("fleet-agents.policy_id:\"%s\"", p.ID))
+	path := fmt.Sprintf("agents?kuery=%s", kuery)
+	statusCode, respBody, err := c.get(path)
+	if err != nil {
+		return -1, errors.Wrapf(err, "could not check agent status; API status code = %d; policy ID = %s; response body = %s", statusCode, p.ID, string(respBody))
+	}
+	var resp struct {
+		Total int `json:"total"`
+	}
+
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return -1, errors.Wrap(err, "could not convert agent list (response) to JSON")
+	}
+
+	return resp.Total, nil
+}
+
 func (c *Client) waitUntilPolicyAssigned(p Policy) error {
-	path := fmt.Sprintf("agent-status?policyId=%s", p.ID)
+	totalAgents, err := c.getTotalAgentForPolicy(p)
+	if err != nil {
+		return errors.Wrapf(err, "could not get number of agents for policy; policy ID = %s", p.ID)
+	}
+	if totalAgents == 0 {
+		return fmt.Errorf("no agent is available")
+	}
 
 	var assigned bool
 	for !assigned {
+		kuery := url.QueryEscape(fmt.Sprintf("fleet-agents.policy_id:\"%s\" and fleet-agents.policy_revision:*", p.ID))
+		path := fmt.Sprintf("agents?kuery=%s", kuery)
 		statusCode, respBody, err := c.get(path)
 		if err != nil {
 			return errors.Wrapf(err, "could not check agent status; API status code = %d; policy ID = %s; response body = %s", statusCode, p.ID, string(respBody))
 		}
 
 		var resp struct {
-			Results struct {
-				Online int `json:"online"`
-				Total  int `json:"total"`
-			} `json:"results"`
+			Total int `json:"total"`
 		}
 
 		if err := json.Unmarshal(respBody, &resp); err != nil {
-			return errors.Wrap(err, "could not convert agent status (response) to JSON")
+			return errors.Wrap(err, "could not convert agent lost (response) to JSON")
 		}
 
-		if resp.Results.Total == 0 {
-			return fmt.Errorf("no agent is available")
-		}
-
-		if resp.Results.Total == resp.Results.Online {
+		if resp.Total == totalAgents {
 			assigned = true
 		}
 


### PR DESCRIPTION
My take on #127 

The `agent-status` is not really reliable to know successfully get a config, this PR change it to use the `policy_revision` that is set when an agent acknowledged a `POLICY_CHANGE`