### PR TITLE
Add note about authorizing tokens to use the Elastic organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Use this command to print the version of elastic-package that you have installed
 
 
 
-#### GitHub authorization
+### GitHub authorization
 
 The `promote` and `publish` commands require access to the GitHub API to open pull requests or check authorized account data.
 The tool uses the GitHub token to authorize user's call to API. The token can be stored in the `~/.elastic/github.token`

--- a/README.md
+++ b/README.md
@@ -235,6 +235,9 @@ Make sure you have enabled the following scopes:
 * `public_repo` — to open pull requests on GitHub repositories.
 * `read:user` and `user:email` — to read your user profile information from GitHub in order to populate pull requests appropriately.
 
+After creating or modifying your personal access token, authorize the token for
+use of the Elastic organization: https://docs.github.com/en/github/authenticating-to-github/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on
+
 ## Development
 
 Even though the project is "go-gettable", there is the `Makefile` present, which can be used to build, format or vendor

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -58,7 +58,7 @@ description of what each command does.
 
 {{ .Cmds }}
 
-#### GitHub authorization
+### GitHub authorization
 
 The `promote` and `publish` commands require access to the GitHub API to open pull requests or check authorized account data.
 The tool uses the GitHub token to authorize user's call to API. The token can be stored in the `~/.elastic/github.token`
@@ -70,6 +70,9 @@ https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-a
 Make sure you have enabled the following scopes:
 * `public_repo` — to open pull requests on GitHub repositories.
 * `read:user` and `user:email` — to read your user profile information from GitHub in order to populate pull requests appropriately.
+
+After creating or modifying your personal access token, authorize the token for
+use of the Elastic organization: https://docs.github.com/en/github/authenticating-to-github/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on
 
 ## Development
 


### PR DESCRIPTION
Add links to the instructions to authorize the Github token to be used for an organization.