### PR TITLE
Filter directory listings by extension

### DIFF
--- a/internal/builder/external_fields.go
+++ b/internal/builder/external_fields.go
@@ -37,7 +37,7 @@ func resolveExternalFields(packageRoot, destinationDir string) error {
 		return errors.Wrap(err, "can't create field dependency manager")
 	}
 
-	fieldsFile, err := filepath.Glob(filepath.Join(destinationDir, "data_stream", "*", "fields", "*"))
+	fieldsFile, err := filepath.Glob(filepath.Join(destinationDir, "data_stream", "*", "fields", "*.yml"))
 	if err != nil {
 		return err
 	}

--- a/internal/docs/readme.go
+++ b/internal/docs/readme.go
@@ -43,7 +43,7 @@ func AreReadmesUpToDate() ([]ReadmeFile, error) {
 		ok, err := isReadmeUpToDate(fileName, packageRoot)
 		if !ok || err != nil {
 			readmeFile := ReadmeFile{
-				FileName: filepath.Base(fileName),
+				FileName: fileName,
 				UpToDate: ok,
 				Error:    err,
 			}

--- a/internal/docs/readme.go
+++ b/internal/docs/readme.go
@@ -32,18 +32,18 @@ func AreReadmesUpToDate() ([]ReadmeFile, error) {
 		return nil, errors.Wrap(err, "package root not found")
 	}
 
-	files, err := os.ReadDir(filepath.Join(packageRoot, "_dev", "build", "docs"))
+	files, err := filepath.Glob(filepath.Join(packageRoot, "_dev", "build", "docs", "*.md"))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return nil, errors.Wrap(err, "reading directory entries failed")
 	}
 
 	var readmeFiles []ReadmeFile
-	for _, f := range files {
-		fileName := f.Name()
+	for _, filePath := range files {
+		fileName := filepath.Base(filePath)
 		ok, err := isReadmeUpToDate(fileName, packageRoot)
 		if !ok || err != nil {
 			readmeFile := ReadmeFile{
-				FileName: fileName,
+				FileName: filepath.Base(fileName),
 				UpToDate: ok,
 				Error:    err,
 			}
@@ -86,14 +86,14 @@ func isReadmeUpToDate(fileName, packageRoot string) (bool, error) {
 // UpdateReadmes function updates all .md readme files using a defined template
 // files. The function doesn't perform any action if the template file is not present.
 func UpdateReadmes(packageRoot string) ([]string, error) {
-	readmeFiles, err := os.ReadDir(filepath.Join(packageRoot, "_dev", "build", "docs"))
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
+	readmeFiles, err := filepath.Glob(filepath.Join(packageRoot, "_dev", "build", "docs", "*.md"))
+	if err != nil {
 		return nil, errors.Wrap(err, "reading directory entries failed")
 	}
 
 	var targets []string
-	for _, readme := range readmeFiles {
-		fileName := readme.Name()
+	for _, filePath := range readmeFiles {
+		fileName := filepath.Base(filePath)
 		target, err := updateReadme(fileName, packageRoot)
 		if err != nil {
 			return nil, errors.Wrapf(err, "updating readme file %s failed", fileName)

--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -101,15 +101,14 @@ func CreateValidatorForDataStream(dataStreamRootPath string, opts ...ValidatorOp
 
 func loadFieldsForDataStream(dataStreamRootPath string) ([]FieldDefinition, error) {
 	fieldsDir := filepath.Join(dataStreamRootPath, "fields")
-	fileInfos, err := os.ReadDir(fieldsDir)
+	files, err := filepath.Glob(filepath.Join(fieldsDir, "*.yml"))
 	if err != nil {
 		return nil, errors.Wrapf(err, "reading directory with fields failed (path: %s)", fieldsDir)
 	}
 
 	var fields []FieldDefinition
-	for _, fileInfo := range fileInfos {
-		f := filepath.Join(fieldsDir, fileInfo.Name())
-		body, err := os.ReadFile(f)
+	for _, file := range files {
+		body, err := os.ReadFile(file)
 		if err != nil {
 			return nil, errors.Wrap(err, "reading fields file failed")
 		}

--- a/internal/testrunner/runners/system/servicedeployer/kubernetes.go
+++ b/internal/testrunner/runners/system/servicedeployer/kubernetes.go
@@ -8,10 +8,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -134,16 +132,14 @@ func (ksd KubernetesServiceDeployer) installCustomDefinitions() error {
 var _ ServiceDeployer = new(KubernetesServiceDeployer)
 
 func findKubernetesDefinitions(definitionsDir string) ([]string, error) {
-	fileInfos, err := os.ReadDir(definitionsDir)
+	files, err := filepath.Glob(filepath.Join(definitionsDir, "*.yaml"))
 	if err != nil {
 		return nil, errors.Wrapf(err, "can't read definitions directory (path: %s)", definitionsDir)
 	}
 
 	var definitionPaths []string
-	for _, fileInfo := range fileInfos {
-		if strings.HasSuffix(fileInfo.Name(), ".yaml") {
-			definitionPaths = append(definitionPaths, filepath.Join(definitionsDir, fileInfo.Name()))
-		}
+	for _, file := range files {
+		definitionPaths = append(definitionPaths, file)
 	}
 	return definitionPaths, nil
 }


### PR DESCRIPTION
This updates elastic-agent internals to filter for the expected extensions when listing directories in various processes, instead of processing all the files in a given directory.

Changed:
- data_streams/*/fields/: Only .yml files are loaded.
- _dev/build/docs/: Only .md files are considered.
- data_streams/*/elasticsearch/ingest_pipelines/: .yml and .json are
  loaded.

This prevents cryptic errors while developing packages, such as:

> ERROR: creating fields validator for data stream failed: can't load fields for data stream (path: /Users/adrian/go/src/github.com/elastic/integrations/packages/carbonback_edr/data_stream/log): unmarshalling field body failed: yaml: control characters are not allowed

In this case this all was caused by a `.swp` file being present in the directory as one of it's files was open in an editor.