### PR TITLE
Modify Docker stack orchestration to be ready for Compose V2

### DIFF
--- a/internal/profile/static_snapshot_yml.go
+++ b/internal/profile/static_snapshot_yml.go
@@ -14,7 +14,7 @@ const SnapshotFile configFile = "snapshot.yml"
 const snapshotYml = `version: '2.3'
 services:
   elasticsearch:
-    image: ${ELASTICSEARCH_IMAGE_REF}
+    image: "${ELASTICSEARCH_IMAGE_REF}"
     healthcheck:
       test: ["CMD", "curl", "-f", "-u", "elastic:changeme", "http://127.0.0.1:9200/"]
       retries: 300
@@ -44,7 +44,7 @@ services:
         condition: service_healthy
 
   kibana:
-    image: ${KIBANA_IMAGE_REF}
+    image: "${KIBANA_IMAGE_REF}"
     depends_on:
       elasticsearch:
         condition: service_healthy
@@ -69,9 +69,9 @@ services:
   package-registry:
     build:
       context: ../../../
-      dockerfile: ${STACK_PATH}/Dockerfile.package-registry
+      dockerfile: "${STACK_PATH}/Dockerfile.package-registry"
       args:
-        PROFILE: ${PROFILE_NAME}
+        PROFILE: "${PROFILE_NAME}"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8080"]
       retries: 300
@@ -86,7 +86,7 @@ services:
         condition: service_healthy
 
   fleet-server:
-    image: ${ELASTIC_AGENT_IMAGE_REF}
+    image: "${ELASTIC_AGENT_IMAGE_REF}"
     depends_on:
       elasticsearch:
         condition: service_healthy
@@ -114,7 +114,7 @@ services:
         condition: service_healthy
 
   elastic-agent:
-    image: ${ELASTIC_AGENT_IMAGE_REF}
+    image: "${ELASTIC_AGENT_IMAGE_REF}"
     depends_on:
       fleet-server:
         condition: service_healthy

--- a/internal/stack/compose.go
+++ b/internal/stack/compose.go
@@ -98,7 +98,7 @@ func dockerComposeDown(options Options) error {
 	}
 
 	downOptions := compose.CommandOptions{
-		Env:       append(appConfig.StackImageRefs(options.StackVersion).AsEnv(), options.Profile.ComposeEnvVars()...),
+		Env: append(appConfig.StackImageRefs(options.StackVersion).AsEnv(), options.Profile.ComposeEnvVars()...),
 		// Remove associated volumes.
 		ExtraArgs: []string{"--volumes"},
 	}

--- a/internal/stack/compose.go
+++ b/internal/stack/compose.go
@@ -20,8 +20,13 @@ func dockerComposeBuild(options Options) error {
 		return errors.Wrap(err, "could not create docker compose project")
 	}
 
+	appConfig, err := install.Configuration()
+	if err != nil {
+		return errors.Wrap(err, "can't read application configuration")
+	}
+
 	opts := compose.CommandOptions{
-		Env:      options.Profile.ComposeEnvVars(),
+		Env:      append(appConfig.StackImageRefs(options.StackVersion).AsEnv(), options.Profile.ComposeEnvVars()...),
 		Services: withIsReadyServices(withDependentServices(options.Services)),
 	}
 
@@ -87,7 +92,13 @@ func dockerComposeDown(options Options) error {
 		return errors.Wrap(err, "could not create docker compose project")
 	}
 
+	appConfig, err := install.Configuration()
+	if err != nil {
+		return errors.Wrap(err, "can't read application configuration")
+	}
+
 	downOptions := compose.CommandOptions{
+		Env:       append(appConfig.StackImageRefs(options.StackVersion).AsEnv(), options.Profile.ComposeEnvVars()...),
 		// Remove associated volumes.
 		ExtraArgs: []string{"--volumes"},
 	}

--- a/internal/stack/shellinit.go
+++ b/internal/stack/shellinit.go
@@ -62,7 +62,7 @@ func ShellInit(elasticStackProfile *profile.Profile) (string, error) {
 	}
 
 	serviceComposeConfig, err := p.Config(compose.CommandOptions{
-		Env:       append(appConfig.StackImageRefs(install.DefaultStackVersion).AsEnv(), elasticStackProfile.ComposeEnvVars()...),
+		Env: append(appConfig.StackImageRefs(install.DefaultStackVersion).AsEnv(), elasticStackProfile.ComposeEnvVars()...),
 	})
 	if err != nil {
 		return "", errors.Wrap(err, "could not get Docker Compose configuration for service")

--- a/internal/stack/shellinit.go
+++ b/internal/stack/shellinit.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/elastic-package/internal/compose"
+	"github.com/elastic/elastic-package/internal/install"
 	"github.com/elastic/elastic-package/internal/profile"
 )
 
@@ -55,7 +56,14 @@ func ShellInit(elasticStackProfile *profile.Profile) (string, error) {
 		return "", errors.Wrap(err, "could not create docker compose project")
 	}
 
-	serviceComposeConfig, err := p.Config(compose.CommandOptions{})
+	appConfig, err := install.Configuration()
+	if err != nil {
+		return "", errors.Wrap(err, "can't read application configuration")
+	}
+
+	serviceComposeConfig, err := p.Config(compose.CommandOptions{
+		Env:       append(appConfig.StackImageRefs(install.DefaultStackVersion).AsEnv(), elasticStackProfile.ComposeEnvVars()...),
+	})
 	if err != nil {
 		return "", errors.Wrap(err, "could not get Docker Compose configuration for service")
 	}


### PR DESCRIPTION
Fixes: https://github.com/elastic/elastic-package/issues/450

This PR sets empty/missed environment variables as the Compose V2 format requires them. We used to work with the Compose V1 format, but just in case be ready for the switch to V2.