### PR TITLE
README: remind about GOPATH/PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Alternatively, you may use `go get` but you will not be able to use the `elastic
 go get github.com/elastic/elastic-package
 ```
 
+_Please make sure the you've correctly [setup variables](https://golang.org/doc/gopath_code.html#GOPATH) -
+`$GOPATH` and `$PATH`, and the `elastic-package` is accessible from your `$PATH`._
+
 Change directory to the package under development. Note: an integration is a specific type of a package.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ go get github.com/elastic/elastic-package
 ```
 
 _Please make sure that you've correctly [setup environment variables](https://golang.org/doc/gopath_code.html#GOPATH) -
-`$GOPATH` and `$PATH`, and the `elastic-package` is accessible from your `$PATH`._
+`$GOPATH` and `$PATH`, and `elastic-package` is accessible from your `$PATH`._
 
 Change directory to the package under development. Note: an integration is a specific type of a package.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Alternatively, you may use `go get` but you will not be able to use the `elastic
 go get github.com/elastic/elastic-package
 ```
 
-_Please make sure the you've correctly [setup variables](https://golang.org/doc/gopath_code.html#GOPATH) -
+_Please make sure that you've correctly [setup environment variables](https://golang.org/doc/gopath_code.html#GOPATH) -
 `$GOPATH` and `$PATH`, and the `elastic-package` is accessible from your `$PATH`._
 
 Change directory to the package under development. Note: an integration is a specific type of a package.


### PR DESCRIPTION
This PR adds a short reminder about setting up the `$GOPATH` and `$PATH` correctly.