### PR TITLE
Enable _dev/deploy for data streams

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/elastic/go-elasticsearch/v7 v7.9.0
 	github.com/elastic/go-licenser v0.3.1
 	github.com/elastic/go-ucfg v0.8.3
-	github.com/elastic/package-spec/code/go v0.0.0-20210125131944-e98a6af2135e
+	github.com/elastic/package-spec/code/go v0.0.0-20210126144901-46090e1310d3
 	github.com/go-git/go-billy/v5 v5.0.0
 	github.com/go-git/go-git/v5 v5.1.0
 	github.com/go-openapi/strfmt v0.19.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -28,5 +28,6 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
+	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/go.sum
+++ b/go.sum
@@ -458,6 +458,8 @@ golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,8 @@ github.com/elastic/go-licenser v0.3.1 h1:RmRukU/JUmts+rpexAw0Fvt2ly7VVu6mw8z4HrE
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=
 github.com/elastic/go-ucfg v0.8.3 h1:leywnFjzr2QneZZWhE6uWd+QN/UpP0sdJRHYyuFvkeo=
 github.com/elastic/go-ucfg v0.8.3/go.mod h1:iaiY0NBIYeasNgycLyTvhJftQlQEUO2hpF+FX0JKxzo=
-github.com/elastic/package-spec/code/go v0.0.0-20210125131944-e98a6af2135e h1:yKE0ydG2iSNrC132l6SYY+79H+hmrV7/IhsCSHeHVFM=
-github.com/elastic/package-spec/code/go v0.0.0-20210125131944-e98a6af2135e/go.mod h1:3W6uyBFCE4/NPcVPb+ZuoLJTMLu8BCTc+PRFDutSvfE=
+github.com/elastic/package-spec/code/go v0.0.0-20210126144901-46090e1310d3 h1:QeQvLQvDx1mRAOBzcJ7T7ebF02mJxcK5HYsYTTOrsik=
+github.com/elastic/package-spec/code/go v0.0.0-20210126144901-46090e1310d3/go.mod h1:3W6uyBFCE4/NPcVPb+ZuoLJTMLu8BCTc+PRFDutSvfE=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -258,7 +258,10 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 
 	// Setup service.
 	logger.Debug("setting up service...")
-	serviceDeployer, err := servicedeployer.Factory(r.options.PackageRootPath)
+	serviceDeployer, err := servicedeployer.Factory(servicedeployer.FactoryOptions{
+		PackageRootPath:    r.options.PackageRootPath,
+		DataStreamRootPath: dataStreamPath,
+	})
 	if err != nil {
 		return result.withError(errors.Wrap(err, "could not create service runner"))
 	}

--- a/internal/testrunner/runners/system/servicedeployer/factory.go
+++ b/internal/testrunner/runners/system/servicedeployer/factory.go
@@ -5,6 +5,7 @@
 package servicedeployer
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -13,7 +14,7 @@ import (
 	"github.com/elastic/elastic-package/internal/logger"
 )
 
-const devDir = "_dev"
+const devDeployDir = "_dev/deploy"
 
 var (
 	// ErrNotFound is returned when the appropriate service runner for a package
@@ -30,36 +31,36 @@ type FactoryOptions struct {
 // Factory chooses the appropriate service runner for the given data stream, depending
 // on service configuration files defined in the package or data stream.
 func Factory(options FactoryOptions) (ServiceDeployer, error) {
-	devPath, err := findDevPath(options)
+	devDeployPath, err := findDevDeployPath(options)
 	if err != nil {
-		logger.Errorf("can't find _dev directory")
+		logger.Errorf("can't find _dev/deploy directory")
 		return nil, ErrNotFound
 	}
+	fmt.Println(devDeployPath)
 
 	// Is the service defined using a docker compose configuration file?
-	dockerComposeYMLPath := filepath.Join(devPath, "deploy", "docker", "docker-compose.yml")
+	dockerComposeYMLPath := filepath.Join(devDeployPath, "docker", "docker-compose.yml")
 	if _, err := os.Stat(dockerComposeYMLPath); err == nil {
 		return NewDockerComposeServiceDeployer(dockerComposeYMLPath)
 	}
-
 	return nil, ErrNotFound
 }
 
-func findDevPath(options FactoryOptions) (string, error) {
-	dataStreamDevPath := filepath.Join(options.DataStreamRootPath, devDir)
-	_, err := os.Stat(dataStreamDevPath)
+func findDevDeployPath(options FactoryOptions) (string, error) {
+	dataStreamDevDeployPath := filepath.Join(options.DataStreamRootPath, devDeployDir)
+	_, err := os.Stat(dataStreamDevDeployPath)
 	if err == nil {
-		return dataStreamDevPath, nil
+		return dataStreamDevDeployPath, nil
 	} else if !os.IsNotExist(err) {
-		return "", errors.Wrapf(err, "stat failed (path: %s)", dataStreamDevPath)
+		return "", errors.Wrapf(err, "stat failed (path: %s)", dataStreamDevDeployPath)
 	}
 
-	packageDevPath := filepath.Join(options.PackageRootPath, devDir)
-	_, err = os.Stat(packageDevPath)
+	packageDevDeployPath := filepath.Join(options.PackageRootPath, devDeployDir)
+	_, err = os.Stat(packageDevDeployPath)
 	if err == nil {
-		return packageDevPath, nil
+		return packageDevDeployPath, nil
 	} else if !os.IsNotExist(err) {
-		return "", errors.Wrapf(err, "stat failed (path: %s)", packageDevPath)
+		return "", errors.Wrapf(err, "stat failed (path: %s)", packageDevDeployPath)
 	}
 	return "", errors.New("_dev directory doesn't exist")
 }

--- a/internal/testrunner/runners/system/servicedeployer/factory.go
+++ b/internal/testrunner/runners/system/servicedeployer/factory.go
@@ -5,10 +5,15 @@
 package servicedeployer
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/elastic-package/internal/logger"
 )
+
+const devDir = "_dev"
 
 var (
 	// ErrNotFound is returned when the appropriate service runner for a package
@@ -16,16 +21,45 @@ var (
 	ErrNotFound = errors.New("unable to find service runner")
 )
 
-// Factory chooses the appropriate service runner for the given package, depending
-// on service configuration files defined in the package.
-func Factory(packageRootPath string) (ServiceDeployer, error) {
-	packageDevPath := filepath.Join(packageRootPath, "_dev")
+// FactoryOptions defines options used to create an instance of a service deployer.
+type FactoryOptions struct {
+	PackageRootPath    string
+	DataStreamRootPath string
+}
+
+// Factory chooses the appropriate service runner for the given data stream, depending
+// on service configuration files defined in the package or data stream.
+func Factory(options FactoryOptions) (ServiceDeployer, error) {
+	devPath, err := findDevPath(options)
+	if err != nil {
+		logger.Errorf("can't find _dev directory")
+		return nil, ErrNotFound
+	}
 
 	// Is the service defined using a docker compose configuration file?
-	dockerComposeYMLPath := filepath.Join(packageDevPath, "deploy", "docker", "docker-compose.yml")
+	dockerComposeYMLPath := filepath.Join(devPath, "deploy", "docker", "docker-compose.yml")
 	if _, err := os.Stat(dockerComposeYMLPath); err == nil {
 		return NewDockerComposeServiceDeployer(dockerComposeYMLPath)
 	}
 
 	return nil, ErrNotFound
+}
+
+func findDevPath(options FactoryOptions) (string, error) {
+	dataStreamDevPath := filepath.Join(options.DataStreamRootPath, devDir)
+	_, err := os.Stat(dataStreamDevPath)
+	if err == nil {
+		return dataStreamDevPath, nil
+	} else if !os.IsNotExist(err) {
+		return "", errors.Wrapf(err, "stat failed (path: %s)", dataStreamDevPath)
+	}
+
+	packageDevPath := filepath.Join(options.PackageRootPath, devDir)
+	_, err = os.Stat(packageDevPath)
+	if err == nil {
+		return packageDevPath, nil
+	} else if !os.IsNotExist(err) {
+		return "", errors.Wrapf(err, "stat failed (path: %s)", packageDevPath)
+	}
+	return "", errors.New("_dev directory doesn't exist")
 }

--- a/internal/testrunner/runners/system/servicedeployer/factory.go
+++ b/internal/testrunner/runners/system/servicedeployer/factory.go
@@ -5,7 +5,6 @@
 package servicedeployer
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -36,7 +35,6 @@ func Factory(options FactoryOptions) (ServiceDeployer, error) {
 		logger.Errorf("can't find _dev/deploy directory")
 		return nil, ErrNotFound
 	}
-	fmt.Println(devDeployPath)
 
 	// Is the service defined using a docker compose configuration file?
 	dockerComposeYMLPath := filepath.Join(devDeployPath, "docker", "docker-compose.yml")
@@ -52,7 +50,7 @@ func findDevDeployPath(options FactoryOptions) (string, error) {
 	if err == nil {
 		return dataStreamDevDeployPath, nil
 	} else if !os.IsNotExist(err) {
-		return "", errors.Wrapf(err, "stat failed (path: %s)", dataStreamDevDeployPath)
+		return "", errors.Wrapf(err, "stat failed for data stream (path: %s)", dataStreamDevDeployPath)
 	}
 
 	packageDevDeployPath := filepath.Join(options.PackageRootPath, devDeployDir)
@@ -60,7 +58,7 @@ func findDevDeployPath(options FactoryOptions) (string, error) {
 	if err == nil {
 		return packageDevDeployPath, nil
 	} else if !os.IsNotExist(err) {
-		return "", errors.Wrapf(err, "stat failed (path: %s)", packageDevDeployPath)
+		return "", errors.Wrapf(err, "stat failed for package (path: %s)", packageDevDeployPath)
 	}
 	return "", errors.New("_dev directory doesn't exist")
 }


### PR DESCRIPTION
Issue: https://github.com/elastic/elastic-package/issues/89

This PR enables custom `_dev/deploy` for data stream. It will be used by the future AWS service deployer.