### PR TITLE
Fix: adjust agent healthcheck

### DIFF
--- a/internal/install/static_snapshot_yml.go
+++ b/internal/install/static_snapshot_yml.go
@@ -82,7 +82,7 @@ services:
       kibana:
         condition: service_healthy
     healthcheck:
-      test: "sh -c 'grep \"Agent is starting\" /usr/share/elastic-agent/elastic-agent.log*'"
+      test: "sh -c 'grep \"Agent is starting\" -r . --include=elastic-agent-json.log'"
       retries: 30
       interval: 1s
     hostname: docker-fleet-agent


### PR DESCRIPTION
This PR modifies the elastic-package JSON log path, so we detect the moment when the agent is ready/healthy.

Issue: https://github.com/elastic/beats/issues/24894