### PR TITLE
Fix: starting security shard

### DIFF
--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -170,6 +170,7 @@ func writeStackResources(elasticPackagePath string) error {
 	}
 
 	err = writeStaticResource(err, filepath.Join(stackPath, "kibana.config.yml"), kibanaConfigYml)
+	err = writeStaticResource(err, filepath.Join(stackPath, "healthcheck.sh"), kibanaHealthcheckSh)
 	err = writeStaticResource(err, filepath.Join(stackPath, "snapshot.yml"), snapshotYml)
 	err = writeStaticResource(err, filepath.Join(stackPath, "package-registry.config.yml"), packageRegistryConfigYml)
 	err = writeStaticResource(err, filepath.Join(stackPath, "Dockerfile.package-registry"), packageRegistryDockerfile)

--- a/internal/install/static_kibana_healthcheck_sh.go
+++ b/internal/install/static_kibana_healthcheck_sh.go
@@ -7,5 +7,5 @@ package install
 const kibanaHealthcheckSh = `#!/bin/bash
 
 curl -s -f http://127.0.0.1:5601/login | grep kbn-injected-metadata 2>&1 >/dev/null
-curl -s -f -u elastic:changeme http://elasticsearch:9200/_cat/shards | grep .security | grep STARTED
+curl -s -f -u elastic:changeme "http://elasticsearch:9200/_cat/indices/.security-*?h=health" | grep -v red
 `

--- a/internal/install/static_kibana_healthcheck_sh.go
+++ b/internal/install/static_kibana_healthcheck_sh.go
@@ -1,0 +1,11 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package install
+
+const kibanaHealthcheckSh = `#!/bin/bash
+
+curl -s -f http://127.0.0.1:5601/login | grep kbn-injected-metadata 2>&1 >/dev/null
+curl -s -f -u elastic:changeme http://elasticsearch:9200/_cat/shards | grep .security | grep STARTED
+`

--- a/internal/install/static_kibana_healthcheck_sh.go
+++ b/internal/install/static_kibana_healthcheck_sh.go
@@ -6,6 +6,8 @@ package install
 
 const kibanaHealthcheckSh = `#!/bin/bash
 
+set -e
+
 curl -s -f http://127.0.0.1:5601/login | grep kbn-injected-metadata 2>&1 >/dev/null
 curl -s -f -u elastic:changeme "http://elasticsearch:9200/_cat/indices/.security-*?h=health" | grep -v red
 `

--- a/internal/install/static_snapshot_yml.go
+++ b/internal/install/static_snapshot_yml.go
@@ -43,11 +43,12 @@ services:
       package-registry:
         condition: service_healthy
     healthcheck:
-      test: "curl -f http://127.0.0.1:5601/login | grep kbn-injected-metadata 2>&1 >/dev/null"
+      test: "sh /usr/share/kibana/healthcheck.sh"
       retries: 600
       interval: 1s
     volumes:
       - ./kibana.config.yml:/usr/share/kibana/config/kibana.yml
+      - ./healthcheck.sh:/usr/share/kibana/healthcheck.sh
     ports:
       - "127.0.0.1:5601:5601"
 


### PR DESCRIPTION
This PR tries to fix the issue with `.security-7` shard:

```
["org.elasticsearch.action.UnavailableShardsException: at least one primary shard for the index [.security-7] is unavailable",
```

Kibana's healthcheck will depend on the shard's state.

Issue: https://github.com/elastic/kibana/issues/95896

Comment:

I've no idea if this will fix the problem, but let's give it a try :)