### PR TITLE
Select service variants with "service up"

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -26,7 +26,7 @@ func setupServiceCommand() *cobraext.Command {
 		RunE:  upCommandAction,
 	}
 	upCommand.Flags().StringP(cobraext.DataStreamFlagName, "d", "", cobraext.DataStreamFlagDescription)
-	upCommand.Flags().StringP(cobraext.VariantFlagName, "s", "", cobraext.VariantFlagDescription)
+	upCommand.Flags().String(cobraext.VariantFlagName, "", cobraext.VariantFlagDescription)
 
 	cmd := &cobra.Command{
 		Use:   "service",

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -26,7 +26,7 @@ func setupServiceCommand() *cobraext.Command {
 		RunE:  upCommandAction,
 	}
 	upCommand.Flags().StringP(cobraext.DataStreamFlagName, "d", "", cobraext.DataStreamFlagDescription)
-	upCommand.Flags().StringP(cobraext.VariantFlagDescription, "s", "", cobraext.VariantFlagDescription)
+	upCommand.Flags().StringP(cobraext.VariantFlagName, "s", "", cobraext.VariantFlagDescription)
 
 	cmd := &cobra.Command{
 		Use:   "service",

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -26,6 +26,7 @@ func setupServiceCommand() *cobraext.Command {
 		RunE:  upCommandAction,
 	}
 	upCommand.Flags().StringP(cobraext.DataStreamFlagName, "d", "", cobraext.DataStreamFlagDescription)
+	upCommand.Flags().StringP(cobraext.VariantFlagDescription, "s", "", cobraext.VariantFlagDescription)
 
 	cmd := &cobra.Command{
 		Use:   "service",
@@ -54,11 +55,14 @@ func upCommandAction(cmd *cobra.Command, args []string) error {
 		dataStreamPath = filepath.Join(packageRoot, "data_stream", dataStreamFlag)
 	}
 
+	variantFlag, _ := cmd.Flags().GetString(cobraext.VariantFlagName)
+
 	_, serviceName := filepath.Split(packageRoot)
 	err = service.BootUp(service.Options{
 		ServiceName:        serviceName,
 		PackageRootPath:    packageRoot,
 		DataStreamRootPath: dataStreamPath,
+		Variant:            variantFlag,
 	})
 	if err != nil {
 		return errors.Wrap(err, "up command failed")

--- a/internal/cobraext/const.go
+++ b/internal/cobraext/const.go
@@ -72,6 +72,9 @@ const (
 	StackDumpOutputFlagName        = "output"
 	StackDumpOutputFlagDescription = "output location for the stack dump"
 
+	VariantFlagName        = "variant"
+	VariantFlagDescription = "service variant"
+
 	VerboseFlagName        = "verbose"
 	VerboseFlagDescription = "verbose mode"
 )

--- a/internal/service/boot.go
+++ b/internal/service/boot.go
@@ -34,6 +34,7 @@ func BootUp(options Options) error {
 	serviceDeployer, err := servicedeployer.Factory(servicedeployer.FactoryOptions{
 		PackageRootPath:    options.DataStreamRootPath,
 		DataStreamRootPath: options.DataStreamRootPath,
+		Variant:            options.Variant,
 	})
 	if err != nil {
 		return errors.Wrap(err, "can't create the service deployer instance")

--- a/internal/service/boot.go
+++ b/internal/service/boot.go
@@ -24,6 +24,8 @@ type Options struct {
 	ServiceName        string
 	PackageRootPath    string
 	DataStreamRootPath string
+
+	Variant string
 }
 
 // BootUp function boots up the service stack.

--- a/internal/testrunner/runners/system/servicedeployer/compose.go
+++ b/internal/testrunner/runners/system/servicedeployer/compose.go
@@ -68,7 +68,7 @@ func (d *DockerComposeServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedSer
 
 	// Boot up service
 	if d.sv.active() {
-		logger.Info("Using service variant: %s", d.sv.String())
+		logger.Infof("Using service variant: %s", d.sv.String())
 	}
 
 	serviceName := inCtxt.Name

--- a/internal/testrunner/runners/system/servicedeployer/compose.go
+++ b/internal/testrunner/runners/system/servicedeployer/compose.go
@@ -20,6 +20,7 @@ import (
 // a Docker Compose file.
 type DockerComposeServiceDeployer struct {
 	ymlPaths []string
+	sv       serviceVariant
 }
 
 type dockerComposeDeployedService struct {
@@ -27,21 +28,24 @@ type dockerComposeDeployedService struct {
 
 	ymlPaths []string
 	project  string
+	sv       serviceVariant
 }
 
 // NewDockerComposeServiceDeployer returns a new instance of a DockerComposeServiceDeployer.
-func NewDockerComposeServiceDeployer(ymlPaths []string) (*DockerComposeServiceDeployer, error) {
+func NewDockerComposeServiceDeployer(ymlPaths []string, sv serviceVariant) (*DockerComposeServiceDeployer, error) {
 	return &DockerComposeServiceDeployer{
 		ymlPaths: ymlPaths,
+		sv:       sv,
 	}, nil
 }
 
 // SetUp sets up the service and returns any relevant information.
-func (r *DockerComposeServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedService, error) {
+func (d *DockerComposeServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedService, error) {
 	logger.Debug("setting up service using Docker Compose service deployer")
 	service := dockerComposeDeployedService{
-		ymlPaths: r.ymlPaths,
+		ymlPaths: d.ymlPaths,
 		project:  "elastic-package-service",
+		sv:       d.sv,
 	}
 	outCtxt := inCtxt
 
@@ -63,9 +67,15 @@ func (r *DockerComposeServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedSer
 	}
 
 	// Boot up service
+	if d.sv.active() {
+		logger.Info("Using service variant: %s", d.sv.String())
+	}
+
 	serviceName := inCtxt.Name
 	opts := compose.CommandOptions{
-		Env:       []string{fmt.Sprintf("%s=%s", serviceLogsDirEnv, outCtxt.Logs.Folder.Local)},
+		Env: append(
+			[]string{fmt.Sprintf("%s=%s", serviceLogsDirEnv, outCtxt.Logs.Folder.Local)},
+			d.sv.env...),
 		ExtraArgs: []string{"--build", "-d"},
 	}
 	if err := p.Up(opts); err != nil {
@@ -137,9 +147,9 @@ func (s *dockerComposeDeployedService) TearDown() error {
 	}
 
 	downOptions := compose.CommandOptions{
-		Env: []string{
-			fmt.Sprintf("%s=%s", serviceLogsDirEnv, s.ctxt.Logs.Folder.Local),
-		},
+		Env: append(
+			[]string{fmt.Sprintf("%s=%s", serviceLogsDirEnv, s.ctxt.Logs.Folder.Local)},
+			s.sv.env...),
 
 		// Remove associated volumes.
 		ExtraArgs: []string{"--volumes"},

--- a/internal/testrunner/runners/system/servicedeployer/factory.go
+++ b/internal/testrunner/runners/system/servicedeployer/factory.go
@@ -19,6 +19,8 @@ const devDeployDir = "_dev/deploy"
 type FactoryOptions struct {
 	PackageRootPath    string
 	DataStreamRootPath string
+
+	Variant string
 }
 
 // Factory chooses the appropriate service runner for the given data stream, depending
@@ -44,7 +46,11 @@ func Factory(options FactoryOptions) (ServiceDeployer, error) {
 	case "docker":
 		dockerComposeYMLPath := filepath.Join(serviceDeployerPath, "docker-compose.yml")
 		if _, err := os.Stat(dockerComposeYMLPath); err == nil {
-			return NewDockerComposeServiceDeployer([]string{dockerComposeYMLPath})
+			sv, err := useServiceVariant(devDeployPath, options.Variant)
+			if err != nil {
+				return nil, errors.Wrap(err, "can't use service variant")
+			}
+			return NewDockerComposeServiceDeployer([]string{dockerComposeYMLPath}, sv)
 		}
 	case "tf":
 		if _, err := os.Stat(serviceDeployerPath); err == nil {

--- a/internal/testrunner/runners/system/servicedeployer/variants.go
+++ b/internal/testrunner/runners/system/servicedeployer/variants.go
@@ -1,0 +1,80 @@
+package servicedeployer
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+)
+
+type variantsFile struct {
+	Default  string `yaml:"default"`
+	Variants map[string]environment
+}
+
+type environment map[string]string
+
+type serviceVariant struct {
+	name string
+	env  []string // Environment variables in format of pairs: key=value
+}
+
+func (sv *serviceVariant) active() bool {
+	return sv.name != ""
+}
+
+func (sv *serviceVariant) String() string {
+	return fmt.Sprintf("ServiceVariant{name: %s, env: %s}", sv.name, strings.Join(sv.env, ","))
+}
+
+func useServiceVariant(devDeployPath, selected string) (serviceVariant, error) {
+	variantsYmlPath := filepath.Join(devDeployPath, "variants.yml")
+	_, err := os.Stat(variantsYmlPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return serviceVariant{}, nil // no "variants.yml" present
+	}
+	if err != nil {
+		return serviceVariant{}, errors.Wrap(err, "can't stat variants file")
+	}
+
+	content, err := ioutil.ReadFile(variantsYmlPath)
+	if err != nil {
+		return serviceVariant{}, errors.Wrap(err, "can't read variants file")
+	}
+
+	var f variantsFile
+	err = yaml.Unmarshal(content, &f)
+	if err != nil {
+		return serviceVariant{}, errors.Wrap(err, "can't unmarshal variants file")
+	}
+
+	if selected == "" {
+		selected = f.Default
+	}
+
+	if f.Default == "" {
+		return serviceVariant{}, errors.New("default variant is undefined")
+	}
+
+	env, ok := f.Variants[selected]
+	if !ok {
+		return serviceVariant{}, fmt.Errorf(`variant "%s" is missing`, selected)
+	}
+
+	return serviceVariant{
+		name: selected,
+		env:  asEnvVarPairs(env),
+	}, nil
+}
+
+func asEnvVarPairs(env environment) []string {
+	var pairs []string
+	for k, v := range env {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", k, v))
+	}
+	return pairs
+}

--- a/internal/testrunner/runners/system/servicedeployer/variants.go
+++ b/internal/testrunner/runners/system/servicedeployer/variants.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package servicedeployer
 
 import (

--- a/test/packages/apache/_dev/deploy/docker/docker-compose.yml
+++ b/test/packages/apache/_dev/deploy/docker/docker-compose.yml
@@ -1,10 +1,13 @@
 version: '2.3'
 services:
   apache:
-    # Commented out `image:` below until we have a process to refresh the hosted images from
-    # Dockerfiles in this repo. Until then, we build the image locally using `build:` below.
-    # image: docker.elastic.co/integrations-ci/beats-apache:${SERVICE_VERSION:-2.4.20}-1
-    build: .
+      # Commented out `image:` below until we have a process to refresh the hosted images from
+      # Dockerfiles in this repo. Until then, we build the image locally using `build:` below.
+      # image: docker.elastic.co/integrations-ci/beats-apache:${SERVICE_VERSION:-2.4.20}-1
+    build:
+      context: .
+      args:
+        SERVICE_VERSION: ${SERVICE_VERSION}
     ports:
       - 80
     volumes:

--- a/test/packages/apache/_dev/deploy/docker/docker-compose.yml
+++ b/test/packages/apache/_dev/deploy/docker/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '2.3'
 services:
   apache:
-      # Commented out `image:` below until we have a process to refresh the hosted images from
-      # Dockerfiles in this repo. Until then, we build the image locally using `build:` below.
-      # image: docker.elastic.co/integrations-ci/beats-apache:${SERVICE_VERSION:-2.4.20}-1
+    # Commented out `image:` below until we have a process to refresh the hosted images from
+    # Dockerfiles in this repo. Until then, we build the image locally using `build:` below.
+    # image: docker.elastic.co/integrations-ci/beats-apache:${SERVICE_VERSION:-2.4.20}-1
     build:
       context: .
       args:

--- a/test/packages/apache/_dev/deploy/variants.yml
+++ b/test/packages/apache/_dev/deploy/variants.yml
@@ -1,4 +1,6 @@
 variants:
-  v2:
+  v2420:
     SERVICE_VERSION: 2.4.20
-default: v2
+  v2443:
+    SERVICE_VERSION: 2.4.43
+default: v2420


### PR DESCRIPTION
Issue: https://github.com/elastic/elastic-package/issues/94

This PR extends the `elastic-package service up` command to select right service variant to boot up. Service factory (for Docker Compose) expects variant information now.

How to test:

```
make build
cd test/packages/apache
elastic-package service up -v -s v2420
ctrl+c...

elastic-package service up -v -s v2443
```