### PR TITLE
Add classname to individual test cases

### DIFF
--- a/internal/testrunner/reporters/formats/xunit.go
+++ b/internal/testrunner/reporters/formats/xunit.go
@@ -79,7 +79,7 @@ func reportXUnitFormat(results []testrunner.TestResult) (string, error) {
 			numErrors++
 		}
 
-		name := fmt.Sprintf("[%s/%s] %s test", r.Package, r.DataStream, r.TestType)
+		name := fmt.Sprintf("%s test", r.TestType)
 		if r.Name != "" {
 			name += ": " + r.Name
 		}

--- a/internal/testrunner/reporters/formats/xunit.go
+++ b/internal/testrunner/reporters/formats/xunit.go
@@ -86,6 +86,7 @@ func reportXUnitFormat(results []testrunner.TestResult) (string, error) {
 
 		c := testCase{
 			Name:          name,
+			ClassName:     fmt.Sprintf("%s.%s", r.Package, r.DataStream),
 			TimeInSeconds: r.TimeElapsed.Seconds(),
 			Error:         r.ErrorMsg,
 			Failure:       failure,

--- a/internal/testrunner/reporters/formats/xunit.go
+++ b/internal/testrunner/reporters/formats/xunit.go
@@ -99,41 +99,6 @@ func reportXUnitFormat(results []testrunner.TestResult) (string, error) {
 	var ts testSuites
 	ts.Suites = make([]testSuite, 0)
 
-	//for testType, packages := range tests {
-	//	testTypeSuite := testSuite{
-	//		Comment: fmt.Sprintf("test suite for %s tests", testType),
-	//		Name:    testType,
-	//
-	//		NumTests:    numTests,
-	//		NumFailures: numFailures,
-	//		NumErrors:   numErrors,
-	//
-	//		Suites: make([]testSuite, 0),
-	//	}
-	//
-	//	for pkgName, pkg := range packages {
-	//		pkgSuite := testSuite{
-	//			Name:    pkgName,
-	//			Comment: fmt.Sprintf("test suite for package: %s", pkgName),
-	//			Suites:  make([]testSuite, 0),
-	//		}
-	//
-	//		for dsName, ds := range pkg {
-	//			dsSuite := testSuite{
-	//				Name:    dsName,
-	//				Comment: fmt.Sprintf("test suite for data stream: %s", dsName),
-	//				Cases:   ds,
-	//			}
-	//
-	//			pkgSuite.Suites = append(pkgSuite.Suites, dsSuite)
-	//		}
-	//
-	//		testTypeSuite.Suites = append(testTypeSuite.Suites, pkgSuite)
-	//	}
-	//
-	//	ts.Suites = append(ts.Suites, testTypeSuite)
-	//}
-
 	for testType, packages := range tests {
 		testTypeSuite := testSuite{
 			Comment: fmt.Sprintf("test suite for %s tests", testType),


### PR DESCRIPTION
Addresses https://github.com/elastic/integrations/pull/315#issuecomment-716457556 (the part about adding `classname`).

This PR:
- populates the `classname` attributed of individual test case elements in xUnit-formatted test results, _and_
- does a bit of clean up by removing commented out code.

