### PR TITLE
Elastic Agent: set FLEET_URL and FLEET_INSECURE

### DIFF
--- a/internal/install/static_kubernetes_elastic_agent_yml.go
+++ b/internal/install/static_kubernetes_elastic_agent_yml.go
@@ -34,6 +34,8 @@ spec:
               value: "1"
             - name: FLEET_INSECURE
               value: "1"
+            - name: FLEET_URL
+              value: "http://kibana:5601"
             - name: KIBANA_HOST
               value: "http://kibana:5601"
             - name: NODE_NAME

--- a/internal/install/static_kubernetes_elastic_agent_yml.go
+++ b/internal/install/static_kubernetes_elastic_agent_yml.go
@@ -32,6 +32,8 @@ spec:
               value: "1"
             - name: FLEET_ENROLL_INSECURE
               value: "1"
+            - name: FLEET_INSECURE
+              value: "1"
             - name: KIBANA_HOST
               value: "http://kibana:5601"
             - name: NODE_NAME

--- a/internal/install/static_kubernetes_elastic_agent_yml.go
+++ b/internal/install/static_kubernetes_elastic_agent_yml.go
@@ -26,8 +26,7 @@ spec:
       serviceAccountName: kind-fleet-agent
       containers:
         - name: kind-fleet-agent-clusterscope
-          # Temporary workaround for: https://github.com/elastic/beats/issues/24310
-          image: docker.elastic.co/beats/elastic-agent@sha256:6182d3ebb975965c4501b551dfed2ddc6b7f47c05187884c62fe6192f7df4625
+          image: docker.elastic.co/beats/elastic-agent:{{ STACK_VERSION }}
           env:
             - name: FLEET_ENROLL
               value: "1"

--- a/internal/install/static_snapshot_yml.go
+++ b/internal/install/static_snapshot_yml.go
@@ -75,8 +75,7 @@ services:
         condition: service_healthy
 
   elastic-agent:
-    # Temporary workaround for: https://github.com/elastic/beats/issues/24310
-    image: docker.elastic.co/beats/elastic-agent@sha256:6182d3ebb975965c4501b551dfed2ddc6b7f47c05187884c62fe6192f7df4625
+    image: docker.elastic.co/beats/elastic-agent:${STACK_VERSION}
     depends_on:
       elasticsearch:
         condition: service_healthy

--- a/internal/install/static_snapshot_yml.go
+++ b/internal/install/static_snapshot_yml.go
@@ -90,6 +90,7 @@ services:
     - "FLEET_ENROLL=1"
     - "FLEET_ENROLL_INSECURE=1"
     - "FLEET_SETUP=1"
+    - "FLEET_URL=1"
     - "KIBANA_HOST=http://kibana:5601"
     volumes:
     - type: bind

--- a/internal/install/static_snapshot_yml.go
+++ b/internal/install/static_snapshot_yml.go
@@ -90,7 +90,7 @@ services:
     - "FLEET_ENROLL=1"
     - "FLEET_ENROLL_INSECURE=1"
     - "FLEET_SETUP=1"
-    - "FLEET_URL=1"
+    - "FLEET_URL=http://kibana:5601"
     - "KIBANA_HOST=http://kibana:5601"
     volumes:
     - type: bind

--- a/internal/install/static_snapshot_yml.go
+++ b/internal/install/static_snapshot_yml.go
@@ -89,6 +89,7 @@ services:
     environment:
     - "FLEET_ENROLL=1"
     - "FLEET_ENROLL_INSECURE=1"
+    - "FLEET_INSECURE=1"
     - "FLEET_SETUP=1"
     - "FLEET_URL=http://kibana:5601"
     - "KIBANA_HOST=http://kibana:5601"


### PR DESCRIPTION
This PR sets the FLEET_URL to Kibana host. 

Either this or https://github.com/elastic/elastic-package/pull/272 will eventually work.

Issue: https://github.com/elastic/beats/issues/24310