### PR TITLE
Fix: skip caching images

### DIFF
--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -41,6 +41,9 @@ for d in test/packages/*/; do
 done
 cd -
 
+# Update the stack
+elastic-package stack update -v
+
 # Boot up the stack
 elastic-package stack up -d -v
 

--- a/scripts/test-stack-command.sh
+++ b/scripts/test-stack-command.sh
@@ -24,6 +24,9 @@ cleanup() {
 
 trap cleanup EXIT
 
+# Update the stack
+elastic-package stack update -v
+
 # Boot up the stack
 elastic-package stack up -d -v
 


### PR DESCRIPTION
This PR ensures that latest stack images are used.