### PR TITLE
Use "docker cp" to copy internal logs

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -91,8 +91,8 @@ pipeline {
               dir("${BASE_DIR}") {
                 script {
                   parallel([
-                    'stack-command': generateTestCommandStage(command: 'test-stack-command', artifacts: ['build/elastic-stack-dump/**/*.log']),
-                    'check-packages': generateTestCommandStage(command: 'test-check-packages', artifacts: ['build/test-results/*.xml', 'build/kubectl-dump.txt', 'build/elastic-stack-dump/**/*.log'], junitArtifacts: true, publishCoverage: true),
+                    'stack-command': generateTestCommandStage(command: 'test-stack-command', artifacts: ['build/elastic-stack-dump/logs/*.log', 'build/elastic-stack-dump/logs/fleet-server-internal/*']),
+                    'check-packages': generateTestCommandStage(command: 'test-check-packages', artifacts: ['build/test-results/*.xml', 'build/kubectl-dump.txt', 'build/elastic-stack-dump/logs/*.log', 'build/elastic-stack-dump/logs/fleet-server-internal/*'], junitArtifacts: true, publishCoverage: true),
                     'profiles-command': generateTestCommandStage(command: 'test-profiles-command'),
                   ])
                 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -91,8 +91,8 @@ pipeline {
               dir("${BASE_DIR}") {
                 script {
                   parallel([
-                    'stack-command': generateTestCommandStage(command: 'test-stack-command', artifacts: ['build/elastic-stack-dump/logs/*.log', 'build/elastic-stack-dump/logs/fleet-server-internal/*']),
-                    'check-packages': generateTestCommandStage(command: 'test-check-packages', artifacts: ['build/test-results/*.xml', 'build/kubectl-dump.txt', 'build/elastic-stack-dump/logs/*.log', 'build/elastic-stack-dump/logs/fleet-server-internal/*'], junitArtifacts: true, publishCoverage: true),
+                    'stack-command': generateTestCommandStage(command: 'test-stack-command', artifacts: ['build/elastic-stack-dump/stack/logs/*.log', 'build/elastic-stack-dump/stack/logs/fleet-server-internal/*']),
+                    'check-packages': generateTestCommandStage(command: 'test-check-packages', artifacts: ['build/test-results/*.xml', 'build/kubectl-dump.txt', 'build/elastic-stack-dump/check/logs/*.log', 'build/elastic-stack-dump/check/logs/fleet-server-internal/*'], junitArtifacts: true, publishCoverage: true),
                     'profiles-command': generateTestCommandStage(command: 'test-profiles-command'),
                   ])
                 }

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -60,7 +60,7 @@ func Pull(image string) error {
 		cmd.Stderr = os.Stderr
 	}
 
-	logger.Debugf("running command: %s", cmd)
+	logger.Debugf("run command: %s", cmd)
 	err := cmd.Run()
 	if err != nil {
 		return errors.Wrap(err, "running docker command failed")
@@ -112,7 +112,7 @@ func ConnectToNetwork(containerID, network string) error {
 	errOutput := new(bytes.Buffer)
 	cmd.Stderr = errOutput
 
-	logger.Debugf("output command: %s", cmd)
+	logger.Debugf("run command: %s", cmd)
 	if err := cmd.Run(); err != nil {
 		return errors.Wrapf(err, "could not attach container to the stack network (stderr=%q)", errOutput.String())
 	}
@@ -142,19 +142,15 @@ func InspectContainers(containerIDs ...string) ([]ContainerDescription, error) {
 	return containerDescriptions, nil
 }
 
-// Exec function executes command inside of the container
-func Exec(containerName string, args ...string) ([]byte, error) {
-	cmdArgs := []string{"exec", "-t", containerName}
-	cmdArgs = append(cmdArgs, args...)
-
-	cmd := exec.Command("docker", cmdArgs...)
+// Copy function copies resources from the container to the local destination.
+func Copy(containerName, containerPath, localPath string) error {
+	cmd := exec.Command("docker", "cp", containerName+":"+containerPath, localPath)
 	errOutput := new(bytes.Buffer)
 	cmd.Stderr = errOutput
 
-	logger.Debugf("output command: %s", cmd)
-	output, err := cmd.Output()
-	if err != nil {
-		return nil, errors.Wrapf(err, "exec failed (stderr=%q)", errOutput.String())
+	logger.Debugf("run command: %s", cmd)
+	if err := cmd.Run(); err != nil {
+		return errors.Wrapf(err, "could not copy files from the container (stderr=%q)", errOutput.String())
 	}
-	return output, nil
+	return nil
 }

--- a/internal/stack/logs.go
+++ b/internal/stack/logs.go
@@ -5,6 +5,8 @@
 package stack
 
 import (
+	"path/filepath"
+
 	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/compose"
@@ -28,20 +30,23 @@ func dockerComposeLogs(serviceName string, snapshotFile string) ([]byte, error) 
 	return out, nil
 }
 
-func dockerInternalLogs(serviceName string) ([]byte, bool, error) {
-	if serviceName != fleetServerService {
-		return nil, false, nil // we need to pull internal logs only from the Fleet Server container
+func copyDockerInternalLogs(serviceName, outputPath string) error {
+	switch serviceName {
+	case elasticAgentService, fleetServerService:
+	default:
+		return nil // we need to pull internal logs only from Elastic-Agent and Fleets Server container
 	}
 
 	p, err := compose.NewProject(DockerComposeProjectName)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "could not create docker compose project")
+		return errors.Wrap(err, "could not create docker compose project")
 	}
 
+	outputPath = filepath.Join(outputPath, serviceName + "-internal")
 	serviceContainer := p.ContainerName(serviceName)
-	out, err := docker.Exec(serviceContainer, "sh", "-c", `find data/logs/default/fleet-server-json* -printf '%p\n' -exec cat {} \;`)
+	err = docker.Copy(serviceContainer, "/usr/share/elastic-agent/data/logs/default", outputPath)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "docker exec failed")
+		return errors.Wrap(err, "docker copy failed")
 	}
-	return out, true, nil
+	return nil
 }

--- a/internal/stack/logs.go
+++ b/internal/stack/logs.go
@@ -42,7 +42,7 @@ func copyDockerInternalLogs(serviceName, outputPath string) error {
 		return errors.Wrap(err, "could not create docker compose project")
 	}
 
-	outputPath = filepath.Join(outputPath, serviceName + "-internal")
+	outputPath = filepath.Join(outputPath, serviceName+"-internal")
 	serviceContainer := p.ContainerName(serviceName)
 	err = docker.Copy(serviceContainer, "/usr/share/elastic-agent/data/logs/default", outputPath)
 	if err != nil {


### PR DESCRIPTION
Issue: https://github.com/elastic/elastic-package/issues/475

This PR modifies the `dump` command to copy files using `docker cp`. It copies internal files from elastic-agent (new feature, metricbeat and filebeat) and fleet-server:

```
$ tree elastic-stack-dump
elastic-stack-dump
└── logs
    ├── elastic-agent-internal
    │   ├── filebeat-json.log
    │   ├── filebeat-json.log-2021-09-14-10-1
    │   ├── filebeat-json.log-2021-09-14-10-2
    │   ├── metricbeat-json.log
    │   ├── metricbeat-json.log-2021-09-14-10-1
    │   └── metricbeat-json.log-2021-09-14-10-2
    ├── elastic-agent.log
    ├── elasticsearch.log
    ├── fleet-server-internal
    │   ├── fleet-server-json.log
    │   ├── fleet-server-json.log-2021-09-14-10-1
    │   ├── fleet-server-json.log-2021-09-14-10-2
    │   └── fleet-server-json.log-2021-09-14-10-3
    ├── fleet-server.log
    ├── kibana.log
    └── package-registry.log

3 directories, 15 files
```

Jenkinsfile has been adjusted to save artifacts for the fleet server only. Elastic agent's logs might contain sensitive information. We will store them in a safe bucket (GCP) - follow up issue. 

Proof:

Collected artifacts: https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Felastic-package/detail/PR-509/2/artifacts