### PR TITLE
Refactoring test runner

### DIFF
--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -44,14 +44,14 @@ func setupTestCommand() *cobra.Command {
 	cmd.PersistentFlags().StringP(cobraext.ReportOutputFlagName, "", string(outputs.ReportOutputSTDOUT), cobraext.ReportOutputFlagDescription)
 	cmd.PersistentFlags().DurationP(cobraext.DeferCleanupFlagName, "", 0, cobraext.DeferCleanupFlagDescription)
 
-	for _, testType := range testrunner.TestTypes() {
-		action := testTypeCommandActionFactory(testType)
+	for testType, runner := range testrunner.TestRunners() {
+		action := testTypeCommandActionFactory(runner)
 		testTypeCmdActions = append(testTypeCmdActions, action)
 
 		testTypeCmd := &cobra.Command{
 			Use:   string(testType),
-			Short: fmt.Sprintf("Run %s tests", testType),
-			Long:  fmt.Sprintf("Run %s tests for the package.", testType),
+			Short: fmt.Sprintf("Run %s tests", runner.String()),
+			Long:  fmt.Sprintf("Run %s tests for the package.", runner.String()),
 			RunE:  action,
 		}
 
@@ -61,7 +61,8 @@ func setupTestCommand() *cobra.Command {
 	return cmd
 }
 
-func testTypeCommandActionFactory(testType testrunner.TestType) cobraext.CommandAction {
+func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.CommandAction {
+	testType := runner.Type()
 	return func(cmd *cobra.Command, args []string) error {
 		cmd.Printf("Run %s tests for the package\n", testType)
 

--- a/internal/testrunner/report_format.go
+++ b/internal/testrunner/report_format.go
@@ -1,0 +1,30 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package testrunner
+
+import "fmt"
+
+// TestReportFormat represents a test report format
+type TestReportFormat string
+
+// ReportFormatFunc defines the report formatter function.
+type ReportFormatFunc func(results []TestResult) (string, error)
+
+var reportFormatters = map[TestReportFormat]ReportFormatFunc{}
+
+// RegisterReporterFormat registers a test report formatter.
+func RegisterReporterFormat(name TestReportFormat, formatFunc ReportFormatFunc) {
+	reportFormatters[name] = formatFunc
+}
+
+// FormatReport delegates formatting of test results to the registered test report formatter
+func FormatReport(name TestReportFormat, results []TestResult) (string, error) {
+	reportFunc, defined := reportFormatters[name]
+	if !defined {
+		return "", fmt.Errorf("unregistered test report format: %s", name)
+	}
+
+	return reportFunc(results)
+}

--- a/internal/testrunner/report_output.go
+++ b/internal/testrunner/report_output.go
@@ -1,0 +1,32 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package testrunner
+
+import (
+	"fmt"
+)
+
+// TestReportOutput represents an output for a test report
+type TestReportOutput string
+
+// ReportOutputFunc defines the report writer function.
+type ReportOutputFunc func(pkg, report string, format TestReportFormat) error
+
+var reportOutputs = map[TestReportOutput]ReportOutputFunc{}
+
+// RegisterReporterOutput registers a test report output.
+func RegisterReporterOutput(name TestReportOutput, outputFunc ReportOutputFunc) {
+	reportOutputs[name] = outputFunc
+}
+
+// WriteReport delegates writing of test results to the registered test report output
+func WriteReport(pkg string, name TestReportOutput, report string, format TestReportFormat) error {
+	outputFunc, defined := reportOutputs[name]
+	if !defined {
+		return fmt.Errorf("unregistered test report output: %s", name)
+	}
+
+	return outputFunc(pkg, report, format)
+}

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -32,9 +32,19 @@ type runner struct {
 	options testrunner.TestOptions
 }
 
+// Type returns the type of test that can be run by this test runner.
+func (r runner) Type() testrunner.TestType {
+	return TestType
+}
+
+// String returns the human-friendly name of the test runner.
+func (r runner) String() string {
+	return "pipeline"
+}
+
 // Run runs the pipeline tests defined under the given folder
-func Run(options testrunner.TestOptions) ([]testrunner.TestResult, error) {
-	r := runner{options}
+func (r runner) Run(options testrunner.TestOptions) ([]testrunner.TestResult, error) {
+	r.options = options
 	return r.run()
 }
 
@@ -260,5 +270,5 @@ func verifyFieldsInTestResult(result *testResult, fieldsValidator *fields.Valida
 }
 
 func init() {
-	testrunner.RegisterRunner(TestType, Run)
+	testrunner.RegisterRunner(runner{})
 }

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -48,6 +48,10 @@ func (r runner) Run(options testrunner.TestOptions) ([]testrunner.TestResult, er
 	return r.run()
 }
 
+// ShutDown shuts down the pipeline test runner.
+func (r runner) TearDown() {
+}
+
 func (r *runner) run() ([]testrunner.TestResult, error) {
 	testCaseFiles, err := r.listTestCaseFiles()
 	if err != nil {

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -33,23 +33,23 @@ type runner struct {
 }
 
 // Type returns the type of test that can be run by this test runner.
-func (r runner) Type() testrunner.TestType {
+func (r *runner) Type() testrunner.TestType {
 	return TestType
 }
 
 // String returns the human-friendly name of the test runner.
-func (r runner) String() string {
+func (r *runner) String() string {
 	return "pipeline"
 }
 
 // Run runs the pipeline tests defined under the given folder
-func (r runner) Run(options testrunner.TestOptions) ([]testrunner.TestResult, error) {
+func (r *runner) Run(options testrunner.TestOptions) ([]testrunner.TestResult, error) {
 	r.options = options
 	return r.run()
 }
 
 // ShutDown shuts down the pipeline test runner.
-func (r runner) TearDown() {
+func (r *runner) TearDown() {
 }
 
 func (r *runner) run() ([]testrunner.TestResult, error) {
@@ -274,5 +274,5 @@ func verifyFieldsInTestResult(result *testResult, fieldsValidator *fields.Valida
 }
 
 func init() {
-	testrunner.RegisterRunner(runner{})
+	testrunner.RegisterRunner(&runner{})
 }

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -49,7 +49,8 @@ func (r *runner) Run(options testrunner.TestOptions) ([]testrunner.TestResult, e
 }
 
 // ShutDown shuts down the pipeline test runner.
-func (r *runner) TearDown() {
+func (r *runner) TearDown() error {
+	return nil
 }
 
 func (r *runner) run() ([]testrunner.TestResult, error) {

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -27,7 +27,7 @@ import (
 )
 
 func init() {
-	testrunner.RegisterRunner(TestType, Run)
+	testrunner.RegisterRunner(runner{})
 }
 
 const (
@@ -59,14 +59,23 @@ type stackSettings struct {
 	}
 }
 
+// Type returns the type of test that can be run by this test runner.
+func (r runner) Type() testrunner.TestType {
+	return TestType
+}
+
+// String returns the human-friendly name of the test runner.
+func (r runner) String() string {
+	return "system"
+}
+
 // Run runs the system tests defined under the given folder
-func Run(options testrunner.TestOptions) ([]testrunner.TestResult, error) {
-	r := runner{
-		testFolder:      options.TestFolder,
-		packageRootPath: options.PackageRootPath,
-		stackSettings:   getStackSettingsFromEnv(),
-		esClient:        options.ESClient,
-	}
+func (r runner) Run(options testrunner.TestOptions) ([]testrunner.TestResult, error) {
+	r.testFolder = options.TestFolder
+	r.packageRootPath = options.PackageRootPath
+	r.stackSettings = getStackSettingsFromEnv()
+	r.esClient = options.ESClient
+
 	defer r.tearDown(options)
 	return r.run()
 }

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -27,7 +27,7 @@ import (
 )
 
 func init() {
-	testrunner.RegisterRunner(runner{})
+	testrunner.RegisterRunner(&runner{})
 }
 
 const (
@@ -58,24 +58,24 @@ type stackSettings struct {
 }
 
 // Type returns the type of test that can be run by this test runner.
-func (r runner) Type() testrunner.TestType {
+func (r *runner) Type() testrunner.TestType {
 	return TestType
 }
 
 // String returns the human-friendly name of the test runner.
-func (r runner) String() string {
+func (r *runner) String() string {
 	return "system"
 }
 
 // Run runs the system tests defined under the given folder
-func (r runner) Run(options testrunner.TestOptions) ([]testrunner.TestResult, error) {
+func (r *runner) Run(options testrunner.TestOptions) ([]testrunner.TestResult, error) {
 	r.options = options
 	r.stackSettings = getStackSettingsFromEnv()
 
 	return r.run()
 }
 
-func (r runner) TearDown() {
+func (r *runner) TearDown() {
 	if r.resetAgentPolicyHandler != nil {
 		r.resetAgentPolicyHandler()
 	}

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -18,12 +18,6 @@ import (
 // TestType represents the various supported test types
 type TestType string
 
-// TestReportFormat represents a test report format
-type TestReportFormat string
-
-// TestReportOutput represents an output for a test report
-type TestReportOutput string
-
 // TestOptions contains test runner options.
 type TestOptions struct {
 	TestFolder         TestFolder
@@ -69,16 +63,6 @@ type TestResult struct {
 	// to an unexpected runtime error in the test execution.
 	ErrorMsg string
 }
-
-// ReportFormatFunc defines the report formatter function.
-type ReportFormatFunc func(results []TestResult) (string, error)
-
-var reportFormatters = map[TestReportFormat]ReportFormatFunc{}
-
-// ReportOutputFunc defines the report writer function.
-type ReportOutputFunc func(pkg, report string, format TestReportFormat) error
-
-var reportOutputs = map[TestReportOutput]ReportOutputFunc{}
 
 // TestFolder encapsulates the test folder path and names of the package + data stream
 // to which the test folder belongs.
@@ -163,36 +147,6 @@ func TestTypes() []TestType {
 		testTypes = append(testTypes, t)
 	}
 	return testTypes
-}
-
-// RegisterReporterFormat registers a test report formatter.
-func RegisterReporterFormat(name TestReportFormat, formatFunc ReportFormatFunc) {
-	reportFormatters[name] = formatFunc
-}
-
-// FormatReport delegates formatting of test results to the registered test report formatter
-func FormatReport(name TestReportFormat, results []TestResult) (string, error) {
-	reportFunc, defined := reportFormatters[name]
-	if !defined {
-		return "", fmt.Errorf("unregistered test report format: %s", name)
-	}
-
-	return reportFunc(results)
-}
-
-// RegisterReporterOutput registers a test report output.
-func RegisterReporterOutput(name TestReportOutput, outputFunc ReportOutputFunc) {
-	reportOutputs[name] = outputFunc
-}
-
-// WriteReport delegates writing of test results to the registered test report output
-func WriteReport(pkg string, name TestReportOutput, report string, format TestReportFormat) error {
-	outputFunc, defined := reportOutputs[name]
-	if !defined {
-		return fmt.Errorf("unregistered test report output: %s", name)
-	}
-
-	return outputFunc(pkg, report, format)
 }
 
 func findTestFolderPaths(packageRootPath, dataStreamGlob, testTypeGlob string) ([]string, error) {

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -171,15 +171,6 @@ func TestRunners() map[TestType]TestRunner {
 	return runners
 }
 
-// TestTypes method returns registered test types.
-func TestTypes() []TestType {
-	var testTypes []TestType
-	for t := range runners {
-		testTypes = append(testTypes, t)
-	}
-	return testTypes
-}
-
 func findTestFolderPaths(packageRootPath, dataStreamGlob, testTypeGlob string) ([]string, error) {
 	testFoldersGlob := filepath.Join(packageRootPath, "data_stream", dataStreamGlob, "_dev", "test", testTypeGlob)
 	paths, err := filepath.Glob(testFoldersGlob)

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -32,10 +32,17 @@ type TestOptions struct {
 
 // TestRunner is the interface all test runners must implement.
 type TestRunner interface {
-	fmt.Stringer
+	// Type returns the test runner's type.
 	Type() TestType
 
+	// String returns the human-friendly name of the test runner.
+	String() string
+
+	// Run executes the test runner.
 	Run(TestOptions) ([]TestResult, error)
+
+	// TearDown cleans up any test runner resources. It must be called
+	// after the test runner has finished executing.
 	TearDown()
 }
 


### PR DESCRIPTION
This PR defines a `TestRunner` interface. All test runners must implement this interface. This will give consumers of test runners access to their lifecycle methods (`Run` and `TearDown`) as well as to informational methods (`Type` and `String`).

Related: https://github.com/elastic/elastic-package/pull/175#issuecomment-730549015
Related: #168