### PR TITLE
chore: decouple test concerns

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -152,19 +152,6 @@ pipeline {
           }
         }
       }
-      post {
-        always {
-          dir("${BASE_DIR}") {
-            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
-            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/kubectl-dump.txt')
-            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/check/logs/*.log')
-            junit(allowEmptyResults: false,
-                keepLongStdio: true,
-                testResults: "build/test-results/*.xml")
-            coverageReport('build/test-coverage')
-          }
-        }
-      }
     }
     stage('Release') {
       when {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -147,7 +147,7 @@ def generateTestCommandStage(Map args = [:]){
           archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
           archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/kubectl-dump.txt')
           archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/**/*.log')
-          junit(allowEmptyResults: false,
+          junit(allowEmptyResults: true,
               keepLongStdio: true,
               testResults: "build/test-results/*.xml")
           coverageReport('build/test-coverage')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -87,32 +87,11 @@ pipeline {
               cleanup()
               dir("${BASE_DIR}") {
                 script {
-                  def artifacts = [:]
-                  def testCommands = ['test-stack-command', 'test-check-packages', 'test-profiles-command']
-
-                  artifacts['test-stack-command'] = [
-                    'build/elastic-stack-dump/**/*.log'
-                  ]
-                  artifacts['test-check-packages'] = [
-                    'build/test-results/*.xml', 'build/kubectl-dump.txt', 'build/elastic-stack-dump/**/*.log'
-                  ]
-                  artifacts['test-profiles-command'] = []
-
-                  def parallelTasks = [:]
-
-                  testCommands.each { testCommand ->
-                    def junitArtifacts = false
-                    def publishCoverage = false
-
-                    if (testCommand == 'test-check-packages') {
-                      junitArtifacts = true
-                      publishCoverage = true
-                    }
-
-                    parallelTasks["${testCommand}"] = generateTestCommandStage(command: "${testCommand}", artifacts: artifacts[testCommand], junitArtifacts: junitArtifacts, publishCoverage: publishCoverage)
-                  }
-
-                  parallel(parallelTasks)
+                  parallel([
+                    'stack-command': generateTestCommandStage(command: 'test-stack-command', artifacts: ['build/elastic-stack-dump/**/*.log']),
+                    'check-packages': generateTestCommandStage(command: 'test-check-packages', artifacts: ['build/test-results/*.xml', 'build/kubectl-dump.txt', 'build/elastic-stack-dump/**/*.log'], junitArtifacts: true, publishCoverage: true),
+                    'profiles-command': generateTestCommandStage(command: 'test-profiles-command'),
+                  ])
                 }
               }
             }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -84,10 +84,6 @@ pipeline {
       options { skipDefaultCheckout() }
       when {
         beforeAgent true
-        anyOf {
-          expression { return env.FORCE_SKIP_GIT_CHECKS == "true" }
-          expression { return env.SKIP_TESTS == "false" }
-        }
       }
       steps {
         cleanup()
@@ -124,10 +120,6 @@ pipeline {
       options { skipDefaultCheckout() }
       when {
         beforeAgent true
-        anyOf {
-          expression { return env.FORCE_SKIP_GIT_CHECKS == "true" }
-          expression { return env.SKIP_TESTS == "false" }
-        }
       }
       steps {
         cleanup()
@@ -164,10 +156,6 @@ pipeline {
       options { skipDefaultCheckout() }
       when {
         beforeAgent true
-        anyOf {
-          expression { return env.FORCE_SKIP_GIT_CHECKS == "true" }
-          expression { return env.SKIP_TESTS == "false" }
-        }
       }
       steps {
         cleanup()

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -28,84 +28,89 @@ pipeline {
     issueCommentTrigger('(?i)(.*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*|^\\/test$)')
   }
   stages {
-    /**
-     Checkout the code and stash it, to use it on other stages.
-     */
-    stage('Checkout') {
-      steps {
-        pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
-        deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}")
-        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
-      }
-    }
-    /**
-     Check the source code.
-     */
-    stage('Check') {
-      steps {
-        cleanup()
-        withMageEnv(){
-          dir("${BASE_DIR}"){
-            sh(label: 'Check',script: 'make check-static')
-          }
-        }
-      }
-    }
-    /**
-     Run the unit tests suite
-     */
-    stage('Unit tests') {
-      steps {
-        cleanup()
-        withMageEnv(){
-          dir("${BASE_DIR}"){
-            sh(label: 'Check',script: 'make test-go-ci')
-          }
-        }
-      }
-      post {
-        always {
-          dir("${BASE_DIR}") {
-            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
-            junit(allowEmptyResults: false,
-                keepLongStdio: true,
-                testResults: "build/test-results/*.xml")
-            coverageReport('build/test-coverage')
-          }
-        }
-      }
-    }
-    stage('Integration Tests') {
-      failFast true
+    stage('Initializing'){
       options { skipDefaultCheckout() }
-      steps {
-        withGithubNotify(context: 'Integration Tests', tab: 'tests') {
-          cleanup()
-          dir("${BASE_DIR}") {
-            script {
-              def testCommands = ['test-stack-command', 'test-check-packages', 'test-profiles-command']
-              def parallelTasks = [:]
-
-              testCommands.each { testCommand ->
-                parallelTasks["${testCommand}"] = generateTestCommandStage(command: "${testCommand}")
+      stages {
+        /**
+        Checkout the code and stash it, to use it on other stages.
+        */
+        stage('Checkout') {
+          steps {
+            pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
+            deleteDir()
+            gitCheckout(basedir: "${BASE_DIR}")
+            stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+          }
+        }
+        /**
+        Check the source code.
+        */
+        stage('Check') {
+          steps {
+            cleanup()
+            withMageEnv(){
+              dir("${BASE_DIR}"){
+                sh(label: 'Check',script: 'make check-static')
               }
-
-              parallel(parallelTasks)
             }
           }
         }
-      }
-    }
-    stage('Release') {
-      when {
-        tag pattern: '(v)?\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
-      }
-      steps {
-        withMageEnv(){
-          withCredentials([string(credentialsId: "${GITHUB_TOKEN_CREDENTIALS}", variable: 'GITHUB_TOKEN')]) {
-            dir("${BASE_DIR}") {
-              sh 'curl -sL https://git.io/goreleaser | bash'
+        /**
+        Run the unit tests suite
+        */
+        stage('Unit tests') {
+          steps {
+            cleanup()
+            withMageEnv(){
+              dir("${BASE_DIR}"){
+                sh(label: 'Check',script: 'make test-go-ci')
+              }
+            }
+          }
+          post {
+            always {
+              dir("${BASE_DIR}") {
+                archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
+                junit(allowEmptyResults: false,
+                    keepLongStdio: true,
+                    testResults: "build/test-results/*.xml")
+                coverageReport('build/test-coverage')
+              }
+            }
+          }
+        }
+        stage('Integration Tests') {
+          failFast true
+          options { skipDefaultCheckout() }
+          steps {
+            withGithubNotify(context: 'Integration Tests', tab: 'tests') {
+              cleanup()
+              dir("${BASE_DIR}") {
+                script {
+                  def testCommands = ['test-stack-command', 'test-check-packages', 'test-profiles-command']
+                  def parallelTasks = [:]
+
+                  testCommands.each { testCommand ->
+                    parallelTasks["${testCommand}"] = generateTestCommandStage(command: "${testCommand}")
+                  }
+
+                  parallel(parallelTasks)
+                }
+              }
+            }
+          }
+        }
+        stage('Release') {
+          when {
+            tag pattern: '(v)?\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
+          }
+          steps {
+            withMageEnv(){
+              withCredentials([string(credentialsId: "${GITHUB_TOKEN_CREDENTIALS}", variable: 'GITHUB_TOKEN')]) {
+                dir("${BASE_DIR}") {
+                  sh 'curl -sL https://git.io/goreleaser | bash'
+                }
+              }
             }
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -88,7 +88,7 @@ pipeline {
               def parallelTasks = [:]
 
               testCommands.each { testCommand ->
-                parallelTasks["${testCommand}"] = generateTestCommandStage(command: "${testComand}")
+                parallelTasks["${testCommand}"] = generateTestCommandStage(command: "${testCommand}")
               }
 
               parallel(parallelTasks)

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -76,78 +76,22 @@ pipeline {
         }
       }
     }
-    /**
-     Run the test suite for stack commands.
-     */
-    stage('Stack Command Tests') {
-      agent { label 'ubuntu-18 && immutable' }
+    stage('Integration Tests') {
+      failFast true
       options { skipDefaultCheckout() }
       steps {
-        cleanup()
-        withMageEnv(){
-          withKubernetes() {
-            withCloudTestEnv() {
-              dir("${BASE_DIR}"){
-                sh(label: 'Check',script: 'make build test-stack-command check-git-clean')
-              }
-            }
-          }
-        }
-      }
-      post {
-        always {
+        withGithubNotify(context: 'Integration Tests', tab: 'tests') {
+          cleanup()
           dir("${BASE_DIR}") {
-            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/stack/logs/*.log')
-          }
-        }
-      }
-    }
-    /**
-     Run the test suite for packages.
-     */
-    stage('Check Packages Tests') {
-      agent { label 'ubuntu-18 && immutable' }
-      options { skipDefaultCheckout() }
-      steps {
-        cleanup()
-        withMageEnv(){
-          withKubernetes() {
-            withCloudTestEnv() {
-              dir("${BASE_DIR}"){
-                sh(label: 'Check',script: 'make build test-check-packages check-git-clean')
+            script {
+              def testCommands = ['test-stack-command', 'test-check-packages', 'test-profiles-command']
+              def parallelTasks = [:]
+
+              testCommands.each { testCommand ->
+                parallelTasks["${testCommand}"] = generateTestCommandStage(command: "${testComand}")
               }
-            }
-          }
-        }
-      }
-      post {
-        always {
-          dir("${BASE_DIR}") {
-            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
-            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/kubectl-dump.txt')
-            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/check/logs/*.log')
-            junit(allowEmptyResults: false,
-                keepLongStdio: true,
-                testResults: "build/test-results/*.xml")
-            coverageReport('build/test-coverage')
-          }
-        }
-      }
-    }
-    /**
-     Run the test suite for profile commands.
-     */
-    stage('Profile Commands Tests') {
-      agent { label 'ubuntu-18 && immutable' }
-      options { skipDefaultCheckout() }
-      steps {
-        cleanup()
-        withMageEnv(){
-          withKubernetes() {
-            withCloudTestEnv() {
-              dir("${BASE_DIR}"){
-                sh(label: 'Check',script: 'make build test-profiles-command')
-              }
+
+              parallel(parallelTasks)
             }
           }
         }
@@ -180,6 +124,37 @@ def cleanup(){
     deleteDir()
   }
   unstash 'source'
+}
+
+def generateTestCommandStage(Map args = [:]){
+  def command = args.get('command')
+
+  return {
+    withNode(labels: "ubuntu-18 && immutable", sleepMax: 20, forceWorkspace: true) {
+      cleanup()
+      try {
+        withMageEnv(){
+          withKubernetes() {
+            withCloudTestEnv() {
+              dir("${BASE_DIR}"){
+                sh(label: 'Check',script: "make build ${command} check-git-clean")
+              }
+            }
+          }
+        }
+      } finally {
+        dir("${BASE_DIR}") {
+          archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
+          archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/kubectl-dump.txt')
+          archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/**/*.log')
+          junit(allowEmptyResults: false,
+              keepLongStdio: true,
+              testResults: "build/test-results/*.xml")
+          coverageReport('build/test-coverage')
+        }
+      }
+    }
+  }
 }
 
 def withKubernetes(Closure body) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -13,6 +13,9 @@ pipeline {
     HOME = "${env.WORKSPACE}"
     KIND_VERSION = 'v0.11.1'
     K8S_VERSION = 'v1.20.2'
+    JOB_GCS_BUCKET = 'beats-ci-temp'
+    JOB_GCS_CREDENTIALS = 'beats-ci-gcs-plugin'
+    JOB_GCS_EXT_CREDENTIALS = 'beats-ci-gcs-plugin-file-credentials'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -74,7 +77,7 @@ pipeline {
                 junit(allowEmptyResults: false,
                     keepLongStdio: true,
                     testResults: "build/test-results/*.xml")
-                coverageReport('build/test-coverage')
+                stashCoverageReport()
               }
             }
           }
@@ -115,6 +118,9 @@ pipeline {
     }
   }
   post {
+    always {
+      publishCoverageReports()
+    }
     cleanup {
       notifyBuildResult(prComment: true)
     }
@@ -160,12 +166,40 @@ def generateTestCommandStage(Map args = [:]){
           }
 
           if (publishCoverage) {
-            coverageReport('build/test-coverage')
+            stashCoverageReport()
           }
         }
       }
     }
   }
+}
+
+def getCoverageBucketURI() {
+  return "gs://${JOB_GCS_BUCKET}/" + getCoveragePathPrefix()
+}
+
+def getCoveragePathPrefix() {
+  return "${env.JOB_NAME}-${env.BUILD_ID}/test-coverage/"
+}
+
+def publishCoverageReports() {
+  stage('Publish coverage reports') {
+    dir("${BASE_DIR}") {
+      def bucketUri = getCoverageBucketURI() + "*.xml"
+      googleStorageDownload(bucketUri: bucketUri, credentialsId: "${JOB_GCS_CREDENTIALS}", localDirectory: 'build/test-coverage', pathPrefix: getCoveragePathPrefix())
+      coverageReport('build/test-coverage')
+    }
+  }
+}
+
+def stashCoverageReport() {
+  r = sh(label: "isCoverageReportPresent", script: "ls build/test-coverage/*.xml", returnStatus: true)
+  if (r != 0) {
+    echo "isCoverageReportPresent: coverage files not found, report won't be stashed"
+    return
+  }
+
+  googleStorageUploadExt(bucket: getCoverageBucketURI(), credentialsId: "${JOB_GCS_EXT_CREDENTIALS}", pattern: "build/test-coverage/*.xml")
 }
 
 def withKubernetes(Closure body) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -87,11 +87,21 @@ pipeline {
               cleanup()
               dir("${BASE_DIR}") {
                 script {
+                  def artifacts = [:]
                   def testCommands = ['test-stack-command', 'test-check-packages', 'test-profiles-command']
+
+                  artifacts['test-stack-command'] = [
+                    'build/elastic-stack-dump/**/*.log'
+                  ]
+                  artifacts['test-check-packages'] = [
+                    'build/test-results/*.xml', 'build/kubectl-dump.txt', 'build/elastic-stack-dump/**/*.log'
+                  ]
+                  artifacts['test-profiles-command'] = []
+
                   def parallelTasks = [:]
 
                   testCommands.each { testCommand ->
-                    parallelTasks["${testCommand}"] = generateTestCommandStage(command: "${testCommand}")
+                    parallelTasks["${testCommand}"] = generateTestCommandStage(command: "${testCommand}", artifacts: artifacts[testCommand])
                   }
 
                   parallel(parallelTasks)
@@ -133,6 +143,7 @@ def cleanup(){
 
 def generateTestCommandStage(Map args = [:]){
   def command = args.get('command')
+  def artifacts = args.get('artifacts')?.trim() ? args.get('artifacts') : []
 
   return {
     withNode(labels: "ubuntu-18 && immutable", sleepMax: 20, forceWorkspace: true) {
@@ -149,9 +160,10 @@ def generateTestCommandStage(Map args = [:]){
         }
       } finally {
         dir("${BASE_DIR}") {
-          archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
-          archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/kubectl-dump.txt')
-          archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/**/*.log')
+          artifacts.each { artifact ->
+            archiveArtifacts(allowEmptyArchive: true, artifacts: "${artifact}")
+          }
+
           junit(allowEmptyResults: true,
               keepLongStdio: true,
               testResults: "build/test-results/*.xml")

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -88,7 +88,7 @@ pipeline {
           withKubernetes() {
             withCloudTestEnv() {
               dir("${BASE_DIR}"){
-                sh(label: 'Check',script: 'make test-stack-command check-git-clean')
+                sh(label: 'Check',script: 'make build test-stack-command check-git-clean')
               }
             }
           }
@@ -121,7 +121,7 @@ pipeline {
           withKubernetes() {
             withCloudTestEnv() {
               dir("${BASE_DIR}"){
-                sh(label: 'Check',script: 'make test-check-packages check-git-clean')
+                sh(label: 'Check',script: 'make build test-check-packages check-git-clean')
               }
             }
           }
@@ -154,7 +154,7 @@ pipeline {
           withKubernetes() {
             withCloudTestEnv() {
               dir("${BASE_DIR}"){
-                sh(label: 'Check',script: 'make test-profiles-command check-git-clean')
+                sh(label: 'Check',script: 'make build test-profiles-command check-git-clean')
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -146,7 +146,7 @@ pipeline {
           withKubernetes() {
             withCloudTestEnv() {
               dir("${BASE_DIR}"){
-                sh(label: 'Check',script: 'make build test-profiles-command check-git-clean')
+                sh(label: 'Check',script: 'make build test-profiles-command')
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -143,7 +143,7 @@ def cleanup(){
 
 def generateTestCommandStage(Map args = [:]){
   def command = args.get('command')
-  def artifacts = args.get('artifacts')? ? args.get('artifacts') : []
+  def artifacts = args.get('artifacts') ? args.get('artifacts') : []
 
   return {
     withNode(labels: "ubuntu-18 && immutable", sleepMax: 20, forceWorkspace: true) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -102,11 +102,14 @@ pipeline {
 
                   testCommands.each { testCommand ->
                     def junitArtifacts = false
+                    def publishCoverage = false
+
                     if (testCommand == 'test-check-packages') {
                       junitArtifacts = true
+                      publishCoverage = true
                     }
 
-                    parallelTasks["${testCommand}"] = generateTestCommandStage(command: "${testCommand}", artifacts: artifacts[testCommand], junitArtifacts: junitArtifacts)
+                    parallelTasks["${testCommand}"] = generateTestCommandStage(command: "${testCommand}", artifacts: artifacts[testCommand], junitArtifacts: junitArtifacts, publishCoverage: publishCoverage)
                   }
 
                   parallel(parallelTasks)
@@ -150,6 +153,7 @@ def generateTestCommandStage(Map args = [:]){
   def command = args.get('command')
   def artifacts = args.get('artifacts') ? args.get('artifacts') : []
   def junitArtifacts = args.get('junitArtifacts') ? args.get('junitArtifacts') : false
+  def publishCoverage = args.get('publishCoverage') ? args.get('publishCoverage') : false
 
   return {
     withNode(labels: "ubuntu-18 && immutable", sleepMax: 20, forceWorkspace: true) {
@@ -176,7 +180,9 @@ def generateTestCommandStage(Map args = [:]){
                 testResults: "build/test-results/*.xml")
           }
 
-          coverageReport('build/test-coverage')
+          if (publishCoverage) {
+            coverageReport('build/test-coverage')
+          }
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -143,7 +143,7 @@ def cleanup(){
 
 def generateTestCommandStage(Map args = [:]){
   def command = args.get('command')
-  def artifacts = args.get('artifacts')?.trim() ? args.get('artifacts') : []
+  def artifacts = args.get('artifacts')? ? args.get('artifacts') : []
 
   return {
     withNode(labels: "ubuntu-18 && immutable", sleepMax: 20, forceWorkspace: true) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -97,14 +97,7 @@ pipeline {
       post {
         always {
           dir("${BASE_DIR}") {
-            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
-            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/kubectl-dump.txt')
             archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/stack/logs/*.log')
-            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/check/logs/*.log')
-            junit(allowEmptyResults: false,
-                keepLongStdio: true,
-                testResults: "build/test-results/*.xml")
-            coverageReport('build/test-coverage')
           }
         }
       }
@@ -132,7 +125,6 @@ pipeline {
           dir("${BASE_DIR}") {
             archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
             archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/kubectl-dump.txt')
-            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/stack/logs/*.log')
             archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/check/logs/*.log')
             junit(allowEmptyResults: false,
                 keepLongStdio: true,
@@ -165,7 +157,6 @@ pipeline {
           dir("${BASE_DIR}") {
             archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
             archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/kubectl-dump.txt')
-            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/stack/logs/*.log')
             archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/check/logs/*.log')
             junit(allowEmptyResults: false,
                 keepLongStdio: true,

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -82,9 +82,6 @@ pipeline {
     stage('Stack Command Tests') {
       agent { label 'ubuntu-18 && immutable' }
       options { skipDefaultCheckout() }
-      when {
-        beforeAgent true
-      }
       steps {
         cleanup()
         withMageEnv(){
@@ -118,9 +115,6 @@ pipeline {
     stage('Check Packages Tests') {
       agent { label 'ubuntu-18 && immutable' }
       options { skipDefaultCheckout() }
-      when {
-        beforeAgent true
-      }
       steps {
         cleanup()
         withMageEnv(){
@@ -154,9 +148,6 @@ pipeline {
     stage('Profile Commands Tests') {
       agent { label 'ubuntu-18 && immutable' }
       options { skipDefaultCheckout() }
-      when {
-        beforeAgent true
-      }
       steps {
         cleanup()
         withMageEnv(){

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -53,16 +53,129 @@ pipeline {
       }
     }
     /**
-     Run the test suite.
+     Run the unit tests suite
      */
-    stage('Tests') {
+    stage('Unit tests') {
+      steps {
+        cleanup()
+        withMageEnv(){
+          dir("${BASE_DIR}"){
+            sh(label: 'Check',script: 'make test-go-ci')
+          }
+        }
+      }
+      post {
+        always {
+          dir("${BASE_DIR}") {
+            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
+            junit(allowEmptyResults: false,
+                keepLongStdio: true,
+                testResults: "build/test-results/*.xml")
+            coverageReport('build/test-coverage')
+          }
+        }
+      }
+    }
+    /**
+     Run the test suite for stack commands.
+     */
+    stage('Stack Command Tests') {
+      agent { label 'ubuntu-18 && immutable' }
+      options { skipDefaultCheckout() }
+      when {
+        beforeAgent true
+        anyOf {
+          expression { return env.FORCE_SKIP_GIT_CHECKS == "true" }
+          expression { return env.SKIP_TESTS == "false" }
+        }
+      }
       steps {
         cleanup()
         withMageEnv(){
           withKubernetes() {
             withCloudTestEnv() {
               dir("${BASE_DIR}"){
-                sh(label: 'Check',script: 'make test check-git-clean')
+                sh(label: 'Check',script: 'make test-stack-command check-git-clean')
+              }
+            }
+          }
+        }
+      }
+      post {
+        always {
+          dir("${BASE_DIR}") {
+            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
+            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/kubectl-dump.txt')
+            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/stack/logs/*.log')
+            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/check/logs/*.log')
+            junit(allowEmptyResults: false,
+                keepLongStdio: true,
+                testResults: "build/test-results/*.xml")
+            coverageReport('build/test-coverage')
+          }
+        }
+      }
+    }
+    /**
+     Run the test suite for packages.
+     */
+    stage('Check Packages Tests') {
+      agent { label 'ubuntu-18 && immutable' }
+      options { skipDefaultCheckout() }
+      when {
+        beforeAgent true
+        anyOf {
+          expression { return env.FORCE_SKIP_GIT_CHECKS == "true" }
+          expression { return env.SKIP_TESTS == "false" }
+        }
+      }
+      steps {
+        cleanup()
+        withMageEnv(){
+          withKubernetes() {
+            withCloudTestEnv() {
+              dir("${BASE_DIR}"){
+                sh(label: 'Check',script: 'make test-check-packages check-git-clean')
+              }
+            }
+          }
+        }
+      }
+      post {
+        always {
+          dir("${BASE_DIR}") {
+            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/test-results/*.xml')
+            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/kubectl-dump.txt')
+            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/stack/logs/*.log')
+            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/elastic-stack-dump/check/logs/*.log')
+            junit(allowEmptyResults: false,
+                keepLongStdio: true,
+                testResults: "build/test-results/*.xml")
+            coverageReport('build/test-coverage')
+          }
+        }
+      }
+    }
+    /**
+     Run the test suite for profile commands.
+     */
+    stage('Profile Commands Tests') {
+      agent { label 'ubuntu-18 && immutable' }
+      options { skipDefaultCheckout() }
+      when {
+        beforeAgent true
+        anyOf {
+          expression { return env.FORCE_SKIP_GIT_CHECKS == "true" }
+          expression { return env.SKIP_TESTS == "false" }
+        }
+      }
+      steps {
+        cleanup()
+        withMageEnv(){
+          withKubernetes() {
+            withCloudTestEnv() {
+              dir("${BASE_DIR}"){
+                sh(label: 'Check',script: 'make test-profiles-command check-git-clean')
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -101,7 +101,12 @@ pipeline {
                   def parallelTasks = [:]
 
                   testCommands.each { testCommand ->
-                    parallelTasks["${testCommand}"] = generateTestCommandStage(command: "${testCommand}", artifacts: artifacts[testCommand])
+                    def junitArtifacts = false
+                    if (testCommand == 'test-check-packages') {
+                      junitArtifacts = true
+                    }
+
+                    parallelTasks["${testCommand}"] = generateTestCommandStage(command: "${testCommand}", artifacts: artifacts[testCommand], junitArtifacts: junitArtifacts)
                   }
 
                   parallel(parallelTasks)
@@ -144,6 +149,7 @@ def cleanup(){
 def generateTestCommandStage(Map args = [:]){
   def command = args.get('command')
   def artifacts = args.get('artifacts') ? args.get('artifacts') : []
+  def junitArtifacts = args.get('junitArtifacts') ? args.get('junitArtifacts') : false
 
   return {
     withNode(labels: "ubuntu-18 && immutable", sleepMax: 20, forceWorkspace: true) {
@@ -164,9 +170,12 @@ def generateTestCommandStage(Map args = [:]){
             archiveArtifacts(allowEmptyArchive: true, artifacts: "${artifact}")
           }
 
-          junit(allowEmptyResults: true,
-              keepLongStdio: true,
-              testResults: "build/test-results/*.xml")
+          if (junitArtifacts) {
+            junit(allowEmptyResults: true,
+                keepLongStdio: true,
+                testResults: "build/test-results/*.xml")
+          }
+
           coverageReport('build/test-coverage')
         }
       }

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,17 @@ test-go:
 	# does not invalidate the cache so having the -count=1 to invalidate the test cache is useful.
 	go test -v -count 1 ./...
 
+# Prepare junit build context
+test-go-ci-pre:
+	mkdir -p $(PWD)/build/test-results
+	GO111MODULE=off go get gotest.tools/gotestsum
+
+test-go-ci: test-go-ci-pre
+	# -count=1 is included to invalidate the test cache. This way, if you run "make test-go" multiple times
+	# you will get fresh test results each time. For instance, changing the source of mocked packages
+	# does not invalidate the cache so having the -count=1 to invalidate the test cache is useful.
+	gotestsum --junitfile "$(PWD)/build/test-results/TEST-unit-$*.xml" --format testname -- -coverprofile=$(PWD)/build/test-coverage/unit.out -count=1 ./...
+
 test-stack-command:
 	./scripts/test-stack-command.sh
 

--- a/Makefile
+++ b/Makefile
@@ -32,16 +32,11 @@ test-go:
 	# does not invalidate the cache so having the -count=1 to invalidate the test cache is useful.
 	go test -v -count 1 -coverprofile=$(CODE_COVERAGE_REPORT_NAME_UNIT).out ./...
 
-# Prepare junit build context
-test-go-ci-pre:
+test-go-ci:
 	mkdir -p $(PWD)/build/test-results
 	mkdir -p $(PWD)/build/test-coverage
-	GO111MODULE=off go get github.com/tebeka/go2xunit
-	GO111MODULE=off go get github.com/boumenot/gocover-cobertura
-
-test-go-ci: test-go-ci-pre
-	$(MAKE) test-go | go2xunit > "$(PWD)/build/test-results/TEST-unit.xml"
-	gocover-cobertura < $(CODE_COVERAGE_REPORT_NAME_UNIT).out > $(CODE_COVERAGE_REPORT_NAME_UNIT).xml
+	$(MAKE) test-go | go run github.com/tebeka/go2xunit > "$(PWD)/build/test-results/TEST-unit.xml"
+	go run github.com/boumenot/gocover-cobertura < $(CODE_COVERAGE_REPORT_NAME_UNIT).out > $(CODE_COVERAGE_REPORT_NAME_UNIT).xml
 
 test-stack-command:
 	./scripts/test-stack-command.sh

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ test-go-ci-pre:
 
 test-go-ci: test-go-ci-pre
 	$(MAKE) test-go | go2xunit > "$(PWD)/build/test-results/TEST-unit.xml"
-	gocover-cobertura < $(PWD)/build/test-coverage/unit.out > $(PWD)/build/test-coverage/unit.xml
+	gocover-cobertura < $(PWD)/build/test-coverage/coverage-unit-report.out > $(PWD)/build/test-coverage/coverage-unit-report.xml
 
 test-stack-command:
 	./scripts/test-stack-command.sh

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+CODE_COVERAGE_REPORT_NAME_UNIT = $(PWD)/build/test-coverage/coverage-unit-report
+
 .PHONY: build
 
 build:
@@ -28,7 +30,7 @@ test-go:
 	# -count=1 is included to invalidate the test cache. This way, if you run "make test-go" multiple times
 	# you will get fresh test results each time. For instance, changing the source of mocked packages
 	# does not invalidate the cache so having the -count=1 to invalidate the test cache is useful.
-	go test -v -count 1 -coverprofile=$(PWD)/build/test-coverage/coverage-unit-report.out ./...
+	go test -v -count 1 -coverprofile=$(CODE_COVERAGE_REPORT_NAME_UNIT).out ./...
 
 # Prepare junit build context
 test-go-ci-pre:
@@ -39,7 +41,7 @@ test-go-ci-pre:
 
 test-go-ci: test-go-ci-pre
 	$(MAKE) test-go | go2xunit > "$(PWD)/build/test-results/TEST-unit.xml"
-	gocover-cobertura < $(PWD)/build/test-coverage/coverage-unit-report.out > $(PWD)/build/test-coverage/coverage-unit-report.xml
+	gocover-cobertura < $(CODE_COVERAGE_REPORT_NAME_UNIT).out > $(CODE_COVERAGE_REPORT_NAME_UNIT).xml
 
 test-stack-command:
 	./scripts/test-stack-command.sh

--- a/Makefile
+++ b/Makefile
@@ -28,20 +28,17 @@ test-go:
 	# -count=1 is included to invalidate the test cache. This way, if you run "make test-go" multiple times
 	# you will get fresh test results each time. For instance, changing the source of mocked packages
 	# does not invalidate the cache so having the -count=1 to invalidate the test cache is useful.
-	go test -v -count 1 ./...
+	go test -v -count 1 -coverprofile=$(PWD)/build/test-coverage/unit.out ./...
 
 # Prepare junit build context
 test-go-ci-pre:
 	mkdir -p $(PWD)/build/test-results
 	mkdir -p $(PWD)/build/test-coverage
-	GO111MODULE=off go get gotest.tools/gotestsum
+	GO111MODULE=off go get github.com/tebeka/go2xunit
 	GO111MODULE=off go get github.com/boumenot/gocover-cobertura
 
 test-go-ci: test-go-ci-pre
-	# -count=1 is included to invalidate the test cache. This way, if you run "make test-go" multiple times
-	# you will get fresh test results each time. For instance, changing the source of mocked packages
-	# does not invalidate the cache so having the -count=1 to invalidate the test cache is useful.
-	gotestsum --junitfile "$(PWD)/build/test-results/TEST-unit-$*.xml" --format testname -- -coverprofile=$(PWD)/build/test-coverage/unit.out -count=1 ./...
+	$(MAKE) test-go | go2xunit > "$(PWD)/build/test-results/TEST-unit.xml"
 	gocover-cobertura < $(PWD)/build/test-coverage/unit.out > $(PWD)/build/test-coverage/unit.xml
 
 test-stack-command:

--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,16 @@ test-go:
 # Prepare junit build context
 test-go-ci-pre:
 	mkdir -p $(PWD)/build/test-results
+	mkdir -p $(PWD)/build/test-coverage
 	GO111MODULE=off go get gotest.tools/gotestsum
+	GO111MODULE=off go get github.com/boumenot/gocover-cobertura
 
 test-go-ci: test-go-ci-pre
 	# -count=1 is included to invalidate the test cache. This way, if you run "make test-go" multiple times
 	# you will get fresh test results each time. For instance, changing the source of mocked packages
 	# does not invalidate the cache so having the -count=1 to invalidate the test cache is useful.
 	gotestsum --junitfile "$(PWD)/build/test-results/TEST-unit-$*.xml" --format testname -- -coverprofile=$(PWD)/build/test-coverage/unit.out -count=1 ./...
+	gocover-cobertura < $(PWD)/build/test-coverage/unit.out > $(PWD)/build/test-coverage/unit.xml
 
 test-stack-command:
 	./scripts/test-stack-command.sh

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test-go:
 	# -count=1 is included to invalidate the test cache. This way, if you run "make test-go" multiple times
 	# you will get fresh test results each time. For instance, changing the source of mocked packages
 	# does not invalidate the cache so having the -count=1 to invalidate the test cache is useful.
-	go test -v -count 1 -coverprofile=$(PWD)/build/test-coverage/unit.out ./...
+	go test -v -count 1 -coverprofile=$(PWD)/build/test-coverage/coverage-unit-report.out ./...
 
 # Prepare junit build context
 test-go-ci-pre:

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.2.16
 	github.com/Masterminds/semver v1.5.0
 	github.com/aymerick/raymond v2.0.2+incompatible
+	github.com/boumenot/gocover-cobertura v1.2.0
 	github.com/cespare/xxhash/v2 v2.1.1
 	github.com/elastic/go-elasticsearch/v7 v7.14.0
 	github.com/elastic/go-licenser v0.3.1
@@ -25,6 +26,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
+	github.com/tebeka/go2xunit v1.4.10
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
+github.com/boumenot/gocover-cobertura v1.2.0 h1:g+VROIASoEHBrEilIyaCmgo7HGm+AV5yKEPLk0qIY+s=
+github.com/boumenot/gocover-cobertura v1.2.0/go.mod h1:fz7ly8dslE42VRR5ZWLt2OHGDHjkTiA2oNvKgJEjLT0=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
@@ -820,6 +822,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/tebeka/go2xunit v1.4.10 h1:0UO+9YoLpXTZ0DL9XbTmIIibgmKBGiwroo8uhFMSyR0=
+github.com/tebeka/go2xunit v1.4.10/go.mod h1:wmc9jKT7KlU4QLU6DNTaIXNnYNOjKKNlp6mjOS0UrqY=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -1170,6 +1174,7 @@ golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200526224456-8b020aee10d2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -9,7 +9,9 @@ package tools
 // Add dependencies on tools.
 // https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 import (
+	_ "github.com/boumenot/gocover-cobertura"
 	_ "github.com/elastic/go-licenser"
+	_ "github.com/tebeka/go2xunit"
 	_ "golang.org/x/lint/golint"
 	_ "golang.org/x/tools/cmd/goimports"
 )


### PR DESCRIPTION
## What does this PR do?
This PR is adding 4 things:

1. a specific Make goal for running Go tests on CI: `make test-go-ci`, which invokes the original `test-go` and generates an xUnit output. For that it installs two go libraries, which will be managed as project's tools, to parse test results and convert the test results into the XML formats accepted by Jenkins.
2. adds code coverage to the `make test-go` command
3. splits the `Tests` stage into two sequential stages:
   1. unit tests, running the new `make test-go-ci` goal
   2. integration tests, which at the same time spreads the tests in three parallel branches
      1. command tests
      2. package tests
      3. profile commands tests
4. A post-stage to collect the code coverage results, publishing to Jenkins just once. We are forced to use an intermediate upload to a GCP bucket to solve https://github.com/elastic/elastic-package/pull/485#issuecomment-901082403.

## Why is it important?
Separation of concerns: if the unit tests fail, we want to stop the soonest but we also want to know it super fast in the pipeline representation.

In 3) we are making explicit what artifacts are being published from each test type, which is also important for this separation of concerns we propose.

## Screenshots
<img width="1750" alt="Screenshot 2021-08-19 at 09 26 38" src="https://user-images.githubusercontent.com/951580/130026243-b8ee8272-19ca-4353-9b35-532b12bab482.png">

## Follow-ups
We could possibly extract the profile commands from the parallel branch, as it's super short, and move it right after the unit tests