### PR TITLE
Collect Elastic stack logs

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -49,6 +49,7 @@ pipeline {
         always {
           dir("${BASE_DIR}") {
             archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
+            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/logs/*.log')
             junit(allowEmptyResults: false,
                 keepLongStdio: true,
                 testResults: "build/test-results/*.xml")

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ elastic-package
 
 # Build directory
 /build
+
+# stack dump
+elastic-stack-dump/

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -81,7 +81,7 @@ func setupStackCommand() *cobra.Command {
 	upCommand.Flags().BoolP(cobraext.DaemonModeFlagName, "d", false, cobraext.DaemonModeFlagDescription)
 	upCommand.Flags().StringSliceP(cobraext.StackServicesFlagName, "s", nil,
 		fmt.Sprintf(cobraext.StackServicesFlagDescription, strings.Join(availableServicesAsList(), ", ")))
-	upCommand.Flags().StringP(cobraext.StackVersionFlagName, "", stack.DefaultVersion, cobraext.StackVersionDescription)
+	upCommand.Flags().StringP(cobraext.StackVersionFlagName, "", stack.DefaultVersion, cobraext.StackVersionFlagDescription)
 
 	downCommand := &cobra.Command{
 		Use:   "down",
@@ -121,7 +121,7 @@ func setupStackCommand() *cobra.Command {
 			return nil
 		},
 	}
-	updateCommand.Flags().StringP(cobraext.StackVersionFlagName, "", stack.DefaultVersion, cobraext.StackVersionDescription)
+	updateCommand.Flags().StringP(cobraext.StackVersionFlagName, "", stack.DefaultVersion, cobraext.StackVersionFlagDescription)
 
 	shellInitCommand := &cobra.Command{
 		Use:   "shellinit",
@@ -136,6 +136,28 @@ func setupStackCommand() *cobra.Command {
 		},
 	}
 
+	dumpCommand := &cobra.Command{
+		Use:   "dump",
+		Short: "Dump stack data for debug purposes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			output, err := cmd.Flags().GetString(cobraext.StackDumpOutputFlagName)
+			if err != nil {
+				return cobraext.FlagParsingError(err, cobraext.StackDumpOutputFlagName)
+			}
+
+			err = stack.Dump(stack.DumpOptions{
+				Output: output,
+			})
+			if err != nil {
+				return errors.Wrap(err, "dump failed")
+			}
+
+			cmd.Println("Done")
+			return nil
+		},
+	}
+	dumpCommand.Flags().StringP(cobraext.StackDumpOutputFlagName, "", "elastic-stack-dump", cobraext.StackDumpOutputFlagDescription)
+
 	cmd := &cobra.Command{
 		Use:   "stack",
 		Short: "Manage the Elastic stack",
@@ -145,7 +167,8 @@ func setupStackCommand() *cobra.Command {
 		upCommand,
 		downCommand,
 		updateCommand,
-		shellInitCommand)
+		shellInitCommand,
+		dumpCommand)
 	return cmd
 }
 

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -147,12 +147,14 @@ func setupStackCommand() *cobra.Command {
 				return cobraext.FlagParsingError(err, cobraext.StackDumpOutputFlagName)
 			}
 
-			err = stack.Dump(stack.DumpOptions{
+			target, err := stack.Dump(stack.DumpOptions{
 				Output: output,
 			})
 			if err != nil {
 				return errors.Wrap(err, "dump failed")
 			}
+
+			cmd.Printf("Path to stack dump: %s\n", target)
 
 			cmd.Println("Done")
 			return nil

--- a/internal/cobraext/const.go
+++ b/internal/cobraext/const.go
@@ -43,5 +43,5 @@ const (
 	StackVersionFlagDescription = "stack version"
 
 	StackDumpOutputFlagName        = "output"
-	StackDumpOutputFlagDescription = "output location for "
+	StackDumpOutputFlagDescription = "output location for the stack dump"
 )

--- a/internal/cobraext/const.go
+++ b/internal/cobraext/const.go
@@ -42,6 +42,6 @@ const (
 	StackVersionFlagName        = "version"
 	StackVersionFlagDescription = "stack version"
 
-	StackDumpOutputFlagName = "output"
+	StackDumpOutputFlagName        = "output"
 	StackDumpOutputFlagDescription = "output location for "
 )

--- a/internal/cobraext/const.go
+++ b/internal/cobraext/const.go
@@ -39,6 +39,9 @@ const (
 	StackServicesFlagName        = "services"
 	StackServicesFlagDescription = "component services (comma-separated values: %s)"
 
-	StackVersionFlagName    = "version"
-	StackVersionDescription = "stack version"
+	StackVersionFlagName        = "version"
+	StackVersionFlagDescription = "stack version"
+
+	StackDumpOutputFlagName = "output"
+	StackDumpOutputFlagDescription = "output location for "
 )

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -217,6 +217,20 @@ func (p *Project) Pull(opts CommandOptions) error {
 	return nil
 }
 
+// Logs returns service logs for the selected service in the Docker Compose project.
+func (p *Project) Logs(opts CommandOptions) ([]byte, error) {
+	args := p.baseArgs()
+	args = append(args, "logs")
+	args = append(args, opts.ExtraArgs...)
+	args = append(args, opts.Services...)
+
+	var b bytes.Buffer
+	if err := p.runDockerComposeCmd(dockerComposeOptions{args: args, env: opts.Env, stdout: &b}); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
 func (p *Project) baseArgs() []string {
 	var args []string
 	for _, path := range p.composeFilePaths {

--- a/internal/stack/boot.go
+++ b/internal/stack/boot.go
@@ -18,7 +18,7 @@ import (
 // Elastic Stack containers.
 const DockerComposeProjectName = "elastic-package-stack"
 
-// BootUp method boots up the testing stack.
+// BootUp function boots up the testing stack.
 func BootUp(options Options) error {
 	buildPackagesPath, found, err := builder.FindBuildPackagesDirectory()
 	if err != nil {
@@ -62,7 +62,7 @@ func BootUp(options Options) error {
 	return nil
 }
 
-// TearDown method takes down the testing stack.
+// TearDown function takes down the testing stack.
 func TearDown() error {
 	err := dockerComposeDown()
 	if err != nil {

--- a/internal/stack/compose.go
+++ b/internal/stack/compose.go
@@ -125,7 +125,7 @@ func dockerComposeLogs(serviceName string) ([]byte, error) {
 	opts := compose.CommandOptions{
 		// We set the STACK_VERSION env var here to avoid showing a warning to the user about
 		// it not being set.
-		Env: []string{fmt.Sprintf("STACK_VERSION=%s", DefaultVersion)},
+		Env:      []string{fmt.Sprintf("STACK_VERSION=%s", DefaultVersion)},
 		Services: []string{serviceName},
 	}
 

--- a/internal/stack/compose.go
+++ b/internal/stack/compose.go
@@ -111,6 +111,31 @@ func dockerComposeDown() error {
 	return nil
 }
 
+func dockerComposeLogs(serviceName string) ([]byte, error) {
+	stackDir, err := install.StackDir()
+	if err != nil {
+		return nil, errors.Wrap(err, "locating stack directory failed")
+	}
+
+	c, err := compose.NewProject(DockerComposeProjectName, filepath.Join(stackDir, snapshotDefinitionFile))
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create docker compose project")
+	}
+
+	opts := compose.CommandOptions{
+		// We set the STACK_VERSION env var here to avoid showing a warning to the user about
+		// it not being set.
+		Env: []string{fmt.Sprintf("STACK_VERSION=%s", DefaultVersion)},
+		Services: []string{serviceName},
+	}
+
+	out, err := c.Logs(opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "running command failed")
+	}
+	return out, nil
+}
+
 func withDependentServices(services []string) []string {
 	for _, aService := range services {
 		if aService == "elastic-agent" {

--- a/internal/stack/dump.go
+++ b/internal/stack/dump.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package stack
 
 import (

--- a/internal/stack/dump.go
+++ b/internal/stack/dump.go
@@ -23,14 +23,14 @@ type DumpOptions struct {
 }
 
 // Dump function exports stack data and dumps them as local artifacts, which can be used for debug purposes.
-func Dump(options DumpOptions) error {
+func Dump(options DumpOptions) (string, error) {
 	logger.Debugf("Dump Elastic stack data")
 
 	err := dumpStackLogs(options)
 	if err != nil {
-		return errors.Wrap(err, "can't dump Elastic stack logs")
+		return "", errors.Wrap(err, "can't dump Elastic stack logs")
 	}
-	return nil
+	return options.Output, nil
 }
 
 func dumpStackLogs(options DumpOptions) error {

--- a/internal/stack/dump.go
+++ b/internal/stack/dump.go
@@ -13,6 +13,7 @@ import (
 
 var observedServices = []string{"elasticsearch", "elastic-agent", "kibana", "package-registry"}
 
+// DumpOptions defines dumping options for Elatic stack data.
 type DumpOptions struct {
 	Output string
 }

--- a/internal/stack/dump.go
+++ b/internal/stack/dump.go
@@ -1,0 +1,39 @@
+package stack
+
+import (
+	"github.com/elastic/elastic-package/internal/logger"
+	"github.com/pkg/errors"
+	"os"
+)
+
+type DumpOptions struct {
+	Output string
+}
+
+// Dump function exports stack data and dumps them as local artifacts, which can be used for debug purposes.
+func Dump(options DumpOptions) error {
+	logger.Debugf("Dump Elastic stack data")
+
+	err := dumpStackLogs(options)
+	if err != nil {
+		return errors.Wrap(err, "can't dump Elastic stack logs")
+	}
+	return nil
+}
+
+func dumpStackLogs(options DumpOptions) error {
+	logger.Debugf("Dump stack logs")
+
+	logger.Debugf("Recreate the output location (path: %s)", options.Output)
+	err := os.RemoveAll(options.Output)
+	if err != nil {
+		return errors.Wrap(err, "can't remove output location")
+	}
+
+	err = os.MkdirAll(options.Output, 0755)
+	if err != nil {
+		return errors.Wrap(err, "can't create output location")
+	}
+
+
+}

--- a/scripts/test-stack-command.sh
+++ b/scripts/test-stack-command.sh
@@ -5,6 +5,9 @@ set -euxo pipefail
 cleanup() {
   r=$?
 
+  # Dump stack logs
+  elastic-package stack dump -v --output build/elastic-stack-dump
+
   # Take down the stack
   elastic-package stack down -v
 


### PR DESCRIPTION
This PR introduces `elastic-package stack dump` command which can save container logs to local files.

Issue: https://github.com/elastic/integrations/issues/380