### PR TITLE
Check if user remote exists when promoting

### DIFF
--- a/internal/promote/storage.go
+++ b/internal/promote/storage.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	remoteName = "elastic"
+	upstream = "elastic"
 
 	snapshotPackage = "snapshot"
 	stagingPackage  = "staging"
@@ -115,10 +115,10 @@ func CloneRepository(user, stage string) (*git.Repository, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "creating user remote failed")
 	}
-	remote, err := r.CreateRemote(&config.RemoteConfig{
-		Name: remoteName,
+	upstreamRemote, err := r.CreateRemote(&config.RemoteConfig{
+		Name: upstream,
 		URLs: []string{
-			fmt.Sprintf(repositoryURL, "elastic"),
+			fmt.Sprintf(repositoryURL, upstream),
 		},
 	})
 	if err != nil {
@@ -141,7 +141,7 @@ func CloneRepository(user, stage string) (*git.Repository, error) {
 	}
 
 	// Fetch and checkout
-	err = remote.Fetch(&git.FetchOptions{
+	err = upstreamRemote.Fetch(&git.FetchOptions{
 		RefSpecs: []config.RefSpec{
 			"HEAD:refs/heads/HEAD",
 			"refs/heads/snapshot:refs/heads/snapshot",


### PR DESCRIPTION
`promote` needs both the elastic and the user repositories to exist. If the user repository doesn't exist, it fails when trying to push:
```
Error: pushing changes failed: pushing branch failed: repository not found
```
It is not clear for the user what repository is missing.

With these changes, the existence of the user remote is checked when the remote is configured. If it doesn't exist, it fails immediately, including the missing repository in the error message:
```
Error: cloning source repository failed (branch: snapshot): checking user remote (jsoriano, url: https://github.com/jsoriano/package-storage): repository not found
```

Code is refactored to avoid fetching anything before doing this check, and to fetch only the latest commit.