### PR TITLE
Clean used resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ _Context: package_
 Use this command to run the `format`, `lint`, and `build` commands all at once, in that order.
 
 
+### `elastic-package clean`
+
+_Context: package_
+
+Use this command to clean resources used for building the package.
+
+
 ### `elastic-package format`
 
 _Context: package_

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -1,0 +1,54 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/elastic-package/internal/cleanup"
+)
+
+func setupCleanCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "clean",
+		Short: "Clean used resources",
+		Long:  "Use clean command to clean resources used for building the package.",
+		RunE:  cleanCommandAction,
+	}
+	return cmd
+}
+
+func cleanCommandAction(cmd *cobra.Command, args []string) error {
+	cmd.Println("Clean used resources")
+
+	target, err := cleanup.Build()
+	if err != nil {
+		return errors.Wrap(err, "can't clean build resources")
+	}
+
+	if target != "" {
+		cmd.Printf("Build resources removed: %s\n", target)
+	}
+
+	target, err = cleanup.Stack()
+	if err != nil {
+		return errors.Wrap(err, "can't clean the development stack")
+	}
+	if target != "" {
+		cmd.Printf("Package removed from the development stack: %s\n", target)
+	}
+
+	target, err = cleanup.ServiceLogs()
+	if err != nil {
+		return errors.Wrap(err, "can't clean temporary service logs")
+	}
+	if target != "" {
+		cmd.Printf("Temporary service logs removed: %s\n", target)
+	}
+
+	cmd.Println("Done")
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ func RootCmd() *cobra.Command {
 	rootCmd.AddCommand(
 		setupBuildCommand(),
 		setupCheckCommand(),
+		setupCleanCommand(),
 		setupExportCommand(),
 		setupStackCommand(),
 		setupFormatCommand(),

--- a/internal/builder/packages.go
+++ b/internal/builder/packages.go
@@ -77,7 +77,7 @@ func FindBuildPackagesDirectory() (string, bool, error) {
 	return "", false, nil
 }
 
-func buildPackage(sourcePath string) (string, error) {
+func buildPackage(packageRoot string) (string, error) {
 	buildDir, found, err := FindBuildPackagesDirectory()
 	if err != nil {
 		return "", errors.Wrap(err, "locating build directory failed")
@@ -89,9 +89,9 @@ func buildPackage(sourcePath string) (string, error) {
 		}
 	}
 
-	m, err := packages.ReadPackageManifestFromPackageRoot(sourcePath)
+	m, err := packages.ReadPackageManifestFromPackageRoot(packageRoot)
 	if err != nil {
-		return "", errors.Wrapf(err, "reading package manifest failed (path: %s)", sourcePath)
+		return "", errors.Wrapf(err, "reading package manifest failed (path: %s)", packageRoot)
 	}
 
 	destinationDir := filepath.Join(buildDir, m.Name, m.Version)
@@ -103,8 +103,8 @@ func buildPackage(sourcePath string) (string, error) {
 		return "", errors.Wrap(err, "clearing package contents failed")
 	}
 
-	logger.Debugf("Copy package content (source: %s)", sourcePath)
-	err = files.CopyWithoutDev(sourcePath, destinationDir)
+	logger.Debugf("Copy package content (source: %s)", packageRoot)
+	err = files.CopyWithoutDev(packageRoot, destinationDir)
 	if err != nil {
 		return "", errors.Wrap(err, "copying package contents failed")
 	}

--- a/internal/cleanup/build.go
+++ b/internal/cleanup/build.go
@@ -1,0 +1,60 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cleanup
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/elastic-package/internal/builder"
+	"github.com/elastic/elastic-package/internal/logger"
+	"github.com/elastic/elastic-package/internal/packages"
+)
+
+// Build function removes package resources from build/.
+func Build() (string, error) {
+	logger.Debug("Clean build resources")
+
+	packageRoot, err := packages.MustFindPackageRoot()
+	if err != nil {
+		return "", errors.Wrap(err, "locating package root failed")
+	}
+
+	m, err := packages.ReadPackageManifestFromPackageRoot(packageRoot)
+	if err != nil {
+		return "", errors.Wrapf(err, "reading package manifest failed (path: %s)", packageRoot)
+	}
+
+	buildDir, found, err := builder.FindBuildPackagesDirectory()
+	if err != nil {
+		return "", errors.Wrap(err, "locating build directory failed")
+	}
+
+	if !found {
+		logger.Debugf("Build directory doesn't exist (missing path: %s)", buildDir)
+		return "", nil
+	}
+
+	destinationDir := filepath.Join(buildDir, m.Name)
+	logger.Debugf("Build directory for integration: %s\n", destinationDir)
+
+	_, err = os.Stat(destinationDir)
+	if err != nil && !os.IsNotExist(err) {
+		return "", errors.Wrapf(err, "stat file failed: %s", destinationDir)
+	}
+	if os.IsNotExist(err) {
+		logger.Debugf("Package hasn't been built (missing path: %s)", destinationDir)
+		return "", nil
+	}
+
+	logger.Debugf("Remove directory (path: %s)", destinationDir)
+	err = os.RemoveAll(destinationDir)
+	if err != nil {
+		return "", errors.Wrapf(err, "can't remove directory (path: %s)", destinationDir)
+	}
+	return destinationDir, nil
+}

--- a/internal/cleanup/service_logs.go
+++ b/internal/cleanup/service_logs.go
@@ -1,0 +1,30 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cleanup
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/elastic/elastic-package/internal/files"
+	"github.com/elastic/elastic-package/internal/install"
+	"github.com/elastic/elastic-package/internal/logger"
+)
+
+// ServiceLogs function removes service logs from temporary directory in the `~/.elastic-package`.
+func ServiceLogs() (string, error) {
+	logger.Debug("Clean all service logs")
+
+	serviceLogsDir, err := install.ServiceLogsDir()
+	if err != nil {
+		return "", errors.Wrap(err, "can't find service logs dir")
+	}
+
+	logger.Debugf("Remove folder content (path: %s)", serviceLogsDir)
+	err = files.RemoveContent(serviceLogsDir)
+	if err != nil {
+		return "", errors.Wrapf(err, "can't remove content (path: %s)", serviceLogsDir)
+	}
+	return serviceLogsDir, nil
+}

--- a/internal/cleanup/stack.go
+++ b/internal/cleanup/stack.go
@@ -1,0 +1,54 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cleanup
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/elastic-package/internal/packages"
+
+	"github.com/elastic/elastic-package/internal/install"
+	"github.com/elastic/elastic-package/internal/logger"
+)
+
+// Stack function removes built package used by the Package Registry image.
+func Stack() (string, error) {
+	logger.Debug("Clean built packages from the development stack")
+
+	packageRoot, err := packages.MustFindPackageRoot()
+	if err != nil {
+		return "", errors.Wrap(err, "locating package root failed")
+	}
+
+	m, err := packages.ReadPackageManifestFromPackageRoot(packageRoot)
+	if err != nil {
+		return "", errors.Wrapf(err, "reading package manifest failed (path: %s)", packageRoot)
+	}
+
+	stackPackagesDir, err := install.StackPackagesDir()
+	if err != nil {
+		return "", errors.Wrap(err, "can't find stack packages dir")
+	}
+	destinationDir := filepath.Join(stackPackagesDir, m.Name)
+
+	_, err = os.Stat(destinationDir)
+	if err != nil && !os.IsNotExist(err) {
+		return "", errors.Wrapf(err, "stat file failed: %s", destinationDir)
+	}
+	if os.IsNotExist(err) {
+		logger.Debugf("Stack package is not part of the development stack (missing path: %s)", destinationDir)
+		return "", nil
+	}
+
+	logger.Debugf("Remove folder (path: %s)", destinationDir)
+	err = os.RemoveAll(destinationDir)
+	if err != nil {
+		return "", errors.Wrapf(err, "can't remove directory (path: %s)", destinationDir)
+	}
+	return destinationDir, nil
+}

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -4,20 +4,40 @@ set -euxo pipefail
 
 cleanup() {
   r=$?
+
+  # Take down the stack
   elastic-package stack down -v
+
+  # Clean used resources
+  for d in test/packages/*/; do
+    (
+      cd $d
+      elastic-package clean -v
+    )
+  done
+
   exit $r
 }
 
 trap cleanup EXIT
 
+# Build/check packages
+for d in test/packages/*/; do
+  (
+    cd $d
+    elastic-package check -v
+  )
+done
+
+# Boot up the stack
 elastic-package stack up -d -v
 
+# Run package tests
 eval "$(elastic-package stack shellinit)"
 
 for d in test/packages/*/; do
   (
     cd $d
-    elastic-package check -v
     elastic-package test -v --report-format xUnit --report-output file
   )
 done

--- a/scripts/test-stack-command.sh
+++ b/scripts/test-stack-command.sh
@@ -4,13 +4,26 @@ set -euxo pipefail
 
 cleanup() {
   r=$?
+
+  # Take down the stack
   elastic-package stack down -v
+
+  # Clean used resources
+  for d in test/packages/*/; do
+    (
+      cd $d
+      elastic-package clean -v
+    )
+  done
+
   exit $r
 }
 
 trap cleanup EXIT
 
+# Boot up the stack
 elastic-package stack up -d -v
 
+# Verify it's accessible
 eval "$(elastic-package stack shellinit)"
 curl -f ${ELASTIC_PACKAGE_KIBANA_HOST}/login | grep kbn-injected-metadata >/dev/null # healthcheck


### PR DESCRIPTION
Resolves https://github.com/elastic/elastic-package/issues/13

Sample output:

```bash
$ elastic-package clean -v
2020/11/24 13:54:32 DEBUG Enable verbose logging
Clean used resources
2020/11/24 13:54:32 DEBUG Clean build resources
2020/11/24 13:54:32 DEBUG Build directory for integration: /Users/marcin.tojek/go/src/github.com/elastic/elastic-package/build/integrations/nginx
2020/11/24 13:54:32 DEBUG Remove directory (path: /Users/Foobar/go/src/github.com/elastic/elastic-package/build/integrations/nginx)
Build resources removed: /Users/Foobar/go/src/github.com/elastic/elastic-package/build/integrations/nginx
2020/11/24 13:54:32 DEBUG Clean built packages from the development stack
2020/11/24 13:54:32 DEBUG Stack package is not part of the development stack (missing path: /Users/Foobar/.elastic-package/stack/development/nginx)
2020/11/24 13:54:32 DEBUG Clean all service logs
2020/11/24 13:54:32 DEBUG Remove folder content (path: /Users/Foobar/.elastic-package/tmp/service_logs)
Temporary service logs removed: /Users/Foobar/.elastic-package/tmp/service_logs
Done
```