### PR TITLE
Revert "Leave system testrunner teardown to main function (#394)"

### DIFF
--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -163,6 +163,9 @@ func (r *runner) run() (results []testrunner.TestResult, err error) {
 		if err != nil {
 			return results, err
 		}
+		if err = r.TearDown(); err != nil {
+			return results, errors.Wrap(err, "failed to teardown runner")
+		}
 	}
 	return results, nil
 }


### PR DESCRIPTION
This reverts commit 7ca3684a19090de1407b4f90c8fbc7bd8d61ba58.

@renekalff Unfortunately I have to revert your fix as it causes problems with system tests for traefik and zeek integrations (mentioned here: https://github.com/elastic/integrations/pull/1284).

If you have some spare time, you can root cause the interference of test results. 