### PR TITLE
Defer cleanup flag

### DIFF
--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -43,6 +43,7 @@ func setupTestCommand() *cobra.Command {
 	cmd.PersistentFlags().StringSliceP(cobraext.DataStreamsFlagName, "d", nil, cobraext.DataStreamsFlagDescription)
 	cmd.PersistentFlags().StringP(cobraext.ReportFormatFlagName, "", string(formats.ReportFormatHuman), cobraext.ReportFormatFlagDescription)
 	cmd.PersistentFlags().StringP(cobraext.ReportOutputFlagName, "", string(outputs.ReportOutputSTDOUT), cobraext.ReportOutputFlagDescription)
+	cmd.PersistentFlags().DurationP(cobraext.DeferCleanupFlagName, "", 0, cobraext.DeferCleanupFlagDescription)
 
 	for _, testType := range testrunner.TestTypes() {
 		action := testTypeCommandActionFactory(testType)

--- a/internal/cobraext/const.go
+++ b/internal/cobraext/const.go
@@ -15,6 +15,9 @@ const (
 	DataStreamsFlagName        = "data-streams"
 	DataStreamsFlagDescription = "comma-separated data streams to test"
 
+	DeferCleanupFlagName        = "defer-cleanup"
+	DeferCleanupFlagDescription = "defer test cleanup for debugging purposes"
+
 	FailOnMissingFlagName        = "fail-on-missing"
 	FailOnMissingFlagDescription = "fail if tests are missing"
 

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -57,9 +57,14 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 		return nil, errors.Wrap(err, "installing ingest pipelines failed")
 	}
 	defer func() {
+		if r.options.DeferCleanup > 0 {
+			logger.Debugf("Waiting for %s before cleanup...", r.options.DeferCleanup)
+			time.Sleep(r.options.DeferCleanup)
+		}
+
 		err := uninstallIngestPipelines(r.options.ESClient, pipelineIDs)
 		if err != nil {
-			logger.Warnf("uninstalling ingest pipelines failed: %v", err)
+			logger.Warnf("Uninstalling ingest pipelines failed: %v", err)
 		}
 	}()
 

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -67,7 +67,7 @@ func Run(options testrunner.TestOptions) ([]testrunner.TestResult, error) {
 		stackSettings:   getStackSettingsFromEnv(),
 		esClient:        options.ESClient,
 	}
-	defer r.tearDown()
+	defer r.tearDown(options)
 	return r.run()
 }
 
@@ -292,13 +292,10 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 	return resultsWith(result, nil)
 }
 
-func (r *runner) tearDown() {
-	if logger.IsDebugMode() {
-		// Sleep to give some time for humans to scrutinize the current
-		// state of the system.
-		sleepFor := 30 * time.Second
-		logger.Debugf("waiting for %s before tearing down...", sleepFor)
-		time.Sleep(sleepFor)
+func (r *runner) tearDown(options testrunner.TestOptions) {
+	if options.DeferCleanup > 0 {
+		logger.Debugf("waiting for %s before tearing down...", options.DeferCleanup)
+		time.Sleep(options.DeferCleanup)
 	}
 
 	if r.resetAgentPolicyHandler != nil {

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -30,6 +30,8 @@ type TestOptions struct {
 	PackageRootPath    string
 	GenerateTestResult bool
 	ESClient           *elasticsearch.Client
+
+	DeferCleanup time.Duration
 }
 
 // RunFunc method defines main run function of a test runner.


### PR DESCRIPTION
This PR modifies the condition for sleeping before tear down and makes it test runner wide.

It adds a new command option: `--defer-cleanup`.