### PR TITLE
Deploy agent with hostNetwork on k8s

### DIFF
--- a/internal/install/static_kubernetes_elastic_agent_yml.go
+++ b/internal/install/static_kubernetes_elastic_agent_yml.go
@@ -30,6 +30,8 @@ spec:
         group: fleet
     spec:
       serviceAccountName: kind-fleet-agent
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: kind-fleet-agent-clusterscope
           image: {{ ELASTIC_AGENT_IMAGE_REF }}

--- a/internal/testrunner/runners/system/servicedeployer/kubernetes.go
+++ b/internal/testrunner/runners/system/servicedeployer/kubernetes.go
@@ -95,6 +95,8 @@ func (ksd KubernetesServiceDeployer) SetUp(ctxt ServiceContext) (DeployedService
 
 	ctxt.Name = kind.ControlPlaneContainerName
 	ctxt.Hostname = kind.ControlPlaneContainerName
+	// kind-control-plane is the name of the kind host where Pod is running since we use hostNetwork setting
+	// to deploy Agent Pod. Because of this, hostname inside pod will be equal to the name of the k8s host.
 	ctxt.Agent.Host.NamePrefix = "kind-control-plane"
 	return &kubernetesDeployedService{
 		ctxt:           ctxt,

--- a/internal/testrunner/runners/system/servicedeployer/kubernetes.go
+++ b/internal/testrunner/runners/system/servicedeployer/kubernetes.go
@@ -95,7 +95,7 @@ func (ksd KubernetesServiceDeployer) SetUp(ctxt ServiceContext) (DeployedService
 
 	ctxt.Name = kind.ControlPlaneContainerName
 	ctxt.Hostname = kind.ControlPlaneContainerName
-	ctxt.Agent.Host.NamePrefix = "kind-fleet-agent-"
+	ctxt.Agent.Host.NamePrefix = "kind-control-plane"
 	return &kubernetesDeployedService{
 		ctxt:           ctxt,
 		definitionsDir: ksd.definitionsDir,


### PR DESCRIPTION
We need to deploy Agent using `hostNetwork` option so as to have access to node's ports directly for testing endpoints like these of scheduler's and controllermanager.