### PR TITLE
Fix json marshaling of empty package.VarValue

### DIFF
--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -51,7 +51,7 @@ func (vv VarValue) MarshalJSON() ([]byte, error) {
 	} else if vv.list != nil {
 		return json.Marshal(vv.list)
 	}
-	return nil, nil
+	return []byte("null"), nil
 }
 
 // Variable is an instance of configuration variable (named, typed).

--- a/internal/packages/packages_test.go
+++ b/internal/packages/packages_test.go
@@ -1,0 +1,44 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package packages
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVarValue_MarshalJSON(t *testing.T) {
+	t.Run("null", func(t *testing.T) {
+		var vv VarValue
+		data, err := json.Marshal(vv)
+		require.NoError(t, err)
+		assert.Equal(t, string(data), "null")
+	})
+
+	t.Run("scalar", func(t *testing.T) {
+		vv := VarValue{
+			scalar: "hello",
+		}
+		data, err := json.Marshal(vv)
+		require.NoError(t, err)
+		assert.Equal(t, string(data), `"hello"`)
+	})
+
+	t.Run("array", func(t *testing.T) {
+		vv := VarValue{
+			list: []interface{}{
+				"hello",
+				"world",
+			},
+		}
+
+		data, err := json.Marshal(vv)
+		require.NoError(t, err)
+		assert.Equal(t, string(data), `["hello","world"]`)
+	})
+}


### PR DESCRIPTION
This fixes marshaling of policies containing a variable without a default value. Below is the error observed.

> Error: error running package system tests: could not complete test run: could not add data stream config to policy: could not convert policy-package (request) to JSON: json: error calling MarshalJSON for type packages.VarValue: unexpected end of JSON input

This is the value that is was marshaling at the time.

> ingestmanager.PackageDataStream{Name:"o365-audit", Description:"", Namespace:"ep", PolicyID:"48d57620-3673-11eb-ae10-f1e5b4e6e377", Enabled:true, OutputID:"", Inputs:[]ingestmanager.Input{ingestmanager.Input{Type:"logfile", Enabled:true, Streams:[]ingestmanager.Stream{ingestmanager.Stream{ID:"logfile-o365.audit", Enabled:true, DataStream:ingestmanager.DataStream{Type:"logs", Dataset:"o365.audit"}, Vars:ingestmanager.Vars{"paths":ingestmanager.Var{Value:packages.VarValue{scalar:interface {}(nil), list:[]interface {}{"/tmp/service_logs/*.log"}}, Type:"text"}, "tags":ingestmanager.Var{Value:packages.VarValue{scalar:interface {}(nil), list:[]interface {}{"forwarded"}}, Type:"text"}, "tenant_names":ingestmanager.Var{Value:packages.VarValue{scalar:interface {}(nil), list:[]interface {}(nil)}, Type:"text"}, "tenants":ingestmanager.Var{Value:packages.VarValue{scalar:interface {}(nil), list:[]interface {}(nil)}, Type:"text"}}}}, Vars:ingestmanager.Vars{}}}, Package:struct { Name string "json:\"name\""; Title string "json:\"title\""; Version string "json:\"version\"" }{Name:"o365", Title:"Office 365", Version:"0.2.6"}}