### PR TITLE
Update apache.status fields

### DIFF
--- a/test/packages/apache/data_stream/status/fields/fields.yml
+++ b/test/packages/apache/data_stream/status/fields/fields.yml
@@ -1,18 +1,14 @@
 - name: apache.status
   type: group
   fields:
-    - name: hostname
-      type: keyword
-      description: |
-        Apache hostname.
     - name: total_accesses
       type: long
       description: |
         Total number of access requests.
-    - name: total_kbytes
+    - name: total_bytes
       type: long
       description: |
-        Total number of kilobytes served.
+        Total number of bytes served.
     - name: requests_per_sec
       type: scaled_float
       description: |


### PR DESCRIPTION
Update the fields for the apache.status data stream. The fields reported from agent changed
due to https://github.com/elastic/beats/pull/23022.

This fixes the broken build in master.