### PR TITLE
Add CLI flags to "promote" command

### DIFF
--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -42,7 +42,7 @@ func setupPromoteCommand() *cobraext.Command {
 		SilenceUsage: true,
 	}
 	cmd.Flags().StringP(cobraext.DirectionFlagName, "d", "", cobraext.DirectionFlagDescription)
-	cmd.Flags().BoolP(cobraext.NewestOnlyFlagName, "n", true, cobraext.NewestOnlyFlagDescription)
+	cmd.Flags().BoolP(cobraext.NewestOnlyFlagName, "n", false, cobraext.NewestOnlyFlagDescription)
 	cmd.Flags().StringSliceP(cobraext.PackagesFlagName, "p", nil, cobraext.PackagesFlagDescription)
 
 	return cobraext.NewCommand(cmd, cobraext.ContextGlobal)

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -41,14 +41,14 @@ func setupPromoteCommand() *cobraext.Command {
 		RunE:         promoteCommandAction,
 		SilenceUsage: true,
 	}
-	cmd.Flags().StringP(cobraext.DirectionFlagName, "d", "", cobraext.FailFastFlagDescription)
+	cmd.Flags().StringP(cobraext.DirectionFlagName, "d", "", cobraext.DirectionFlagDescription)
 	cmd.Flags().BoolP(cobraext.NewestOnlyFlagName, "n", true, cobraext.NewestOnlyFlagDescription)
 	cmd.Flags().StringSliceP(cobraext.PackagesFlagName, "p", nil, cobraext.PackagesFlagDescription)
 
 	return cobraext.NewCommand(cmd, cobraext.ContextGlobal)
 }
 
-func promoteCommandAction(cmd *cobra.Command, args []string) error {
+func promoteCommandAction(cmd *cobra.Command, _ []string) error {
 	cmd.Println("Promote packages")
 
 	// Setup GitHub

--- a/internal/cobraext/const.go
+++ b/internal/cobraext/const.go
@@ -18,6 +18,9 @@ const (
 	DataStreamsFlagName        = "data-streams"
 	DataStreamsFlagDescription = "comma-separated data streams to test"
 
+	DirectionFlagName        = "direction"
+	DirectionFlagDescription = "promotion direction"
+
 	DeferCleanupFlagName        = "defer-cleanup"
 	DeferCleanupFlagDescription = "defer test cleanup for debugging purposes"
 
@@ -32,6 +35,12 @@ const (
 
 	GenerateTestResultFlagName        = "generate"
 	GenerateTestResultFlagDescription = "generate test result file"
+
+	NewestOnlyFlagName        = "newest-only"
+	NewestOnlyFlagDescription = "promote newest packages and remove old ones"
+
+	PackagesFlagName        = "packages"
+	PackagesFlagDescription = "packages to be promoted"
 
 	ReportFormatFlagName        = "report-format"
 	ReportFormatFlagDescription = "format of test report"

--- a/internal/cobraext/const.go
+++ b/internal/cobraext/const.go
@@ -40,7 +40,7 @@ const (
 	NewestOnlyFlagDescription = "promote newest packages and remove old ones"
 
 	PackagesFlagName        = "packages"
-	PackagesFlagDescription = "packages to be promoted"
+	PackagesFlagDescription = "packages to be promoted (comma-separated values: apache-1.2.3,nginx-5.6.7)"
 
 	ReportFormatFlagName        = "report-format"
 	ReportFormatFlagDescription = "format of test report"

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/Masterminds/semver"
 	"github.com/go-git/go-billy/v5"
@@ -79,7 +80,7 @@ func (pv *PackageVersion) path() string {
 
 // Equal method can be used to compare two PackageVersions.
 func (pv *PackageVersion) Equal(other PackageVersion) bool {
-	return pv.semver.Equal(&other.semver)
+	return pv.semver.Equal(&other.semver) && pv.Name == other.Name
 }
 
 // String method returns a string representation of the PackageVersion.
@@ -130,6 +131,24 @@ func (prs PackageVersions) Strings() []string {
 		entries = append(entries, pr.String())
 	}
 	return entries
+}
+
+// ParsePackageVersions function parses string representation of revisions into structure.
+func ParsePackageVersions(packageVersions []string) (PackageVersions, error) {
+	var parsed PackageVersions
+	for _, pv := range packageVersions {
+		s := strings.Split(pv, "-")
+		if len(s) != 2 {
+			return nil, fmt.Errorf("invalid package revision format (expected: <package_name>-<version>): %s", pv)
+		}
+
+		revision, err := NewPackageVersion(s[0], s[1])
+		if err != nil {
+			return nil, errors.Wrapf(err, "can't create package version (%s)", s)
+		}
+		parsed = append(parsed, *revision)
+	}
+	return parsed, nil
 }
 
 // CloneRepository function clones the repository and changes branch to stage.


### PR DESCRIPTION
Fixes: https://github.com/elastic/elastic-package/issues/305

This PR introduces alternative flags to "promote" commands, so it's not required to use TUI.

Sample usage:

```
elastic-package promote  --direction snapshot-production --newest-only --packages redis-0.3.7,windows-0.8.0
```