### PR TITLE
Use different API to check assigned policy revisions

### DIFF
--- a/internal/kibana/policies.go
+++ b/internal/kibana/policies.go
@@ -19,6 +19,7 @@ type Policy struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	Namespace   string `json:"namespace"`
+	Revision    int `json:"revision,omitempty"`
 }
 
 // CreatePolicy persists the given Policy in the Ingest Manager.
@@ -35,6 +36,29 @@ func (c *Client) CreatePolicy(p Policy) (*Policy, error) {
 
 	if statusCode != 200 {
 		return nil, fmt.Errorf("could not create policy; API status code = %d; response body = %s", statusCode, respBody)
+	}
+
+	var resp struct {
+		Item Policy `json:"item"`
+	}
+
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, errors.Wrap(err, "could not convert policy (response) to JSON")
+	}
+
+	return &resp.Item, nil
+}
+
+
+// GetPolicy fetches the given Policy in the Ingest Manager.
+func (c *Client) GetPolicy(policyID string) (*Policy, error) {
+	statusCode, respBody, err := c.get(fmt.Sprintf("%s/agent_policies/%s", FleetAPI, policyID))
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get policy")
+	}
+
+	if statusCode != 200 {
+		return nil, fmt.Errorf("could not get policy; API status code = %d; response body = %s", statusCode, respBody)
 	}
 
 	var resp struct {

--- a/internal/kibana/policies.go
+++ b/internal/kibana/policies.go
@@ -19,7 +19,7 @@ type Policy struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	Namespace   string `json:"namespace"`
-	Revision    int `json:"revision,omitempty"`
+	Revision    int    `json:"revision,omitempty"`
 }
 
 // CreatePolicy persists the given Policy in the Ingest Manager.
@@ -48,7 +48,6 @@ func (c *Client) CreatePolicy(p Policy) (*Policy, error) {
 
 	return &resp.Item, nil
 }
-
 
 // GetPolicy fetches the given Policy in the Ingest Manager.
 func (c *Client) GetPolicy(policyID string) (*Policy, error) {

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -299,6 +299,7 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 	agent := agents[0]
 	origPolicy := kibana.Policy{
 		ID: agent.PolicyID,
+		Revision: agent.PolicyRevision,
 	}
 
 	// Configure package (single data stream) via Ingest Manager APIs.
@@ -375,8 +376,13 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 		return nil
 	}
 
+	policyWithDataStream, err := kib.GetPolicy(policy.ID)
+	if err != nil {
+		return result.WithError(errors.Wrap(err, "could not read the policy with data stream"))
+	}
+
 	logger.Debug("assigning package data stream to agent...")
-	if err := kib.AssignPolicyToAgent(agent, *policy); err != nil {
+	if err := kib.AssignPolicyToAgent(agent, *policyWithDataStream); err != nil {
 		return result.WithError(errors.Wrap(err, "could not assign policy to agent"))
 	}
 

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -298,7 +298,7 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 	}
 	agent := agents[0]
 	origPolicy := kibana.Policy{
-		ID: agent.PolicyID,
+		ID:       agent.PolicyID,
 		Revision: agent.PolicyRevision,
 	}
 

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -419,7 +419,6 @@ func checkEnrolledAgents(client *kibana.Client, ctxt servicedeployer.ServiceCont
 
 		agents = filterAgents(allAgents, ctxt)
 		logger.Debugf("found %d enrolled agent(s)", len(agents))
-
 		if len(agents) == 0 {
 			return false, nil // selected agents are unavailable yet
 		}
@@ -560,6 +559,10 @@ func filterAgents(allAgents []kibana.Agent, ctx servicedeployer.ServiceContext) 
 
 	var filtered []kibana.Agent
 	for _, agent := range allAgents {
+		if agent.PolicyRevision == 0 {
+			continue // For some reason Kibana doesn't always return a valid policy revision (eventually it will be present and valid)
+		}
+
 		if ctx.Agent.Host.NamePrefix != "" && !strings.HasPrefix(agent.LocalMetadata.Host.Name, ctx.Agent.Host.NamePrefix) {
 			continue
 		}


### PR DESCRIPTION
This PR modifies test runner to use different API methods to check agents which picked up latest policy revisions (kuery has been removed).

This is a workaround for https://github.com/elastic/kibana/issues/94053 . 