### PR TITLE
Fix compatibility check snapshot

### DIFF
--- a/internal/packages/conditions.go
+++ b/internal/packages/conditions.go
@@ -66,6 +66,7 @@ func parsePackageRequirements(keyValuePairs []string) (*packageRequirements, err
 			// Constraint validation doesn't handle prerelease tags. It fails with error:
 			// "1.2.3-SNAPSHOT a prerelease version and the constraint is only looking for release versions"
 			// In order to use the library's constraint validation, prerelease tags must be skipped.
+			// Source code reference: https://github.com/Masterminds/semver/blob/7e314bd12e4aa8ea9742b1e4765f3fe65de38c2d/constraints.go#L89
 			withoutPrerelease, err := ver.SetPrerelease("") // clean prerelease tag
 			if err != nil {
 				return nil, errors.Wrap(err, "can't clean prerelease tag from semver")

--- a/internal/packages/conditions.go
+++ b/internal/packages/conditions.go
@@ -49,7 +49,6 @@ func CheckConditions(manifest PackageManifest, keyValuePairs []string) error {
 
 func parsePackageRequirements(keyValuePairs []string) (*packageRequirements, error) {
 	var pr packageRequirements
-	var err error
 
 	for _, keyPair := range keyValuePairs {
 		s := strings.SplitN(keyPair, "=", 2)
@@ -59,10 +58,15 @@ func parsePackageRequirements(keyValuePairs []string) (*packageRequirements, err
 
 		switch s[0] {
 		case kibanaVersionRequirement:
-			pr.kibana.version, err = semver.NewVersion(s[1])
+			ver, err := semver.NewVersion(s[1])
 			if err != nil {
 				return nil, errors.Wrap(err, "can't parse kibana.version as valid semver")
 			}
+			withoutPrerelease, err := ver.SetPrerelease("") // clean prerelease tag
+			if err != nil {
+				return nil, errors.Wrap(err, "can't clean prerelease tag from semver")
+			}
+			pr.kibana.version = &withoutPrerelease
 		default:
 			return nil, fmt.Errorf("unknown package requirement: %s", s[0])
 		}

--- a/internal/packages/conditions.go
+++ b/internal/packages/conditions.go
@@ -62,6 +62,10 @@ func parsePackageRequirements(keyValuePairs []string) (*packageRequirements, err
 			if err != nil {
 				return nil, errors.Wrap(err, "can't parse kibana.version as valid semver")
 			}
+
+			// Constraint validation doesn't handle prerelease tags. It fails with error:
+			// "1.2.3-SNAPSHOT a prerelease version and the constraint is only looking for release versions"
+			// In order to use the library's constraint validation, prerelease tags must be skipped.
 			withoutPrerelease, err := ver.SetPrerelease("") // clean prerelease tag
 			if err != nil {
 				return nil, errors.Wrap(err, "can't clean prerelease tag from semver")

--- a/internal/packages/conditions_test.go
+++ b/internal/packages/conditions_test.go
@@ -1,0 +1,59 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package packages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckConditions_InvalidRelease(t *testing.T) {
+	manifest := PackageManifest{
+		Conditions: Conditions{
+			Kibana: KibanaConditions{Version: "^7.11.0"},
+		},
+		PolicyTemplates: nil,
+	}
+
+	err := CheckConditions(manifest, []string{"kibana.version=7.10.1"})
+	assert.Error(t, err, "package requires higher major version")
+}
+
+func TestCheckConditions_ValidRelease(t *testing.T) {
+	manifest := PackageManifest{
+		Conditions: Conditions{
+			Kibana: KibanaConditions{Version: "^7.11.0"},
+		},
+		PolicyTemplates: nil,
+	}
+
+	err := CheckConditions(manifest, []string{"kibana.version=7.11.1"})
+	assert.NoError(t, err)
+}
+
+func TestCheckConditions_InvalidSnapshot(t *testing.T) {
+	manifest := PackageManifest{
+		Conditions: Conditions{
+			Kibana: KibanaConditions{Version: "^7.11.0"},
+		},
+		PolicyTemplates: nil,
+	}
+
+	err := CheckConditions(manifest, []string{"kibana.version=7.10.1-SNAPSHOT"})
+	assert.Error(t, err, "package requires higher major version")
+}
+
+func TestCheckConditions_ValidSnapshot(t *testing.T) {
+	manifest := PackageManifest{
+		Conditions: Conditions{
+			Kibana: KibanaConditions{Version: "^7.11.0"},
+		},
+		PolicyTemplates: nil,
+	}
+
+	err := CheckConditions(manifest, []string{"kibana.version=7.11.1-SNAPSHOT"})
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
This PR modifies the version compatibility check to properly handle SNAPSHOTs (just ignore them).

We need this change to enable testing against the Elastic stack v7.12.0-SNAPSHOT (which hasn't been released). So far we can depend only on release versions:

https://github.com/elastic/integrations/blob/master/.ci/Jenkinsfile#L17-L18