### PR TITLE
Fix: skip packages without data streams in coverage calculation

### DIFF
--- a/internal/testrunner/coverageoutput.go
+++ b/internal/testrunner/coverageoutput.go
@@ -144,13 +144,16 @@ func collectTestCoverageDetails(packageRootPath, packageName string, testType Te
 }
 
 func findDataStreamsWithoutTests(packageRootPath string, testType TestType) ([]string, error) {
+	var noTests []string
+
 	dataStreamDir := filepath.Join(packageRootPath, "data_stream")
 	dataStreams, err := ioutil.ReadDir(dataStreamDir)
-	if err != nil {
+	if errors.Is(err, os.ErrNotExist) {
+		return noTests, nil // there are packages that don't have any data streams (fleet_server, security_detection_engine)
+	} else if err != nil {
 		return nil, errors.Wrap(err, "can't list data streams directory")
 	}
 
-	var noTests []string
 	for _, dataStream := range dataStreams {
 		if !dataStream.IsDir() {
 			continue


### PR DESCRIPTION
Issue: https://github.com/elastic/integrations/issues/755

This PR fixes problems spotted in https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/PR-1344/1/pipeline/405

```
[2021-07-22T12:50:01.661Z] + ../../build/elastic-package test -v --report-format xUnit --report-output file --test-coverage
[2021-07-22T12:50:01.921Z] 2021/07/22 12:50:01  WARN CommitHash is undefined, in both /var/lib/jenkins/workspace/est-manager_integrations_PR-1344/.elastic-package/version and the compiled binary, config may be out of date.
[2021-07-22T12:50:01.921Z] 2021/07/22 12:50:01 DEBUG Enable verbose logging
[2021-07-22T12:50:01.921Z] 2021/07/22 12:50:01 DEBUG Distribution built without a version tag, can't determine release chronology. Please consider using official releases at https://github.com/elastic/elastic-package/releases
[2021-07-22T12:50:01.921Z] Run test suite for the package
[2021-07-22T12:50:01.921Z] Run system tests for the package
[2021-07-22T12:50:01.921Z] Error: error writing test coverage: can't collect test coverage details: can't find data streams without tests: can't list data streams directory: open /var/lib/jenkins/workspace/est-manager_integrations_PR-1344/src/github.com/elastic/integrations/packages/security_detection_engine/data_stream: no such file or directory
script returned exit code 1
```