### PR TITLE
Remove references to internal parameter

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -62,7 +62,6 @@ func getPackageStatus(packageName string, showAll bool) (*status.PackageStatus, 
 	if packageName != "" {
 		return status.RemotePackage(packageName, registry.SearchOptions{
 			All:          showAll,
-			Internal:     true,
 			Experimental: true,
 		})
 	}
@@ -75,7 +74,6 @@ func getPackageStatus(packageName string, showAll bool) (*status.PackageStatus, 
 	}
 	return status.LocalPackage(packageRootPath, registry.SearchOptions{
 		All:          showAll,
-		Internal:     true,
 		Experimental: true,
 	})
 }

--- a/internal/registry/revisions.go
+++ b/internal/registry/revisions.go
@@ -19,7 +19,6 @@ import (
 
 // SearchOptions specify the query parameters without the package name for the search API
 type SearchOptions struct {
-	Internal     bool `url:"internal"`
 	Experimental bool `url:"experimental"`
 	All          bool `url:"all"`
 }


### PR DESCRIPTION
Remove references to the internal parameter, that is not available anymore in the registry, see https://github.com/elastic/package-registry/pull/765.