### PR TITLE
Honor data stream dataset if provided

### DIFF
--- a/internal/packages/assets.go
+++ b/internal/packages/assets.go
@@ -112,7 +112,13 @@ func loadElasticsearchAssets(pkgRootPath string) ([]Asset, error) {
 			return nil, errors.Wrap(err, "reading data stream manifest failed")
 		}
 
-		indexTemplateName := fmt.Sprintf("%s-%s.%s", dsManifest.Type, pkgManifest.Name, dsManifest.Name)
+		var indexTemplateName string
+		if dsManifest.Dataset == "" {
+			indexTemplateName = fmt.Sprintf("%s-%s.%s", dsManifest.Type, pkgManifest.Name, dsManifest.Name)
+		} else {
+			indexTemplateName = fmt.Sprintf("%s-%s", dsManifest.Dataset)
+		}
+
 		asset := Asset{
 			ID:         indexTemplateName,
 			Type:       AssetTypeElasticsearchIndexTemplate,

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -103,6 +103,7 @@ type DataStreamManifest struct {
 	Name          string `config:"name" json:"name" yaml:"name"`
 	Title         string `config:"title" json:"title" yaml:"title"`
 	Type          string `config:"type" json:"type" yaml:"type"`
+	Dataset       string `config:"dataset" yaml:"dataset"`
 	Elasticsearch *struct {
 		IngestPipeline *struct {
 			Name string `config:"name" json:"name" yaml:"name"`


### PR DESCRIPTION
This PR fixes a bug in the asset test runner, related to Elasticsearch index template assets.

Prior to this PR, the asset test runner was assuming that Elasticsearch index templates installed by a package were always named `<package type>-<package name>.<data stream name>`. 

However, a data stream may optionally define a `dataset` in its `manifest.yml`. If this field is defined, the installed index template name becomes `<package type>-<dataset>`. This PR checks for the optional `dataset` field and, if it exists, uses it to create the index template name.