### PR TITLE
Skip failing aws test

### DIFF
--- a/test/packages/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
+++ b/test/packages/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
@@ -1,3 +1,6 @@
+skip:
+  reason: "Test fails"
+  link: https://github.com/elastic/integrations/issues/1566
 vars:
   access_key_id: '{{AWS_ACCESS_KEY_ID}}'
   secret_access_key: '{{AWS_SECRET_ACCESS_KEY}}'


### PR DESCRIPTION
This AWS test is failing, something related to beats/agent? https://github.com/elastic/integrations/issues/1566

Reported in https://github.com/elastic/elastic-package/issues/501.