### PR TITLE
Bump up stack version to 7.13.0-SNAPSHOT

### DIFF
--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "7.12.0-SNAPSHOT"
+	DefaultStackVersion = "7.13.0-SNAPSHOT"
 )

--- a/internal/install/static_kubernetes_elastic_agent_yml.go
+++ b/internal/install/static_kubernetes_elastic_agent_yml.go
@@ -26,8 +26,7 @@ spec:
       serviceAccountName: kind-fleet-agent
       containers:
         - name: kind-fleet-agent-clusterscope
-          # FIXME Must remove this workaround once https://github.com/elastic/beats/issues/24198 is fixed
-          image: docker.elastic.co/beats/elastic-agent@sha256:75c9fbf835a7d24166bceb82f28f4c6c5d00048ba9f0a25b945818e4cf2bba69
+          image: docker.elastic.co/beats/elastic-agent:{{ STACK_VERSION }}
           env:
             - name: FLEET_ENROLL
               value: "1"

--- a/internal/install/static_snapshot_yml.go
+++ b/internal/install/static_snapshot_yml.go
@@ -75,8 +75,7 @@ services:
         condition: service_healthy
 
   elastic-agent:
-    # FIXME Must remove this workaround once https://github.com/elastic/beats/issues/24198 is fixed
-    image: docker.elastic.co/beats/elastic-agent@sha256:75c9fbf835a7d24166bceb82f28f4c6c5d00048ba9f0a25b945818e4cf2bba69
+    image: docker.elastic.co/beats/elastic-agent:${STACK_VERSION}
     depends_on:
       elasticsearch:
         condition: service_healthy


### PR DESCRIPTION
This PR bumps up the stack to 7.13.0-SNAPSHOT.