### PR TITLE
Testing: Add config option to accept numeric keywords

### DIFF
--- a/internal/fields/testdata/fields/fields.yml
+++ b/internal/fields/testdata/fields/fields.yml
@@ -1,6 +1,8 @@
 - name: foo
   type: group
   fields:
+    - name: code
+      type: keyword
     - name: flattened
       type: group
       fields:

--- a/internal/fields/testdata/numeric.json
+++ b/internal/fields/testdata/numeric.json
@@ -1,6 +1,6 @@
 {
   "foo": {
-    "code": "42",
+    "code": 42,
     "flattened": {
       "request_parameters": {
         "userName": "Bob",

--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -211,17 +211,7 @@ func parseElementValue(key string, definition FieldDefinition, val interface{}) 
 
 	var valid bool
 	switch definition.Type {
-	case "constant_keyword", "keyword":
-		// Accept numeric fields as valid keywords.
-		if _, isStr := val.(string); !isStr {
-			f64, ok := val.(float64)
-			if !ok {
-				break
-			}
-			val = fmt.Sprintf("%g", f64)
-		}
-		fallthrough
-	case "date", "ip", "text":
+	case "date", "ip", "text", "constant_keyword", "keyword":
 		var valStr string
 		valStr, valid = val.(string)
 		if !valid || definition.Pattern == "" {

--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -233,7 +233,7 @@ func parseElementValue(key string, definition FieldDefinition, val interface{}) 
 			return errors.Wrap(err, "invalid pattern")
 		}
 		if !valid {
-			return fmt.Errorf("field \"%s\"'s value, %s, does not match the expected pattern: %s", key, valStr, definition.Pattern)
+			return fmt.Errorf("field %q's value, %s, does not match the expected pattern: %s", key, valStr, definition.Pattern)
 		}
 	case "float", "long", "double":
 		_, valid = val.(float64)
@@ -242,7 +242,7 @@ func parseElementValue(key string, definition FieldDefinition, val interface{}) 
 	}
 
 	if !valid {
-		return fmt.Errorf("field \"%s\"'s Go type, %T, does not match the expected field type: %s (field value: %v)", key, val, definition.Type, val)
+		return fmt.Errorf("field %q's Go type, %T, does not match the expected field type: %s (field value: %v)", key, val, definition.Type, val)
 	}
 	return nil
 }

--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -211,7 +211,7 @@ func parseElementValue(key string, definition FieldDefinition, val interface{}) 
 
 	var valid bool
 	switch definition.Type {
-	case "date", "ip", "text", "constant_keyword", "keyword":
+	case "date", "ip", "constant_keyword", "keyword", "text":
 		var valStr string
 		valStr, valid = val.(string)
 		if !valid || definition.Pattern == "" {

--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -218,7 +218,7 @@ func parseElementValue(key string, definition FieldDefinition, val interface{}) 
 			if !ok {
 				break
 			}
-			val = fmt.Sprintf("%f", f64)
+			val = fmt.Sprintf("%g", f64)
 		}
 		fallthrough
 	case "date", "ip", "text":
@@ -233,7 +233,7 @@ func parseElementValue(key string, definition FieldDefinition, val interface{}) 
 			return errors.Wrap(err, "invalid pattern")
 		}
 		if !valid {
-			return fmt.Errorf("field \"%s\"''s value, %s, does not match the expected pattern: %s", key, valStr, definition.Pattern)
+			return fmt.Errorf("field \"%s\"'s value, %s, does not match the expected pattern: %s", key, valStr, definition.Pattern)
 		}
 	case "float", "long", "double":
 		_, valid = val.(float64)

--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -211,16 +211,16 @@ func parseElementValue(key string, definition FieldDefinition, val interface{}) 
 
 	var valid bool
 	switch definition.Type {
-        case "constant_keyword", "keyword":
-                // Accept numeric fields as valid keywords.
-                if _, isStr := val.(string); !isStr {
-                    f64, ok := val.(float64)
-                    if !ok {
-                        break
-                    }
-                    val = fmt.Sprintf("%f", f64)
-                }
-                fallthrough
+	case "constant_keyword", "keyword":
+		// Accept numeric fields as valid keywords.
+		if _, isStr := val.(string); !isStr {
+			f64, ok := val.(float64)
+			if !ok {
+				break
+			}
+			val = fmt.Sprintf("%f", f64)
+		}
+		fallthrough
 	case "date", "ip", "text":
 		var valStr string
 		valStr, valid = val.(string)

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -17,7 +17,7 @@ type results struct {
 }
 
 func TestValidate_NoWildcardFields(t *testing.T) {
-	validator, err := CreateValidatorForDataStream("../../test/packages/aws/data_stream/elb_logs", nil)
+	validator, err := CreateValidatorForDataStream("../../test/packages/aws/data_stream/elb_logs")
 	require.NoError(t, err)
 	require.NotNil(t, validator)
 
@@ -29,7 +29,7 @@ func TestValidate_NoWildcardFields(t *testing.T) {
 }
 
 func TestValidate_WithWildcardFields(t *testing.T) {
-	validator, err := CreateValidatorForDataStream("../../test/packages/aws/data_stream/sns", nil)
+	validator, err := CreateValidatorForDataStream("../../test/packages/aws/data_stream/sns")
 	require.NoError(t, err)
 	require.NotNil(t, validator)
 
@@ -39,7 +39,7 @@ func TestValidate_WithWildcardFields(t *testing.T) {
 }
 
 func TestValidate_WithFlattenedFields(t *testing.T) {
-	validator, err := CreateValidatorForDataStream("testdata", nil)
+	validator, err := CreateValidatorForDataStream("testdata")
 	require.NoError(t, err)
 	require.NotNil(t, validator)
 
@@ -49,7 +49,8 @@ func TestValidate_WithFlattenedFields(t *testing.T) {
 }
 
 func TestValidate_WithNumericKeywordFields(t *testing.T) {
-	validator, err := CreateValidatorForDataStream("testdata", []string{"foo.code"})
+	validator, err := CreateValidatorForDataStream("testdata",
+		WithNumericKeywordFields([]string{"foo.code"}))
 	require.NoError(t, err)
 	require.NotNil(t, validator)
 

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package fields_test
+package fields
 
 import (
 	"encoding/json"
@@ -10,8 +10,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/elastic/elastic-package/internal/fields"
 )
 
 type results struct {
@@ -19,7 +17,7 @@ type results struct {
 }
 
 func TestValidate_NoWildcardFields(t *testing.T) {
-	validator, err := fields.CreateValidatorForDataStream("../../test/packages/aws/data_stream/elb_logs")
+	validator, err := CreateValidatorForDataStream("../../test/packages/aws/data_stream/elb_logs")
 	require.NoError(t, err)
 	require.NotNil(t, validator)
 
@@ -31,7 +29,7 @@ func TestValidate_NoWildcardFields(t *testing.T) {
 }
 
 func TestValidate_WithWildcardFields(t *testing.T) {
-	validator, err := fields.CreateValidatorForDataStream("../../test/packages/aws/data_stream/sns")
+	validator, err := CreateValidatorForDataStream("../../test/packages/aws/data_stream/sns")
 	require.NoError(t, err)
 	require.NotNil(t, validator)
 
@@ -41,13 +39,168 @@ func TestValidate_WithWildcardFields(t *testing.T) {
 }
 
 func TestValidate_WithFlattenedFields(t *testing.T) {
-	validator, err := fields.CreateValidatorForDataStream("testdata")
+	validator, err := CreateValidatorForDataStream("testdata")
 	require.NoError(t, err)
 	require.NotNil(t, validator)
 
 	e := readSampleEvent(t, "testdata/flattened.json")
 	errs := validator.ValidateDocumentBody(e)
 	require.Empty(t, errs)
+}
+
+func Test_parseElementValue(t *testing.T) {
+	for _, test := range []struct {
+		key string
+		value interface{}
+		definition FieldDefinition
+		fail bool
+	} {
+		// Arrays (only first value checked)
+		{
+			key:   "string array to keyword",
+			value: []interface{}{"hello", "world"},
+			definition: FieldDefinition{
+				Type: "keyword",
+			},
+		},
+		{
+			key:   "numeric string array to long",
+			value: []interface{}{"123", "42"},
+			definition: FieldDefinition{
+				Type: "long",
+			},
+			fail: true,
+		},
+
+		// keyword and constant_keyword (string)
+		{
+			key: "constant_keyword with pattern",
+			value: "some value",
+			definition: FieldDefinition{
+				Type: "constant_keyword",
+				Pattern: `^[a-z]+\s[a-z]+$`,
+			},
+		},
+		{
+			key: "constant_keyword fails pattern",
+			value: "some value",
+			definition: FieldDefinition{
+				Type: "constant_keyword",
+				Pattern: `[0-9]`,
+			},
+			fail: true,
+		},
+		// keyword and constant_keyword (numeric)
+		{
+			key: "numeric keyword works",
+			value: 1234.5,
+			definition: FieldDefinition{
+				Type: "keyword",
+				Pattern: `^[0-9.]+$`,
+			},
+		},
+		{
+			key: "numeric keyword applies pattern",
+			value: 1234.5,
+			definition: FieldDefinition{
+				Type: "keyword",
+				Pattern: `0`,
+			},
+			fail: true,
+		},
+		// keyword and constant_keyword (other)
+		{
+			key: "bad type for keyword",
+			value: map[string]interface{}{},
+			definition: FieldDefinition{
+				Type: "keyword",
+			},
+			fail: true,
+		},
+		// date
+		{
+			key: "date",
+			value: "2020-11-02T18:01:03Z",
+			definition: FieldDefinition{
+				Type: "date",
+				Pattern: "^[0-9]{4}(-[0-9]{2}){2}[T ][0-9]{2}(:[0-9]{2}){2}Z$",
+			},
+		},
+		{
+			key: "bad date",
+			value: "10 Oct 2020 3:42PM",
+			definition: FieldDefinition{
+				Type: "date",
+				Pattern: "^[0-9]{4}(-[0-9]{2}){2}[T ][0-9]{2}(:[0-9]{2}){2}Z$",
+			},
+			fail: true,
+		},
+		// ip
+		{
+			key: "ip",
+			value: "127.0.0.1",
+			definition: FieldDefinition{
+				Type: "ip",
+				Pattern: "^[0-9.]+$",
+			},
+		},
+		{
+			key: "bad ip",
+			value: "localhost",
+			definition: FieldDefinition{
+				Type: "ip",
+				Pattern: "^[0-9.]+$",
+			},
+			fail: true,
+		},
+		// text
+		{
+			key: "text",
+			value: "some text",
+			definition: FieldDefinition{
+				Type: "text",
+			},
+		},
+		{
+			key: "text with pattern",
+			value: "more text",
+			definition: FieldDefinition{
+				Type: "ip",
+				Pattern: "[A-Z]",
+			},
+			fail: true,
+		},
+		// float
+		{
+			key: "float",
+			value: 3.1416,
+			definition: FieldDefinition{
+				Type:        "float",
+			},
+		},
+		// long
+		{
+			key: "bad long",
+			value: "65537",
+			definition: FieldDefinition{
+				Type:        "long",
+			},
+			fail: true,
+		},
+	} {
+
+		t.Run(test.key, func(t *testing.T) {
+			err := parseElementValue(test.key, test.definition, test.value)
+			if err != nil {
+				t.Log(err)
+			}
+			if test.fail {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
 func readTestResults(t *testing.T, path string) (f results) {

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -50,11 +50,11 @@ func TestValidate_WithFlattenedFields(t *testing.T) {
 
 func Test_parseElementValue(t *testing.T) {
 	for _, test := range []struct {
-		key string
-		value interface{}
+		key        string
+		value      interface{}
 		definition FieldDefinition
-		fail bool
-	} {
+		fail       bool
+	}{
 		// Arrays (only first value checked)
 		{
 			key:   "string array to keyword",
@@ -74,43 +74,43 @@ func Test_parseElementValue(t *testing.T) {
 
 		// keyword and constant_keyword (string)
 		{
-			key: "constant_keyword with pattern",
+			key:   "constant_keyword with pattern",
 			value: "some value",
 			definition: FieldDefinition{
-				Type: "constant_keyword",
+				Type:    "constant_keyword",
 				Pattern: `^[a-z]+\s[a-z]+$`,
 			},
 		},
 		{
-			key: "constant_keyword fails pattern",
+			key:   "constant_keyword fails pattern",
 			value: "some value",
 			definition: FieldDefinition{
-				Type: "constant_keyword",
+				Type:    "constant_keyword",
 				Pattern: `[0-9]`,
 			},
 			fail: true,
 		},
 		// keyword and constant_keyword (numeric)
 		{
-			key: "numeric keyword works",
+			key:   "numeric keyword works",
 			value: 1234.5,
 			definition: FieldDefinition{
-				Type: "keyword",
+				Type:    "keyword",
 				Pattern: `^[0-9.]+$`,
 			},
 		},
 		{
-			key: "numeric keyword applies pattern",
+			key:   "numeric keyword applies pattern",
 			value: 1234.5,
 			definition: FieldDefinition{
-				Type: "keyword",
+				Type:    "keyword",
 				Pattern: `0`,
 			},
 			fail: true,
 		},
 		// keyword and constant_keyword (other)
 		{
-			key: "bad type for keyword",
+			key:   "bad type for keyword",
 			value: map[string]interface{}{},
 			definition: FieldDefinition{
 				Type: "keyword",
@@ -119,71 +119,71 @@ func Test_parseElementValue(t *testing.T) {
 		},
 		// date
 		{
-			key: "date",
+			key:   "date",
 			value: "2020-11-02T18:01:03Z",
 			definition: FieldDefinition{
-				Type: "date",
+				Type:    "date",
 				Pattern: "^[0-9]{4}(-[0-9]{2}){2}[T ][0-9]{2}(:[0-9]{2}){2}Z$",
 			},
 		},
 		{
-			key: "bad date",
+			key:   "bad date",
 			value: "10 Oct 2020 3:42PM",
 			definition: FieldDefinition{
-				Type: "date",
+				Type:    "date",
 				Pattern: "^[0-9]{4}(-[0-9]{2}){2}[T ][0-9]{2}(:[0-9]{2}){2}Z$",
 			},
 			fail: true,
 		},
 		// ip
 		{
-			key: "ip",
+			key:   "ip",
 			value: "127.0.0.1",
 			definition: FieldDefinition{
-				Type: "ip",
+				Type:    "ip",
 				Pattern: "^[0-9.]+$",
 			},
 		},
 		{
-			key: "bad ip",
+			key:   "bad ip",
 			value: "localhost",
 			definition: FieldDefinition{
-				Type: "ip",
+				Type:    "ip",
 				Pattern: "^[0-9.]+$",
 			},
 			fail: true,
 		},
 		// text
 		{
-			key: "text",
+			key:   "text",
 			value: "some text",
 			definition: FieldDefinition{
 				Type: "text",
 			},
 		},
 		{
-			key: "text with pattern",
+			key:   "text with pattern",
 			value: "more text",
 			definition: FieldDefinition{
-				Type: "ip",
+				Type:    "ip",
 				Pattern: "[A-Z]",
 			},
 			fail: true,
 		},
 		// float
 		{
-			key: "float",
+			key:   "float",
 			value: 3.1416,
 			definition: FieldDefinition{
-				Type:        "float",
+				Type: "float",
 			},
 		},
 		// long
 		{
-			key: "bad long",
+			key:   "bad long",
 			value: "65537",
 			definition: FieldDefinition{
-				Type:        "long",
+				Type: "long",
 			},
 			fail: true,
 		},

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -90,24 +90,6 @@ func Test_parseElementValue(t *testing.T) {
 			},
 			fail: true,
 		},
-		// keyword and constant_keyword (numeric)
-		{
-			key:   "numeric keyword works",
-			value: 1234.5,
-			definition: FieldDefinition{
-				Type:    "keyword",
-				Pattern: `^[0-9.]+$`,
-			},
-		},
-		{
-			key:   "numeric keyword applies pattern",
-			value: 1234.5,
-			definition: FieldDefinition{
-				Type:    "keyword",
-				Pattern: `0`,
-			},
-			fail: true,
-		},
 		// keyword and constant_keyword (other)
 		{
 			key:   "bad type for keyword",

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -17,7 +17,7 @@ type results struct {
 }
 
 func TestValidate_NoWildcardFields(t *testing.T) {
-	validator, err := CreateValidatorForDataStream("../../test/packages/aws/data_stream/elb_logs")
+	validator, err := CreateValidatorForDataStream("../../test/packages/aws/data_stream/elb_logs", nil)
 	require.NoError(t, err)
 	require.NotNil(t, validator)
 
@@ -29,7 +29,7 @@ func TestValidate_NoWildcardFields(t *testing.T) {
 }
 
 func TestValidate_WithWildcardFields(t *testing.T) {
-	validator, err := CreateValidatorForDataStream("../../test/packages/aws/data_stream/sns")
+	validator, err := CreateValidatorForDataStream("../../test/packages/aws/data_stream/sns", nil)
 	require.NoError(t, err)
 	require.NotNil(t, validator)
 
@@ -39,11 +39,21 @@ func TestValidate_WithWildcardFields(t *testing.T) {
 }
 
 func TestValidate_WithFlattenedFields(t *testing.T) {
-	validator, err := CreateValidatorForDataStream("testdata")
+	validator, err := CreateValidatorForDataStream("testdata", nil)
 	require.NoError(t, err)
 	require.NotNil(t, validator)
 
 	e := readSampleEvent(t, "testdata/flattened.json")
+	errs := validator.ValidateDocumentBody(e)
+	require.Empty(t, errs)
+}
+
+func TestValidate_WithNumericKeywordFields(t *testing.T) {
+	validator, err := CreateValidatorForDataStream("testdata", []string{"foo.code"})
+	require.NoError(t, err)
+	require.NotNil(t, validator)
+
+	e := readSampleEvent(t, "testdata/numeric.json")
 	errs := validator.ValidateDocumentBody(e)
 	require.Empty(t, errs)
 }

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -206,6 +206,11 @@ func (r *runner) verifyResults(testCaseFile string, config *testConfig, result *
 		return errors.Wrap(err, "comparing test results failed")
 	}
 
+	err = convertNumericKeywordFields(result, config)
+	if err != nil {
+		return err
+	}
+
 	err = verifyDynamicFields(result, config)
 	if err != nil {
 		return err
@@ -257,6 +262,54 @@ func verifyDynamicFields(result *testResult, config *testConfig) error {
 	if len(multiErr) > 0 {
 		return testrunner.ErrTestCaseFailed{
 			Reason:  "one or more problems with dynamic fields found in documents",
+			Details: multiErr.Unique().Error(),
+		}
+	}
+	return nil
+}
+
+func convertNumericKeywordFields(result *testResult, config *testConfig) error {
+	if config == nil || len(config.NumericKeywordFields) == 0 {
+		return nil
+	}
+
+	var multiErr multierror.Error
+	for idx, event := range result.events {
+		var m common.MapStr
+		err := json.Unmarshal(event, &m)
+		if err != nil {
+			return errors.Wrap(err, "can't unmarshal event")
+		}
+
+		modified := false
+		for _, key := range config.NumericKeywordFields {
+			val, err := m.GetValue(key)
+			if err != nil && err != common.ErrKeyNotFound {
+				return errors.Wrap(err, "can't convert numeric field")
+			}
+
+			switch v := val.(type) {
+			case nil, string: // Nothing to do.
+			case float64: // Store the numeric value in string format, for further validation.
+				m.Put(key, fmt.Sprintf("%g", v))
+				modified = true
+			default:
+				multiErr = append(multiErr, fmt.Errorf("numeric keyword field %q's type %T should be a number or string",
+					key, val))
+			}
+		}
+		if modified {
+			if event, err = json.Marshal(m); err != nil {
+				multiErr = append(multiErr, errors.Wrap(err, "failed to serialize numeric keywords back into JSON"))
+				continue
+			}
+			result.events[idx] = event
+		}
+	}
+
+	if len(multiErr) > 0 {
+		return testrunner.ErrTestCaseFailed{
+			Reason:  "one or more problems with numeric keyword fields found in documents",
 			Details: multiErr.Unique().Error(),
 		}
 	}

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -110,7 +110,8 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 		}
 
 		tr.TimeElapsed = time.Now().Sub(startTime)
-		fieldsValidator, err := fields.CreateValidatorForDataStream(dataStreamPath, tc.config.NumericKeywordFields)
+		fieldsValidator, err := fields.CreateValidatorForDataStream(dataStreamPath,
+			fields.WithNumericKeywordFields(tc.config.NumericKeywordFields))
 		if err != nil {
 			return nil, errors.Wrapf(err, "creating fields validator for data stream failed (path: %s, test case file: %s)", dataStreamPath, testCaseFile)
 		}

--- a/internal/testrunner/runners/pipeline/test_config.go
+++ b/internal/testrunner/runners/pipeline/test_config.go
@@ -20,6 +20,10 @@ type testConfig struct {
 	Multiline     *multiline             `json:"multiline"`
 	Fields        map[string]interface{} `json:"fields"`
 	DynamicFields map[string]string      `json:"dynamic_fields"`
+
+	// NumericKeywordFields holds a list of fields that have keyword
+	// type but can be ingested as numeric type.
+	NumericKeywordFields []string `json:"numeric_keyword_fields"`
 }
 
 type multiline struct {

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -259,7 +259,7 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 		return nil
 	}
 
-	fieldsValidator, err := fields.CreateValidatorForDataStream(dataStreamPath)
+	fieldsValidator, err := fields.CreateValidatorForDataStream(dataStreamPath, testConfig.NumericKeywordFields)
 	if err != nil {
 		return resultsWith(result, errors.Wrapf(err, "creating fields validator for data stream failed (path: %s)", dataStreamPath))
 	}

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -259,7 +259,8 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 		return nil
 	}
 
-	fieldsValidator, err := fields.CreateValidatorForDataStream(dataStreamPath, testConfig.NumericKeywordFields)
+	fieldsValidator, err := fields.CreateValidatorForDataStream(dataStreamPath,
+		fields.WithNumericKeywordFields(testConfig.NumericKeywordFields))
 	if err != nil {
 		return resultsWith(result, errors.Wrapf(err, "creating fields validator for data stream failed (path: %s)", dataStreamPath))
 	}

--- a/internal/testrunner/runners/system/test_config.go
+++ b/internal/testrunner/runners/system/test_config.go
@@ -27,6 +27,10 @@ type testConfig struct {
 	DataStream struct {
 		Vars map[string]packages.VarValue `config:"vars"`
 	} `config:"data_stream"`
+
+	// NumericKeywordFields holds a list of fields that have keyword
+	// type but can be ingested as numeric type.
+	NumericKeywordFields []string `config:"numeric_keyword_fields"`
 }
 
 func newConfig(systemTestFolderPath string, ctxt servicedeployer.ServiceContext) (*testConfig, error) {


### PR DESCRIPTION
Keyword fields are not necessarily ingested as JSON strings. It's common to ingest numbers (integer or floating point) as keyword type.

~~This updates the fields validator to accept numeric values. They are converted to string so that any defined patterns can be checked.~~

This adds a new configuration option, `numeric_keyword_fields`, to pipeline test cases and system tests so that selected fields can have numeric type and be ingested into a text-like field.

Example configuration:

```
{
    "dynamic_fields": {
        "event.ingested": ".*"
    },
    "numeric_keyword_fields": [
        "network.iana_number",
        "event.code",
        "syslog.facility"
    ]
}
``` 
