### PR TITLE
chore: support destroying orphan containers when destroying the stack with down command

### DIFF
--- a/internal/stack/compose.go
+++ b/internal/stack/compose.go
@@ -100,7 +100,7 @@ func dockerComposeDown(options Options) error {
 	downOptions := compose.CommandOptions{
 		Env: append(appConfig.StackImageRefs(options.StackVersion).AsEnv(), options.Profile.ComposeEnvVars()...),
 		// Remove associated volumes.
-		ExtraArgs: []string{"--volumes"},
+		ExtraArgs: []string{"--volumes", "--remove-orphans"},
 	}
 	if err := c.Down(downOptions); err != nil {
 		return errors.Wrap(err, "running command failed")


### PR DESCRIPTION
## What does this PR do?
It adds the `--remove-orphans` flag as an extra-arg to the commpose down method

## Why is it important?
In the e2e-testing project we are starting/destroying services on the fly, appending them to the elastic-package network.

When down-ing the stack compose, we want to remove orphan containers in that network.