### PR TITLE
Revert: use api/status as healthcheck for fleet-server

### DIFF
--- a/internal/install/static_snapshot_yml.go
+++ b/internal/install/static_snapshot_yml.go
@@ -84,9 +84,9 @@ services:
       kibana:
         condition: service_healthy
     healthcheck:
-      test: "elastic-agent status"
-      retries: 60
-      interval: 1s
+      test: "curl -f http://127.0.0.1:8220/api/status | grep HEALTHY 2>&1 >/dev/null"
+      retries: 12
+      interval: 5s
     hostname: docker-fleet-server
     environment:
     - "FLEET_SERVER_ENABLE=1"


### PR DESCRIPTION
This PR reverts changes introduced around fleet-server's healthcheck. Unfortunately it doesn't work well, so we have to switch back to the api/status.