### PR TITLE
Create test reports folder if it doesn't exist

### DIFF
--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -35,14 +35,8 @@ func setupTestCommand() *cobra.Command {
 				return fmt.Errorf("unsupported test type: %s", args[0])
 			}
 
-			reportOutput, err := cmd.Flags().GetString(cobraext.ReportOutputFlagName)
-			if err != nil {
-				return cobraext.FlagParsingError(err, cobraext.ReportOutputFlagName)
-			}
-			if reportOutput == string(outputs.ReportOutputFile) {
-				if err := outputs.CleanTestReportsDir(); err != nil {
-					return cobraext.FlagParsingError(err, cobraext.ReportOutputFlagName)
-				}
+			if err := setupTestReportsFolder(cmd); err != nil {
+				return errors.Wrap(err, "could not setup test reports folder")
 			}
 
 			return cobraext.ComposeCommandActions(cmd, args, testTypeCmdActions...)
@@ -62,7 +56,13 @@ func setupTestCommand() *cobra.Command {
 			Use:   string(testType),
 			Short: fmt.Sprintf("Run %s tests", testType),
 			Long:  fmt.Sprintf("Run %s tests for the package", testType),
-			RunE:  action,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				if err := setupTestReportsFolder(cmd); err != nil {
+					return errors.Wrap(err, "could not setup test reports folder")
+				}
+
+				return action(cmd, args)
+			},
 		}
 
 		cmd.AddCommand(testTypeCmd)
@@ -73,6 +73,10 @@ func setupTestCommand() *cobra.Command {
 
 func testTypeCommandActionFactory(testType testrunner.TestType) cobraext.CommandAction {
 	return func(cmd *cobra.Command, args []string) error {
+		if err := setupTestReportsFolder(cmd); err != nil {
+			return errors.Wrap(err, "could not setup test reports folder")
+		}
+
 		cmd.Printf("Run %s tests for the package\n", testType)
 
 		failOnMissing, err := cmd.Flags().GetBool(cobraext.FailOnMissingFlagName)
@@ -164,4 +168,17 @@ func testTypeCommandActionFactory(testType testrunner.TestType) cobraext.Command
 		}
 		return nil
 	}
+}
+
+func setupTestReportsFolder(cmd *cobra.Command) error {
+	reportOutput, err := cmd.Flags().GetString(cobraext.ReportOutputFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.ReportOutputFlagName)
+	}
+	if reportOutput == string(outputs.ReportOutputFile) {
+		if err := outputs.CleanTestReportsDir(); err != nil {
+			return cobraext.FlagParsingError(err, cobraext.ReportOutputFlagName)
+		}
+	}
+	return nil
 }

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -35,10 +35,6 @@ func setupTestCommand() *cobra.Command {
 				return fmt.Errorf("unsupported test type: %s", args[0])
 			}
 
-			if err := setupTestReportsFolder(cmd); err != nil {
-				return errors.Wrap(err, "could not setup test reports folder")
-			}
-
 			return cobraext.ComposeCommandActions(cmd, args, testTypeCmdActions...)
 		}}
 
@@ -56,13 +52,7 @@ func setupTestCommand() *cobra.Command {
 			Use:   string(testType),
 			Short: fmt.Sprintf("Run %s tests", testType),
 			Long:  fmt.Sprintf("Run %s tests for the package", testType),
-			RunE: func(cmd *cobra.Command, args []string) error {
-				if err := setupTestReportsFolder(cmd); err != nil {
-					return errors.Wrap(err, "could not setup test reports folder")
-				}
-
-				return action(cmd, args)
-			},
+			RunE:  action,
 		}
 
 		cmd.AddCommand(testTypeCmd)
@@ -73,10 +63,6 @@ func setupTestCommand() *cobra.Command {
 
 func testTypeCommandActionFactory(testType testrunner.TestType) cobraext.CommandAction {
 	return func(cmd *cobra.Command, args []string) error {
-		if err := setupTestReportsFolder(cmd); err != nil {
-			return errors.Wrap(err, "could not setup test reports folder")
-		}
-
 		cmd.Printf("Run %s tests for the package\n", testType)
 
 		failOnMissing, err := cmd.Flags().GetBool(cobraext.FailOnMissingFlagName)
@@ -168,17 +154,4 @@ func testTypeCommandActionFactory(testType testrunner.TestType) cobraext.Command
 		}
 		return nil
 	}
-}
-
-func setupTestReportsFolder(cmd *cobra.Command) error {
-	reportOutput, err := cmd.Flags().GetString(cobraext.ReportOutputFlagName)
-	if err != nil {
-		return cobraext.FlagParsingError(err, cobraext.ReportOutputFlagName)
-	}
-	if reportOutput == string(outputs.ReportOutputFile) {
-		if err := outputs.CleanTestReportsDir(); err != nil {
-			return cobraext.FlagParsingError(err, cobraext.ReportOutputFlagName)
-		}
-	}
-	return nil
 }

--- a/internal/testrunner/reporters/outputs/file.go
+++ b/internal/testrunner/reporters/outputs/file.go
@@ -33,6 +33,14 @@ func reportToFile(pkg, report string, format testrunner.TestReportFormat) error 
 		return errors.Wrap(err, "could not determine test reports folder")
 	}
 
+	// Create test reports folder if it doesn't exist
+	_, err = os.Stat(dest)
+	if err != nil && os.IsNotExist(err) {
+		if err := os.MkdirAll(dest, 0755); err != nil {
+			return errors.Wrap(err, "could not create test reports folder")
+		}
+	}
+
 	ext := "txt"
 	if format == formats.ReportFormatXUnit {
 		ext = "xml"
@@ -55,29 +63,4 @@ func testReportsDir() (string, error) {
 		return "", errors.Wrap(err, "locating build directory failed")
 	}
 	return filepath.Join(buildDir, "test-results"), nil
-}
-
-// CleanTestReportsDir removes the test reports folder if it already exists, then
-// creates it, effectively resulting in a clean (aka empty) test reports folder.
-func CleanTestReportsDir() error {
-	dest, err := testReportsDir()
-	if err != nil {
-		return errors.Wrap(err, "could not determine test reports folder")
-	}
-
-	if _, err := os.Stat(dest); err == nil {
-		// Destination path exists; remove it so we can have an empty folder for new
-		// test report files.
-		if err := os.RemoveAll(dest); err != nil {
-			return errors.Wrap(err, "could not remove old test reports")
-		}
-	} else if !os.IsNotExist(err) {
-		return errors.Wrap(err, "could not check test reports folder path")
-	}
-
-	if err := os.MkdirAll(dest, 0755); err != nil {
-		return errors.Wrap(err, "could not create test reports folder")
-	}
-
-	return nil
 }


### PR DESCRIPTION
Follow up to #172.

In #172 we only create the test reports folder if `elastic-package test` is invoked. That is, the test reports folder was not being created if `elastic-package test pipeline` or `elastic-package test system` was invoked.

Initially I tried to fix this problem by creating the test reports folder for all possible invocations of `elastic-package test`, including it's subcommands. However, this led to another problem: if `elastic-package test system` was run followed by `elastic-package test pipeline` (or vice versa), the test results from the first subcommand invocation were being cleaned out by the second subcommand invocation.

So finally I decided that we should simply not clean out the test reports folder at all when `elastic-package test` or any of its subcommands are run. Instead, a user can use `elastic-package clean` ([when we implement it](https://github.com/elastic/elastic-package/issues/13#issuecomment-722174887)) to clean out the test reports folder as needed.