### PR TITLE
Bump up stack version to next 7.15.1

### DIFF
--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "7.15.0-SNAPSHOT"
+	DefaultStackVersion = "7.16.0-SNAPSHOT"
 )

--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "7.16.0-SNAPSHOT"
+	DefaultStackVersion = "7.15.1"
 )


### PR DESCRIPTION
This PR bumps up the default stack version to 7.16.0-SNAPSHOT