### PR TITLE
Render units and metric type in exported fields table

### DIFF
--- a/internal/docs/exported_fields.go
+++ b/internal/docs/exported_fields.go
@@ -19,6 +19,8 @@ type fieldsTableRecord struct {
 	name        string
 	description string
 	aType       string
+	unit        string
+	metricType  string
 }
 
 func renderExportedFields(packageRoot, dataStreamName string) (string, error) {
@@ -40,13 +42,51 @@ func renderExportedFields(packageRoot, dataStreamName string) (string, error) {
 		builder.WriteString("(no fields available)\n")
 		return builder.String(), nil
 	}
-	builder.WriteString("| Field | Description | Type |\n")
-	builder.WriteString("|---|---|---|\n")
+	renderFieldsTable(&builder, collected)
+	return builder.String(), nil
+}
+
+func renderFieldsTable(builder *strings.Builder, collected []fieldsTableRecord) {
+	unitsPresent := areUnitsPresent(collected)
+	metricTypesPresent := areMetricTypesPresent(collected)
+
+	builder.WriteString("| Field | Description | Type |")
+	if unitsPresent {
+		builder.WriteString(" Unit |")
+	}
+	if metricTypesPresent {
+		builder.WriteString(" Metric Type |")
+	}
+
+	builder.WriteString("\n")
+	builder.WriteString("|---|---|---|")
+	if unitsPresent {
+		builder.WriteString("---|")
+	}
+	if metricTypesPresent {
+		builder.WriteString("---|")
+	}
+
+	builder.WriteString("\n")
 	for _, c := range collected {
 		description := strings.TrimSpace(strings.ReplaceAll(c.description, "\n", " "))
-		builder.WriteString(fmt.Sprintf("| %s | %s | %s |\n", c.name, description, c.aType))
+		builder.WriteString(fmt.Sprintf("| %s | %s | %s |", c.name, description, c.aType))
+		if unitsPresent {
+			builder.WriteString(fmt.Sprintf(" %s |", c.unit))
+		}
+		if metricTypesPresent {
+			builder.WriteString(fmt.Sprintf(" %s |", c.metricType))
+		}
+		builder.WriteString("\n")
 	}
-	return builder.String(), nil
+}
+
+func areUnitsPresent(collected []fieldsTableRecord) bool {
+	return false // TODO
+}
+
+func areMetricTypesPresent(collected []fieldsTableRecord) bool {
+	return false // TODO
 }
 
 func collectFieldsFromDefinitions(fieldDefinitions []fields.FieldDefinition) ([]fieldsTableRecord, error) {
@@ -75,6 +115,8 @@ func visitFields(namePrefix string, f fields.FieldDefinition, records []fieldsTa
 			name:        name,
 			description: f.Description,
 			aType:       f.Type,
+			unit:        f.Unit,
+			metricType:  f.MetricType,
 		})
 		return records, nil
 	}

--- a/internal/docs/exported_fields.go
+++ b/internal/docs/exported_fields.go
@@ -82,11 +82,21 @@ func renderFieldsTable(builder *strings.Builder, collected []fieldsTableRecord) 
 }
 
 func areUnitsPresent(collected []fieldsTableRecord) bool {
-	return false // TODO
+	for _, c := range collected {
+		if c.unit != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func areMetricTypesPresent(collected []fieldsTableRecord) bool {
-	return false // TODO
+	for _, c := range collected {
+		if c.metricType != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func collectFieldsFromDefinitions(fieldDefinitions []fields.FieldDefinition) ([]fieldsTableRecord, error) {

--- a/internal/fields/model.go
+++ b/internal/fields/model.go
@@ -10,5 +10,7 @@ type FieldDefinition struct {
 	Description string            `yaml:"description"`
 	Type        string            `yaml:"type"`
 	Pattern     string            `yaml:"pattern"`
+	Unit        string            `yaml:"unit"`
+	MetricType  string            `yaml:"metric_type"`
 	Fields      []FieldDefinition `yaml:"fields"`
 }

--- a/test/packages/apache/data_stream/access/fields/ecs.yml
+++ b/test/packages/apache/data_stream/access/fields/ecs.yml
@@ -29,6 +29,8 @@
       type: long
       format: bytes
       description: Size in bytes of the response body.
+      unit: byte
+      metric_type: gauge
     - name: response.status_code
       level: extended
       type: long

--- a/test/packages/apache/docs/README.md
+++ b/test/packages/apache/docs/README.md
@@ -16,43 +16,43 @@ Access logs collects the Apache access logs.
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| apache.access.ssl.cipher | SSL cipher name. | keyword |
-| apache.access.ssl.protocol | SSL protocol version. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version |  | keyword |
-| http.request.method | HTTP request method. Prior to ECS 1.6.0 the following guidance was provided: "The field value must be normalized to lowercase for querying." As of ECS 1.6.0, the guidance is deprecated because the original case of the method may be useful in anomaly detection.  Original case will be mandated in ECS 2.0.0 | keyword |
-| http.request.referrer | Referrer for this HTTP request. | keyword |
-| http.response.body.bytes | Size in bytes of the response body. | long |
-| http.response.status_code | HTTP response status code. | long |
-| http.version | HTTP version. | keyword |
-| input.type |  | keyword |
-| log.file.path |  | keyword |
-| log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
-| log.offset |  | long |
-| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
-| process.pid | Process id. | long |
-| process.thread.id | Thread ID. | long |
-| source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
-| source.geo.city_name | City name. | keyword |
-| source.geo.continent_name | Name of the continent. | keyword |
-| source.geo.country_iso_code | Country ISO code. | keyword |
-| source.geo.location | Longitude and latitude. | geo_point |
-| source.geo.region_iso_code | Region ISO code. | keyword |
-| source.geo.region_name | Region name. | keyword |
-| source.ip |  | ip |
-| url.original | Unmodified original url as seen in the event source. Note that in network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path. This field is meant to represent the URL as it was observed, complete or not. | keyword |
-| user.name | Short name or login of the user. | keyword |
-| user_agent.device.name | Name of the device. | keyword |
-| user_agent.name | Name of the user agent. | keyword |
-| user_agent.original | Unparsed user_agent string. | keyword |
-| user_agent.os.name | Operating system name, without the version. | keyword |
-| user_agent.os.version | Operating system version as a raw string. | keyword |
-| user_agent.version | Version of the user agent. | keyword |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| apache.access.ssl.cipher | SSL cipher name. | keyword |  |  |
+| apache.access.ssl.protocol | SSL protocol version. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version |  | keyword |  |  |
+| http.request.method | HTTP request method. Prior to ECS 1.6.0 the following guidance was provided: "The field value must be normalized to lowercase for querying." As of ECS 1.6.0, the guidance is deprecated because the original case of the method may be useful in anomaly detection.  Original case will be mandated in ECS 2.0.0 | keyword |  |  |
+| http.request.referrer | Referrer for this HTTP request. | keyword |  |  |
+| http.response.body.bytes | Size in bytes of the response body. | long | byte | gauge |
+| http.response.status_code | HTTP response status code. | long |  |  |
+| http.version | HTTP version. | keyword |  |  |
+| input.type |  | keyword |  |  |
+| log.file.path |  | keyword |  |  |
+| log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |  |  |
+| log.offset |  | long |  |  |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |  |  |
+| process.pid | Process id. | long |  |  |
+| process.thread.id | Thread ID. | long |  |  |
+| source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |  |  |
+| source.geo.city_name | City name. | keyword |  |  |
+| source.geo.continent_name | Name of the continent. | keyword |  |  |
+| source.geo.country_iso_code | Country ISO code. | keyword |  |  |
+| source.geo.location | Longitude and latitude. | geo_point |  |  |
+| source.geo.region_iso_code | Region ISO code. | keyword |  |  |
+| source.geo.region_name | Region name. | keyword |  |  |
+| source.ip |  | ip |  |  |
+| url.original | Unmodified original url as seen in the event source. Note that in network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path. This field is meant to represent the URL as it was observed, complete or not. | keyword |  |  |
+| user.name | Short name or login of the user. | keyword |  |  |
+| user_agent.device.name | Name of the device. | keyword |  |  |
+| user_agent.name | Name of the user agent. | keyword |  |  |
+| user_agent.original | Unparsed user_agent string. | keyword |  |  |
+| user_agent.os.name | Operating system name, without the version. | keyword |  |  |
+| user_agent.os.version | Operating system version as a raw string. | keyword |  |  |
+| user_agent.version | Version of the user agent. | keyword |  |  |
 
 
 ### Error Logs


### PR DESCRIPTION
Fixes: https://github.com/elastic/elastic-package/issues/181

This PR modifies the builder code to render exported fields table with units and metric types (if present).