### PR TITLE
Disable the new default fleet-server

### DIFF
--- a/internal/install/static_kibana_config_yml.go
+++ b/internal/install/static_kibana_config_yml.go
@@ -12,6 +12,7 @@ elasticsearch.hosts: [ "http://elasticsearch:9200" ]
 elasticsearch.username: elastic
 elasticsearch.password: changeme
 xpack.monitoring.ui.container.elasticsearch.enabled: true
+xpack.fleet.agents.fleetServerEnabled: false
 
 xpack.fleet.enabled: true
 xpack.fleet.registryUrl: "http://package-registry:8080"


### PR DESCRIPTION
Fleet-server setup was enabled by default. This disables it for now until the new setup is fully working.