### PR TITLE
Add flag to select the kibana version in elastic-package status

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -37,7 +37,7 @@ func setupStatusCommand() *cobraext.Command {
 		RunE:  statusCommandAction,
 	}
 	cmd.Flags().BoolP(cobraext.ShowAllFlagName, "a", false, cobraext.ShowAllFlagDescription)
-	cmd.Flags().String(cobraext.StackVersionFlagName, "", cobraext.StackVersionFlagDescription)
+	cmd.Flags().String(cobraext.StatusKibanaVersionFlagName, "", cobraext.StatusKibanaVersionFlagDescription)
 
 	return cobraext.NewCommand(cmd, cobraext.ContextPackage)
 }
@@ -53,9 +53,9 @@ func statusCommandAction(cmd *cobra.Command, args []string) error {
 		packageName = args[0]
 	}
 
-	kibanaVersion, err := cmd.Flags().GetString(cobraext.StackVersionFlagName)
+	kibanaVersion, err := cmd.Flags().GetString(cobraext.StatusKibanaVersionFlagName)
 	if err != nil {
-		return cobraext.FlagParsingError(err, cobraext.StackVersionFlagName)
+		return cobraext.FlagParsingError(err, cobraext.StatusKibanaVersionFlagName)
 	}
 	options := registry.SearchOptions{
 		All:           showAll,

--- a/internal/cobraext/const.go
+++ b/internal/cobraext/const.go
@@ -84,6 +84,9 @@ const (
 	StackDumpOutputFlagName        = "output"
 	StackDumpOutputFlagDescription = "output location for the stack dump"
 
+	StatusKibanaVersionFlagName        = "kibana-version"
+	StatusKibanaVersionFlagDescription = "show packages for the given kibana version"
+
 	TestCoverageFlagName        = "test-coverage"
 	TestCoverageFlagDescription = "generate Cobertura test coverage reports"
 

--- a/internal/registry/revisions.go
+++ b/internal/registry/revisions.go
@@ -19,9 +19,10 @@ import (
 
 // SearchOptions specify the query parameters without the package name for the search API
 type SearchOptions struct {
-	Internal     bool `url:"internal"`
-	Experimental bool `url:"experimental"`
-	All          bool `url:"all"`
+	Internal      bool   `url:"internal"`
+	Experimental  bool   `url:"experimental"`
+	All           bool   `url:"all"`
+	KibanaVersion string `url:"kibana.version,omitempty"`
 }
 
 // searchQuery specify the package and query parameters for the search API


### PR DESCRIPTION
With this flag elastic-package status can be used to check the versions
available of a package for a given version of the stack.

For example:
```
$ elastic-package status apache --version 8.0.0
Package: apache
Package Versions:
+-------------+---------+---------+--------------------+--------------------------------+
| ENVIRONMENT | VERSION | RELEASE |       TITLE        |          DESCRIPTION           |
+-------------+---------+---------+--------------------+--------------------------------+
| Snapshot    | 1.3.0   | ga      | Apache HTTP Server | Collect logs and metrics from  |
|             |         |         |                    | Apache servers with Elastic    |
|             |         |         |                    | Agent.                         |
+-------------+---------+---------+--------------------+--------------------------------+
| Staging     | -       | -       | -                  | -                              |
+-------------+---------+---------+--------------------+--------------------------------+
| Production  | -       | -       | -                  | -                              |
+-------------+---------+---------+--------------------+--------------------------------+
```