### PR TITLE
Enable goreleaser to release binaries

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
     }
     stage('Release') {
       when {
-        buildingTag()
+        tag pattern: '(v)?\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
       }
       steps {
         withCredentials([string(credentialsId: "${GITHUB_TOKEN_CREDENTIALS}", variable: 'GITHUB_TOKEN')]) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
   environment {
     BASE_DIR="src/github.com/elastic/elastic-package"
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
+    GITHUB_TOKEN_CREDENTIALS = "2a9602aa-ab9f-4e52-baf3-b71ca88469c7"
     PIPELINE_LOG_LEVEL='INFO'
     AWS_ACCOUNT_SECRET = 'secret/observability-team/ci/elastic-observability-aws-account-auth'
     HOME = "${env.WORKSPACE}"
@@ -64,6 +65,16 @@ pipeline {
                 keepLongStdio: true,
                 testResults: "build/test-results/*.xml")
           }
+        }
+      }
+    }
+    stage('Release') {
+      when {
+        buildingTag()
+      }
+      steps {
+        withCredentials([string(credentialsId: "${GITHUB_TOKEN_CREDENTIALS}", variable: 'GITHUB_TOKEN')]) {
+          sh 'curl -sL https://git.io/goreleaser | bash'
         }
       }
     }


### PR DESCRIPTION
This PR enables support for GoReleaser to release elastic-package distributions.

Issue: https://github.com/elastic/elastic-package/issues/32

How to trigger a release:

```bash
git tag -a v0.1.0 -m "First release"
git push origin v0.1.0
```
(source: [Quick start](https://goreleaser.com/quick-start/))