### PR TITLE
Fix: correctly filter AWS instance type

### DIFF
--- a/test/packages/aws/data_stream/ec2_metrics/_dev/deploy/tf/main.tf
+++ b/test/packages/aws/data_stream/ec2_metrics/_dev/deploy/tf/main.tf
@@ -18,6 +18,6 @@ data "aws_ami" "latest-amzn" {
   owners = [ "amazon" ] # AWS
   filter {
     name   = "name"
-    values = ["amzn2-ami-hvm-*"]
+    values = ["amzn2-ami-minimal-hvm-*-ebs"]
   }
 }


### PR DESCRIPTION
This PR modifies the test package "AWS" to prevent the following problem:

```
Error: Error launching source instance: UnsupportedOperation: Microsoft SQL Server Enterprise Edition is not supported for the instance type 't1.micro'.
	status code: 400, request id: 3cfb03a1-c3f5-44fe-9fbe-fa66c5ca1902

  on main.tf line 7, in resource "aws_instance" "i":
   7: resource "aws_instance" "i" {
```