### PR TITLE
Allow installing older versions of the package

### DIFF
--- a/internal/kibana/packages.go
+++ b/internal/kibana/packages.go
@@ -16,7 +16,9 @@ import (
 // InstallPackage installs the given package in Fleet.
 func (c *Client) InstallPackage(pkg packages.PackageManifest) ([]packages.Asset, error) {
 	path := fmt.Sprintf("%s/epm/packages/%s-%s", FleetAPI, pkg.Name, pkg.Version)
-	statusCode, respBody, err := c.post(path, nil)
+	reqBody := []byte(`{"force":true}`) // allows installing older versions of the package being tested
+
+	statusCode, respBody, err := c.post(path, reqBody)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not install package")
 	}

--- a/test/packages/apache/manifest.yml
+++ b/test/packages/apache/manifest.yml
@@ -1,10 +1,7 @@
 format_version: 1.0.0
 name: apache
 title: Apache
-# version is set to something very large to so this test package can
-# be installed in the package registry regardless of the version of
-# the actual apache package in the registry at any given time.
-version: 999.999.999
+version: 0.0.1
 license: basic
 description: Apache Integration
 type: integration


### PR DESCRIPTION
### What does this PR do

This PR allows the system test runner to install the version of the package under test, even if that version may be older than the latest version of the same package available in the package registry. 

### Why is this PR important

Package developers may want to create new patch versions from older minor versions of a package, even though a newer minor version of the same package might already have been released. For example, `system-0.9.2` and `system-0.10.5` may already have been released. A package developer might want to create+test+release a `system-0.9.3` package next that builds upon the `system-0.9.2` package but does not or cannot include all the changes from the `system-0.10.5` package.