### PR TITLE
Support data stream type == traces

### DIFF
--- a/internal/packages/assets.go
+++ b/internal/packages/assets.go
@@ -120,7 +120,7 @@ func loadElasticsearchAssets(pkgRootPath string) ([]Asset, error) {
 		}
 		assets = append(assets, asset)
 
-		if dsManifest.Type == dataStreamTypeLogs {
+		if dsManifest.Type == dataStreamTypeLogs || dsManifest.Type == dataStreamTypeTraces {
 			elasticsearchDirPath := filepath.Join(filepath.Dir(dsManifestPath), "elasticsearch", "ingest_pipeline")
 			pipelineFiles, _ := ioutil.ReadDir(elasticsearchDirPath)
 			if pipelineFiles == nil || len(pipelineFiles) == 0 {

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -25,6 +25,7 @@ const (
 
 	dataStreamTypeLogs    = "logs"
 	dataStreamTypeMetrics = "metrics"
+	dataStreamTypeTraces  = "traces"
 )
 
 // VarValue represents a variable value as defined in a package or data stream
@@ -248,5 +249,7 @@ func isDataStreamManifest(path string) (bool, error) {
 	if err != nil {
 		return false, errors.Wrapf(err, "reading package manifest failed (path: %s)", path)
 	}
-	return m.Title != "" && (m.Type == dataStreamTypeLogs || m.Type == dataStreamTypeMetrics), nil
+	return m.Title != "" &&
+			(m.Type == dataStreamTypeLogs || m.Type == dataStreamTypeMetrics || m.Type == dataStreamTypeTraces),
+		nil
 }


### PR DESCRIPTION
Looking in all three active branches of the `package-storage` repo, I have confirmed that the `apm` package is the only one that is using `type: traces` in [one of its data streams](https://github.com/elastic/package-storage/blob/c5925eb82898dfc3e879a521871c7383513804c7/packages/apm/0.1.0-dev.5/data_stream/traces/manifest.yml#L2). I looked at this data stream and it defines [ingest pipelines](https://github.com/elastic/package-storage/tree/snapshot/packages/apm/0.1.0-dev.5/data_stream/traces/elasticsearch/ingest_pipeline).

This PR updates `elastic-package` to support `type: traces` for the above use case. Specifically:
- it updates the check for valid data streams to include data streams of `type: traces`, and
- it allows running pipeline tests on data streams of `type: traces`

Resolves #223.