### PR TITLE
Publish: check error after cloning repository

### DIFF
--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -59,6 +59,9 @@ func Package(githubUser string, githubClient *github.Client, skipPullRequest boo
 
 	fmt.Println("Clone package-storage repository")
 	r, err := storage.CloneRepository(githubUser, productionStage)
+	if err != nil {
+		return errors.Wrap(err, "cloning source repository failed")
+	}
 
 	fmt.Printf("Find latest package revision of \"%s\" in package-storage\n", m.Name)
 	latestRevision, stage, err := findLatestPackageRevision(r, m.Name)


### PR DESCRIPTION
This PR fixes the missing check for potential error.

Spotted in: https://github.com/elastic/integrations/pull/815

Most likely it will result in follow-ups (need to fix the root cause).