### PR TITLE
Fix: folder is not a git repository

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -74,7 +74,9 @@ pipeline {
       }
       steps {
         withCredentials([string(credentialsId: "${GITHUB_TOKEN_CREDENTIALS}", variable: 'GITHUB_TOKEN')]) {
-          sh 'curl -sL https://git.io/goreleaser | bash'
+          dir("${BASE_DIR}") {
+            sh 'curl -sL https://git.io/goreleaser | bash'
+          }
         }
       }
     }


### PR DESCRIPTION
This PR fixes problem spotted in https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Felastic-package/detail/v0.9.0/1/pipeline/ 

Issue: https://github.com/elastic/elastic-package/issues/32