### PR TITLE
chore: decouple pipeline concerns

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -33,6 +33,7 @@ pipeline {
      */
     stage('Checkout') {
       steps {
+        pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
           withKubernetes() {
             withCloudTestEnv() {
               dir("${BASE_DIR}"){
-                sh(label: 'Check',script: 'make test')
+                sh(label: 'Check',script: 'make test check-git-clean')
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
       }
     }
     /**
-     Check the source code.
+     Run the test suite.
      */
     stage('Tests') {
       steps {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -45,10 +45,23 @@ pipeline {
       steps {
         cleanup()
         withMageEnv(){
+          dir("${BASE_DIR}"){
+            sh(label: 'Check',script: 'make check-static')
+          }
+        }
+      }
+    }
+    /**
+     Check the source code.
+     */
+    stage('Tests') {
+      steps {
+        cleanup()
+        withMageEnv(){
           withKubernetes() {
             withCloudTestEnv() {
               dir("${BASE_DIR}"){
-                sh(label: 'Check',script: 'make check')
+                sh(label: 'Check',script: 'make test')
               }
             }
           }

--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,6 @@ check-git-clean:
 	git update-index --really-refresh
 	git diff-index --quiet HEAD
 
-check: build format lint licenser gomod update check-git-clean test check-git-clean
+check: check-static test check-git-clean
+
+check-static: build format lint licenser gomod update check-git-clean

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-WARNING: This is a generated file. Do NOT edit it manually. To regenerate this file, run `make readme`.
+WARNING: This is a generated file. Do NOT edit it manually. To regenerate this file, run `make update-readme`.
 -->
 
 # elastic-package

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -1,5 +1,5 @@
 <!--
-WARNING: This is a generated file. Do NOT edit it manually. To regenerate this file, run `make readme`.
+WARNING: This is a generated file. Do NOT edit it manually. To regenerate this file, run `make update-readme`.
 -->
 
 # elastic-package


### PR DESCRIPTION
## What does this PR do?
It separates the concerns for running static analys checks from the execution of tests.

For that we are providing a new Make goal `make check-static`, which will run `build format lint licenser gomod update check-git-clean` goals. In the same manner, `check` will keep its former behaviour, as it will call `check-static` first, keeping build expectations.

Finally, we are adding a new stage in the pipeline, separating static checks from tests.

## Why is it important?
Separation of concerns: when the pipeline fails, we want to know in a first look what caused it.

## Follow-ups
We'd like to decouple the pipeline a little bit more right after the team approves/discusses this PR. Some ideas that we have in mind are:

- running unit tests (`make test-go`) in parallel with the static analysis.
- running stack-command, check-packages and profiles-command in separated stages, ideally in parallel.

But we'd like to find an agreement with the team on that first.

## Screenshots
**Before**:
<img width="1777" alt="Screenshot 2021-08-17 at 13 23 39" src="https://user-images.githubusercontent.com/951580/129717771-0e9e61ea-3fc3-440f-a62a-1ac5ab69c7d8.png">


**After**:
<img width="1766" alt="Screenshot 2021-08-17 at 13 22 21" src="https://user-images.githubusercontent.com/951580/129717595-1e3a955f-922d-4440-b584-29aac4dc82d7.png">
