### PR TITLE
Add fleet-server to available services

### DIFF
--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -20,9 +20,9 @@ import (
 
 var availableServices = map[string]struct{}{
 	"elasticsearch":    {},
+	"fleet-server":     {},
 	"kibana":           {},
 	"package-registry": {},
-	"fleet-server":     {},
 }
 
 const stackLongDescription = `Use this command to spin up a Docker-based Elastic Stack consisting of Elasticsearch, Kibana, and the Package Registry. By default the latest released version of the stack is spun up but it is possible to specify a different version, including SNAPSHOT versions.

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -22,6 +22,7 @@ var availableServices = map[string]struct{}{
 	"elasticsearch":    {},
 	"kibana":           {},
 	"package-registry": {},
+	"fleet-server":     {},
 }
 
 const stackLongDescription = `Use this command to spin up a Docker-based Elastic Stack consisting of Elasticsearch, Kibana, and the Package Registry. By default the latest released version of the stack is spun up but it is possible to specify a different version, including SNAPSHOT versions.

--- a/internal/install/static_snapshot_yml.go
+++ b/internal/install/static_snapshot_yml.go
@@ -98,6 +98,12 @@ services:
     ports:
       - "127.0.0.1:8220:8220"
 
+  fleet-server_is_ready:
+    image: tianon/true
+    depends_on:
+      fleet-server:
+        condition: service_healthy
+
   elastic-agent:
     image: ${ELASTIC_AGENT_IMAGE_REF}
     depends_on:


### PR DESCRIPTION
This will allow users to start up fleet server individually via the `--services` CLI flag.