### PR TITLE
Remove reference to integrations folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,10 @@ go get github.com/elastic/elastic-package
 _Please make sure that you've correctly [setup environment variables](https://golang.org/doc/gopath_code.html#GOPATH) -
 `$GOPATH` and `$PATH`, and `elastic-package` is accessible from your `$PATH`._
 
-Change directory to the package under development. Note: an integration is a specific type of a package.
+Change directory to the package under development. 
 
 ```bash
-cd integrations
-cd package/my-package
+cd my-package
 ```
 
 Run the `help` command and see available commands:


### PR DESCRIPTION
This PR removes a reference to the `integrations` folder (resulting from checking out the `elastic/integrations` repository locally) from the README. This is because `elastic-package` should be usable regardless of whether packages are coming from the `elastic/integrations` repository or not.