### PR TITLE
Fix: fail testruns on error or failure

### DIFF
--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -146,6 +146,12 @@ func testTypeCommandActionFactory(testType testrunner.TestType) cobraext.Command
 			return errors.Wrap(err, "error writing test report")
 		}
 
+		// Check if there is any error or failure reported
+		for _, r := range results {
+			if r.ErrorMsg != "" || r.FailureMsg != "" {
+				return errors.New("one or more test cases failed")
+			}
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
This PR fixes bug in the `test` command. The application should exit with an error code in case of an error or a failure. 

Spotted in https://github.com/elastic/integrations/pull/345