### PR TITLE
AWS EC2 metrics: use latency option

### DIFF
--- a/test/packages/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
+++ b/test/packages/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
@@ -5,7 +5,7 @@ vars:
   session_token: '{{AWS_SESSION_TOKEN}}'
 data_stream:
   vars:
-    period: 60s
+    period: 5m
     latency: 10m
     tags_filter: |-
       - key: Name


### PR DESCRIPTION
Another try to fix the problem reported in: https://github.com/elastic/integrations/issues/1566