### PR TITLE
Fix: show validation errors

### DIFF
--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -388,7 +388,7 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 	}
 
 	if err := validateFields(docs, fieldsValidator, dataStream); err != nil {
-		return result.WithError(errors.Wrap(err, "failed to validate fields"))
+		return result.WithError(err)
 	}
 
 	// Write sample events file from first doc, if requested


### PR DESCRIPTION
This PR fixes the issue with not showing validation errors during system tests. With lost error types validation errors can't be properly handled.

Proof:

```
2021/04/20 11:59:56 DEBUG running command: /usr/local/bin/docker-compose -f /Users/marcin.tojek/go/src/github.com/elastic/elastic-package/test/packages/apache/_dev/deploy/docker/docker-compose.yml -p elastic-package-service down
Stopping elastic-package-service_apache_1 ... done
Removing elastic-package-service_apache_1 ... done
Removing network elastic-package-service_default
2021/04/20 11:59:58 DEBUG deleting data in data stream...
--- Test results for package: apache - START ---
╭─────────┬─────────────┬───────────┬───────────┬────────────────────────────────────────────────────────────────────────────────────────────┬─────────────────╮
│ PACKAGE │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT                                                                                     │    TIME ELAPSED │
├─────────┼─────────────┼───────────┼───────────┼────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────┤
│ apache  │ status      │ system    │ default   │ FAIL: one or more errors found in documents stored in metrics-apache.status-ep data stream │ 1m59.058645428s │
╰─────────┴─────────────┴───────────┴───────────┴────────────────────────────────────────────────────────────────────────────────────────────┴─────────────────╯

FAILURE DETAILS:

apache/status default:
[0] field "apache.status.workers.busy" is undefined
--- Test results for package: apache - END   ---
Done
Error: one or more test cases failed
```