### PR TITLE
ci: use withMageEnv after the dir

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -215,7 +215,9 @@ def withKubernetes(Closure body) {
        chmod +x ${HOME}/bin/kubectl
        kubectl version --client
        ''') }
-    body()
+    withEnv(["PATH+TOOLS=${HOME}/bin"]) {
+      body()
+    }
 }
 
 def withCloudTestEnv(Closure body) {


### PR DESCRIPTION
### What

Run `withMageEnv` within the BASE_DIR folder in order to read the `.go-version` file. Otherwise it honours the default go version set in the shared library step.

Add the tools to the PATH when running the k8s/kind stuff.

### Before

![image](https://user-images.githubusercontent.com/2871786/136922015-c568743c-67e0-4c93-a8a3-28a855239f06.png)

### After

![image](https://user-images.githubusercontent.com/2871786/136921937-d894ceb7-072b-4c80-93b9-32ba155cad56.png)
