### PR TITLE
Add missing new line in test report

### DIFF
--- a/internal/testrunner/reporters/formats/human.go
+++ b/internal/testrunner/reporters/formats/human.go
@@ -40,7 +40,7 @@ func reportHumanFormat(results []testrunner.TestResult) (string, error) {
 			headerPrinted = true
 		}
 
-		detail := fmt.Sprintf("%s/%s %s:\n%s", r.Package, r.DataStream, r.Name, r.FailureDetails)
+		detail := fmt.Sprintf("%s/%s %s:\n%s\n", r.Package, r.DataStream, r.Name, r.FailureDetails)
 		report.WriteString(detail)
 	}
 	if headerPrinted {


### PR DESCRIPTION
A new line is missing after errors report, incorrectly logging reports with failures in multiple data streams.

Probably introduced by #381.