### PR TITLE
Fix: use ioutil

### DIFF
--- a/internal/testrunner/runners/system/servicedeployer/kubernetes.go
+++ b/internal/testrunner/runners/system/servicedeployer/kubernetes.go
@@ -5,7 +5,6 @@
 package servicedeployer
 
 import (
-	"io"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
@@ -171,7 +170,7 @@ func downloadElasticAgentManagedYAML(url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	b, err := io.ReadAll(resp.Body)
+	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}


### PR DESCRIPTION
Fix for: https://beats-ci.elastic.co/job/Ingest-manager/job/elastic-package/view/tags/job/v0.13.0/1/console

The build process runs for Go 1.15. I will fix it properly in https://github.com/elastic/elastic-package/pull/455, but temporarily we have to fix in the code (use ioutil). 