### PR TITLE
Install Elastic Agent in Kubernetes cluster in compatible stack version

### DIFF
--- a/internal/install/application_configuration.go
+++ b/internal/install/application_configuration.go
@@ -64,11 +64,6 @@ func (ir ImageRefs) AsEnv() []string {
 	return vars
 }
 
-// DefaultStackImageRefs function selects the appropriate set of Docker image references for the default stack version.
-func (ac *ApplicationConfiguration) DefaultStackImageRefs() ImageRefs {
-	return ac.StackImageRefs(DefaultStackVersion)
-}
-
 // StackImageRefs function selects the appropriate set of Docker image references for the given stack version.
 func (ac *ApplicationConfiguration) StackImageRefs(version string) ImageRefs {
 	refs := ac.c.Stack.ImageRefOverridesForVersion(version)

--- a/internal/kibana/injected_metadata.go
+++ b/internal/kibana/injected_metadata.go
@@ -55,9 +55,9 @@ func extractInjectedMetadata(body []byte) (*InjectedMetadata, error) {
 }
 
 func extractRawInjectedMetadata(body []byte) ([]byte, error) {
-	matches := kbnInjectedMetadataRegexp.FindStringSubmatch(body)
+	matches := kbnInjectedMetadataRegexp.FindSubmatch(body)
 	if len(matches) < 2 { // index:0 - matched regexp, index:1 - matched data
 		return nil, errors.New("expected to find at least one <kbn-injected-metadata> tag")
 	}
-	return []byte(html.UnescapeString(matches[1])), nil
+	return []byte(html.UnescapeString(string(matches[1]))), nil
 }

--- a/internal/kibana/injected_metadata.go
+++ b/internal/kibana/injected_metadata.go
@@ -55,9 +55,9 @@ func extractInjectedMetadata(body []byte) (*InjectedMetadata, error) {
 }
 
 func extractRawInjectedMetadata(body []byte) ([]byte, error) {
-	matches := kbnInjectedMetadataRegexp.FindSubmatch(body)
+	matches := kbnInjectedMetadataRegexp.FindStringSubmatch(body)
 	if len(matches) < 2 { // index:0 - matched regexp, index:1 - matched data
 		return nil, errors.New("expected to find at least one <kbn-injected-metadata> tag")
 	}
-	return []byte(html.UnescapeString(string(matches[1]))), nil
+	return []byte(html.UnescapeString(matches[1])), nil
 }

--- a/internal/kibana/injected_metadata.go
+++ b/internal/kibana/injected_metadata.go
@@ -1,0 +1,55 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kibana
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+// InjectedMetadata represents the Kibana metadata structure exposed in the web UI.
+type InjectedMetadata struct {
+	// Stack version
+	Version string `json:"version"`
+}
+
+// InjectedMetadata method returns the Kibana metadata. The metadata is always present, even if the client is
+// unauthorized.
+func (c *Client) InjectedMetadata() (*InjectedMetadata, error) {
+	statusCode, respBody, err := c.get("/login")
+	if err != nil {
+		return nil, errors.Wrap(err, "could not reach login endpoint")
+	}
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf("could not reach login endpoint; API status code = %d; response body = %s", statusCode, string(respBody))
+	}
+
+	im, err := extractInjectedMetadata(respBody)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't extract injected metadata")
+	}
+	return im, nil
+}
+
+func extractInjectedMetadata(body []byte) (*InjectedMetadata, error) {
+	rawInjectedMetadata, err := extractRawInjectedMetadata(body)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't extract raw metadata")
+	}
+
+	var im InjectedMetadata
+	err = json.Unmarshal(rawInjectedMetadata, &im)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't unmarshal raw injected metadata")
+	}
+	return &im, nil
+}
+
+func extractRawInjectedMetadata(body []byte) ([]byte, error) {
+	return nil, nil // TODO
+}

--- a/internal/kibana/injected_metadata.go
+++ b/internal/kibana/injected_metadata.go
@@ -7,10 +7,14 @@ package kibana
 import (
 	"encoding/json"
 	"fmt"
+	"html"
 	"net/http"
+	"regexp"
 
 	"github.com/pkg/errors"
 )
+
+var kbnInjectedMetadataRegexp = regexp.MustCompile(`<kbn-injected-metadata data="(.+)"></kbn-injected-metadata>`)
 
 // InjectedMetadata represents the Kibana metadata structure exposed in the web UI.
 type InjectedMetadata struct {
@@ -51,5 +55,9 @@ func extractInjectedMetadata(body []byte) (*InjectedMetadata, error) {
 }
 
 func extractRawInjectedMetadata(body []byte) ([]byte, error) {
-	return nil, nil // TODO
+	matches := kbnInjectedMetadataRegexp.FindSubmatch(body)
+	if len(matches) < 2 { // index:0 - matched regexp, index:1 - matched data
+		return nil, errors.New("expected to find at least one <kbn-injected-metadata> tag")
+	}
+	return []byte(html.UnescapeString(string(matches[1]))), nil
 }

--- a/internal/kibana/injected_metadata_test.go
+++ b/internal/kibana/injected_metadata_test.go
@@ -1,0 +1,36 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kibana
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// sampleLoginPage represents Kibana login page without redundant styles, fonts, noise in metadata, etc.
+var sampleLoginPage = []byte(`<!DOCTYPE html><html lang="en"><head><meta charSet="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/><meta name="viewport" content="width=device-width"/><title>Elastic</title><style>
+          @keyframes kbnProgress {
+            0% {
+              transform: scaleX(1) translateX(-100%);
+            }
+
+            100% {
+              transform: scaleX(1) translateX(100%);
+            }
+          }
+        </style><link rel="stylesheet" type="text/css" href="/44185/bundles/kbn-ui-shared-deps/kbn-ui-shared-deps.css"/><link rel="stylesheet" type="text/css" href="/44185/bundles/kbn-ui-shared-deps/kbn-ui-shared-deps.v8.light.css"/><link rel="stylesheet" type="text/css" href="/node_modules/@kbn/ui-framework/dist/kui_light.css"/><link rel="stylesheet" type="text/css" href="/ui/legacy_light_theme.css"/><meta name="add-styles-here"/><meta name="add-scripts-here"/></head><body><kbn-csp data="{&quot;strictCsp&quot;:false}"></kbn-csp><kbn-injected-metadata data="{&quot;version&quot;:&quot;7.15.1&quot;,&quot;buildNumber&quot;:44185,&quot;branch&quot;:&quot;7.15&quot;,&quot;basePath&quot;:&quot;&quot;}"></kbn-injected-metadata><div class="kbnWelcomeView" id="kbn_loading_message" style="display:none" data-test-subj="kbnLoadingMessage"><div class="kbnLoaderWrap"><h2 class="kbnWelcomeTitle">Please upgrade your browser</h2><div class="kbnWelcomeText">This Elastic installation has strict security requirements enabled that your current browser does not meet.</div></div><script>
+            // Since this is an unsafe inline script, this code will not run
+            // in browsers that support content security policy(CSP). This is
+            // intentional as we check for the existence of __kbnCspNotEnforced__ in
+            // bootstrap.
+            window.__kbnCspNotEnforced__ = true;
+          </script><script src="/bootstrap.js"></script></body></html>`)
+
+func TestExtractRawInjectedMetadata(t *testing.T) {
+	im, err := extractInjectedMetadata(sampleLoginPage)
+	require.NoError(t, err)
+	require.Equal(t, "7.15.1", im.Version)
+}

--- a/internal/testrunner/runners/system/servicedeployer/kubernetes.go
+++ b/internal/testrunner/runners/system/servicedeployer/kubernetes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/install"
+	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/kind"
 	"github.com/elastic/elastic-package/internal/kubectl"
 	"github.com/elastic/elastic-package/internal/logger"
@@ -141,7 +142,17 @@ func findKubernetesDefinitions(definitionsDir string) ([]string, error) {
 func installElasticAgentInCluster() error {
 	logger.Debug("install Elastic Agent in the Kubernetes cluster")
 
-	elasticAgentManagedYaml, err := getElasticAgentYAML()
+	kibanaClient, err := kibana.NewClient()
+	if err != nil {
+		return errors.Wrap(err, "can't create Kibana client")
+	}
+
+	metadata, err := kibanaClient.InjectedMetadata()
+	if err != nil {
+		return errors.Wrap(err, "can't read Kibana injected metadata")
+	}
+
+	elasticAgentManagedYaml, err := getElasticAgentYAML(metadata.Version)
 	if err != nil {
 		return errors.Wrap(err, "can't retrieve Kubernetes file for Elastic Agent")
 	}
@@ -156,7 +167,9 @@ func installElasticAgentInCluster() error {
 //go:embed elastic-agent-managed.yaml.tmpl
 var elasticAgentManagedYamlTmpl string
 
-func getElasticAgentYAML() ([]byte, error) {
+func getElasticAgentYAML(stackVersion string) ([]byte, error) {
+	logger.Debugf("Prepare YAML definition for Elastic Agent running in stack v%s", stackVersion)
+
 	appConfig, err := install.Configuration()
 	if err != nil {
 		return nil, errors.Wrap(err, "can't read application configuration")
@@ -167,7 +180,7 @@ func getElasticAgentYAML() ([]byte, error) {
 	var elasticAgentYaml bytes.Buffer
 	err = tmpl.Execute(&elasticAgentYaml, map[string]string{
 		"fleetURL":          "http://fleet-server:8220",
-		"elasticAgentImage": appConfig.DefaultStackImageRefs().ElasticAgent,
+		"elasticAgentImage": appConfig.StackImageRefs(stackVersion).ElasticAgent,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "can't generate elastic agent manifest")

--- a/internal/testrunner/runners/system/servicedeployer/kubernetes.go
+++ b/internal/testrunner/runners/system/servicedeployer/kubernetes.go
@@ -147,12 +147,12 @@ func installElasticAgentInCluster() error {
 		return errors.Wrap(err, "can't create Kibana client")
 	}
 
-	metadata, err := kibanaClient.InjectedMetadata()
+	stackVersion, err := kibanaClient.Version()
 	if err != nil {
 		return errors.Wrap(err, "can't read Kibana injected metadata")
 	}
 
-	elasticAgentManagedYaml, err := getElasticAgentYAML(metadata.Version)
+	elasticAgentManagedYaml, err := getElasticAgentYAML(stackVersion)
 	if err != nil {
 		return errors.Wrap(err, "can't retrieve Kubernetes file for Elastic Agent")
 	}


### PR DESCRIPTION
Fixes: https://github.com/elastic/elastic-package/issues/567

Kubernetes service deployer selects the stack version based on the running Kibana:

```
[2021-11-03T08:31:55.324Z] 2021/11/03 08:31:54 DEBUG install Elastic Agent in the Kubernetes cluster
[2021-11-03T08:31:55.324Z] 2021/11/03 08:31:54 DEBUG GET http://127.0.0.1:5601/login
[2021-11-03T08:31:55.324Z] 2021/11/03 08:31:54 DEBUG Prepare YAML definition for Elastic Agent running in stack v7.15.1
[2021-11-03T08:31:55.324Z] 2021/11/03 08:31:54 DEBUG Apply Kubernetes stdin
[2021-11-03T08:31:55.324Z] 2021/11/03 08:31:54 DEBUG run command: /var/lib/jenkins/workspace/PR-569-2-05934679-d7fa-4f01-8c4c-248efecf3bf3/bin/kubectl apply -f - -o yaml
[2021-11-03T08:31:55.324Z] 2021/11/03 08:31:55 DEBUG Handle "apply" command output
[2021-11-03T08:31:55.324Z] 2021/11/03 08:31:55 DEBUG Extract resources from command output
[2021-11-03T08:31:55.324Z] 2021/11/03 08:31:55 DEBUG Wait for ready resources
[2021-11-03T08:31:55.324Z] 2021/11/03 08:31:55 DEBUG Sync resource info: elastic-agent (kind: DaemonSet, namespace: kube-system)
[2021-11-03T08:31:55.324Z] 2021/11/03 08:31:55 DEBUG Sync resource info: elastic-agent (kind: ClusterRoleBinding, namespace: )
[2021-11-03T08:31:55.324Z] 2021/11/03 08:31:55 DEBUG Sync resource info: elastic-agent (kind: RoleBinding, namespace: kube-system)
[2021-11-03T08:31:55.324Z] 2021/11/03 08:31:55 DEBUG Sync resource info: elastic-agent-kubeadm-config (kind: RoleBinding, namespace: kube-system)
[2021-11-03T08:31:55.591Z] 2021/11/03 08:31:55 DEBUG Sync resource info: elastic-agent (kind: ClusterRole, namespace: )
[2021-11-03T08:31:55.591Z] 2021/11/03 08:31:55 DEBUG Sync resource info: elastic-agent (kind: Role, namespace: kube-system)
[2021-11-03T08:31:55.591Z] 2021/11/03 08:31:55 DEBUG Sync resource info: elastic-agent-kubeadm-config (kind: Role, namespace: kube-system)
[2021-11-03T08:31:55.591Z] 2021/11/03 08:31:55 DEBUG Sync resource info: elastic-agent (kind: ServiceAccount, namespace: kube-system)
[2021-11-03T08:31:55.591Z] 2021/11/03 08:31:55 DEBUG beginning wait for 8 resources with timeout of 10m0s
``` 