### PR TITLE
Don't generate empty tables if there are no test results

### DIFF
--- a/internal/testrunner/reporters/formats/human.go
+++ b/internal/testrunner/reporters/formats/human.go
@@ -23,6 +23,10 @@ const (
 )
 
 func reportHumanFormat(results []testrunner.TestResult) (string, error) {
+	if len(results) == 0 {
+		return "No test results", nil
+	}
+
 	t := table.NewWriter()
 	t.AppendHeader(table.Row{"Package", "Data stream", "Test type", "Test name", "Result", "Time elapsed"})
 


### PR DESCRIPTION
This PR improves the `human` report formatter. When there are no test results to report, this formatter will return the string `No test results` instead of return a string consisting of an empty table.