### PR TITLE
Temporary switch to stable image of Elastic Agent

### DIFF
--- a/internal/install/static_kubernetes_elastic_agent_yml.go
+++ b/internal/install/static_kubernetes_elastic_agent_yml.go
@@ -26,7 +26,8 @@ spec:
       serviceAccountName: kind-fleet-agent
       containers:
         - name: kind-fleet-agent-clusterscope
-          image: docker.elastic.co/beats/elastic-agent:{{ STACK_VERSION }}
+          # Temporary workaround for: https://github.com/elastic/beats/issues/24310
+          image: docker.elastic.co/beats/elastic-agent@sha256:6182d3ebb975965c4501b551dfed2ddc6b7f47c05187884c62fe6192f7df4625
           env:
             - name: FLEET_ENROLL
               value: "1"

--- a/internal/install/static_snapshot_yml.go
+++ b/internal/install/static_snapshot_yml.go
@@ -75,7 +75,7 @@ services:
         condition: service_healthy
 
   elastic-agent:
-    image: docker.elastic.co/beats/elastic-agent:${STACK_VERSION}
+    image: docker.elastic.co/beats/elastic-agent@sha256:6182d3ebb975965c4501b551dfed2ddc6b7f47c05187884c62fe6192f7df4625
     depends_on:
       elasticsearch:
         condition: service_healthy

--- a/internal/install/static_snapshot_yml.go
+++ b/internal/install/static_snapshot_yml.go
@@ -75,6 +75,7 @@ services:
         condition: service_healthy
 
   elastic-agent:
+    # Temporary workaround for: https://github.com/elastic/beats/issues/24310
     image: docker.elastic.co/beats/elastic-agent@sha256:6182d3ebb975965c4501b551dfed2ddc6b7f47c05187884c62fe6192f7df4625
     depends_on:
       elasticsearch:


### PR DESCRIPTION
This PR is a quick mitigation to the problem of fault Elastic Agent image reported in https://github.com/elastic/beats/issues/24310.

Unfortunately it block older stacks from execution until https://github.com/elastic/elastic-package/issues/271 is fixed.