### PR TITLE
Publish: don't push changes to repo if PR is open

### DIFF
--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -79,6 +79,16 @@ func Package(githubUser string, githubClient *github.Client, fork, skipPullReque
 		logger.Debugf("Copy sources of the latest package revision to index")
 	}
 
+	fmt.Println("Check if pull request is already open")
+	alreadyOpen, err := checkIfPullRequestAlreadyOpen(githubClient, *m)
+	if err != nil {
+		return errors.Wrapf(err, "can't check if pull request is already open")
+	}
+	if alreadyOpen {
+		fmt.Println("Pull request with package update is already open")
+		return nil
+	}
+
 	destination, err := copyLatestRevisionIfAvailable(r, latestRevision, stage, m)
 	if err != nil {
 		return errors.Wrap(err, "can't copy sources of latest package revision")
@@ -97,16 +107,6 @@ func Package(githubUser string, githubClient *github.Client, fork, skipPullReque
 
 	if skipPullRequest {
 		fmt.Println("Skip opening a new pull request")
-		return nil
-	}
-
-	fmt.Println("Check if pull request is already open")
-	alreadyOpen, err := checkIfPullRequestAlreadyOpen(githubClient, *m)
-	if err != nil {
-		return errors.Wrapf(err, "can't check if pull request is already open")
-	}
-	if alreadyOpen {
-		fmt.Println("Pull request with package update is already open")
 		return nil
 	}
 

--- a/internal/publish/pull_requests.go
+++ b/internal/publish/pull_requests.go
@@ -34,7 +34,7 @@ func checkIfPullRequestAlreadyOpen(githubClient *github.Client, manifest package
 
 	for _, item := range searchResults.Issues {
 		if *item.Title == expectedTitle {
-			logger.Debugf("Found pull request: ", *item.HTMLURL)
+			logger.Debugf("Found pull request: %s", *item.HTMLURL)
 			return true, nil
 		}
 	}


### PR DESCRIPTION
This PR modifies the publishing procedure:
* don't push changes to repo if PR is open

Spotted in: https://github.com/elastic/integrations/pull/815