### PR TITLE
Bump elastic stack version automation

### DIFF
--- a/.ci/bump-stack-version.sh
+++ b/.ci/bump-stack-version.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Given the stack version this script will bump the version.
+#
+# This script is executed by the automation we are putting in place
+# and it requires the git add/commit commands.
+#
+# Parameters:
+#	$1 -> the version to be bumped. Mandatory.
+#	$2 -> whether to create a branch where to commit the changes to.
+#		  this is required when reusing an existing Pull Request.
+#		  Optional. Default true.
+#
+set -euo pipefail
+MSG="parameter missing."
+VERSION=${1:?$MSG}
+CREATE_BRANCH=${2:-true}
+
+OS=$(uname -s| tr '[:upper:]' '[:lower:]')
+
+if [ "${OS}" == "darwin" ] ; then
+	SED="sed -i .bck"
+else
+	SED="sed -i"
+fi
+
+echo "Update stack with version ${VERSION}"
+${SED} -E -e "s#(DefaultStackVersion) = \"[0-9]+\.[0-9]+\.[0-9]+(-[a-f0-9]{8})?#\1 = \"${VERSION}#g" internal/install/stack_version.go
+
+echo "Commit changes"
+if [ "$CREATE_BRANCH" = "true" ]; then
+	git checkout -b "update-stack-version-$(date "+%Y%m%d%H%M%S")"
+else
+	echo "Branch creation disabled."
+fi
+git add internal/install/stack_version.go
+git diff --staged --quiet || git commit -m "bump stack version ${VERSION}"
+git --no-pager log -1
+
+echo "You can now push and create a Pull Request"

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ elastic-package
 
 # stack dump
 elastic-stack-dump/
+
+# Bump automation
+*.bck

--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "7.13.0-SNAPSHOT"
+	DefaultStackVersion = "8.0.0-SNAPSHOT"
 )


### PR DESCRIPTION
## What does this PR do?

Script to bump the versions:




```diff
$ ./.ci/bump-stack-version.sh 8.0.0-3beeb19e false                                                
Update stack with version 8.0.0-3beeb19e
Commit changes
Branch creation disabled.
$ git --no-pager diff                                    
diff --git a/.ci/bump-stack-version.sh b/.ci/bump-stack-version.sh
index 6402105..0b0ec68 100755
--- a/.ci/bump-stack-version.sh
+++ b/.ci/bump-stack-version.sh
@@ -33,6 +33,7 @@ if [ "$CREATE_BRANCH" = "true" ]; then
 else
 	echo "Branch creation disabled."
 fi
+exit 0
 git add internal/install/stack_version.go
 git diff --staged --quiet || git commit -m "bump stack version ${VERSION}"
 git --no-pager log -1
diff --git a/internal/install/stack_version.go b/internal/install/stack_version.go
index 3195512..74b855b 100644
--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "8.0.0-SNAPSHOT"
+	DefaultStackVersion = "8.0.0-3beeb19e-SNAPSHOT"
 )
```

This PR is one part of the required changes to enable the automation. 

## Why is it important?

Handle the stack versions on a PR basis to ensure breaking changes are handled correctly. Unfortunately we cannot use `dependabot` since those versions are handled differently.

## Issues

Similar to https://github.com/elastic/package-registry/pull/691

## Questions

- What's the backport policy for the `master` branch?

## Follow ups

- Enable automerge with `mergify`?
- This project uses a different branch strategy so there is a requirement to match the branches with the elastic stack branch strategy (7.x, 7.<minor>, master=8.0.0...)