### PR TITLE
Include package name in test reports

### DIFF
--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -136,7 +137,12 @@ func testTypeCommandActionFactory(testType testrunner.TestType) cobraext.Command
 			return errors.Wrap(err, "error formatting test report")
 		}
 
-		if err := testrunner.WriteReport(testrunner.TestReportOutput(reportOutput), report, format); err != nil {
+		m, err := packages.ReadPackageManifest(filepath.Join(packageRootPath, packages.PackageManifestFile))
+		if err != nil {
+			return errors.Wrapf(err, "reading package manifest failed (path: %s)", packageRootPath)
+		}
+
+		if err := testrunner.WriteReport(m.Name, testrunner.TestReportOutput(reportOutput), report, format); err != nil {
 			return errors.Wrap(err, "error writing test report")
 		}
 

--- a/internal/testrunner/reporters/outputs/file.go
+++ b/internal/testrunner/reporters/outputs/file.go
@@ -7,7 +7,6 @@ package outputs
 import (
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"time"
@@ -28,7 +27,7 @@ const (
 	ReportOutputFile testrunner.TestReportOutput = "file"
 )
 
-func reportToFile(report string, format testrunner.TestReportFormat) error {
+func reportToFile(pkg, report string, format testrunner.TestReportFormat) error {
 	dest, err := install.TestReportsDir()
 	if err != nil {
 		return errors.Wrap(err, "could not determine test reports folder")
@@ -48,7 +47,7 @@ func reportToFile(report string, format testrunner.TestReportFormat) error {
 		ext = "xml"
 	}
 
-	fileName := fmt.Sprintf("%d%2d.%s", time.Now().Unix(), rand.Int31n(100), ext)
+	fileName := fmt.Sprintf("%s_%d.%s", pkg, time.Now().UnixNano(), ext)
 	filePath := filepath.Join(dest, fileName)
 
 	if err := ioutil.WriteFile(filePath, []byte(report+"\n"), 0644); err != nil {

--- a/internal/testrunner/reporters/outputs/stdout.go
+++ b/internal/testrunner/reporters/outputs/stdout.go
@@ -19,10 +19,10 @@ const (
 	ReportOutputSTDOUT testrunner.TestReportOutput = "stdout"
 )
 
-func reportToSTDOUT(report string, _ testrunner.TestReportFormat) error {
-	fmt.Println("--- Test results: START ---")
+func reportToSTDOUT(pkg, report string, _ testrunner.TestReportFormat) error {
+	fmt.Printf("--- Test results for package: %s - START ---\n", pkg)
 	fmt.Println(report)
-	fmt.Println("--- Test results: END ---")
+	fmt.Printf("--- Test results for package: %s - END   ---\n", pkg)
 	fmt.Println("Done")
 
 	return nil

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -74,7 +74,7 @@ type ReportFormatFunc func(results []TestResult) (string, error)
 var reportFormatters = map[TestReportFormat]ReportFormatFunc{}
 
 // ReportOutputFunc defines the report writer function.
-type ReportOutputFunc func(report string, format TestReportFormat) error
+type ReportOutputFunc func(pkg, report string, format TestReportFormat) error
 
 var reportOutputs = map[TestReportOutput]ReportOutputFunc{}
 
@@ -184,13 +184,13 @@ func RegisterReporterOutput(name TestReportOutput, outputFunc ReportOutputFunc) 
 }
 
 // WriteReport delegates writing of test results to the registered test report output
-func WriteReport(name TestReportOutput, report string, format TestReportFormat) error {
+func WriteReport(pkg string, name TestReportOutput, report string, format TestReportFormat) error {
 	outputFunc, defined := reportOutputs[name]
 	if !defined {
 		return fmt.Errorf("unregistered test report output: %s", name)
 	}
 
-	return outputFunc(report, format)
+	return outputFunc(pkg, report, format)
 }
 
 func findTestFolderPaths(packageRootPath, dataStreamGlob, testTypeGlob string) ([]string, error) {


### PR DESCRIPTION
This PR improves the test reporter's outputs by allowing them to take the package name as an argument. This allows the `file` output to include the package name in the report file name, making it more descriptive and easier to debug.

Related: https://github.com/elastic/integrations/pull/315#issuecomment-713650483.