### PR TITLE
Temporarily hardcode agent image reference

### DIFF
--- a/internal/install/static_kubernetes_elastic_agent_yml.go
+++ b/internal/install/static_kubernetes_elastic_agent_yml.go
@@ -26,7 +26,8 @@ spec:
       serviceAccountName: kind-fleet-agent
       containers:
         - name: kind-fleet-agent-clusterscope
-          image: docker.elastic.co/beats/elastic-agent:{{ STACK_VERSION }}
+          # FIXME Must remove this workaround once https://github.com/elastic/beats/issues/24198 is fixed
+          image: docker.elastic.co/beats/elastic-agent@sha256:75c9fbf835a7d24166bceb82f28f4c6c5d00048ba9f0a25b945818e4cf2bba69
           env:
             - name: FLEET_ENROLL
               value: "1"

--- a/internal/install/static_snapshot_yml.go
+++ b/internal/install/static_snapshot_yml.go
@@ -75,6 +75,7 @@ services:
         condition: service_healthy
 
   elastic-agent:
+    # FIXME Must remove this workaround once https://github.com/elastic/beats/issues/24198 is fixed
     image: docker.elastic.co/beats/elastic-agent@sha256:75c9fbf835a7d24166bceb82f28f4c6c5d00048ba9f0a25b945818e4cf2bba69
     depends_on:
       elasticsearch:

--- a/internal/install/static_snapshot_yml.go
+++ b/internal/install/static_snapshot_yml.go
@@ -75,7 +75,7 @@ services:
         condition: service_healthy
 
   elastic-agent:
-    image: docker.elastic.co/beats/elastic-agent:${STACK_VERSION}
+    image: docker.elastic.co/beats/elastic-agent@sha256:75c9fbf835a7d24166bceb82f28f4c6c5d00048ba9f0a25b945818e4cf2bba69
     depends_on:
       elasticsearch:
         condition: service_healthy


### PR DESCRIPTION
This PR will temporarily hardcode the Docker image reference for Elastic Agent to the stable image. Unfortunately this fix will cause that 7.12.0-SNAPSHOT will be the only working one, but most likely will unblock development.

Related: https://github.com/elastic/beats/issues/24198