### PR TITLE
Refactoring: move test errors out of test runners folder

### DIFF
--- a/internal/testrunner/errors.go
+++ b/internal/testrunner/errors.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package testerrors
+package testrunner
 
 import "fmt"
 

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -18,7 +18,6 @@ import (
 	"github.com/elastic/elastic-package/internal/multierror"
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/testrunner"
-	"github.com/elastic/elastic-package/internal/testrunner/runners/testerrors"
 )
 
 const (
@@ -94,7 +93,7 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 
 		tr.TimeElapsed = time.Now().Sub(startTime)
 		err = r.verifyResults(testCaseFile, result, fieldsValidator)
-		if e, ok := err.(testerrors.ErrTestCaseFailed); ok {
+		if e, ok := err.(testrunner.ErrTestCaseFailed); ok {
 			tr.FailureMsg = e.Error()
 			tr.FailureDetails = e.Details
 
@@ -170,7 +169,7 @@ func (r *runner) verifyResults(testCaseFile string, result *testResult, fieldsVa
 	}
 
 	err := compareResults(testCasePath, result)
-	if _, ok := err.(testerrors.ErrTestCaseFailed); ok {
+	if _, ok := err.(testrunner.ErrTestCaseFailed); ok {
 		return err
 	}
 	if err != nil {
@@ -195,7 +194,7 @@ func verifyFieldsInTestResult(result *testResult, fieldsValidator *fields.Valida
 
 	if len(multiErr) > 0 {
 		multiErr = multiErr.Unique()
-		return testerrors.ErrTestCaseFailed{
+		return testrunner.ErrTestCaseFailed{
 			Reason:  "one or more problems with fields found in documents",
 			Details: multiErr.Error(),
 		}

--- a/internal/testrunner/runners/pipeline/test_result.go
+++ b/internal/testrunner/runners/pipeline/test_result.go
@@ -10,10 +10,10 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/elastic/elastic-package/internal/testrunner/runners/testerrors"
-
 	"github.com/kylelemons/godebug/diff"
 	"github.com/pkg/errors"
+
+	"github.com/elastic/elastic-package/internal/testrunner"
 )
 
 const expectedTestResultSuffix = "-expected.json"
@@ -54,7 +54,7 @@ func compareResults(testCasePath string, result *testResult) error {
 
 	report := diff.Diff(string(expected), string(actual))
 	if report != "" {
-		return testerrors.ErrTestCaseFailed{
+		return testrunner.ErrTestCaseFailed{
 			Reason:  "Expected results are different from actual ones",
 			Details: report,
 		}

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -24,7 +24,6 @@ import (
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/testrunner"
 	"github.com/elastic/elastic-package/internal/testrunner/runners/system/servicedeployer"
-	"github.com/elastic/elastic-package/internal/testrunner/runners/testerrors"
 )
 
 func init() {
@@ -85,7 +84,7 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 			return []testrunner.TestResult{tr}, nil
 		}
 
-		if tcf, ok := err.(testerrors.ErrTestCaseFailed); ok {
+		if tcf, ok := err.(testrunner.ErrTestCaseFailed); ok {
 			tr.FailureMsg = tcf.Reason
 			tr.FailureDetails = tcf.Details
 			return []testrunner.TestResult{tr}, nil
@@ -276,7 +275,7 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 
 		if len(multiErr) > 0 {
 			multiErr = multiErr.Unique()
-			return false, testerrors.ErrTestCaseFailed{
+			return false, testrunner.ErrTestCaseFailed{
 				Reason:  fmt.Sprintf("one or more errors found in documents stored in %s data stream", dataStream),
 				Details: multiErr.Error(),
 			}


### PR DESCRIPTION
We should keep the `runners` folder for implementations of various test runners. So this PR moves the error definition code out of this folder.