### PR TITLE
Emergency fix: Use stable Docker images

### DIFF
--- a/internal/install/application_configuration_yml.go
+++ b/internal/install/application_configuration_yml.go
@@ -28,4 +28,9 @@ const applicationConfigurationYml = `stack:
 
 const applicationConfigurationYml = `stack:
   image_ref_overrides:
+    7.13.0-SNAPSHOT:
+      # Use stable image versions for Agent and Kibana
+      elasticsearch: ` + elasticsearchImageName + `@sha256:4103fceb802f73356092beff5502e87ec2faa97048d066135d69f04e42b5ca81
+      elastic-agent: ` + elasticAgentImageName + `@sha256:41e99398b69a9ce35a597839b084287f595aef0f3ed7d6c92dd035a3d75caf3a
+      kibana: ` + kibanaImageName + `@sha256:4c345ad24128a3e8084079b9c193bdc84ec338b34fe18be5d1c879cd66487e38
 `


### PR DESCRIPTION
This PR fixes the issue with bad/unstable images of Kibana/Elastic-Agent.