### PR TITLE
Include stderr with returned docker error

### DIFF
--- a/internal/testrunner/runners/system/servicedeployer/compose.go
+++ b/internal/testrunner/runners/system/servicedeployer/compose.go
@@ -5,6 +5,7 @@
 package servicedeployer
 
 import (
+	"bytes"
 	"fmt"
 	"os/exec"
 
@@ -77,8 +78,10 @@ func (r *DockerComposeServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedSer
 	stackNetwork := fmt.Sprintf("%s_default", stack.DockerComposeProjectName)
 	logger.Debugf("attaching service container %s to stack network %s", serviceContainer, stackNetwork)
 	cmd := exec.Command("docker", "network", "connect", stackNetwork, serviceContainer)
+	errOutput := new(bytes.Buffer)
+	cmd.Stderr = errOutput
 	if err := cmd.Run(); err != nil {
-		return nil, errors.Wrap(err, "could not attach service container to the stack network")
+		return nil, errors.Wrapf(err, "could not attach service container to the stack network (stderr=%q)", errOutput.String())
 	}
 
 	logger.Debugf("adding service container %s internal ports to context", serviceContainer)


### PR DESCRIPTION
Include the stderr output when `docker network connect` fails. This helps with debugging failures.

As an example, here's the output.

    Starting elastic-package-service_foo_1 ... done
    2020/11/24 21:52:31 DEBUG attaching service container elastic-package-service_apache_1 to stack network elastic-package-stack_default
    Error: error running package system tests: could not complete test run: could not setup service: could not attach service container to the stack network (stderr="Error response from daemon: No such container: elastic-package-service_apache_1\n"): exit status 1