### PR TITLE
fix: add elastic-agent as available service

### DIFF
--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -19,6 +19,7 @@ import (
 )
 
 var availableServices = map[string]struct{}{
+	"elastic-agent":    {},
 	"elasticsearch":    {},
 	"fleet-server":     {},
 	"kibana":           {},

--- a/cmd/stack_test.go
+++ b/cmd/stack_test.go
@@ -1,0 +1,49 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateServicesFlag(t *testing.T) {
+	t.Run("a non available service returns error", func(t *testing.T) {
+		err := validateServicesFlag([]string{"non-existing-service"})
+		require.NotNil(t, err)
+	})
+
+	t.Run("a non available service in a valid stack returns error", func(t *testing.T) {
+		err := validateServicesFlag([]string{"elasticsearch", "non-existing-service"})
+		require.NotNil(t, err)
+	})
+
+	t.Run("not possible to start a service twice", func(t *testing.T) {
+		err := validateServicesFlag([]string{"elasticsearch", "elasticsearch"})
+		require.NotNil(t, err)
+	})
+
+	availableStackServicesTest := []struct {
+		services []string
+	}{
+		{services: []string{"elastic-agent"}},
+		{services: []string{"elastic-agent", "elasticsearch"}},
+		{services: []string{"elasticsearch"}},
+		{services: []string{"kibana"}},
+		{services: []string{"package-registry"}},
+		{services: []string{"fleet-server"}},
+		{services: []string{"elasticsearch", "fleet-server"}},
+	}
+
+	for _, srv := range availableStackServicesTest {
+		t.Run(fmt.Sprintf("%v are available as a stack service", srv.services), func(t *testing.T) {
+			err := validateServicesFlag(srv.services)
+			require.Nil(t, err)
+		})
+	}
+
+}

--- a/cmd/stack_test.go
+++ b/cmd/stack_test.go
@@ -14,17 +14,17 @@ import (
 func TestValidateServicesFlag(t *testing.T) {
 	t.Run("a non available service returns error", func(t *testing.T) {
 		err := validateServicesFlag([]string{"non-existing-service"})
-		require.NotNil(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("a non available service in a valid stack returns error", func(t *testing.T) {
 		err := validateServicesFlag([]string{"elasticsearch", "non-existing-service"})
-		require.NotNil(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("not possible to start a service twice", func(t *testing.T) {
 		err := validateServicesFlag([]string{"elasticsearch", "elasticsearch"})
-		require.NotNil(t, err)
+		require.Error(t, err)
 	})
 
 	availableStackServicesTest := []struct {


### PR DESCRIPTION
## What does this PR do?
It adds the elastic-agent service as available service in the stack

## Why is it important?
It's not possible to start the stack without the agent, and then start the agent alone, even though the elastic-agent is part of the initial compose snapshot.yml file. The use case where I discovered this bug is:

1. run the stack without the agent
2. wait for the stack is ready (kibana, es, fleet-server)
3. run the agent to automatically enroll

## Steps to reproduce
1. elastic-package stack up --daemon --version 8.0.0-56a61c29-SNAPSHOT --services elasticsearch,fleet-server,kibana,package-registry -v
1. elastic-package stack up --daemon --version 8.0.0-56a61c29-SNAPSHOT --services elastic-agent

#### Expected behaviour
The agent is started alongside the existing stack

#### Current behaviour
The program fails as the agent is not part of the available services in the stack
```shell
$ elastic-package stack up --daemon --version 8.0.0-SNAPSHOT --services elasticsearch,fleet-server,kibana,package-registry,elastic-agent -v
2021/08/23 11:17:37 DEBUG Enable verbose logging
2021/08/23 11:17:37 DEBUG Distribution built without a version tag, can't determine release chronology. Please consider using official releases at https://github.com/elastic/elastic-package/releases
Boot up the Elastic stack
Error: validating services failed: service "elastic-agent" is not available
```

## Related issues
- Closes #492