### PR TITLE
Adjust test coverage calculation

### DIFF
--- a/internal/testrunner/coverageoutput.go
+++ b/internal/testrunner/coverageoutput.go
@@ -183,7 +183,7 @@ func transformToCoberturaReport(details *testCoverageDetails) *coberturaCoverage
 
 		if len(testCases) == 0 {
 			methods = append(methods, &coberturaMethod{
-				Name:  "missing",
+				Name:  "Missing",
 				Lines: []*coberturaLine{{Number: 1, Hits: 0}},
 			})
 		} else {

--- a/internal/testrunner/coverageoutput.go
+++ b/internal/testrunner/coverageoutput.go
@@ -175,6 +175,10 @@ func findDataStreamsWithoutTests(packageRootPath string, testType TestType) ([]s
 func transformToCoberturaReport(details *testCoverageDetails) *coberturaCoverage {
 	var classes []*coberturaClass
 	for dataStream, testCases := range details.dataStreams {
+		if dataStream == "" {
+			continue // ignore tests running in the package context (not data stream), mostly referring to installed assets
+		}
+
 		var methods []*coberturaMethod
 
 		if len(testCases) == 0 {
@@ -187,10 +191,6 @@ func transformToCoberturaReport(details *testCoverageDetails) *coberturaCoverage
 				Name:  "OK",
 				Lines: []*coberturaLine{{Number: 1, Hits: 1}},
 			})
-		}
-
-		if dataStream == "" {
-			dataStream = "-" // workaround for Cobertura to properly analyze tests running in the package context (not data stream)
 		}
 
 		aClass := &coberturaClass{

--- a/internal/testrunner/coverageoutput.go
+++ b/internal/testrunner/coverageoutput.go
@@ -179,16 +179,14 @@ func transformToCoberturaReport(details *testCoverageDetails) *coberturaCoverage
 
 		if len(testCases) == 0 {
 			methods = append(methods, &coberturaMethod{
-				Name:  "no-test",
+				Name:  "missing",
 				Lines: []*coberturaLine{{Number: 1, Hits: 0}},
 			})
 		} else {
-			for i, tc := range testCases {
-				methods = append(methods, &coberturaMethod{
-					Name:  tc,
-					Lines: []*coberturaLine{{Number: i + 1, Hits: 1}},
-				})
-			}
+			methods = append(methods, &coberturaMethod{
+				Name:  "OK",
+				Lines: []*coberturaLine{{Number: 1, Hits: 1}},
+			})
 		}
 
 		if dataStream == "" {


### PR DESCRIPTION
This PR adjusts test coverage calculation:

- [x] verify if test is actually expected (no pipeline defined = no need for pipeline tests)
- [x] don't include package context tests in calculation (artificially increases coverage, e.g. installed asset = test unit, so larger packages have better coverage)
- [x] consider multiple test cases as one (just check if tests are present or not) 

Testing:

Before - https://beats-ci.elastic.co/job/Ingest-manager/job/elastic-package/job/master/168/cobertura/apache/
After - https://beats-ci.elastic.co/job/Ingest-manager/job/elastic-package/job/PR-447/1/cobertura/apache/