### PR TITLE
Fix: don't fallback to default stack version

### DIFF
--- a/internal/install/application_configuration.go
+++ b/internal/install/application_configuration.go
@@ -36,26 +36,15 @@ type stack struct {
 
 func checkImageRefOverride(envVar, fallback string) string {
 	refOverride := os.Getenv(envVar)
-	if refOverride == "" {
-		return fallback
-	}
-	return refOverride
+	return stringOrDefault(refOverride, fallback)
 }
 
 func (s stack) ImageRefOverridesForVersion(version string) ImageRefs {
-	appConfigImageRefs, ok := s.ImageRefOverrides[version]
-	if ok {
-		return ImageRefs{
-			ElasticAgent:  checkImageRefOverride("ELASTIC_AGENT_IMAGE_REF_OVERRIDE", appConfigImageRefs.ElasticAgent),
-			Elasticsearch: checkImageRefOverride("ELASTICSEARCH_IMAGE_REF_OVERRIDE", appConfigImageRefs.Elasticsearch),
-			Kibana:        checkImageRefOverride("KIBANA_IMAGE_REF_OVERRIDE", appConfigImageRefs.Kibana),
-		}
-	}
-
+	appConfigImageRefs := s.ImageRefOverrides[version]
 	return ImageRefs{
-		ElasticAgent:  checkImageRefOverride("ELASTIC_AGENT_IMAGE_REF_OVERRIDE", ""),
-		Elasticsearch: checkImageRefOverride("ELASTICSEARCH_IMAGE_REF_OVERRIDE", ""),
-		Kibana:        checkImageRefOverride("KIBANA_IMAGE_REF_OVERRIDE", ""),
+		ElasticAgent:  checkImageRefOverride("ELASTIC_AGENT_IMAGE_REF_OVERRIDE", stringOrDefault(appConfigImageRefs.ElasticAgent, "")),
+		Elasticsearch: checkImageRefOverride("ELASTICSEARCH_IMAGE_REF_OVERRIDE", stringOrDefault(appConfigImageRefs.Elasticsearch, "")),
+		Kibana:        checkImageRefOverride("KIBANA_IMAGE_REF_OVERRIDE", stringOrDefault(appConfigImageRefs.Kibana, "")),
 	}
 }
 


### PR DESCRIPTION
Bug spotted in: https://github.com/elastic/integrations/pull/1877

This PR fixes bug in fallback selection of stack version. Default stack version should be selected in later processing, otherwise every ENV override var is 7.15.0-SNAPSHOT and `--version` is ignored.

Testing:

```
elastic-package stack up -v --version 7.98.0-SNAPSHOT
```

```
Error response from daemon: manifest for docker.elastic.co/beats/elastic-agent-complete:7.98.0-SNAPSHOT not found: manifest unknown: manifest unknown
Error: booting up the stack failed: running docker-compose failed: running command failed: running Docker Compose up command failed: exit status 18
```