### PR TITLE
Implement wait routine for Docker Compose

### DIFF
--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -279,6 +279,11 @@ func (p *Project) WaitForHealthy(opts CommandOptions) error {
 		for _, containerDescription := range descriptions {
 			logger.Debugf("Container status: %s", containerDescription.String())
 
+			// No healthcheck defined for service
+			if containerDescription.State.Status == "running" && containerDescription.State.Health == nil {
+				continue
+			}
+
 			// Service is up and running and it's healthy
 			if containerDescription.State.Status == "running" && containerDescription.State.Health.Status == "healthy" {
 				continue

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -31,7 +31,7 @@ type ContainerDescription struct {
 	State struct {
 		Status   string
 		ExitCode int
-		Health   struct {
+		Health   *struct {
 			Status string
 			Log    []struct {
 				Start    time.Time

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -21,6 +23,32 @@ type NetworkDescription struct {
 	Containers map[string]struct {
 		Name string
 	}
+}
+
+// ContainerDescription describes the Docker container.
+type ContainerDescription struct {
+	ID    string
+	State struct {
+		Status   string
+		ExitCode int
+		Health   struct {
+			Status string
+			Log    []struct {
+				Start    time.Time
+				ExitCode int
+				Output   string
+			}
+		}
+	}
+}
+
+// String function dumps string representation of the container description.
+func (c *ContainerDescription) String() string {
+	b, err := json.Marshal(c)
+	if err != nil {
+		return "error: can't marshal container description"
+	}
+	return string(b)
 }
 
 // Pull downloads the latest available revision of the image.
@@ -89,4 +117,27 @@ func ConnectToNetwork(containerID, network string) error {
 		return errors.Wrapf(err, "could not attach container to the stack network (stderr=%q)", errOutput.String())
 	}
 	return nil
+}
+
+// InspectContainers function inspects selected Docker containers.
+func InspectContainers(containerIDs ...string) ([]ContainerDescription, error) {
+	args := []string{"inspect"}
+	args = append(args, containerIDs...)
+	cmd := exec.Command("docker", args...)
+
+	errOutput := new(bytes.Buffer)
+	cmd.Stderr = errOutput
+
+	logger.Debugf("output command: %s", cmd)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not inspect containers (stderr=%q)", errOutput.String())
+	}
+
+	var containerDescriptions []ContainerDescription
+	err = json.Unmarshal(output, &containerDescriptions)
+	if err != nil {
+		return nil, errors.Wrapf(err, "can't unmarshal container inspect for %s (stderr=%q)", strings.Join(containerIDs, ","), errOutput.String())
+	}
+	return containerDescriptions, nil
 }

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -49,23 +49,3 @@ func modifyKubernetesResources(action string, definitionPaths ...string) ([]byte
 	}
 	return output, nil
 }
-
-func getKubernetesResource(kind, name, namespace string) ([]byte, error) {
-	args := []string{"get", kind, name}
-	if namespace != "" {
-		args = append(args, "-n", namespace)
-	}
-	args = append(args, "-o", "yaml")
-
-	cmd := exec.Command("kubectl", args...)
-	errOutput := new(bytes.Buffer)
-	cmd.Stderr = errOutput
-
-	logger.Debugf("run command: %s", cmd)
-	output, err := cmd.Output()
-	if err != nil {
-		return nil, errors.Wrapf(err, "kubectl get failed (stderr=%q)", errOutput.String())
-	}
-	return output, nil
-
-}

--- a/internal/testrunner/runners/system/servicedeployer/compose.go
+++ b/internal/testrunner/runners/system/servicedeployer/compose.go
@@ -51,7 +51,7 @@ func (d *DockerComposeServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedSer
 
 	p, err := compose.NewProject(service.project, service.ymlPaths...)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create docker compose project for service")
+		return nil, errors.Wrap(err, "could not create Docker Compose project for service")
 	}
 
 	// Verify the Elastic stack network
@@ -78,8 +78,14 @@ func (d *DockerComposeServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedSer
 			d.sv.Env...),
 		ExtraArgs: []string{"--build", "-d"},
 	}
-	if err := p.Up(opts); err != nil {
-		return nil, errors.Wrap(err, "could not boot up service using docker compose")
+	err = p.Up(opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not boot up service using Docker Compose")
+	}
+
+	err = p.WaitForHealthy(opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "service is unhealthy")
 	}
 
 	// Build service container name
@@ -120,7 +126,7 @@ func (d *DockerComposeServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedSer
 func (s *dockerComposeDeployedService) Signal(signal string) error {
 	p, err := compose.NewProject(s.project, s.ymlPaths...)
 	if err != nil {
-		return errors.Wrap(err, "could not create docker compose project for service")
+		return errors.Wrap(err, "could not create Docker Compose project for service")
 	}
 
 	opts := compose.CommandOptions{ExtraArgs: []string{"-s", signal}}
@@ -133,7 +139,7 @@ func (s *dockerComposeDeployedService) Signal(signal string) error {
 
 // TearDown tears down the service.
 func (s *dockerComposeDeployedService) TearDown() error {
-	logger.Debugf("tearing down service using docker compose runner")
+	logger.Debugf("tearing down service using Docker Compose runner")
 	defer func() {
 		err := files.RemoveContent(s.ctxt.Logs.Folder.Local)
 		if err != nil {
@@ -143,7 +149,7 @@ func (s *dockerComposeDeployedService) TearDown() error {
 
 	p, err := compose.NewProject(s.project, s.ymlPaths...)
 	if err != nil {
-		return errors.Wrap(err, "could not create docker compose project for service")
+		return errors.Wrap(err, "could not create Docker Compose project for service")
 	}
 
 	downOptions := compose.CommandOptions{
@@ -155,7 +161,7 @@ func (s *dockerComposeDeployedService) TearDown() error {
 		ExtraArgs: []string{"--volumes"},
 	}
 	if err := p.Down(downOptions); err != nil {
-		return errors.Wrap(err, "could not shut down service using docker compose")
+		return errors.Wrap(err, "could not shut down service using Docker Compose")
 	}
 	return nil
 }

--- a/internal/testrunner/runners/system/servicedeployer/terraform.go
+++ b/internal/testrunner/runners/system/servicedeployer/terraform.go
@@ -34,7 +34,7 @@ func (tsd TerraformServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedServic
 
 	ymlPaths, err := tsd.loadComposeDefinitions()
 	if err != nil {
-		return nil, errors.Wrap(err, "can't load docker compose definitions")
+		return nil, errors.Wrap(err, "can't load Docker Compose definitions")
 	}
 
 	service := dockerComposeDeployedService{
@@ -45,7 +45,7 @@ func (tsd TerraformServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedServic
 
 	p, err := compose.NewProject(service.project, service.ymlPaths...)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create docker compose project for service")
+		return nil, errors.Wrap(err, "could not create Docker Compose project for service")
 	}
 
 	// Clean service logs
@@ -61,7 +61,7 @@ func (tsd TerraformServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedServic
 	}
 	outCtxt.CustomProperties, err = buildTerraformAliases(serviceComposeConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't build terraform aliases")
+		return nil, errors.Wrap(err, "can't build Terraform aliases")
 	}
 
 	// Boot up service
@@ -70,8 +70,15 @@ func (tsd TerraformServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedServic
 		Env:       tfEnvironment,
 		ExtraArgs: []string{"--build", "-d"},
 	}
-	if err := p.Up(opts); err != nil {
-		return nil, errors.Wrap(err, "could not boot up service using docker compose")
+
+	err = p.Up(opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not boot up service using Docker Compose")
+	}
+
+	err = p.WaitForHealthy(opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "Terraform deployer is unhealthy")
 	}
 
 	outCtxt.Agent.Host.NamePrefix = "docker-fleet-agent"
@@ -82,7 +89,7 @@ func (tsd TerraformServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedServic
 func (tsd TerraformServiceDeployer) loadComposeDefinitions() ([]string, error) {
 	locationManager, err := locations.NewLocationManager()
 	if err != nil {
-		return nil, errors.Wrap(err, "can't locate docker compose file for Terraform deployer")
+		return nil, errors.Wrap(err, "can't locate Docker Compose file for Terraform deployer")
 	}
 
 	envYmlPath := filepath.Join(tsd.definitionsDir, envYmlFile)


### PR DESCRIPTION
Fixes: https://github.com/elastic/elastic-package/issues/406

This PR introduces a wait routine to Docker Compose service deployer (and also Terraform which bases on the Compose). 

Testing:

I used `mysql` integration with removed [mysql_is_ready](https://github.com/elastic/integrations/blob/master/packages/mysql/_dev/deploy/docker/docker-compose.yml#L10-L14) service. Frankly speaking I'm not convinced if I prefer `tianon/true` solution more :)