### PR TITLE
Publish: support no fork mode

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -28,6 +28,9 @@ func setupPublishCommand() *cobra.Command {
 		RunE:  publishCommandAction,
 	}
 
+	// Fork flag can be a workaround for users that don't own forks of the Package Storage.
+	cmd.Flags().BoolP(cobraext.ForkFlagName, "f", true, cobraext.ForkFlagDescription)
+
 	// SkipPullRequest flag can used to verify if the "publish" command works properly (finds correct revisions),
 	// for which the operator doesn't want to immediately close just opened PRs (standard dry-run).
 	cmd.Flags().BoolP(cobraext.SkipPullRequestFlagName, "s", false, cobraext.SkipPullRequestFlagDescription)
@@ -37,6 +40,7 @@ func setupPublishCommand() *cobra.Command {
 func publishCommandAction(cmd *cobra.Command, args []string) error {
 	cmd.Println("Publish the package")
 
+	fork, _ := cmd.Flags().GetBool(cobraext.ForkFlagName)
 	skipPullRequest, _ := cmd.Flags().GetBool(cobraext.SkipPullRequestFlagName)
 
 	// Setup GitHub
@@ -58,7 +62,7 @@ func publishCommandAction(cmd *cobra.Command, args []string) error {
 	cmd.Printf("Current GitHub user: %s\n", githubUser)
 
 	// Publish the package
-	err = publish.Package(githubUser, githubClient, skipPullRequest)
+	err = publish.Package(githubUser, githubClient, fork, skipPullRequest)
 	if err != nil {
 		return errors.Wrap(err, "can't publish the package")
 	}

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -38,11 +38,18 @@ func setupPublishCommand() *cobraext.Command {
 func publishCommandAction(cmd *cobra.Command, args []string) error {
 	cmd.Println("Publish the package")
 
-	fork, _ := cmd.Flags().GetBool(cobraext.ForkFlagName)
-	skipPullRequest, _ := cmd.Flags().GetBool(cobraext.SkipPullRequestFlagName)
+	fork, err := cmd.Flags().GetBool(cobraext.ForkFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.ForkFlagName)
+	}
+
+	skipPullRequest, err := cmd.Flags().GetBool(cobraext.SkipPullRequestFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.SkipPullRequestFlagName)
+	}
 
 	// Setup GitHub
-	err := github.EnsureAuthConfigured()
+	err = github.EnsureAuthConfigured()
 	if err != nil {
 		return errors.Wrap(err, "GitHub auth configuration failed")
 	}

--- a/internal/cobraext/const.go
+++ b/internal/cobraext/const.go
@@ -27,6 +27,9 @@ const (
 	FailFastFlagName        = "fail-fast"
 	FailFastFlagDescription = "fail immediately if any file requires updates (do not overwrite)"
 
+	ForkFlagName        = "fork"
+	ForkFlagDescription = "use fork mode"
+
 	GenerateTestResultFlagName        = "generate"
 	GenerateTestResultFlagDescription = "generate test result file"
 

--- a/internal/cobraext/const.go
+++ b/internal/cobraext/const.go
@@ -28,7 +28,7 @@ const (
 	FailFastFlagDescription = "fail immediately if any file requires updates (do not overwrite)"
 
 	ForkFlagName        = "fork"
-	ForkFlagDescription = "use fork mode"
+	ForkFlagDescription = "use fork mode (set to \"false\" if user can't fork the storage repository)"
 
 	GenerateTestResultFlagName        = "generate"
 	GenerateTestResultFlagDescription = "generate test result file"

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -28,7 +28,7 @@ const (
 )
 
 // Package function publishes the current package to the package-storage.
-func Package(githubUser string, githubClient *github.Client, skipPullRequest bool) error {
+func Package(githubUser string, githubClient *github.Client, fork, skipPullRequest bool) error {
 	packageRoot, err := packages.MustFindPackageRoot()
 	if err != nil {
 		return errors.Wrap(err, "locating package root failed")
@@ -58,7 +58,7 @@ func Package(githubUser string, githubClient *github.Client, skipPullRequest boo
 	}
 
 	fmt.Println("Clone package-storage repository")
-	r, err := storage.CloneRepository(githubUser, productionStage)
+	r, err := storage.CloneRepositoryWithFork(githubUser, productionStage, fork)
 	if err != nil {
 		return errors.Wrap(err, "cloning source repository failed")
 	}
@@ -90,7 +90,7 @@ func Package(githubUser string, githubClient *github.Client, skipPullRequest boo
 	}
 
 	fmt.Println("Push new package revision to storage")
-	err = storage.PushChanges(githubUser, r, destination)
+	err = storage.PushChangesWithFork(githubUser, r, fork, destination)
 	if err != nil {
 		return errors.Wrapf(err, "pushing changes failed")
 	}
@@ -111,7 +111,7 @@ func Package(githubUser string, githubClient *github.Client, skipPullRequest boo
 	}
 
 	fmt.Println("Open new pull request")
-	err = openPullRequest(githubClient, githubUser, destination, *m, commitHash)
+	err = openPullRequest(githubClient, githubUser, destination, *m, commitHash, fork)
 	if err != nil {
 		return errors.Wrapf(err, "can't open a new pull request")
 	}

--- a/internal/publish/pull_requests.go
+++ b/internal/publish/pull_requests.go
@@ -42,7 +42,7 @@ func checkIfPullRequestAlreadyOpen(githubClient *github.Client, manifest package
 }
 
 func openPullRequest(githubClient *github.Client, githubUser, destinationBranch string, manifest packages.PackageManifest, commitHash string, fork bool) error {
-	var user = repositoryOwner
+	user := repositoryOwner
 	if fork {
 		user = githubUser
 	}

--- a/internal/publish/pull_requests.go
+++ b/internal/publish/pull_requests.go
@@ -41,12 +41,17 @@ func checkIfPullRequestAlreadyOpen(githubClient *github.Client, manifest package
 	return false, nil
 }
 
-func openPullRequest(githubClient *github.Client, githubUser, destinationBranch string, manifest packages.PackageManifest, commitHash string) error {
+func openPullRequest(githubClient *github.Client, githubUser, destinationBranch string, manifest packages.PackageManifest, commitHash string, fork bool) error {
+	var user = repositoryOwner
+	if fork {
+		user = githubUser
+	}
+
 	title := buildPullRequestTitle(manifest)
-	diffURL := buildPullRequestDiffURL(githubUser, commitHash)
+	diffURL := buildPullRequestDiffURL(user, commitHash)
 	description := buildPullRequestDescription(manifest, diffURL)
 
-	userHead := fmt.Sprintf("%s:%s", githubUser, destinationBranch)
+	userHead := fmt.Sprintf("%s:%s", user, destinationBranch)
 	maintainerCanModify := true
 	base := snapshotStage
 

--- a/internal/publish/pull_requests.go
+++ b/internal/publish/pull_requests.go
@@ -46,6 +46,7 @@ func openPullRequest(githubClient *github.Client, githubUser, destinationBranch 
 	if fork {
 		user = githubUser
 	}
+	logger.Debugf("Current user: %s", user)
 
 	title := buildPullRequestTitle(manifest)
 	diffURL := buildPullRequestDiffURL(user, commitHash)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -572,7 +572,7 @@ func PushChangesWithFork(user string, r *git.Repository, fork bool, stages ...st
 		refSpecs = append(refSpecs, config.RefSpec(fmt.Sprintf("refs/heads/%s:refs/heads/%s", stage, stage)))
 	}
 
-	var remoteName = upstream
+	remoteName := upstream
 	if fork {
 		remoteName = user
 	}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -133,6 +133,7 @@ func (prs PackageVersions) Strings() []string {
 }
 
 // CloneRepository function clones the repository and changes branch to stage.
+// It assumes that user has already forked the storage repository.
 func CloneRepository(user, stage string) (*git.Repository, error) {
 	return CloneRepositoryWithFork(user, stage, true)
 }
@@ -555,6 +556,7 @@ func RemovePackages(r *git.Repository, sourceStage string, packages PackageVersi
 }
 
 // PushChanges function pushes branches to the remote repository.
+// It assumes that user has already forked the storage repository.
 func PushChanges(user string, r *git.Repository, stages ...string) error {
 	return PushChangesWithFork(user, r, true, stages...)
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -573,10 +573,11 @@ func PushChangesWithFork(user string, r *git.Repository, fork bool, stages ...st
 	}
 
 	var remoteName = upstream
-	if !fork {
+	if fork {
 		remoteName = user
 	}
 
+	logger.Debugf("Push to remote: %s", remoteName)
 	err = r.Push(&git.PushOptions{
 		RemoteName: remoteName,
 		RefSpecs:   refSpecs,


### PR DESCRIPTION
This PR fixes issue spotted in https://github.com/elastic/integrations/pull/815. 

CI uses "elasticmachine" account which doesn't have a fork of package-storage, but has permissions to push changes to the original repository.

Sample PR: https://github.com/elastic/package-storage/pull/1083

Testing:

```
cd test/packages/apache
elastic-package publish -v --fork=false
```