### PR TITLE
Check if build/integrations directory doesn't exist

### DIFF
--- a/internal/builder/packages.go
+++ b/internal/builder/packages.go
@@ -65,6 +65,9 @@ func FindBuildPackagesDirectory() (string, bool, error) {
 	if found {
 		path := filepath.Join(buildDir, "integrations") // TODO add support for other package types
 		fileInfo, err := os.Stat(path)
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
 		if err != nil {
 			return "", false, err
 		}


### PR DESCRIPTION
This PR checks if the `build/integrations` directory is absent. If it is, it does not return an `error` but instead sets the `found` return boolean value to `false`. This allows the caller to create the absent directory.

Related: https://github.com/elastic/integrations/pull/395#issuecomment-726190676.

