### PR TITLE
Fix check to stop looking for build path

### DIFF
--- a/internal/builder/packages.go
+++ b/internal/builder/packages.go
@@ -5,6 +5,7 @@
 package builder
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -37,6 +38,8 @@ func findBuildDirectory() (string, bool, error) {
 	}
 
 	dir := workDir
+	// required for multi platform support
+	root := fmt.Sprintf("%s%c", filepath.VolumeName(dir), os.PathSeparator)
 	for dir != "." {
 		path := filepath.Join(dir, "build")
 		fileInfo, err := os.Stat(path)
@@ -44,7 +47,7 @@ func findBuildDirectory() (string, bool, error) {
 			return path, true, nil
 		}
 
-		if dir == "/" {
+		if dir == root {
 			break
 		}
 		dir = filepath.Dir(dir)


### PR DESCRIPTION
While executing `elastic-package stack up` or others, a search for the `build` dir is done. Prior to this change, in windows platforms this ended up in an infinite loop since it was matching against `/` which was never found. This change builds the root path using `VolumeName` and `PathSeparator` to build the root path based on the current platform.