### PR TITLE
Avoid trying to adjust dropped events on test results

### DIFF
--- a/internal/testrunner/runners/pipeline/test_result.go
+++ b/internal/testrunner/runners/pipeline/test_result.go
@@ -103,10 +103,15 @@ func adjustTestResult(result *testResult, config *testConfig) (*testResult, erro
 	// Strip dynamic fields from test result
 	var stripped testResult
 	for _, event := range result.events {
+		if event == nil {
+			stripped.events = append(stripped.events, nil)
+			continue
+		}
+
 		var m common.MapStr
 		err := json.Unmarshal(event, &m)
 		if err != nil {
-			return nil, errors.Wrap(err, "can't unmarshal event")
+			return nil, errors.Wrapf(err, "can't unmarshal event: %s", string(event))
 		}
 
 		for key := range config.DynamicFields {


### PR DESCRIPTION
Pipelines can drop events, and they appear as null values in the test result, avoid trying to convert these null events into `common.MapStr`, producing errors like:
```
ERROR: verifying test result failed: comparing test results failed: can't adjust test results: can't unmarshal event: unexpected end of JSON input
```