### PR TITLE
Fix defer-cleanup flag functionality for system testrunner

### DIFF
--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -162,9 +162,6 @@ func (r *runner) run() (results []testrunner.TestResult, err error) {
 		if err != nil {
 			return results, err
 		}
-		if err = r.TearDown(); err != nil {
-			return results, errors.Wrap(err, "failed to teardown runner")
-		}
 	}
 	return results, nil
 }


### PR DESCRIPTION
Currently the system testrunner is calling TearDown itself bypassing the defer-cleanup functionality. This MR resolves this by leaving calling TearDown to the testrunner main function.