### PR TITLE
Bump up the stack to 7.14.0-SNAPSHOT

### DIFF
--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "7.13.0-SNAPSHOT"
+	DefaultStackVersion = "7.14.0-SNAPSHOT"
 )


### PR DESCRIPTION
This PR bumps up the stack version to 7.14.0-SNAPSHOT.