### PR TITLE
Allow to override attributes from external fields

### DIFF
--- a/internal/docs/exported_fields.go
+++ b/internal/docs/exported_fields.go
@@ -131,16 +131,14 @@ func visitFields(namePrefix string, f fields.FieldDefinition, records []fieldsTa
 			if err != nil {
 				return nil, errors.Wrap(err, "can't import field")
 			}
-			f.Type = imported.Type
-			if f.Description == "" {
-				f.Description = imported.Description
-			}
-			if f.Unit == "" {
-				f.Unit = imported.Unit
-			}
-			if f.MetricType == "" {
-				f.MetricType = imported.MetricType
-			}
+
+			// Override imported fields with the definition, except for the type and external.
+			var updated fields.FieldDefinition
+			updated.Update(imported)
+			updated.Update(f)
+			updated.Type = imported.Type
+			updated.External = ""
+			f = updated
 		}
 		records = append(records, fieldsTableRecord{
 			name:        name,

--- a/internal/docs/exported_fields.go
+++ b/internal/docs/exported_fields.go
@@ -127,10 +127,19 @@ func visitFields(namePrefix string, f fields.FieldDefinition, records []fieldsTa
 
 	if len(f.Fields) == 0 && f.Type != "group" {
 		if f.External != "" {
-			var err error
-			f, err = fdm.ImportField(f.External, name)
+			imported, err := fdm.ImportField(f.External, name)
 			if err != nil {
 				return nil, errors.Wrap(err, "can't import field")
+			}
+			f.Type = imported.Type
+			if f.Description == "" {
+				f.Description = imported.Description
+			}
+			if f.Unit == "" {
+				f.Unit = imported.Unit
+			}
+			if f.MetricType == "" {
+				f.MetricType = imported.MetricType
 			}
 		}
 		records = append(records, fieldsTableRecord{

--- a/internal/fields/dependency_manager.go
+++ b/internal/fields/dependency_manager.go
@@ -149,6 +149,7 @@ func (dm *DependencyManager) injectFieldsWithRoot(root string, defs []common.Map
 			// Allow overrides of everything, except the imported type, for consistency.
 			transformed.DeepUpdate(def)
 			transformed["type"] = imported.Type
+			transformed.Delete("external")
 
 			updated = append(updated, transformed)
 			changed = true

--- a/internal/fields/dependency_manager.go
+++ b/internal/fields/dependency_manager.go
@@ -145,8 +145,11 @@ func (dm *DependencyManager) injectFieldsWithRoot(root string, defs []common.Map
 			}
 
 			transformed := transformImportedField(imported)
-			originalName, _ := def.GetValue("name")
-			transformed.Put("name", originalName)
+
+			// Allow overrides of everything, except the imported type, for consistency.
+			transformed.DeepUpdate(def)
+			transformed["type"] = imported.Type
+
 			updated = append(updated, transformed)
 			changed = true
 			continue

--- a/internal/fields/dependency_manager_test.go
+++ b/internal/fields/dependency_manager_test.go
@@ -1,0 +1,163 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package fields
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elastic-package/internal/common"
+)
+
+func TestDependencyManagerInjectExternalFields(t *testing.T) {
+	cases := []struct {
+		title   string
+		defs    []common.MapStr
+		result  []common.MapStr
+		changed bool
+		valid   bool
+	}{
+		{
+			title:   "empty defs",
+			defs:    []common.MapStr{},
+			changed: false,
+			valid:   true,
+		},
+		{
+			title: "dataset value override",
+			defs: []common.MapStr{
+				{
+					"name":     "data_stream.dataset",
+					"external": "test",
+					"value":    "nginx.access",
+				},
+				{
+					"name":     "data_stream.type",
+					"external": "test",
+					"value":    "logs",
+				},
+			},
+			result: []common.MapStr{
+				{
+					"name":        "data_stream.dataset",
+					"type":        "constant_keyword",
+					"description": "Data stream dataset.",
+					"value":       "nginx.access",
+				},
+				{
+					"name":        "data_stream.type",
+					"type":        "constant_keyword",
+					"description": "Data stream type (logs, metrics).",
+					"value":       "logs",
+				},
+			},
+			changed: true,
+			valid:   true,
+		},
+		{
+			title: "external dimension",
+			defs: []common.MapStr{
+				{
+					"name":      "container.id",
+					"external":  "test",
+					"dimension": "true",
+				},
+			},
+			result: []common.MapStr{
+				{
+					"name":        "container.id",
+					"type":        "keyword",
+					"description": "Container identifier.",
+					"dimension":   "true",
+				},
+			},
+			changed: true,
+			valid:   true,
+		},
+		{
+			title: "external dimension",
+			defs: []common.MapStr{
+				{
+					"name":      "container.id",
+					"external":  "test",
+					"dimension": "true",
+				},
+			},
+			result: []common.MapStr{
+				{
+					"name":        "container.id",
+					"type":        "keyword",
+					"description": "Container identifier.",
+					"dimension":   "true",
+				},
+			},
+			changed: true,
+			valid:   true,
+		},
+		{
+			title: "type override",
+			defs: []common.MapStr{
+				{
+					"name":     "container.id",
+					"external": "test",
+					"type":     "long",
+				},
+			},
+			result: []common.MapStr{
+				{
+					"name":        "container.id",
+					"type":        "keyword",
+					"description": "Container identifier.",
+				},
+			},
+			changed: true,
+			valid:   true,
+		},
+		{
+			title: "unknown field",
+			defs: []common.MapStr{
+				{
+					"name":     "container.identifier",
+					"external": "test",
+				},
+			},
+			valid: false,
+		},
+	}
+
+	schema := map[string][]FieldDefinition{"test": []FieldDefinition{
+		{
+			Name:        "container.id",
+			Description: "Container identifier.",
+			Type:        "keyword",
+		},
+		{
+			Name:        "data_stream.type",
+			Description: "Data stream type (logs, metrics).",
+			Type:        "constant_keyword",
+		},
+		{
+			Name:        "data_stream.dataset",
+			Description: "Data stream dataset.",
+			Type:        "constant_keyword",
+		},
+	}}
+	dm := &DependencyManager{schema: schema}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			result, changed, err := dm.InjectFields(c.defs)
+			if !c.valid {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, c.changed, changed)
+			assert.EqualValues(t, c.result, result)
+		})
+	}
+}

--- a/internal/fields/model.go
+++ b/internal/fields/model.go
@@ -16,3 +16,52 @@ type FieldDefinition struct {
 	External    string            `yaml:"external"`
 	Fields      []FieldDefinition `yaml:"fields"`
 }
+
+func (orig *FieldDefinition) Update(fd FieldDefinition) {
+	if fd.Name != "" {
+		orig.Name = fd.Name
+	}
+	if fd.Description != "" {
+		orig.Description = fd.Description
+	}
+	if fd.Type != "" {
+		orig.Type = fd.Type
+	}
+	if fd.Value != "" {
+		orig.Value = fd.Value
+	}
+	if fd.Pattern != "" {
+		orig.Pattern = fd.Pattern
+	}
+	if fd.Unit != "" {
+		orig.Unit = fd.Unit
+	}
+	if fd.MetricType != "" {
+		orig.MetricType = fd.MetricType
+	}
+	if fd.External != "" {
+		orig.External = fd.External
+	}
+
+	if len(fd.Fields) > 0 {
+		// When a subfield the same name exists, update it. When not, append it.
+		updatedFields := make([]FieldDefinition, len(orig.Fields))
+		copy(updatedFields, orig.Fields)
+		for _, newField := range fd.Fields {
+			found := false
+			for i, origField := range orig.Fields {
+				if origField.Name != newField.Name {
+					continue
+				}
+
+				found = true
+				updatedFields[i].Update(newField)
+				break
+			}
+			if !found {
+				updatedFields = append(updatedFields, newField)
+			}
+		}
+		orig.Fields = updatedFields
+	}
+}

--- a/internal/fields/model_test.go
+++ b/internal/fields/model_test.go
@@ -1,0 +1,174 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package fields
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldDefinitionUpdate(t *testing.T) {
+	cases := []struct {
+		title    string
+		original FieldDefinition
+		updated  FieldDefinition
+		result   FieldDefinition
+	}{
+		{
+			"empty", FieldDefinition{}, FieldDefinition{}, FieldDefinition{},
+		},
+		{
+			"external field update",
+			FieldDefinition{
+				Name:     "container.id",
+				External: "ecs",
+			},
+			FieldDefinition{
+				Name:        "container.id",
+				Description: "A container id.",
+				Type:        "keyword",
+			},
+			FieldDefinition{
+				Name:        "container.id",
+				Description: "A container id.",
+				External:    "ecs",
+				Type:        "keyword",
+			},
+		},
+		{
+			"field with subfields",
+			FieldDefinition{
+				Name: "data_stream",
+				Fields: []FieldDefinition{
+					{
+						Name:  "type",
+						Value: "logs",
+					},
+					{
+						Name:  "dataset",
+						Value: "nginx.access",
+					},
+				},
+			},
+			FieldDefinition{
+				Name: "data_stream",
+				Fields: []FieldDefinition{
+					{
+						Name: "dataset",
+						Type: "constant_keyword",
+					},
+					{
+						Name: "type",
+						Type: "constant_keyword",
+					},
+				},
+			},
+			FieldDefinition{
+				Name: "data_stream",
+				Fields: []FieldDefinition{
+					{
+						Name:  "type",
+						Value: "logs",
+						Type:  "constant_keyword",
+					},
+					{
+						Name:  "dataset",
+						Value: "nginx.access",
+						Type:  "constant_keyword",
+					},
+				},
+			},
+		},
+		{
+			"field with more subfields",
+			FieldDefinition{
+				Name: "data_stream",
+				Fields: []FieldDefinition{
+					{
+						Name:  "type",
+						Value: "logs",
+					},
+					{
+						Name:  "dataset",
+						Value: "nginx.access",
+					},
+				},
+			},
+			FieldDefinition{
+				Name: "data_stream",
+				Type: "group",
+				Fields: []FieldDefinition{
+					{
+						Name: "dataset",
+						Type: "constant_keyword",
+					},
+				},
+			},
+			FieldDefinition{
+				Name: "data_stream",
+				Type: "group",
+				Fields: []FieldDefinition{
+					{
+						Name:  "type",
+						Value: "logs",
+					},
+					{
+						Name:  "dataset",
+						Value: "nginx.access",
+						Type:  "constant_keyword",
+					},
+				},
+			},
+		},
+		{
+			"field with less subfields",
+			FieldDefinition{
+				Name: "data_stream",
+				Fields: []FieldDefinition{
+					{
+						Name:  "dataset",
+						Value: "nginx.access",
+					},
+				},
+			},
+			FieldDefinition{
+				Name: "data_stream",
+				Fields: []FieldDefinition{
+					{
+						Name: "type",
+						Type: "constant_keyword",
+					},
+					{
+						Name: "dataset",
+						Type: "constant_keyword",
+					},
+				},
+			},
+			FieldDefinition{
+				Name: "data_stream",
+				Fields: []FieldDefinition{
+					{
+						Name:  "dataset",
+						Type:  "constant_keyword",
+						Value: "nginx.access",
+					},
+					{
+						Name: "type",
+						Type: "constant_keyword",
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			def := c.original
+			def.Update(c.updated)
+			assert.EqualValues(t, c.result, def)
+		})
+	}
+}

--- a/test/packages/nginx/data_stream/access/fields/base-fields.yml
+++ b/test/packages/nginx/data_stream/access/fields/base-fields.yml
@@ -1,12 +1,13 @@
 - name: data_stream.type
-  type: constant_keyword
+  external: ecs
   description: Data stream type.
+  value: logs
 - name: data_stream.dataset
-  type: constant_keyword
+  external: ecs
   description: Data stream dataset.
+  value: nginx.access
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: '@timestamp'
   type: date
   description: Event timestamp.

--- a/test/packages/nginx/data_stream/error/fields/base-fields.yml
+++ b/test/packages/nginx/data_stream/error/fields/base-fields.yml
@@ -1,12 +1,13 @@
 - name: data_stream.type
-  type: constant_keyword
+  external: ecs
   description: Data stream type.
+  value: logs
 - name: data_stream.dataset
-  type: constant_keyword
+  external: ecs
   description: Data stream dataset.
+  value: nginx.error
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: '@timestamp'
   type: date
   description: Event timestamp.

--- a/test/packages/nginx/data_stream/ingress_controller/fields/base-fields.yml
+++ b/test/packages/nginx/data_stream/ingress_controller/fields/base-fields.yml
@@ -1,12 +1,13 @@
 - name: data_stream.type
-  type: constant_keyword
+  external: ecs
   description: Data stream type.
+  value: logs
 - name: data_stream.dataset
-  type: constant_keyword
+  external: ecs
   description: Data stream dataset.
+  value: nginx.ingress_controller
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: '@timestamp'
   type: date
   description: Event timestamp.

--- a/test/packages/nginx/data_stream/stubstatus/fields/base-fields.yml
+++ b/test/packages/nginx/data_stream/stubstatus/fields/base-fields.yml
@@ -1,12 +1,13 @@
 - name: data_stream.type
-  type: constant_keyword
+  external: ecs
   description: Data stream type.
+  value: metrics
 - name: data_stream.dataset
-  type: constant_keyword
+  external: ecs
   description: Data stream dataset.
+  value: nginx.stubstatus
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: '@timestamp'
   type: date
   description: Event timestamp.

--- a/test/packages/nginx/docs/README.md
+++ b/test/packages/nginx/docs/README.md
@@ -6,7 +6,7 @@
 |---|---|---|
 | @timestamp | Event timestamp. | date |
 | data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
+| data_stream.namespace | A user defined namespace. Namespaces are useful to allow grouping of data. Many users already organize their indices this way, and the data stream naming scheme now provides this best practice as a default. Many users will populate this field with `default`. If no value is used, it falls back to `default`. Beyond the Elasticsearch index naming criteria noted above, `namespace` value has the additional restrictions:   \* Must not contain `-`   \* No longer than 100 characters | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
 | event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
@@ -45,7 +45,7 @@
 |---|---|---|
 | @timestamp | Event timestamp. | date |
 | data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
+| data_stream.namespace | A user defined namespace. Namespaces are useful to allow grouping of data. Many users already organize their indices this way, and the data stream naming scheme now provides this best practice as a default. Many users will populate this field with `default`. If no value is used, it falls back to `default`. Beyond the Elasticsearch index naming criteria noted above, `namespace` value has the additional restrictions:   \* Must not contain `-`   \* No longer than 100 characters | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | event.created | Date/time when the event was first read by an agent, or by your pipeline. | date |
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
@@ -61,7 +61,7 @@
 |---|---|---|
 | @timestamp | Event timestamp. | date |
 | data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
+| data_stream.namespace | A user defined namespace. Namespaces are useful to allow grouping of data. Many users already organize their indices this way, and the data stream naming scheme now provides this best practice as a default. Many users will populate this field with `default`. If no value is used, it falls back to `default`. Beyond the Elasticsearch index naming criteria noted above, `namespace` value has the additional restrictions:   \* Must not contain `-`   \* No longer than 100 characters | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | nginx.stubstatus.accepts | The total number of accepted client connections. | long |


### PR DESCRIPTION
Attributes defined in the fields definition are combined with the imported field, with some exceptions:
* `external` is removed, as it doesn't make sense in the final definition.
* `type` is always used as defined in the imported field, to avoid having ECS fields with different types.

Some use cases:
* Give an integration-specific description to a field.
* Set a value for a `constant_keyword` (https://github.com/elastic/elastic-package/issues/392).
* Use an external field as dimension (https://github.com/elastic/package-spec/issues/247).


Fixes https://github.com/elastic/elastic-package/issues/392
Fixes https://github.com/elastic/package-spec/issues/247