### PR TITLE
Fix: defer cleanup and signal handling

### DIFF
--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -17,6 +17,7 @@ import (
 	"github.com/elastic/elastic-package/internal/common"
 	"github.com/elastic/elastic-package/internal/elasticsearch"
 	"github.com/elastic/elastic-package/internal/packages"
+	"github.com/elastic/elastic-package/internal/signal"
 	"github.com/elastic/elastic-package/internal/testrunner"
 	"github.com/elastic/elastic-package/internal/testrunner/reporters/formats"
 	"github.com/elastic/elastic-package/internal/testrunner/reporters/outputs"
@@ -121,6 +122,8 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 		if err != nil {
 			return errors.Wrap(err, "locating package root failed")
 		}
+
+		signal.Enable()
 
 		var testFolders []testrunner.TestFolder
 		if runner.CanRunPerDataStream() {

--- a/internal/kibana/agents.go
+++ b/internal/kibana/agents.go
@@ -9,9 +9,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/elastic/elastic-package/internal/logger"
-
 	"github.com/pkg/errors"
+
+	"github.com/elastic/elastic-package/internal/logger"
+	"github.com/elastic/elastic-package/internal/signal"
 )
 
 // Agent represents an Elastic Agent enrolled with fleet.
@@ -71,6 +72,10 @@ func (c *Client) AssignPolicyToAgent(a Agent, p Policy) error {
 
 func (c *Client) waitUntilPolicyAssigned(a Agent, p Policy) error {
 	for {
+		if signal.SIGINT() {
+			return errors.New("SIGINT: cancel waiting for policy assigned")
+		}
+
 		agent, err := c.getAgent(a.ID)
 		if err != nil {
 			return errors.Wrap(err, "can't get the agent")

--- a/internal/signal/sigint.go
+++ b/internal/signal/sigint.go
@@ -4,12 +4,15 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/elastic/elastic-package/internal/logger"
 )
 
 var ch chan os.Signal
 
-func init() {
-	ch = make(chan os.Signal)
+// Enable function enables signal notifications.
+func Enable() {
+	ch = make(chan os.Signal, 1)
 	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 }
 
@@ -17,6 +20,7 @@ func init() {
 func SIGINT() bool {
 	select {
 	case <-ch:
+		logger.Info("Signal caught!")
 		return true
 	default:
 		return false

--- a/internal/signal/sigint.go
+++ b/internal/signal/sigint.go
@@ -1,0 +1,24 @@
+package signal
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+var ch chan os.Signal
+
+func init() {
+	ch = make(chan os.Signal)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+}
+
+// SIGINT function returns true if ctrl+c was pressed
+func SIGINT() bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/signal/sigint.go
+++ b/internal/signal/sigint.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package signal
 
 import (

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -85,6 +85,11 @@ func (r *runner) Run(options testrunner.TestOptions) ([]testrunner.TestResult, e
 }
 
 func (r *runner) TearDown() error {
+	if r.options.DeferCleanup > 0 {
+		logger.Debugf("waiting for %s before tearing down...", r.options.DeferCleanup)
+		time.Sleep(r.options.DeferCleanup)
+	}
+
 	if r.resetAgentPolicyHandler != nil {
 		if err := r.resetAgentPolicyHandler(); err != nil {
 			return err

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -340,6 +340,10 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 	}
 
 	cleared, err := waitUntilTrue(func() (bool, error) {
+		if signal.SIGINT() {
+			return true, errors.New("SIGINT: cancel clearing data")
+		}
+
 		docs, err := r.getDocs(dataStream)
 		return len(docs) == 0, err
 	}, 2*time.Minute)
@@ -381,7 +385,7 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 	var docs []common.MapStr
 	passed, err := waitUntilTrue(func() (bool, error) {
 		if signal.SIGINT() {
-			return false, errors.New("SIGINT: cancel waiting for policy assigned")
+			return true, errors.New("SIGINT: cancel waiting for policy assigned")
 		}
 
 		var err error

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/multierror"
 	"github.com/elastic/elastic-package/internal/packages"
+	"github.com/elastic/elastic-package/internal/signal"
 	"github.com/elastic/elastic-package/internal/testrunner"
 	"github.com/elastic/elastic-package/internal/testrunner/runners/system/servicedeployer"
 )
@@ -84,7 +85,12 @@ func (r *runner) Run(options testrunner.TestOptions) ([]testrunner.TestResult, e
 	return r.run()
 }
 
+// TearDown method doesn't perform any global action as the "tear down" is executed per test case.
 func (r *runner) TearDown() error {
+	return nil
+}
+
+func (r *runner) tearDownTest() error {
 	if r.options.DeferCleanup > 0 {
 		logger.Debugf("waiting for %s before tearing down...", r.options.DeferCleanup)
 		time.Sleep(r.options.DeferCleanup)
@@ -165,11 +171,12 @@ func (r *runner) run() (results []testrunner.TestResult, err error) {
 		}
 
 		results = append(results, partial...)
+		tdErr := r.tearDownTest()
 		if err != nil {
 			return results, err
 		}
-		if err = r.TearDown(); err != nil {
-			return results, errors.Wrap(err, "failed to teardown runner")
+		if tdErr != nil {
+			return results, errors.Wrap(tdErr, "failed to tear down runner")
 		}
 	}
 	return results, nil
@@ -373,6 +380,10 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 	logger.Debug("checking for expected data in data stream...")
 	var docs []common.MapStr
 	passed, err := waitUntilTrue(func() (bool, error) {
+		if signal.SIGINT() {
+			return false, errors.New("SIGINT: cancel waiting for policy assigned")
+		}
+
 		var err error
 		docs, err = r.getDocs(dataStream)
 		return len(docs) > 0, err
@@ -412,6 +423,10 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 func checkEnrolledAgents(client *kibana.Client, ctxt servicedeployer.ServiceContext) ([]kibana.Agent, error) {
 	var agents []kibana.Agent
 	enrolled, err := waitUntilTrue(func() (bool, error) {
+		if signal.SIGINT() {
+			return false, errors.New("SIGINT: cancel checking enrolled agents")
+		}
+
 		allAgents, err := client.ListAgents()
 		if err != nil {
 			return false, errors.Wrap(err, "could not list agents")

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -252,6 +252,8 @@ func Run(testType TestType, options TestOptions) ([]TestResult, error) {
 	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-ch
+		signal.Stop(ch)
+
 		logger.Info("Signal caught!")
 
 		err := runner.TearDown()

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -61,16 +61,16 @@ type testRunnerWrapper struct {
 }
 
 func (w testRunnerWrapper) Type() TestType {
-	return w.Type()
+	return w.r.Type()
 }
 
 func (w testRunnerWrapper) String() string {
-	return w.String()
+	return w.r.String()
 }
 
 func (w *testRunnerWrapper) Run(options TestOptions) ([]TestResult, error) {
 	w.options = options
-	return w.Run(options)
+	return w.r.Run(options)
 }
 
 func (w testRunnerWrapper) TearDown() error {
@@ -82,11 +82,11 @@ func (w testRunnerWrapper) TearDown() error {
 }
 
 func (w testRunnerWrapper) CanRunPerDataStream() bool {
-	return w.CanRunPerDataStream()
+	return w.r.CanRunPerDataStream()
 }
 
 func (w testRunnerWrapper) TestFolderRequired() bool {
-	return w.TestFolderRequired()
+	return w.r.TestFolderRequired()
 }
 
 var _ TestRunner = new(testRunnerWrapper)

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -55,42 +55,6 @@ type TestRunner interface {
 	TestFolderRequired() bool
 }
 
-type testRunnerWrapper struct {
-	r       TestRunner
-	options TestOptions
-}
-
-func (w testRunnerWrapper) Type() TestType {
-	return w.r.Type()
-}
-
-func (w testRunnerWrapper) String() string {
-	return w.r.String()
-}
-
-func (w *testRunnerWrapper) Run(options TestOptions) ([]TestResult, error) {
-	w.options = options
-	return w.r.Run(options)
-}
-
-func (w testRunnerWrapper) TearDown() error {
-	if w.options.DeferCleanup > 0 {
-		logger.Debugf("waiting for %s before tearing down...", w.options.DeferCleanup)
-		time.Sleep(w.options.DeferCleanup)
-	}
-	return w.r.TearDown()
-}
-
-func (w testRunnerWrapper) CanRunPerDataStream() bool {
-	return w.r.CanRunPerDataStream()
-}
-
-func (w testRunnerWrapper) TestFolderRequired() bool {
-	return w.r.TestFolderRequired()
-}
-
-var _ TestRunner = new(testRunnerWrapper)
-
 var runners = map[TestType]TestRunner{}
 
 // TestResult contains a single test's results
@@ -273,7 +237,7 @@ func FindTestFolders(packageRootPath string, dataStreams []string, testType Test
 
 // RegisterRunner method registers the test runner.
 func RegisterRunner(runner TestRunner) {
-	runners[runner.Type()] = &testRunnerWrapper{r: runner}
+	runners[runner.Type()] = runner
 }
 
 // Run method delegates execution to the registered test runner, based on the test type.


### PR DESCRIPTION
This PR refactors the logic around the "defer cleanup" flag and "SIGINT handling".

Fixes:
* Bug: SIGINT caught multiple times, once per test config file. If the user pressed Ctrl+C for the last, third test case, signal got caught 3 times
* Bug: Defer Cleanup doesn't trigger second (extra) tear down
* SIGINT breaks only long lasting operations (waiting for data, for agent)
* Bug: there is an extra "tear down" call for system test runner, even though it's called per every single test case (in PR: it's called only per test case)
* Bug: defer cleanup happens after data is already removed :) 

Related:
- https://github.com/elastic/elastic-package/pull/394
- https://github.com/elastic/elastic-package/pull/399