### PR TITLE
Elastic Agent: use fleet server

### DIFF
--- a/internal/install/static_kibana_config_yml.go
+++ b/internal/install/static_kibana_config_yml.go
@@ -17,6 +17,7 @@ xpack.fleet.enabled: true
 xpack.fleet.registryUrl: "http://package-registry:8080"
 xpack.fleet.agents.enabled: true
 xpack.fleet.agents.elasticsearch.host: "http://elasticsearch:9200"
+xpack.fleet.agents.fleetServerEnabled: true
 xpack.fleet.agents.kibana.host: "http://kibana:5601"
 xpack.fleet.agents.tlsCheckDisabled: true
 xpack.encryptedSavedObjects.encryptionKey: "12345678901234567890123456789012"

--- a/internal/install/static_snapshot_yml.go
+++ b/internal/install/static_snapshot_yml.go
@@ -89,6 +89,7 @@ services:
     environment:
     - "FLEET_ENROLL=1"
     - "FLEET_ENROLL_INSECURE=1"
+    - "FLEET_SERVER_ENABLE=1"
     - "FLEET_SETUP=1"
     - "KIBANA_HOST=http://kibana:5601"
     volumes:


### PR DESCRIPTION
This PR enables the Fleet server in the Elastic stack.

Unsolved issues:
- [ ] correctly handle another default policy (verify system tests)
- [ ] correct healthcheck that will mark that the Agent has a policy assigned
- [ ] assign the default policy (should be done by fleet server?)

Issue: https://github.com/elastic/beats/issues/24310