### PR TITLE
Build service containers for system tests

### DIFF
--- a/internal/testrunner/runners/system/servicedeployer/compose.go
+++ b/internal/testrunner/runners/system/servicedeployer/compose.go
@@ -63,7 +63,7 @@ func (r *DockerComposeServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedSer
 	// Boot up service
 	opts := compose.CommandOptions{
 		Env:       []string{fmt.Sprintf("%s=%s", serviceLogsDirEnv, outCtxt.Logs.Folder.Local)},
-		ExtraArgs: []string{"-d"},
+		ExtraArgs: []string{"--build", "-d"},
 	}
 	if err := p.Up(opts); err != nil {
 		return nil, errors.Wrap(err, "could not boot up service using docker compose")


### PR DESCRIPTION
This changes the `docker-compose up` command to include `--build` so that images
will be rebuilt if there were changes. While developing tests you are often making
changes to the service container and it's nice if the changes are automatically
detected, rebuilt, and deployed on system test.