### PR TITLE
[ES docker] Fixing script compilation settings to resolve CI errors

### DIFF
--- a/internal/profile/_static/docker-compose-stack.yml
+++ b/internal/profile/_static/docker-compose-stack.yml
@@ -16,6 +16,7 @@ services:
     - "xpack.security.enabled=true"
     - "xpack.security.authc.api_key.enabled=true"
     - "ELASTIC_PASSWORD=changeme"
+    - "script.max_compilations_rate=use-context"
     - "script.context.template.max_compilations_rate=unlimited"
     - "script.context.ingest.cache_max_size=2000"
     - "script.context.processor_conditional.cache_max_size=2000"


### PR DESCRIPTION
This PR resolves errors like this:
```
[36melasticsearch_1              |[0m java.lang.IllegalArgumentException: Context cache settings [script.context.ingest.cache_max_size, script.context.processor_conditional.cache_max_size, script.context.template.cache_max_size, script.context.template.max_compilations_rate] requires [script.max_compilations_rate] to be [use-context]
[36melasticsearch_1              |[0m 	at org.elasticsearch.script.ScriptService.validateCacheSettings(ScriptService.java:289)
[36melasticsearch_1              |[0m 	at org.elasticsearch.script.ScriptService.<init>(ScriptService.java:214)
[36melasticsearch_1              |[0m 	at org.elasticsearch.node.Node.newScriptService(Node.java:1296)
[36melasticsearch_1              |[0m 	at org.elasticsearch.node.Node.<init>(Node.java:444)
[36melasticsearch_1              |[0m 	at org.elasticsearch.node.Node.<init>(Node.java:291)
[36melasticsearch_1              |[0m 	at org.elasticsearch.bootstrap.Bootstrap$5.<init>(Bootstrap.java:221)
[36melasticsearch_1              |[0m 	at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:221)
[36melasticsearch_1              |[0m 	at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:401)
[36melasticsearch_1              |[0m 	at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:167)
[36melasticsearch_1              |[0m 	at org.elasticsearch.bootstrap.Elasticsearch.execute(Elasticsearch.java:158)
[36melasticsearch_1              |[0m 	at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:75)
[36melasticsearch_1              |[0m 	at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:114)
[36melasticsearch_1              |[0m 	at org.elasticsearch.cli.Command.main(Command.java:79)
[36melasticsearch_1              |[0m 	at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:123)
[36melasticsearch_1              |[0m 	at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:81)
[36melasticsearch_1              |[0m For complete error details, refer to the log at /usr/share/elasticsearch/logs/docker-cluster.log
```

However this is a short term resolution. From 7.16+ it is deprecated to set context specific settings for compilation rates etc, all of these should be removed:
```
    - "script.max_compilations_rate=use-context"
    - "script.context.template.max_compilations_rate=unlimited"
    - "script.context.ingest.cache_max_size=2000"
    - "script.context.processor_conditional.cache_max_size=2000"
    - "script.context.template.cache_max_size=2000"
```
To make this PR work with both older and newer versions however, I have simply added the setting that was missing, so that build can pass on both new and old.

Deprecation notice: https://www.elastic.co/guide/en/elasticsearch/reference/7.16/migrating-7.16.html#breaking_716_cluster_deprecations