### PR TITLE
Fix Apache test: use total_bytes instead of total_kbytes

### DIFF
--- a/test/packages/apache/data_stream/status/fields/fields.yml
+++ b/test/packages/apache/data_stream/status/fields/fields.yml
@@ -9,10 +9,10 @@
       type: long
       description: |
         Total number of access requests.
-    - name: total_kbytes
+    - name: total_bytes
       type: long
       description: |
-        Total number of kilobytes served.
+        Total number of bytes served.
     - name: requests_per_sec
       type: scaled_float
       description: |

--- a/test/packages/apache/data_stream/status/sample_event.json
+++ b/test/packages/apache/data_stream/status/sample_event.json
@@ -20,7 +20,7 @@
                     "closing": 0
                 }
             },
-            "total_kbytes": 128,
+            "total_bytes": 128,
             "cpu": {
                 "children_user": 0,
                 "children_system": 0,

--- a/test/packages/apache/docs/README.md
+++ b/test/packages/apache/docs/README.md
@@ -128,7 +128,7 @@ An example event for `status` looks as following:
                     "closing": 0
                 }
             },
-            "total_kbytes": 128,
+            "total_bytes": 128,
             "cpu": {
                 "children_user": 0,
                 "children_system": 0,
@@ -236,7 +236,7 @@ An example event for `status` looks as following:
 | apache.status.scoreboard.total | Total. | long |
 | apache.status.scoreboard.waiting_for_connection | Waiting for connections. | long |
 | apache.status.total_accesses | Total number of access requests. | long |
-| apache.status.total_kbytes | Total number of kilobytes served. | long |
+| apache.status.total_bytes | Total number of bytes served. | long |
 | apache.status.uptime.server_uptime | Server uptime in seconds. | long |
 | apache.status.uptime.uptime | Server uptime. | long |
 | apache.status.workers.busy | Number of busy workers. | long |

--- a/test/packages/apache/kibana/visualization/apache-HTTPD-Total-accesses-and-kbytes.json
+++ b/test/packages/apache/kibana/visualization/apache-HTTPD-Total-accesses-and-kbytes.json
@@ -16,7 +16,7 @@
                     "id": "1",
                     "params": {
                         "customLabel": "Total kbytes",
-                        "field": "apache.status.total_kbytes"
+                        "field": "apache.status.total_bytes"
                     },
                     "schema": "metric",
                     "type": "max"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

This PR adjusts the `apache.status` data stream to recent changes in filebeat (use field `total_bytes`).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/integrations/issues/370

Filebeat changes:
- https://github.com/elastic/beats/pull/23022
- https://github.com/elastic/beats/pull/23055 (cherry-pick)
