### PR TITLE
Accept strings that parse as numbers as numeric types

### DIFF
--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -10,14 +10,14 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
-
-	"github.com/elastic/elastic-package/internal/multierror"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/elastic-package/internal/common"
+	"github.com/elastic/elastic-package/internal/multierror"
 )
 
 // Validator is responsible for fields validation.
@@ -267,7 +267,13 @@ func parseElementValue(key string, definition FieldDefinition, val interface{}) 
 			return fmt.Errorf("field %q's value, %s, does not match the expected pattern: %s", key, valStr, definition.Pattern)
 		}
 	case "float", "long", "double":
-		_, valid = val.(float64)
+		switch val := val.(type) {
+		case float64, int:
+			valid = true
+		case string:
+			_, err := strconv.ParseFloat(val, 64)
+			valid = err == nil
+		}
 	default:
 		valid = true // all other types are considered valid not blocking validation
 	}

--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -271,6 +271,7 @@ func parseElementValue(key string, definition FieldDefinition, val interface{}) 
 		case float64, int:
 			valid = true
 		case string:
+			// Elasticsearch can ingest numbers represented as strings in the JSON document.
 			_, err := strconv.ParseFloat(val, 64)
 			valid = err == nil
 		}

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -80,7 +80,6 @@ func Test_parseElementValue(t *testing.T) {
 			definition: FieldDefinition{
 				Type: "long",
 			},
-			fail: true,
 		},
 
 		// keyword and constant_keyword (string)
@@ -171,10 +170,38 @@ func Test_parseElementValue(t *testing.T) {
 				Type: "float",
 			},
 		},
+		{
+			key:   "float as long",
+			value: 65537,
+			definition: FieldDefinition{
+				Type: "float",
+			},
+		},
+		{
+			key:   "float as string",
+			value: "3.1416",
+			definition: FieldDefinition{
+				Type: "float",
+			},
+		},
 		// long
 		{
-			key:   "bad long",
+			key:   "long",
+			value: 65537,
+			definition: FieldDefinition{
+				Type: "long",
+			},
+		},
+		{
+			key:   "long as string",
 			value: "65537",
+			definition: FieldDefinition{
+				Type: "long",
+			},
+		},
+		{
+			key:   "bad long",
+			value: "0xCEBADA",
 			definition: FieldDefinition{
 				Type: "long",
 			},


### PR DESCRIPTION
`elastic-package test` fails if a document contains a string value with a number in a field with numeric type, such as:
```
[5] parsing field value failed: field "process.pid"'s Go type, string, does not match the expected field type: long (field value: 87)
```
But these values are accepted by Elasticsearch.

Modify the check to accept also strings that can be parsed as numbers.