### PR TITLE
Add option to notify test service after agent policy is applied

### DIFF
--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -183,6 +183,20 @@ func (p *Project) Build(opts CommandOptions) error {
 	return nil
 }
 
+// Kill sends a signal to a service container.
+func (p *Project) Kill(opts CommandOptions) error {
+	args := p.baseArgs()
+	args = append(args, "kill")
+	args = append(args, opts.ExtraArgs...)
+	args = append(args, opts.Services...)
+
+	if err := p.runDockerComposeCmd(dockerComposeOptions{args: args, env: opts.Env}); err != nil {
+		return errors.Wrap(err, "running Docker Compose kill command failed")
+	}
+
+	return nil
+}
+
 // Config returns the combined configuration for a Docker Compose project.
 func (p *Project) Config(opts CommandOptions) (*Config, error) {
 	args := p.baseArgs()

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -382,6 +382,13 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 		return nil
 	}
 
+	// Signal to the service that the agent is ready (policy is assigned).
+	if config.ServiceNotifySignal != "" {
+		if err = service.Signal(config.ServiceNotifySignal); err != nil {
+			return result.withError(errors.Wrap(err, "failed to notify test service"))
+		}
+	}
+
 	// (TODO in future) Optionally exercise service to generate load.
 	logger.Debug("checking for expected data in data stream...")
 	passed, err := waitUntilTrue(r.hasNumDocs(dataStream, fieldsValidator, func(n int) bool {

--- a/internal/testrunner/runners/system/servicedeployer/compose.go
+++ b/internal/testrunner/runners/system/servicedeployer/compose.go
@@ -104,6 +104,21 @@ func (r *DockerComposeServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedSer
 	return &service, nil
 }
 
+// Signal sends a signal to the service.
+func (s *dockerComposeDeployedService) Signal(signal string) error {
+	p, err := compose.NewProject(s.project, s.ymlPath)
+	if err != nil {
+		return errors.Wrap(err, "could not create docker compose project for service")
+	}
+
+	opts := compose.CommandOptions{ExtraArgs: []string{"-s", signal}}
+	if s.ctxt.Name != "" {
+		opts.Services = append(opts.Services, s.ctxt.Name)
+	}
+
+	return errors.Wrapf(p.Kill(opts), "could not send %q signal", signal)
+}
+
 // TearDown tears down the service.
 func (s *dockerComposeDeployedService) TearDown() error {
 	logger.Debugf("tearing down service using docker compose runner")

--- a/internal/testrunner/runners/system/servicedeployer/deployed_service.go
+++ b/internal/testrunner/runners/system/servicedeployer/deployed_service.go
@@ -9,6 +9,9 @@ type DeployedService interface {
 	// TearDown implements the logic for tearing down a service.
 	TearDown() error
 
+	// Signal sends a signal to the service.
+	Signal(signal string) error
+
 	// Context returns the current context from the service.
 	Context() ServiceContext
 

--- a/internal/testrunner/runners/system/test_config.go
+++ b/internal/testrunner/runners/system/test_config.go
@@ -23,10 +23,11 @@ import (
 var systemTestConfigFilePattern = regexp.MustCompile(`^test-([a-z0-9_.-]+)-config.yml$`)
 
 type testConfig struct {
-	Input      string                       `config:"input"`
-	Service    string                       `config:"service"`
-	Vars       map[string]packages.VarValue `config:"vars"`
-	DataStream struct {
+	Input               string                       `config:"input"`
+	Service             string                       `config:"service"`
+	ServiceNotifySignal string                       `config:"service_notify_signal"` // Signal to send when the agent policy is applied.
+	Vars                map[string]packages.VarValue `config:"vars"`
+	DataStream          struct {
 		Vars map[string]packages.VarValue `config:"vars"`
 	} `config:"data_stream"`
 

--- a/test/packages/multiinput/data_stream/test/_dev/test/system/test-udp-config.yml
+++ b/test/packages/multiinput/data_stream/test/_dev/test/system/test-udp-config.yml
@@ -1,5 +1,6 @@
 input: udp
 service: test-udp
+service_notify_signal: SIGHUP
 vars: ~
 data_stream:
   vars:


### PR DESCRIPTION
This adds a config option, `service_notify_signal`, to the system test runner to
allow the test runner to notify the service via a signal (e.g. SIGHUP) after the
policy has been applied by the Agent.

This is useful when the test service is connecting to the listening agent or streaming data
to the agent.

It helps address two issues that I encountered.
  1. While repeatedly testing the agent stays up with the old policy applied, but
      before the new policy is applied and the old ES data cleared the test service would
      connect and deliver data to the "old" agent/policy.
  2. For UDP streams there is no reliable way to know that the agent is ready and listening.

An alternative would be to start the test service container after the policy is applied, but
this could affect tests where the agent connects to the service (e.g. a prometheus exporter)
since the test might expect the service to be ready at startup.

### Test Logs

```
2021/01/21 09:03:13 DEBUG Wait until the policy (ID: 5df0cc00-5bf1-11eb-b44a-31c22f285a18) is assigned to all agents...
2021/01/21 09:03:15 DEBUG running command: /usr/local/bin/docker-compose -f /Users/akroh/go/src/github.com/elastic/elastic-package/test/packages/multiinput/_dev/deploy/docker/docker-compose.yml -p elastic-package-service kill -s SIGHUP test-udp
Killing elastic-package-service_test-udp_1 ... done
2021/01/21 09:03:16 DEBUG checking for expected data in data stream...
2021/01/21 09:03:16 DEBUG found 30 hits in logs-multiinput.test-ep data stream
2021/01/21 09:03:16 DEBUG reassigning original policy back to agent...
```