### PR TITLE
Fix goreleaser: populate ldflags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,4 @@
+builds:
+  - ldflags:
+      - -X github.com/elastic/elastic-package/internal/version.CommitHash={{.ShortCommit}}
+      - -X github.com/elastic/elastic-package/internal/version.BuildTime={{.Timestamp}}


### PR DESCRIPTION
This PR fixes missing build info while user runs `elastic-package version`.

Issue: https://github.com/elastic/elastic-package/issues/32

Tested:

```
$ goreleaser build --skip-validate --single-target
$ ./dist/elastic-package_darwin_amd64/elastic-package version
elastic-package has been installed.
elastic-package version-hash e59a09c (build time: 2021-07-16T13:11:19+02:00)
```

@jsoriano Thank you for suggestions in https://github.com/elastic/elastic-package/pull/431#discussion_r671170415 . I suggest to review and merge this PR, and then we can review the entire working solution in terms of further adjustments. This distribution method is not advertised yet, so we can disable it if we decide it doesn't meet our requirements.