### PR TITLE
Fix custom resource init for k8s deployer

### DIFF
--- a/internal/testrunner/runners/system/servicedeployer/kubernetes.go
+++ b/internal/testrunner/runners/system/servicedeployer/kubernetes.go
@@ -115,7 +115,7 @@ func (ksd KubernetesServiceDeployer) installCustomDefinitions() error {
 		return nil
 	}
 
-	err = kubectl.Delete(definitionPaths...)
+	err = kubectl.Apply(definitionPaths...)
 	if err != nil {
 		return errors.Wrap(err, "can't install custom definitions")
 	}


### PR DESCRIPTION
This PR fixes a bug with custom resources not being able to be installed on k8s when using k8s service deployer. The deployer `delete`s the resources instead of `apply`ing them.