### PR TITLE
feat: list profiles in json or table format

### DIFF
--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -119,7 +119,7 @@ User profiles are not overwritten on upgrade of elastic-stack, and can be freely
 			}
 		},
 	}
-	profileListCommand.Flags().String(cobraext.ProfileFormatFlagName, "table", cobraext.ProfileFormatFlagDescription)
+	profileListCommand.Flags().String(cobraext.ProfileFormatFlagName, tableFormat, cobraext.ProfileFormatFlagDescription)
 
 	profileCommand.AddCommand(profileNewCommand, profileDeleteCommand, profileListCommand)
 

--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -140,7 +140,7 @@ func formatJSON(profileList []profile.Metadata) error {
 
 func formatTable(profileList []profile.Metadata) error {
 	table := tablewriter.NewWriter(os.Stdout)
-	var profilestable = profileToList(profileList)
+	var profilesTable = profileToList(profileList)
 
 	table.SetHeader([]string{"Name", "Date Created", "User", "Version", "Path"})
 	table.SetHeaderColor(
@@ -160,7 +160,7 @@ func formatTable(profileList []profile.Metadata) error {
 
 	table.SetAutoMergeCells(false)
 	table.SetRowLine(true)
-	table.AppendBulk(profilestable)
+	table.AppendBulk(profilesTable)
 	table.Render()
 
 	return nil

--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -143,9 +143,9 @@ User profiles are not overwritten on upgrade of elastic-stack, and can be freely
 				}
 				fmt.Print(string(data))
 				return nil
+			default:
+				return fmt.Errorf("format %s not supported", format)
 			}
-
-			return fmt.Errorf("format %s not supported", format)
 		},
 	}
 	profileListCommand.Flags().String(cobraext.ProfileFormatFlagName, "table", cobraext.ProfileFormatFlagDescription)

--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -145,7 +145,7 @@ User profiles are not overwritten on upgrade of elastic-stack, and can be freely
 				return nil
 			}
 
-			return errors.New("format " + format + " not supported")
+			return fmt.Errorf("format %s not supported", format)
 		},
 	}
 	profileListCommand.Flags().String(cobraext.ProfileFormatFlagName, "table", cobraext.ProfileFormatFlagDescription)

--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -19,6 +19,12 @@ import (
 	"github.com/elastic/elastic-package/internal/profile"
 )
 
+// jsonFormat is the format for JSON output
+const jsonFormat = "json"
+
+// tableFormat is the format for table output
+const tableFormat = "table"
+
 // profileNameEnvVar is the name of the environment variable to set the default profile
 const profileNameEnvVar = "ELASTIC_PACKAGE_PROFILE"
 
@@ -104,7 +110,7 @@ User profiles are not overwritten on upgrade of elastic-stack, and can be freely
 			}
 
 			switch format {
-			case "table":
+			case tableFormat:
 				table := tablewriter.NewWriter(os.Stdout)
 				var profilestable = profileToList(profileList)
 
@@ -130,7 +136,7 @@ User profiles are not overwritten on upgrade of elastic-stack, and can be freely
 				table.Render()
 
 				return nil
-			case "json":
+			case jsonFormat:
 				data, err := json.Marshal(profileList)
 				if err != nil {
 					return errors.Wrap(err, "error listing all profiles in JSON format")

--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -124,7 +124,6 @@ User profiles are not overwritten on upgrade of elastic-stack, and can be freely
 	profileCommand.AddCommand(profileNewCommand, profileDeleteCommand, profileListCommand)
 
 	return cobraext.NewCommand(profileCommand, cobraext.ContextGlobal)
-
 }
 
 func formatJSON(profileList []profile.Metadata) error {

--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -130,7 +131,12 @@ User profiles are not overwritten on upgrade of elastic-stack, and can be freely
 
 				return nil
 			case "json":
-				return errors.New("json not implemented yet")
+				data, err := json.Marshal(profileList)
+				if err != nil {
+					return errors.Wrap(err, "error listing all profiles in JSON format")
+				}
+				fmt.Print(string(data))
+				return nil
 			}
 
 			return errors.New("format " + format + " not supported")

--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -97,33 +97,46 @@ User profiles are not overwritten on upgrade of elastic-stack, and can be freely
 				return errors.Wrap(err, "error listing all profiles")
 			}
 
-			table := tablewriter.NewWriter(os.Stdout)
-			var profilestable = profileToList(profileList)
+			format, err := cmd.Flags().GetString(cobraext.ProfileFormatFlagName)
+			if err != nil {
+				return cobraext.FlagParsingError(err, cobraext.ProfileFromFlagName)
+			}
 
-			table.SetHeader([]string{"Name", "Date Created", "User", "Version", "Path"})
-			table.SetHeaderColor(
-				twColor(tablewriter.Colors{tablewriter.Bold}),
-				twColor(tablewriter.Colors{tablewriter.Bold}),
-				twColor(tablewriter.Colors{tablewriter.Bold}),
-				twColor(tablewriter.Colors{tablewriter.Bold}),
-				twColor(tablewriter.Colors{tablewriter.Bold}),
-			)
-			table.SetColumnColor(
-				twColor(tablewriter.Colors{tablewriter.Bold, tablewriter.FgCyanColor}),
-				tablewriter.Colors{},
-				tablewriter.Colors{},
-				tablewriter.Colors{},
-				tablewriter.Colors{},
-			)
+			switch format {
+			case "table":
+				table := tablewriter.NewWriter(os.Stdout)
+				var profilestable = profileToList(profileList)
 
-			table.SetAutoMergeCells(false)
-			table.SetRowLine(true)
-			table.AppendBulk(profilestable)
-			table.Render()
+				table.SetHeader([]string{"Name", "Date Created", "User", "Version", "Path"})
+				table.SetHeaderColor(
+					twColor(tablewriter.Colors{tablewriter.Bold}),
+					twColor(tablewriter.Colors{tablewriter.Bold}),
+					twColor(tablewriter.Colors{tablewriter.Bold}),
+					twColor(tablewriter.Colors{tablewriter.Bold}),
+					twColor(tablewriter.Colors{tablewriter.Bold}),
+				)
+				table.SetColumnColor(
+					twColor(tablewriter.Colors{tablewriter.Bold, tablewriter.FgCyanColor}),
+					tablewriter.Colors{},
+					tablewriter.Colors{},
+					tablewriter.Colors{},
+					tablewriter.Colors{},
+				)
 
-			return nil
+				table.SetAutoMergeCells(false)
+				table.SetRowLine(true)
+				table.AppendBulk(profilestable)
+				table.Render()
+
+				return nil
+			case "json":
+				return errors.New("json not implemented yet")
+			}
+
+			return errors.New("format " + format + " not supported")
 		},
 	}
+	profileListCommand.Flags().String(cobraext.ProfileFormatFlagName, "table", cobraext.ProfileFormatFlagDescription)
 
 	profileCommand.AddCommand(profileNewCommand, profileDeleteCommand, profileListCommand)
 

--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -111,38 +111,9 @@ User profiles are not overwritten on upgrade of elastic-stack, and can be freely
 
 			switch format {
 			case tableFormat:
-				table := tablewriter.NewWriter(os.Stdout)
-				var profilestable = profileToList(profileList)
-
-				table.SetHeader([]string{"Name", "Date Created", "User", "Version", "Path"})
-				table.SetHeaderColor(
-					twColor(tablewriter.Colors{tablewriter.Bold}),
-					twColor(tablewriter.Colors{tablewriter.Bold}),
-					twColor(tablewriter.Colors{tablewriter.Bold}),
-					twColor(tablewriter.Colors{tablewriter.Bold}),
-					twColor(tablewriter.Colors{tablewriter.Bold}),
-				)
-				table.SetColumnColor(
-					twColor(tablewriter.Colors{tablewriter.Bold, tablewriter.FgCyanColor}),
-					tablewriter.Colors{},
-					tablewriter.Colors{},
-					tablewriter.Colors{},
-					tablewriter.Colors{},
-				)
-
-				table.SetAutoMergeCells(false)
-				table.SetRowLine(true)
-				table.AppendBulk(profilestable)
-				table.Render()
-
-				return nil
+				return formatTable(profileList)
 			case jsonFormat:
-				data, err := json.Marshal(profileList)
-				if err != nil {
-					return errors.Wrap(err, "error listing all profiles in JSON format")
-				}
-				fmt.Print(string(data))
-				return nil
+				return formatJSON(profileList)
 			default:
 				return fmt.Errorf("format %s not supported", format)
 			}
@@ -154,6 +125,45 @@ User profiles are not overwritten on upgrade of elastic-stack, and can be freely
 
 	return cobraext.NewCommand(profileCommand, cobraext.ContextGlobal)
 
+}
+
+func formatJSON(profileList []profile.Metadata) error {
+	data, err := json.Marshal(profileList)
+	if err != nil {
+		return errors.Wrap(err, "error listing all profiles in JSON format")
+	}
+
+	fmt.Print(string(data))
+
+	return nil
+}
+
+func formatTable(profileList []profile.Metadata) error {
+	table := tablewriter.NewWriter(os.Stdout)
+	var profilestable = profileToList(profileList)
+
+	table.SetHeader([]string{"Name", "Date Created", "User", "Version", "Path"})
+	table.SetHeaderColor(
+		twColor(tablewriter.Colors{tablewriter.Bold}),
+		twColor(tablewriter.Colors{tablewriter.Bold}),
+		twColor(tablewriter.Colors{tablewriter.Bold}),
+		twColor(tablewriter.Colors{tablewriter.Bold}),
+		twColor(tablewriter.Colors{tablewriter.Bold}),
+	)
+	table.SetColumnColor(
+		twColor(tablewriter.Colors{tablewriter.Bold, tablewriter.FgCyanColor}),
+		tablewriter.Colors{},
+		tablewriter.Colors{},
+		tablewriter.Colors{},
+		tablewriter.Colors{},
+	)
+
+	table.SetAutoMergeCells(false)
+	table.SetRowLine(true)
+	table.AppendBulk(profilestable)
+	table.Render()
+
+	return nil
 }
 
 func profileToList(profiles []profile.Metadata) [][]string {

--- a/internal/cobraext/const.go
+++ b/internal/cobraext/const.go
@@ -45,6 +45,9 @@ const (
 	ProfileFromFlagName        = "from"
 	ProfileFromFlagDescription = "copy profile from the specified existing profile"
 
+	ProfileFormatFlagName        = "format"
+	ProfileFormatFlagDescription = "format of the profiles list (table | json)"
+
 	NewestOnlyFlagName        = "newest-only"
 	NewestOnlyFlagDescription = "promote newest packages and remove old ones"
 


### PR DESCRIPTION
## What does this PR do?
It exposes a new flag to set the format when listing existing profiles. The supported formats are `table` and `json`, being `table` the default one.

```shell
$ go run main.go profiles list --help
2021/10/06 06:14:55  WARN CommitHash is undefined, in both /Users/mdelapenya/.elastic-package/version and the compiled binary, config may be out of date.
List available profiles

Usage:
  elastic-package profiles list [flags]

Flags:
      --format string   format of the profiles list (table | json) (default "table")
  -h, --help            help for list

Global Flags:
  -v, --verbose   verbose mode
```

## Why is it important?
We'd like the tool to provide the existing profiles in a machine-readable format, as we want to check if there is a profile. Yes, we could directly check the filesystem, but this is more consistent :)

## How to test this locally

Run the tool in table format:
```shell
$ go run main.go profiles list
2021/10/06 06:07:47  WARN CommitHash is undefined, in both /Users/mdelapenya/.elastic-package/version and the compiled binary, config may be out of date.
+------------------------------+---------------------------+------------+-----------+--------------------------------------------------------------------------+
|             NAME             |       DATE CREATED        |    USER    |  VERSION  |                                   PATH                                   |
+------------------------------+---------------------------+------------+-----------+--------------------------------------------------------------------------+
| custom-pr                    | 2021-10-04T18:02:48+02:00 | mdelapenya | 1af18c9   | /Users/mdelapenya/.elastic-package/profiles/custom-pr                    |
+------------------------------+---------------------------+------------+-----------+--------------------------------------------------------------------------+
| default                      | 2021-10-06T06:01:26+02:00 | mdelapenya | undefined | /Users/mdelapenya/.elastic-package/profiles/default                      |
+------------------------------+---------------------------+------------+-----------+--------------------------------------------------------------------------+
| default_1af18c9_1629958780   | 2021-08-26T08:19:40+02:00 | mdelapenya | 1af18c9   | /Users/mdelapenya/.elastic-package/profiles/default_1af18c9_1629958780   |
+------------------------------+---------------------------+------------+-----------+--------------------------------------------------------------------------+
| default_undefined_1633422611 | 2021-10-05T10:30:11+02:00 | mdelapenya | undefined | /Users/mdelapenya/.elastic-package/profiles/default_undefined_1633422611 |
+------------------------------+---------------------------+------------+-----------+--------------------------------------------------------------------------+
```

Run the tool in JSON format:
```shell
$ go run main.go profiles list --format json
2021/10/06 06:07:47  WARN CommitHash is undefined, in both /Users/mdelapenya/.elastic-package/version and the compiled binary, config may be out of date.
[{"name":"custom-pr","date_created":"2021-10-04T18:02:48.167182+02:00","user":"mdelapenya","version":"1af18c9","path":"/Users/mdelapenya/.elastic-package/profiles/custom-pr"},{"name":"default","date_created":"2021-10-06T06:01:26.74122+02:00","user":"mdelapenya","version":"undefined","path":"/Users/mdelapenya/.elastic-package/profiles/default"},{"name":"default_1af18c9_1629958780","date_created":"2021-08-26T08:19:40.39341+02:00","user":"mdelapenya","version":"1af18c9","path":"/Users/mdelapenya/.elastic-package/profiles/default_1af18c9_1629958780"},{"name":"default_undefined_1633422611","date_created":"2021-10-05T10:30:11.968095+02:00","user":"mdelapenya","version":"undefined","path":"/Users/mdelapenya/.elastic-package/profiles/default_undefined_1633422611"}]
```

Run the tool with a non-supported format:
```shell
$ go run main.go profiles list --format FOO
2021/10/06 06:12:07  WARN CommitHash is undefined, in both /Users/mdelapenya/.elastic-package/version and the compiled binary, config may be out of date.
Error: format FOO not supported
exit status 1
```