### PR TITLE
Store test reports in build/test-results/ folder

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -47,10 +47,12 @@ pipeline {
       }
       post {
         always {
-          archiveArtifacts(allowEmptyArchive: true, artifacts: 'src/github.com/elastic/elastic-package/build/test-results/*.xml')
-          junit(allowEmptyResults: false,
+          dir("${BASE_DIR}") {
+            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
+            junit(allowEmptyResults: false,
                 keepLongStdio: true,
-                testResults: "src/github.com/elastic/elastic-package/build/test-results/*.xml")
+                testResults: "build/test-results/*.xml")
+          }
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -47,10 +47,10 @@ pipeline {
       }
       post {
         always {
-          archiveArtifacts(allowEmptyArchive: true, artifacts: '.elastic-package/build/test-results/*.xml')
+          archiveArtifacts(allowEmptyArchive: true, artifacts: 'src/github.com/elastic/elastic-package/build/test-results/*.xml')
           junit(allowEmptyResults: false,
                 keepLongStdio: true,
-                testResults: ".elastic-package/build/test-results/*.xml")
+                testResults: "src/github.com/elastic/elastic-package/build/test-results/*.xml")
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -47,10 +47,10 @@ pipeline {
       }
       post {
         always {
-          archiveArtifacts(allowEmptyArchive: true, artifacts: '.elastic-package/tmp/test/reports/*.xml')
+          archiveArtifacts(allowEmptyArchive: true, artifacts: '.elastic-package/build/test-results/*.xml')
           junit(allowEmptyResults: false,
                 keepLongStdio: true,
-                testResults: ".elastic-package/tmp/test/reports/*.xml")
+                testResults: ".elastic-package/build/test-results/*.xml")
         }
       }
     }

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -35,6 +35,16 @@ func setupTestCommand() *cobra.Command {
 				return fmt.Errorf("unsupported test type: %s", args[0])
 			}
 
+			reportOutput, err := cmd.Flags().GetString(cobraext.ReportOutputFlagName)
+			if err != nil {
+				return cobraext.FlagParsingError(err, cobraext.ReportOutputFlagName)
+			}
+			if reportOutput == string(outputs.ReportOutputFile) {
+				if err := outputs.CleanTestReportsDir(); err != nil {
+					return cobraext.FlagParsingError(err, cobraext.ReportOutputFlagName)
+				}
+			}
+
 			return cobraext.ComposeCommandActions(cmd, args, testTypeCmdActions...)
 		}}
 

--- a/internal/builder/packages.go
+++ b/internal/builder/packages.go
@@ -65,7 +65,11 @@ func FindBuildPackagesDirectory() (string, bool, error) {
 	if found {
 		path := filepath.Join(buildDir, "integrations") // TODO add support for other package types
 		fileInfo, err := os.Stat(path)
-		if err == nil && fileInfo.IsDir() {
+		if err != nil {
+			return "", false, err
+		}
+
+		if fileInfo.IsDir() {
 			return path, true, nil
 		}
 	}

--- a/internal/builder/packages.go
+++ b/internal/builder/packages.go
@@ -32,8 +32,8 @@ func BuildPackage() error {
 	return nil
 }
 
-// FindBuildPackagesDirectory method locates the target build directory for packages.
-func FindBuildPackagesDirectory() (string, bool, error) {
+// FindBuildDirectory locates the target build directory.
+func FindBuildDirectory() (string, bool, error) {
 	workDir, err := os.Getwd()
 	if err != nil {
 		return "", false, errors.Wrap(err, "locating working directory failed")
@@ -41,7 +41,7 @@ func FindBuildPackagesDirectory() (string, bool, error) {
 
 	dir := workDir
 	for dir != "." {
-		path := filepath.Join(dir, "build", "integrations") // TODO add support for other package types
+		path := filepath.Join(dir, "build")
 		fileInfo, err := os.Stat(path)
 		if err == nil && fileInfo.IsDir() {
 			return path, true, nil
@@ -52,6 +52,24 @@ func FindBuildPackagesDirectory() (string, bool, error) {
 		}
 		dir = filepath.Dir(dir)
 	}
+	return "", false, nil
+}
+
+// FindBuildPackagesDirectory method locates the target build directory for packages.
+func FindBuildPackagesDirectory() (string, bool, error) {
+	buildDir, found, err := FindBuildDirectory()
+	if err != nil {
+		return "", false, err
+	}
+
+	if found {
+		path := filepath.Join(buildDir, "integrations") // TODO add support for other package types
+		fileInfo, err := os.Stat(path)
+		if err == nil && fileInfo.IsDir() {
+			return path, true, nil
+		}
+	}
+
 	return "", false, nil
 }
 

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+
+	"github.com/elastic/elastic-package/internal/builder"
 )
 
 const (
@@ -18,11 +20,11 @@ const (
 	stackDir          = "stack"
 	packagesDir       = "development"
 	temporaryDir      = "tmp"
+	testReportsDir    = "test-results"
 )
 
 var (
 	serviceLogsDir = filepath.Join(temporaryDir, "service_logs")
-	testReportsDir = filepath.Join("build", "test-results")
 )
 
 const versionFilename = "version"
@@ -96,11 +98,11 @@ func ServiceLogsDir() (string, error) {
 
 // TestReportsDir returns the location of the directory to store test reports.
 func TestReportsDir() (string, error) {
-	configurationDir, err := configurationDir()
+	buildDir, _, err := builder.FindBuildDirectory()
 	if err != nil {
-		return "", errors.Wrap(err, "locating configuration directory failed")
+		return "", errors.Wrap(err, "locating build directory failed")
 	}
-	return filepath.Join(configurationDir, testReportsDir), nil
+	return filepath.Join(buildDir, testReportsDir), nil
 }
 
 func configurationDir() (string, error) {

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -60,10 +60,6 @@ func EnsureInstalled() error {
 		return errors.Wrap(err, "creating service logs directory failed")
 	}
 
-	if err := createTestReportsDir(elasticPackagePath); err != nil {
-		return errors.Wrap(err, "creating test reports directory failed")
-	}
-
 	fmt.Fprintln(os.Stderr, "elastic-package has been installed.")
 	return nil
 }
@@ -169,15 +165,6 @@ func writeStaticResource(err error, path, content string) error {
 
 func createServiceLogsDir(elasticPackagePath string) error {
 	dirPath := filepath.Join(elasticPackagePath, serviceLogsDir)
-	err := os.MkdirAll(dirPath, 0755)
-	if err != nil {
-		return errors.Wrapf(err, "mkdir failed (path: %s)", dirPath)
-	}
-	return nil
-}
-
-func createTestReportsDir(elasticPackagePath string) error {
-	dirPath := filepath.Join(elasticPackagePath, testReportsDir)
 	err := os.MkdirAll(dirPath, 0755)
 	if err != nil {
 		return errors.Wrapf(err, "mkdir failed (path: %s)", dirPath)

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -22,7 +22,7 @@ const (
 
 var (
 	serviceLogsDir = filepath.Join(temporaryDir, "service_logs")
-	testReportsDir = filepath.Join(temporaryDir, "test", "reports")
+	testReportsDir = filepath.Join("build", "test-results")
 )
 
 const versionFilename = "version"
@@ -56,6 +56,10 @@ func EnsureInstalled() error {
 
 	if err := createServiceLogsDir(elasticPackagePath); err != nil {
 		return errors.Wrap(err, "creating service logs directory failed")
+	}
+
+	if err := createTestReportsDir(elasticPackagePath); err != nil {
+		return errors.Wrap(err, "creating test reports directory failed")
 	}
 
 	fmt.Fprintln(os.Stderr, "elastic-package has been installed.")
@@ -163,6 +167,15 @@ func writeStaticResource(err error, path, content string) error {
 
 func createServiceLogsDir(elasticPackagePath string) error {
 	dirPath := filepath.Join(elasticPackagePath, serviceLogsDir)
+	err := os.MkdirAll(dirPath, 0755)
+	if err != nil {
+		return errors.Wrapf(err, "mkdir failed (path: %s)", dirPath)
+	}
+	return nil
+}
+
+func createTestReportsDir(elasticPackagePath string) error {
+	dirPath := filepath.Join(elasticPackagePath, testReportsDir)
 	err := os.MkdirAll(dirPath, 0755)
 	if err != nil {
 		return errors.Wrapf(err, "mkdir failed (path: %s)", dirPath)

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -11,8 +11,6 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
-
-	"github.com/elastic/elastic-package/internal/builder"
 )
 
 const (
@@ -20,7 +18,6 @@ const (
 	stackDir          = "stack"
 	packagesDir       = "development"
 	temporaryDir      = "tmp"
-	testReportsDir    = "test-results"
 )
 
 var (
@@ -90,15 +87,6 @@ func ServiceLogsDir() (string, error) {
 		return "", errors.Wrap(err, "locating configuration directory failed")
 	}
 	return filepath.Join(configurationDir, serviceLogsDir), nil
-}
-
-// TestReportsDir returns the location of the directory to store test reports.
-func TestReportsDir() (string, error) {
-	buildDir, _, err := builder.FindBuildDirectory()
-	if err != nil {
-		return "", errors.Wrap(err, "locating build directory failed")
-	}
-	return filepath.Join(buildDir, testReportsDir), nil
 }
 
 func configurationDir() (string, error) {

--- a/internal/testrunner/reporters/outputs/file.go
+++ b/internal/testrunner/reporters/outputs/file.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/elastic/elastic-package/internal/install"
+	"github.com/elastic/elastic-package/internal/builder"
 	"github.com/elastic/elastic-package/internal/testrunner"
 	"github.com/elastic/elastic-package/internal/testrunner/reporters/formats"
 )
@@ -28,7 +28,7 @@ const (
 )
 
 func reportToFile(pkg, report string, format testrunner.TestReportFormat) error {
-	dest, err := install.TestReportsDir()
+	dest, err := testReportsDir()
 	if err != nil {
 		return errors.Wrap(err, "could not determine test reports folder")
 	}
@@ -55,4 +55,13 @@ func reportToFile(pkg, report string, format testrunner.TestReportFormat) error 
 	}
 
 	return nil
+}
+
+// testReportsDir returns the location of the directory to store test reports.
+func testReportsDir() (string, error) {
+	buildDir, _, err := builder.FindBuildDirectory()
+	if err != nil {
+		return "", errors.Wrap(err, "locating build directory failed")
+	}
+	return filepath.Join(buildDir, "test-results"), nil
 }

--- a/internal/testrunner/reporters/outputs/file.go
+++ b/internal/testrunner/reporters/outputs/file.go
@@ -57,7 +57,7 @@ func testReportsDir() (string, error) {
 	return filepath.Join(buildDir, "test-results"), nil
 }
 
-// CleanTestReportsDir removes creates the test reports folder if it already exists, then
+// CleanTestReportsDir removes the test reports folder if it already exists, then
 // creates it, effectively resulting in a clean (aka empty) test reports folder.
 func CleanTestReportsDir() error {
 	dest, err := testReportsDir()

--- a/internal/testrunner/reporters/outputs/file.go
+++ b/internal/testrunner/reporters/outputs/file.go
@@ -71,7 +71,7 @@ func CleanTestReportsDir() error {
 		if err := os.RemoveAll(dest); err != nil {
 			return errors.Wrap(err, "could not remove old test reports")
 		}
-	} else {
+	} else if !os.IsNotExist(err) {
 		return errors.Wrap(err, "could not check test reports folder path")
 	}
 

--- a/internal/testrunner/reporters/outputs/file.go
+++ b/internal/testrunner/reporters/outputs/file.go
@@ -33,10 +33,6 @@ func reportToFile(pkg, report string, format testrunner.TestReportFormat) error 
 		return errors.Wrap(err, "could not determine test reports folder")
 	}
 
-	if err := os.MkdirAll(dest, 0755); err != nil {
-		return errors.Wrap(err, "could not create test reports folder")
-	}
-
 	ext := "txt"
 	if format == formats.ReportFormatXUnit {
 		ext = "xml"
@@ -61,6 +57,8 @@ func testReportsDir() (string, error) {
 	return filepath.Join(buildDir, "test-results"), nil
 }
 
+// CleanTestReportsDir removes creates the test reports folder if it already exists, then
+// creates it, effectively resulting in a clean (aka empty) test reports folder.
 func CleanTestReportsDir() error {
 	dest, err := testReportsDir()
 	if err != nil {
@@ -75,6 +73,10 @@ func CleanTestReportsDir() error {
 		}
 	} else {
 		return errors.Wrap(err, "could not check test reports folder path")
+	}
+
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return errors.Wrap(err, "could not create test reports folder")
 	}
 
 	return nil

--- a/internal/testrunner/reporters/outputs/file.go
+++ b/internal/testrunner/reporters/outputs/file.go
@@ -34,12 +34,18 @@ func reportToFile(pkg, report string, format testrunner.TestReportFormat) error 
 	}
 
 	_, err = os.Stat(dest)
-	if os.IsNotExist(err) {
-		if err := os.MkdirAll(dest, 0755); err != nil {
-			return errors.Wrap(err, "could not create test reports folder")
+	if err == nil {
+		// Destination path exists; remove it so we can have an empty folder for new
+		// test report files.
+		if err := os.RemoveAll(dest); err != nil {
+			return errors.Wrap(err, "could not remove old test reports")
 		}
-	} else if err != nil {
-		return errors.Wrap(err, "could not check test reports folder")
+	} else {
+		return errors.Wrap(err, "could not check test reports folder path")
+	}
+
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return errors.Wrap(err, "could not create test reports folder")
 	}
 
 	ext := "txt"

--- a/internal/testrunner/reporters/outputs/file.go
+++ b/internal/testrunner/reporters/outputs/file.go
@@ -33,17 +33,6 @@ func reportToFile(pkg, report string, format testrunner.TestReportFormat) error 
 		return errors.Wrap(err, "could not determine test reports folder")
 	}
 
-	_, err = os.Stat(dest)
-	if err == nil {
-		// Destination path exists; remove it so we can have an empty folder for new
-		// test report files.
-		if err := os.RemoveAll(dest); err != nil {
-			return errors.Wrap(err, "could not remove old test reports")
-		}
-	} else {
-		return errors.Wrap(err, "could not check test reports folder path")
-	}
-
 	if err := os.MkdirAll(dest, 0755); err != nil {
 		return errors.Wrap(err, "could not create test reports folder")
 	}
@@ -70,4 +59,23 @@ func testReportsDir() (string, error) {
 		return "", errors.Wrap(err, "locating build directory failed")
 	}
 	return filepath.Join(buildDir, "test-results"), nil
+}
+
+func CleanTestReportsDir() error {
+	dest, err := testReportsDir()
+	if err != nil {
+		return errors.Wrap(err, "could not determine test reports folder")
+	}
+
+	if _, err := os.Stat(dest); err == nil {
+		// Destination path exists; remove it so we can have an empty folder for new
+		// test report files.
+		if err := os.RemoveAll(dest); err != nil {
+			return errors.Wrap(err, "could not remove old test reports")
+		}
+	} else {
+		return errors.Wrap(err, "could not check test reports folder path")
+	}
+
+	return nil
 }


### PR DESCRIPTION
Addresses https://github.com/elastic/integrations/pull/315#discussion_r511854030.

This PR stores test reports generated by `elastic-package test --report-output file` into `build/test-results/`. Before this PR they were being stored in `~/.elastic-package/tmp/test/reports/`.