### PR TITLE
System tests: start all services in compose project

### DIFF
--- a/internal/testrunner/runners/system/servicedeployer/compose.go
+++ b/internal/testrunner/runners/system/servicedeployer/compose.go
@@ -61,7 +61,7 @@ func (r *DockerComposeServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedSer
 	serviceName := inCtxt.Name
 	opts := compose.CommandOptions{
 		Env:       []string{fmt.Sprintf("%s=%s", serviceLogsDirEnv, outCtxt.Logs.Folder.Local)},
-		ExtraArgs: []string{"--build", "-d", serviceName},
+		ExtraArgs: []string{"--build", "-d"},
 	}
 	if err := p.Up(opts); err != nil {
 		return nil, errors.Wrap(err, "could not boot up service using docker compose")


### PR DESCRIPTION
This reverts part a change introduced by #209 as some tests may require more than one container running at the same time.

Relates https://github.com/elastic/integrations/issues/520