### PR TITLE
Report ingest pipeline processor coverage

### DIFF
--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -149,10 +149,6 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 				if err != nil {
 					return cobraext.FlagParsingError(err, cobraext.DataStreamsFlagName)
 				}
-
-				if testCoverage && len(dataStreams) > 0 {
-					return cobraext.FlagParsingError(errors.New("test coverage can be calculated only if all data streams are selected"), cobraext.DataStreamsFlagName)
-				}
 			}
 
 			if runner.TestFolderRequired() {
@@ -203,6 +199,7 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 				API:                esClient.API,
 				DeferCleanup:       deferCleanup,
 				ServiceVariant:     variantFlag,
+				WithCoverage:       testCoverage,
 			})
 
 			results = append(results, r...)

--- a/internal/elasticsearch/node_stats/stats_api.go
+++ b/internal/elasticsearch/node_stats/stats_api.go
@@ -1,0 +1,144 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package node_stats
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/elastic-package/internal/elasticsearch"
+	"github.com/elastic/elastic-package/internal/elasticsearch/pipeline"
+)
+
+// StatsRecord contains stats for a measurable entity (pipeline, processor, etc.)
+type StatsRecord struct {
+	Count, Current, Failed int64
+	TimeInMillis           int64 `json:"time_in_millis"`
+}
+
+// ProcessorStats contains a processor's stats and some metadata.
+type ProcessorStats struct {
+	Type, Extra string
+	Conditional bool
+	Stats       StatsRecord
+}
+
+// PipelineStats contains stats for a pipeline.
+type PipelineStats struct {
+	StatsRecord
+	Processors []ProcessorStats
+}
+
+// PipelineStatsMap holds the stats for a set of pipelines.
+type PipelineStatsMap map[string]*PipelineStats
+
+type wrappedProcessor map[string]ProcessorStats
+
+func (p wrappedProcessor) extract() (stats ProcessorStats, err error) {
+	if len(p) != 1 {
+		return stats, errors.Errorf("can't extract processor stats. Need a single processor, got %d: %+v", len(p), p)
+	}
+	for k, v := range p {
+		stats = v
+		if off := strings.Index(k, ":"); off != -1 {
+			stats.Extra = k[off+1:]
+			k = k[:off]
+		}
+		switch v.Type {
+		case "conditional":
+			stats.Conditional = true
+		case k:
+		default:
+			return stats, errors.Errorf("can't understand processor identifier '%s' in %+v", k, p)
+		}
+		stats.Type = k
+	}
+	return stats, nil
+}
+
+type pipelineStatsRecord struct {
+	StatsRecord
+	Processors []wrappedProcessor
+}
+
+type pipelineStatsRecordMap map[string]pipelineStatsRecord
+
+func (r pipelineStatsRecord) extract() (stats *PipelineStats, err error) {
+	stats = &PipelineStats{
+		StatsRecord: r.StatsRecord,
+		Processors:  make([]ProcessorStats, len(r.Processors)),
+	}
+	for idx, wrapped := range r.Processors {
+		if stats.Processors[idx], err = wrapped.extract(); err != nil {
+			return stats, errors.Wrapf(err, "converting processor %d", idx)
+		}
+	}
+	return stats, nil
+}
+
+type pipelinesStatsNode struct {
+	Ingest struct {
+		Pipelines pipelineStatsRecordMap
+	}
+}
+
+type pipelinesStatsResponse struct {
+	Nodes map[string]pipelinesStatsNode
+}
+
+func GetPipelineStats(esClient *elasticsearch.API, pipelines []pipeline.Resource) (stats PipelineStatsMap, err error) {
+	statsReq := esClient.Nodes.Stats.WithFilterPath("nodes.*.ingest.pipelines")
+	resp, err := esClient.Nodes.Stats(statsReq)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Node Stats API call failed")
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read Stats API response body")
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, errors.Wrapf(elasticsearch.NewError(body), "unexpected response status for Node Stats (%d): %s", resp.StatusCode, resp.Status())
+	}
+
+	var statsResponse pipelinesStatsResponse
+	if err = json.Unmarshal(body, &statsResponse); err != nil {
+		return nil, errors.Wrap(err, "error decoding Node Stats response")
+	}
+
+	if nodeCount := len(statsResponse.Nodes); nodeCount != 1 {
+		return nil, errors.Errorf("more than 1 ES node in stats response (%d)", nodeCount)
+	}
+	var nodePipelines map[string]pipelineStatsRecord
+	for _, node := range statsResponse.Nodes {
+		nodePipelines = node.Ingest.Pipelines
+	}
+	stats = make(PipelineStatsMap, len(pipelines))
+	for _, requested := range pipelines {
+		for pName, pStats := range nodePipelines {
+			if requested.Name == pName {
+				if stats[pName], err = pStats.extract(); err != nil {
+					return stats, errors.Wrapf(err, "converting pipeline %s", pName)
+				}
+			}
+		}
+	}
+	if len(stats) != len(pipelines) {
+		var missing []string
+		for _, requested := range pipelines {
+			if _, found := stats[requested.Name]; !found {
+				missing = append(missing, requested.Name)
+			}
+		}
+		return stats, errors.Wrapf(err, "Node Stats response is missing some expected pipelines: %v", missing)
+	}
+
+	return stats, nil
+}

--- a/internal/elasticsearch/pipeline/coverage/coverage.go
+++ b/internal/elasticsearch/pipeline/coverage/coverage.go
@@ -1,0 +1,123 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package coverage
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/elastic-package/internal/elasticsearch/node_stats"
+	"github.com/elastic/elastic-package/internal/elasticsearch/pipeline"
+	"github.com/elastic/elastic-package/internal/packages"
+	"github.com/elastic/elastic-package/internal/testrunner"
+)
+
+// Get returns a coverage report for the provided set of ingest pipelines.
+func Get(options testrunner.TestOptions, pipelines []pipeline.Resource) (*testrunner.CoberturaCoverage, error) {
+	packagePath, err := packages.MustFindPackageRoot()
+	if err != nil {
+		return nil, errors.Wrap(err, "error finding package root")
+	}
+
+	dataStreamPath, found, err := packages.FindDataStreamRootForPath(options.TestFolder.Path)
+	if err != nil {
+		return nil, errors.Wrap(err, "locating data_stream root failed")
+	}
+	if !found {
+		return nil, errors.New("data stream root not found")
+	}
+
+	// Use the Node Stats API to get stats for all installed pipelines.
+	// These stats contain hit counts for all main processors in a pipeline.
+	stats, err := node_stats.GetPipelineStats(options.API, pipelines)
+	if err != nil {
+		return nil, errors.Wrap(err, "error fetching pipeline stats for code coverage calculations")
+	}
+
+	// Construct the Cobertura report.
+	pkg := &testrunner.CoberturaPackage{
+		Name: options.TestFolder.Package + "." + options.TestFolder.DataStream,
+	}
+
+	coverage := &testrunner.CoberturaCoverage{
+		Sources: []*testrunner.CoberturaSource{
+			{
+				Path: packagePath,
+			},
+		},
+		Packages:  []*testrunner.CoberturaPackage{pkg},
+		Timestamp: time.Now().UnixNano(),
+	}
+
+	for _, p := range pipelines {
+		// Load the list of main processors from the pipeline source code, annotated with line numbers.
+		src, err := p.Processors()
+		if err != nil {
+			return nil, err
+		}
+
+		pstats := stats[p.Name]
+		if pstats == nil {
+			return nil, errors.Errorf("pipeline '%s' not installed in Elasticsearch", p.Name)
+		}
+
+		// Ensure there is no inconsistency in the list of processors in stats vs obtained from source.
+		if len(src) != len(pstats.Processors) {
+			return nil, errors.Errorf("processor count mismatch for %s (src:%d stats:%d)", p.FileName(), len(src), len(pstats.Processors))
+		}
+		for idx, st := range pstats.Processors {
+			// Elasticsearch will return a `compound` processor in the case of `foreach` and
+			// any processor that defines `on_failure` processors.
+			if st.Type == "compound" {
+				continue
+			}
+			if st.Type != src[idx].Type {
+				return nil, errors.Errorf("processor type mismatch for %s processor %d (src:%s stats:%s)", p.FileName(), idx, src[idx].Type, st.Type)
+			}
+		}
+		// Tests install pipelines as `filename-<nonce>` (without original extension).
+		// Use the filename part for the report.
+		pipelineName := p.Name
+		if nameEnd := strings.LastIndexByte(pipelineName, '-'); nameEnd != -1 {
+			pipelineName = pipelineName[:nameEnd]
+		}
+		// File path has to be relative to the packagePath added to the cobertura Sources list.
+		pipelinePath := filepath.Join(dataStreamPath, "elasticsearch", "ingest_pipeline", p.FileName())
+		pipelineRelPath, err := filepath.Rel(packagePath, pipelinePath)
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot create relative path to pipeline file. Package root: '%s', pipeline path: '%s'", packagePath, pipelinePath)
+		}
+		// Report every pipeline as a "class".
+		classCov := testrunner.CoberturaClass{
+			Name:     pipelineName,
+			Filename: pipelineRelPath,
+		}
+
+		// Calculate covered and total processors (reported as both lines and methods).
+		covered := 0
+		for idx, srcProc := range src {
+			if pstats.Processors[idx].Stats.Count > 0 {
+				covered++
+			}
+			line := &testrunner.CoberturaLine{
+				Number: srcProc.Line,
+				Hits:   pstats.Processors[idx].Stats.Count,
+			}
+			classCov.Methods = append(classCov.Methods, &testrunner.CoberturaMethod{
+				Name:  srcProc.Type,
+				Lines: []*testrunner.CoberturaLine{line},
+				Hits:  pstats.Processors[idx].Stats.Count,
+			})
+			classCov.Lines = append(classCov.Lines, line)
+		}
+		pkg.Classes = append(pkg.Classes, &classCov)
+		coverage.LinesValid += int64(len(src))
+		coverage.LinesCovered += int64(covered)
+	}
+	return coverage, nil
+}

--- a/internal/elasticsearch/pipeline/coverage/coverage.go
+++ b/internal/elasticsearch/pipeline/coverage/coverage.go
@@ -104,16 +104,19 @@ func Get(options testrunner.TestOptions, pipelines []pipeline.Resource) (*testru
 			if pstats.Processors[idx].Stats.Count > 0 {
 				covered++
 			}
-			line := &testrunner.CoberturaLine{
-				Number: srcProc.Line,
-				Hits:   pstats.Processors[idx].Stats.Count,
+			method := testrunner.CoberturaMethod{
+				Name: srcProc.Type,
+				Hits: pstats.Processors[idx].Stats.Count,
 			}
-			classCov.Methods = append(classCov.Methods, &testrunner.CoberturaMethod{
-				Name:  srcProc.Type,
-				Lines: []*testrunner.CoberturaLine{line},
-				Hits:  pstats.Processors[idx].Stats.Count,
-			})
-			classCov.Lines = append(classCov.Lines, line)
+			for num := srcProc.FirstLine; num <= srcProc.LastLine; num++ {
+				line := &testrunner.CoberturaLine{
+					Number: num,
+					Hits:   pstats.Processors[idx].Stats.Count,
+				}
+				classCov.Lines = append(classCov.Lines, line)
+				method.Lines = append(method.Lines, line)
+			}
+			classCov.Methods = append(classCov.Methods, &method)
 		}
 		pkg.Classes = append(pkg.Classes, &classCov)
 		coverage.LinesValid += int64(len(src))

--- a/internal/elasticsearch/pipeline/processors.go
+++ b/internal/elasticsearch/pipeline/processors.go
@@ -1,0 +1,186 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package pipeline
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+)
+
+type Processor struct {
+	Type        string `yaml:"-"`
+	Tag         string
+	Description string
+	Line        int `yaml:"-"`
+}
+
+func (p Resource) Processors() (procs []Processor, err error) {
+	switch p.Format {
+	case "yaml", "yml":
+		procs, err = ProcessorsFromYAMLPipeline(p.Content)
+	case "json":
+		procs, err = ProcessorsFromJSONPipeline(p.Content)
+	default:
+		return nil, errors.Errorf("unsupported pipeline Format: %s", p.Format)
+	}
+	return procs, errors.Wrapf(err, "failure processing %s pipeline '%s'", p.Format, p.FileName())
+}
+
+func ProcessorsFromYAMLPipeline(content []byte) (procs []Processor, err error) {
+	type pipeline struct {
+		Processors []yaml.Node
+	}
+	var p pipeline
+	if err = yaml.Unmarshal(content, &p); err != nil {
+		return nil, err
+	}
+	for idx, entry := range p.Processors {
+		if entry.Kind != yaml.MappingNode || len(entry.Content) != 2 {
+			return nil, errors.Errorf("processor#%d is not a single key map (kind:%v Content:%d)", idx, entry.Kind, len(entry.Content))
+		}
+		var proc Processor
+		if err := entry.Content[1].Decode(&proc); err != nil {
+			return nil, errors.Wrapf(err, "error decoding processor#%d configuration", idx)
+		}
+		if err := entry.Content[0].Decode(&proc.Type); err != nil {
+			return nil, errors.Wrapf(err, "error decoding processor#%d type", idx)
+		}
+		proc.Line = entry.Line
+		procs = append(procs, proc)
+	}
+	return procs, nil
+}
+
+type tokenStack []json.Token
+
+func (s *tokenStack) Push(t json.Token) {
+	*s = append(*s, t)
+}
+
+func (s *tokenStack) Pop() json.Token {
+	top := s.Top()
+	if n := len(*s); n > 0 {
+		*s = (*s)[:n-1]
+	}
+	return top
+}
+
+func (s *tokenStack) PopUntil(d json.Delim) {
+	for {
+		switch s.Pop() {
+		case d, io.EOF:
+			return
+		}
+	}
+}
+
+func (s *tokenStack) Top() json.Token {
+	if n := len(*s); n > 0 {
+		return (*s)[n-1]
+	}
+	return io.EOF // ???
+}
+
+func (s *tokenStack) TopIsString() bool {
+	if n := len(*s); n > 0 {
+		_, ok := (*s)[n-1].(string)
+		return ok
+	}
+	return false
+}
+
+func (s *tokenStack) Equals(b tokenStack) bool {
+	if len(*s) != len(b) {
+		return false
+	}
+	for idx, tk := range *s {
+		if b[idx] != tk {
+			return false
+		}
+	}
+	return true
+}
+
+var processorJSONPath = tokenStack{json.Delim('{'), "processors", json.Delim('['), json.Delim('{')}
+
+func ProcessorsFromJSONPipeline(content []byte) (procs []Processor, err error) {
+	var processors []string
+	var offsets []int
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	var stack tokenStack
+
+	for {
+		off := int(decoder.InputOffset())
+		tk, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		delim, isDelim := tk.(json.Delim)
+		if isDelim && (delim == '}' || delim == ']') {
+			stack.PopUntil(delim - 2) // `}`-2 = `{` and `]`-2 = `[`
+			if stack.TopIsString() {
+				stack.Pop()
+			}
+			continue
+		}
+		if !isDelim && stack.TopIsString() {
+			stack.Pop()
+			continue
+		}
+		if str, ok := tk.(string); ok && stack.Equals(processorJSONPath) {
+			processors = append(processors, str)
+			offsets = append(offsets, off)
+		}
+		stack.Push(tk)
+	}
+	lines, err := offsetsToLineNumbers(offsets, content)
+	if err != nil {
+		return nil, err
+	}
+
+	procs = make([]Processor, len(processors))
+	for idx, proc := range processors {
+		procs[idx] = Processor{
+			Type: proc,
+			Line: lines[idx],
+		}
+	}
+	return procs, nil
+}
+
+func offsetsToLineNumbers(offsets []int, content []byte) (lines []int, err error) {
+	nextNewline := func(r []byte, offset int) int {
+		n := len(r)
+		if offset >= n {
+			return n
+		}
+		if delta := bytes.IndexByte(r[offset+1:], '\n'); delta > -1 {
+			return offset + delta + 1
+		}
+		return n
+	}
+	lineEnd := nextNewline(content, -1)
+	line := 1
+	lines = make([]int, len(offsets))
+	for i := 0; i < len(offsets); {
+		if offsets[i] < lineEnd {
+			lines[i] = line
+			i++
+			continue
+		}
+		for offsets[i] >= lineEnd {
+			if lineEnd == len(content) {
+				return nil, io.ErrUnexpectedEOF
+			}
+			line++
+			lineEnd = nextNewline(content, lineEnd)
+		}
+	}
+	return lines, nil
+}

--- a/internal/elasticsearch/pipeline/processors_test.go
+++ b/internal/elasticsearch/pipeline/processors_test.go
@@ -1,0 +1,255 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResource_Processors(t *testing.T) {
+	tests := []struct {
+		name     string
+		format   string
+		content  []byte
+		expected []Processor
+		wantErr  bool
+	}{
+		{
+			name:   "Yaml pipeline",
+			format: "yml",
+			content: []byte(`---
+description: Made up pipeline
+processors:
+# First processor.
+- grok:
+    tag: Extract header
+    field: message
+    patterns:
+    - \[%{APACHE_TIME:apache.error.timestamp}\] \[%{LOGLEVEL:log.level}\]( \[client
+      %{IPORHOST:source.address}(:%{POSINT:source.port})?\])? %{GREEDYDATA:message}
+    - \[%{APACHE_TIME:apache.error.timestamp}\] \[%{DATA:apache.error.module}:%{LOGLEVEL:log.level}\]
+      \[pid %{NUMBER:process.pid:long}(:tid %{NUMBER:process.thread.id:long})?\](
+      \[client %{IPORHOST:source.address}(:%{POSINT:source.port})?\])? %{GREEDYDATA:message}
+    pattern_definitions:
+      APACHE_TIME: '%{DAY} %{MONTH} %{MONTHDAY} %{TIME} %{YEAR}'
+    ignore_missing: true
+
+- date:
+    field: apache.error.timestamp
+    target_field: '@timestamp'
+    formats:
+    - EEE MMM dd H:m:s yyyy
+    - EEE MMM dd H:m:s.SSSSSS yyyy
+    on_failure:
+    - append:
+        field: error.message
+        value: '{{ _ingest.on_failure_message }}'
+- set:
+    description: Set event category
+    field: event.category
+    value: web
+# Some script
+- script:
+    lang: painless
+    source: >-
+      [...]
+
+- grok:
+    field: source.address
+    ignore_missing: true
+    patterns:
+    - ^(%{IP:source.ip}|%{HOSTNAME:source.domain})$
+- rename:
+    field: source.as.organization_name
+    target_field: source.as.organization.name
+    ignore_missing: true
+on_failure:
+- set:
+    field: error.message
+    value: '{{ _ingest.on_failure_message }}'
+`),
+			expected: []Processor{
+				{Type: "grok", Line: 5, Tag: "Extract header"},
+				{Type: "date", Line: 18},
+				{Type: "set", Line: 28, Description: "Set event category"},
+				{Type: "script", Line: 33},
+				{Type: "grok", Line: 38},
+				{Type: "rename", Line: 43},
+			},
+		},
+		{
+			name:   "Json pipeline",
+			format: "json",
+			content: []byte(`{
+  "description": "Pipeline for parsing silly logs.",
+  "processors": [{"drop": {"if":"ctx.drop!=null"}},
+	{
+    "set": {
+      "field": "event.ingested",
+      "value": "{{_ingest.timestamp}}"
+    }
+  }, {"remove":{"field": "message"}}, {"set": {"field": "temp.duration","value":1234}},
+  {
+    "set":{
+      "field": "event.kind",
+      "value": "event"
+    }
+  }],
+  "on_failure" : [{
+    "set" : {
+      "field" : "error.message",
+      "value" : "{{ _ingest.on_failure_message }}"
+    }
+  }]
+}
+`),
+			expected: []Processor{
+				{Type: "drop", Line: 3},
+				{Type: "set", Line: 5},
+				{Type: "remove", Line: 9},
+				{Type: "set", Line: 9},
+				{Type: "set", Line: 11},
+			},
+		},
+		{
+			name:     "Empty Yaml pipeline",
+			format:   "yml",
+			content:  []byte(``),
+			expected: nil,
+		},
+		{
+			name:     "Empty Json pipeline",
+			format:   "json",
+			content:  []byte(``),
+			expected: nil,
+		},
+		{
+			name:    "Json pipeline one liner",
+			format:  "json",
+			content: []byte(`{"processors": [{"drop": {}}]}`),
+			expected: []Processor{
+				{Type: "drop", Line: 1},
+			},
+		},
+		{
+			name:     "Malformed Json pipeline",
+			format:   "json",
+			content:  []byte(`{"processors": {"drop": {}}}`),
+			expected: nil,
+		},
+		{
+			name:    "Broken Json",
+			format:  "json",
+			content: []byte(`{"processors": {"drop": {}},"`),
+			wantErr: true,
+		},
+		{
+			name:   "Malformed Yaml pipeline",
+			format: "yml",
+			content: []byte(`---
+processors:
+ foo:
+  bar: baz`),
+			wantErr: true,
+		},
+		{
+			name:    "Malformed Yaml",
+			format:  "yml",
+			content: []byte(`foo123"`),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Resource{
+				Name:    tt.name,
+				Format:  tt.format,
+				Content: tt.content,
+			}
+			procs, err := p.Processors()
+			if !tt.wantErr {
+				if !assert.NoError(t, err) {
+					t.Fatal(err)
+				}
+			} else {
+				if !assert.Error(t, err) {
+					t.Fatal("error expected")
+				}
+			}
+			if !assert.Equal(t, tt.expected, procs) {
+				t.Errorf("Processors() gotProcs = %v, want %v", procs, tt.expected)
+			}
+		})
+	}
+}
+
+func Test_offsetsToLineNumbers(t *testing.T) {
+	raw := []byte(`1111
+2
+3333
+
+555`)
+	tests := []struct {
+		name     string
+		content  []byte
+		offsets  []int
+		expected []int
+		wantErr  bool
+	}{
+		{
+			name:     "valid",
+			content:  raw,
+			offsets:  []int{0, 3, 5, 8, 14},
+			expected: []int{1, 1, 2, 3, 5},
+		},
+		{
+			name:     "first char",
+			content:  raw,
+			offsets:  []int{0, 5, 7, 12, 13},
+			expected: []int{1, 2, 3, 4, 5},
+		},
+		{
+			name:     "newline belongs to current line",
+			content:  raw,
+			offsets:  []int{4, 6, 11, 12},
+			expected: []int{1, 2, 3, 4},
+		},
+		{
+			name:    "out of range offset",
+			content: raw,
+			offsets: []int{0, 1, 2, 3, 9000},
+			wantErr: true,
+		},
+		{
+			name:    "unordered",
+			content: raw,
+			offsets: []int{3, 0, 14, 8, 12},
+			wantErr: true,
+		},
+		{
+			name:     "empty",
+			content:  raw,
+			offsets:  []int{},
+			expected: []int{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines, err := offsetsToLineNumbers(tt.offsets, tt.content)
+			if !tt.wantErr {
+				if !assert.NoError(t, err) {
+					t.Fatal(err)
+				}
+			} else {
+				if !assert.Error(t, err) {
+					t.Fatal("error expected")
+				}
+			}
+			assert.Equal(t, tt.expected, lines)
+		})
+	}
+}

--- a/internal/elasticsearch/pipeline/processors_test.go
+++ b/internal/elasticsearch/pipeline/processors_test.go
@@ -73,12 +73,12 @@ on_failure:
     value: '{{ _ingest.on_failure_message }}'
 `),
 			expected: []Processor{
-				{Type: "grok", Line: 5, Tag: "Extract header"},
-				{Type: "date", Line: 18},
-				{Type: "set", Line: 28, Description: "Set event category"},
-				{Type: "script", Line: 33},
-				{Type: "grok", Line: 38},
-				{Type: "rename", Line: 43},
+				{Type: "grok", FirstLine: 5, LastLine: 16, Tag: "Extract header"},
+				{Type: "date", FirstLine: 18, LastLine: 27},
+				{Type: "set", FirstLine: 28, LastLine: 31, Description: "Set event category"},
+				{Type: "script", FirstLine: 33, LastLine: 35},
+				{Type: "grok", FirstLine: 38, LastLine: 42},
+				{Type: "rename", FirstLine: 43, LastLine: 46},
 			},
 		},
 		{
@@ -108,11 +108,11 @@ on_failure:
 }
 `),
 			expected: []Processor{
-				{Type: "drop", Line: 3},
-				{Type: "set", Line: 5},
-				{Type: "remove", Line: 9},
-				{Type: "set", Line: 9},
-				{Type: "set", Line: 11},
+				{Type: "drop", FirstLine: 3, LastLine: 3},
+				{Type: "set", FirstLine: 5, LastLine: 8},
+				{Type: "remove", FirstLine: 9, LastLine: 9},
+				{Type: "set", FirstLine: 9, LastLine: 9},
+				{Type: "set", FirstLine: 11, LastLine: 14},
 			},
 		},
 		{
@@ -132,7 +132,7 @@ on_failure:
 			format:  "json",
 			content: []byte(`{"processors": [{"drop": {}}]}`),
 			expected: []Processor{
-				{Type: "drop", Line: 1},
+				{Type: "drop", FirstLine: 1, LastLine: 1},
 			},
 		},
 		{

--- a/internal/elasticsearch/pipeline/resource.go
+++ b/internal/elasticsearch/pipeline/resource.go
@@ -21,6 +21,9 @@ type Resource struct {
 
 func (p *Resource) FileName() string {
 	pos := strings.LastIndexByte(p.Name, '-')
+	if pos == -1 {
+		pos = len(p.Name)
+	}
 	return p.Name[:pos] + "." + p.Format
 }
 

--- a/internal/elasticsearch/pipeline/resource.go
+++ b/internal/elasticsearch/pipeline/resource.go
@@ -1,0 +1,53 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package pipeline
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+)
+
+type Resource struct {
+	Name    string
+	Format  string
+	Content []byte
+	asJSON  []byte
+}
+
+func (p *Resource) FileName() string {
+	pos := strings.LastIndexByte(p.Name, '-')
+	return p.Name[:pos] + "." + p.Format
+}
+
+func (p *Resource) JSON() ([]byte, error) {
+	if len(p.asJSON) == 0 {
+		if err := p.toJSON(); err != nil {
+			return nil, err
+		}
+	}
+	return p.asJSON, nil
+}
+
+func (p *Resource) toJSON() error {
+	switch p.Format {
+	case "json":
+		p.asJSON = p.Content
+	case "yaml", "yml":
+		var node map[string]interface{}
+		err := yaml.Unmarshal(p.Content, &node)
+		if err != nil {
+			return errors.Wrapf(err, "unmarshalling pipeline Content failed (pipeline: %s)", p.Name)
+		}
+		if p.asJSON, err = json.Marshal(&node); err != nil {
+			return errors.Wrapf(err, "marshalling pipeline Content failed (pipeline: %s)", p.Name)
+		}
+	default:
+		return errors.Errorf("unsupported pipeline Format '%s' for pipeline %s", p.Format, p.Name)
+	}
+	return nil
+}

--- a/internal/testrunner/coverageoutput.go
+++ b/internal/testrunner/coverageoutput.go
@@ -135,14 +135,13 @@ func (c *CoberturaClass) Merge(b *CoberturaClass) error {
 	equal := c.Name == b.Name &&
 		c.Filename == b.Filename &&
 		len(c.Lines) == len(b.Lines) &&
-		len(c.Methods) == len(b.Methods) &&
-		len(c.Lines) == len(c.Methods)
+		len(c.Methods) == len(b.Methods)
 	for idx := range c.Lines {
-		equal = equal && c.Lines[idx].Number == b.Lines[idx].Number &&
-			c.Methods[idx].Name == b.Methods[idx].Name &&
-			len(c.Methods[idx].Lines) == 1 &&
-			len(b.Methods[idx].Lines) == 1 &&
-			c.Methods[idx].Lines[0].Number == b.Methods[idx].Lines[0].Number
+		equal = equal && c.Lines[idx].Number == b.Lines[idx].Number
+	}
+	for idx := range c.Methods {
+		equal = equal && c.Methods[idx].Name == b.Methods[idx].Name &&
+			len(c.Methods[idx].Lines) == len(b.Methods[idx].Lines)
 	}
 	if !equal {
 		return errors.Errorf("merging incompatible classes: %+v != %+v", *c, *b)
@@ -150,7 +149,9 @@ func (c *CoberturaClass) Merge(b *CoberturaClass) error {
 	// Update methods
 	for idx := range b.Methods {
 		c.Methods[idx].Hits += b.Methods[idx].Hits
-		c.Methods[idx].Lines[0].Hits += b.Methods[idx].Lines[0].Hits
+		for l := range b.Methods[idx].Lines {
+			c.Methods[idx].Lines[l].Hits += b.Methods[idx].Lines[l].Hits
+		}
 	}
 	// Rebuild lines
 	c.Lines = nil

--- a/internal/testrunner/coverageoutput.go
+++ b/internal/testrunner/coverageoutput.go
@@ -49,7 +49,7 @@ func (tcd *testCoverageDetails) withTestResults(results []TestResult) *testCover
 			if err := tcd.cobertura.Merge(result.Coverage); err != nil {
 				tcd.errors = append(tcd.errors, errors.Wrapf(err, "can't merge Cobertura coverage for test `%s`", result.Name))
 			}
-		} else {
+		} else if tcd.cobertura == nil {
 			tcd.cobertura = result.Coverage
 		}
 	}

--- a/internal/testrunner/coverageoutput_test.go
+++ b/internal/testrunner/coverageoutput_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package testrunner
 
 import (

--- a/internal/testrunner/coverageoutput_test.go
+++ b/internal/testrunner/coverageoutput_test.go
@@ -117,6 +117,10 @@ func TestCoberturaCoverage_Merge(t *testing.T) {
 												Number: 13,
 												Hits:   2,
 											},
+											{
+												Number: 14,
+												Hits:   2,
+											},
 										},
 									},
 									{
@@ -133,6 +137,10 @@ func TestCoberturaCoverage_Merge(t *testing.T) {
 								Lines: []*CoberturaLine{
 									{
 										Number: 13,
+										Hits:   2,
+									},
+									{
+										Number: 14,
 										Hits:   2,
 									},
 									{
@@ -155,10 +163,14 @@ func TestCoberturaCoverage_Merge(t *testing.T) {
 								Methods: []*CoberturaMethod{
 									{
 										Name: "foo",
-										Hits: 3,
+										Hits: 1,
 										Lines: []*CoberturaLine{
 											{
 												Number: 13,
+												Hits:   1,
+											},
+											{
+												Number: 14,
 												Hits:   1,
 											},
 										},
@@ -180,8 +192,12 @@ func TestCoberturaCoverage_Merge(t *testing.T) {
 										Hits:   1,
 									},
 									{
+										Number: 14,
+										Hits:   1,
+									},
+									{
 										Number: 24,
-										Hits:   2,
+										Hits:   1,
 									},
 								},
 							},
@@ -190,8 +206,8 @@ func TestCoberturaCoverage_Merge(t *testing.T) {
 				},
 			},
 			expected: CoberturaCoverage{
-				LinesCovered: 2,
-				LinesValid:   2,
+				LinesCovered: 3,
+				LinesValid:   3,
 				Packages: []*CoberturaPackage{
 					{
 						Name: "a",
@@ -201,10 +217,14 @@ func TestCoberturaCoverage_Merge(t *testing.T) {
 								Methods: []*CoberturaMethod{
 									{
 										Name: "foo",
-										Hits: 5,
+										Hits: 3,
 										Lines: []*CoberturaLine{
 											{
 												Number: 13,
+												Hits:   3,
+											},
+											{
+												Number: 14,
 												Hits:   3,
 											},
 										},
@@ -223,6 +243,10 @@ func TestCoberturaCoverage_Merge(t *testing.T) {
 								Lines: []*CoberturaLine{
 									{
 										Number: 13,
+										Hits:   3,
+									},
+									{
+										Number: 14,
 										Hits:   3,
 									},
 									{

--- a/internal/testrunner/coverageoutput_test.go
+++ b/internal/testrunner/coverageoutput_test.go
@@ -1,0 +1,251 @@
+package testrunner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCoberturaCoverage_Merge(t *testing.T) {
+	tests := []struct {
+		name               string
+		rhs, lhs, expected CoberturaCoverage
+		wantErr            bool
+	}{
+		{
+			name: "merge sources",
+			rhs: CoberturaCoverage{
+				Sources: []*CoberturaSource{
+					{Path: "/a"},
+					{Path: "/c"},
+				},
+			},
+			lhs: CoberturaCoverage{
+				Sources: []*CoberturaSource{
+					{Path: "/b"},
+					{Path: "/c"},
+				},
+			},
+			expected: CoberturaCoverage{
+				Sources: []*CoberturaSource{
+					{Path: "/a"},
+					{Path: "/c"},
+					{Path: "/b"},
+				},
+			},
+		},
+		{
+			name: "merge packages and classes",
+			rhs: CoberturaCoverage{
+				Packages: []*CoberturaPackage{
+					{
+						Name: "a",
+						Classes: []*CoberturaClass{
+							{Name: "a.a"},
+							{Name: "a.b"},
+						},
+					},
+					{
+						Name: "b",
+						Classes: []*CoberturaClass{
+							{Name: "b.a"},
+						},
+					},
+				},
+			},
+			lhs: CoberturaCoverage{
+				Packages: []*CoberturaPackage{
+					{
+						Name: "c",
+						Classes: []*CoberturaClass{
+							{Name: "a.a"},
+						},
+					},
+					{
+						Name: "b",
+						Classes: []*CoberturaClass{
+							{Name: "b.a"},
+							{Name: "b.b"},
+						},
+					},
+				},
+			},
+			expected: CoberturaCoverage{
+				Packages: []*CoberturaPackage{
+					{
+						Name: "a",
+						Classes: []*CoberturaClass{
+							{Name: "a.a"},
+							{Name: "a.b"},
+						},
+					},
+					{
+						Name: "b",
+						Classes: []*CoberturaClass{
+							{Name: "b.a"},
+							{Name: "b.b"},
+						},
+					},
+					{
+						Name: "c",
+						Classes: []*CoberturaClass{
+							{Name: "a.a"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "merge methods and lines",
+			rhs: CoberturaCoverage{
+				Packages: []*CoberturaPackage{
+					{
+						Name: "a",
+						Classes: []*CoberturaClass{
+							{
+								Name: "a.a",
+								Methods: []*CoberturaMethod{
+									{
+										Name: "foo",
+										Hits: 2,
+										Lines: []*CoberturaLine{
+											{
+												Number: 13,
+												Hits:   2,
+											},
+										},
+									},
+									{
+										Name: "bar",
+										Hits: 1,
+										Lines: []*CoberturaLine{
+											{
+												Number: 24,
+												Hits:   1,
+											},
+										},
+									},
+								},
+								Lines: []*CoberturaLine{
+									{
+										Number: 13,
+										Hits:   2,
+									},
+									{
+										Number: 24,
+										Hits:   1,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			lhs: CoberturaCoverage{
+				Packages: []*CoberturaPackage{
+					{
+						Name: "a",
+						Classes: []*CoberturaClass{
+							{
+								Name: "a.a",
+								Methods: []*CoberturaMethod{
+									{
+										Name: "foo",
+										Hits: 3,
+										Lines: []*CoberturaLine{
+											{
+												Number: 13,
+												Hits:   1,
+											},
+										},
+									},
+									{
+										Name: "bar",
+										Hits: 1,
+										Lines: []*CoberturaLine{
+											{
+												Number: 24,
+												Hits:   1,
+											},
+										},
+									},
+								},
+								Lines: []*CoberturaLine{
+									{
+										Number: 13,
+										Hits:   1,
+									},
+									{
+										Number: 24,
+										Hits:   2,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: CoberturaCoverage{
+				LinesCovered: 2,
+				LinesValid:   2,
+				Packages: []*CoberturaPackage{
+					{
+						Name: "a",
+						Classes: []*CoberturaClass{
+							{
+								Name: "a.a",
+								Methods: []*CoberturaMethod{
+									{
+										Name: "foo",
+										Hits: 5,
+										Lines: []*CoberturaLine{
+											{
+												Number: 13,
+												Hits:   3,
+											},
+										},
+									},
+									{
+										Name: "bar",
+										Hits: 2,
+										Lines: []*CoberturaLine{
+											{
+												Number: 24,
+												Hits:   2,
+											},
+										},
+									},
+								},
+								Lines: []*CoberturaLine{
+									{
+										Number: 13,
+										Hits:   3,
+									},
+									{
+										Number: 24,
+										Hits:   2,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.rhs.Merge(&tt.lhs)
+			if !tt.wantErr {
+				if !assert.NoError(t, err) {
+					t.Fatal(err)
+				}
+			} else {
+				if !assert.Error(t, err) {
+					t.Fatal("error expected")
+				}
+			}
+			assert.Equal(t, tt.expected, tt.rhs)
+		})
+	}
+}

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -16,6 +16,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/common"
+	"github.com/elastic/elastic-package/internal/elasticsearch/pipeline"
+	"github.com/elastic/elastic-package/internal/elasticsearch/pipeline/coverage"
 	"github.com/elastic/elastic-package/internal/fields"
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/multierror"
@@ -30,7 +32,7 @@ const (
 
 type runner struct {
 	options   testrunner.TestOptions
-	pipelines []pipelineResource
+	pipelines []pipeline.Resource
 }
 
 func (r *runner) TestFolderRequired() bool {
@@ -155,6 +157,12 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 			continue
 		}
 
+		if r.options.WithCoverage {
+			tr.Coverage, err = coverage.Get(r.options, r.pipelines)
+			if err != nil {
+				return nil, errors.Wrap(err, "error calculating pipeline coverage")
+			}
+		}
 		results = append(results, tr)
 	}
 	return results, nil

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -29,6 +29,7 @@ type TestOptions struct {
 
 	DeferCleanup   time.Duration
 	ServiceVariant string
+	WithCoverage   bool
 }
 
 // TestRunner is the interface all test runners must implement.
@@ -86,6 +87,9 @@ type TestResult struct {
 	// If the test was skipped, the reason it was skipped and a link for more
 	// details.
 	Skipped *SkipConfig
+
+	// Coverage details in Cobertura format (optional).
+	Coverage *CoberturaCoverage
 }
 
 // ResultComposer wraps a TestResult and provides convenience methods for


### PR DESCRIPTION
This PR updates the pipeline tests to generate code-coverage (at the processor level) for ingest pipelines:

<img width="1199" alt="image" src="https://user-images.githubusercontent.com/15056957/147055877-2120ae36-d796-4338-8ebf-4d250c48f08b.png">

<img width="1215" alt="image" src="https://user-images.githubusercontent.com/15056957/147063249-c2cf893c-6a45-46f0-b8c2-e510fc205aca.png">

Screenshots taken using [Report Generator.](https://github.com/danielpalme/ReportGenerator)



