### PR TITLE
Remove ambiguous elasticsearch imports

### DIFF
--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -200,7 +200,7 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 				TestFolder:         folder,
 				PackageRootPath:    packageRootPath,
 				GenerateTestResult: generateTestResult,
-				ESClient:           esClient,
+				API:                esClient.API,
 				DeferCleanup:       deferCleanup,
 				ServiceVariant:     variantFlag,
 			})

--- a/internal/elasticsearch/client.go
+++ b/internal/elasticsearch/client.go
@@ -10,9 +10,19 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/go-elasticsearch/v7"
+	"github.com/elastic/go-elasticsearch/v7/esapi"
 
 	"github.com/elastic/elastic-package/internal/stack"
 )
+
+// API contains the elasticsearch APIs
+type API = esapi.API
+
+// IngestSimulateRequest configures the Ingest Simulate API request.
+type IngestSimulateRequest = esapi.IngestSimulateRequest
+
+// IngestGetPipelineRequest configures the Ingest Get Pipeline API request.
+type IngestGetPipelineRequest = esapi.IngestGetPipelineRequest
 
 // Client method creates new instance of the Elasticsearch client.
 func Client() (*elasticsearch.Client, error) {

--- a/internal/testrunner/runners/asset/runner.go
+++ b/internal/testrunner/runners/asset/runner.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	es "github.com/elastic/go-elasticsearch/v7"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/logger"
@@ -29,7 +28,6 @@ const (
 type runner struct {
 	testFolder      testrunner.TestFolder
 	packageRootPath string
-	esClient        *es.Client
 
 	// Execution order of following handlers is defined in runner.tearDown() method.
 	removePackageHandler func() error
@@ -55,7 +53,6 @@ func (r runner) CanRunPerDataStream() bool {
 func (r runner) Run(options testrunner.TestOptions) ([]testrunner.TestResult, error) {
 	r.testFolder = options.TestFolder
 	r.packageRootPath = options.PackageRootPath
-	r.esClient = options.ESClient
 
 	return r.run()
 }

--- a/internal/testrunner/runners/pipeline/ingest_pipeline.go
+++ b/internal/testrunner/runners/pipeline/ingest_pipeline.go
@@ -17,12 +17,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elastic/go-elasticsearch/v7"
-	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
-	es "github.com/elastic/elastic-package/internal/elasticsearch"
+	"github.com/elastic/elastic-package/internal/elasticsearch"
 	"github.com/elastic/elastic-package/internal/packages"
 )
 
@@ -50,7 +48,7 @@ type pipelineIngestedDocument struct {
 	Doc pipelineDocument `json:"doc"`
 }
 
-func installIngestPipelines(esClient *elasticsearch.Client, dataStreamPath string) (string, []pipelineResource, error) {
+func installIngestPipelines(api *elasticsearch.API, dataStreamPath string) (string, []pipelineResource, error) {
 	dataStreamManifest, err := packages.ReadDataStreamManifest(filepath.Join(dataStreamPath, packages.DataStreamManifestFile))
 	if err != nil {
 		return "", nil, errors.Wrap(err, "reading data stream manifest failed")
@@ -69,7 +67,7 @@ func installIngestPipelines(esClient *elasticsearch.Client, dataStreamPath strin
 		return "", nil, errors.Wrap(err, "converting pipelines failed")
 	}
 
-	err = installPipelinesInElasticsearch(esClient, jsonPipelines)
+	err = installPipelinesInElasticsearch(api, jsonPipelines)
 	if err != nil {
 		return "", nil, errors.Wrap(err, "installing pipelines failed")
 	}
@@ -141,25 +139,25 @@ func convertPipelineToJSON(pipelines []pipelineResource) ([]pipelineResource, er
 	return jsonPipelines, nil
 }
 
-func installPipelinesInElasticsearch(esClient *elasticsearch.Client, pipelines []pipelineResource) error {
+func installPipelinesInElasticsearch(api *elasticsearch.API, pipelines []pipelineResource) error {
 	for _, pipeline := range pipelines {
-		if err := installPipeline(esClient, pipeline); err != nil {
+		if err := installPipeline(api, pipeline); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func installPipeline(esClient *elasticsearch.Client, pipeline pipelineResource) error {
-	if err := putIngestPipeline(esClient, pipeline); err != nil {
+func installPipeline(api *elasticsearch.API, pipeline pipelineResource) error {
+	if err := putIngestPipeline(api, pipeline); err != nil {
 		return err
 	}
 	// Just to be sure the pipeline has been uploaded.
-	return getIngestPipeline(esClient, pipeline.name)
+	return getIngestPipeline(api, pipeline.name)
 }
 
-func putIngestPipeline(esClient *elasticsearch.Client, pipeline pipelineResource) error {
-	r, err := esClient.API.Ingest.PutPipeline(pipeline.name, bytes.NewReader(pipeline.content))
+func putIngestPipeline(api *elasticsearch.API, pipeline pipelineResource) error {
+	r, err := api.Ingest.PutPipeline(pipeline.name, bytes.NewReader(pipeline.content))
 	if err != nil {
 		return errors.Wrapf(err, "PutPipeline API call failed (pipelineName: %s)", pipeline.name)
 	}
@@ -171,14 +169,14 @@ func putIngestPipeline(esClient *elasticsearch.Client, pipeline pipelineResource
 	}
 
 	if r.StatusCode != http.StatusOK {
-		return errors.Wrapf(es.NewError(body), "unexpected response status for PutPipeline (%d): %s (pipelineName: %s)",
+		return errors.Wrapf(elasticsearch.NewError(body), "unexpected response status for PutPipeline (%d): %s (pipelineName: %s)",
 			r.StatusCode, r.Status(), pipeline.name)
 	}
 	return nil
 }
 
-func getIngestPipeline(esClient *elasticsearch.Client, pipelineName string) error {
-	r, err := esClient.API.Ingest.GetPipeline(func(request *esapi.IngestGetPipelineRequest) {
+func getIngestPipeline(api *elasticsearch.API, pipelineName string) error {
+	r, err := api.Ingest.GetPipeline(func(request *elasticsearch.IngestGetPipelineRequest) {
 		request.PipelineID = pipelineName
 	})
 	if err != nil {
@@ -192,15 +190,15 @@ func getIngestPipeline(esClient *elasticsearch.Client, pipelineName string) erro
 	}
 
 	if r.StatusCode != http.StatusOK {
-		return errors.Wrapf(es.NewError(body), "unexpected response status for GetPipeline (%d): %s (pipelineName: %s)",
+		return errors.Wrapf(elasticsearch.NewError(body), "unexpected response status for GetPipeline (%d): %s (pipelineName: %s)",
 			r.StatusCode, r.Status(), pipelineName)
 	}
 	return nil
 }
 
-func uninstallIngestPipelines(esClient *elasticsearch.Client, pipelines []pipelineResource) error {
+func uninstallIngestPipelines(api *elasticsearch.API, pipelines []pipelineResource) error {
 	for _, pipeline := range pipelines {
-		_, err := esClient.API.Ingest.DeletePipeline(pipeline.name)
+		_, err := api.Ingest.DeletePipeline(pipeline.name)
 		if err != nil {
 			return errors.Wrapf(err, "DeletePipeline API call failed (pipelineName: %s)", pipeline.name)
 		}
@@ -212,7 +210,7 @@ func getWithPipelineNameWithNonce(pipelineName string, nonce int64) string {
 	return fmt.Sprintf("%s-%d", pipelineName, nonce)
 }
 
-func simulatePipelineProcessing(esClient *elasticsearch.Client, pipelineName string, tc *testCase) (*testResult, error) {
+func simulatePipelineProcessing(api *elasticsearch.API, pipelineName string, tc *testCase) (*testResult, error) {
 	var request simulatePipelineRequest
 	for _, event := range tc.events {
 		request.Docs = append(request.Docs, pipelineDocument{
@@ -225,7 +223,7 @@ func simulatePipelineProcessing(esClient *elasticsearch.Client, pipelineName str
 		return nil, errors.Wrap(err, "marshalling simulate request failed")
 	}
 
-	r, err := esClient.API.Ingest.Simulate(bytes.NewReader(requestBody), func(request *esapi.IngestSimulateRequest) {
+	r, err := api.Ingest.Simulate(bytes.NewReader(requestBody), func(request *elasticsearch.IngestSimulateRequest) {
 		request.PipelineID = pipelineName
 	})
 	if err != nil {
@@ -239,7 +237,7 @@ func simulatePipelineProcessing(esClient *elasticsearch.Client, pipelineName str
 	}
 
 	if r.StatusCode != http.StatusOK {
-		return nil, errors.Wrapf(es.NewError(body), "unexpected response status for Simulate (%d): %s", r.StatusCode, r.Status())
+		return nil, errors.Wrapf(elasticsearch.NewError(body), "unexpected response status for Simulate (%d): %s", r.StatusCode, r.Status())
 	}
 
 	var response simulatePipelineResponse

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -60,7 +60,7 @@ func (r *runner) TearDown() error {
 		time.Sleep(r.options.DeferCleanup)
 	}
 
-	err := uninstallIngestPipelines(r.options.ESClient, r.pipelines)
+	err := uninstallIngestPipelines(r.options.API, r.pipelines)
 	if err != nil {
 		return errors.Wrap(err, "uninstalling ingest pipelines failed")
 	}
@@ -88,7 +88,7 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 	}
 
 	var entryPipeline string
-	entryPipeline, r.pipelines, err = installIngestPipelines(r.options.ESClient, dataStreamPath)
+	entryPipeline, r.pipelines, err = installIngestPipelines(r.options.API, dataStreamPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "installing ingest pipelines failed")
 	}
@@ -121,7 +121,7 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 			continue
 		}
 
-		result, err := simulatePipelineProcessing(r.options.ESClient, entryPipeline, tc)
+		result, err := simulatePipelineProcessing(r.options.API, entryPipeline, tc)
 		if err != nil {
 			err := errors.Wrap(err, "simulating pipeline processing failed")
 			tr.ErrorMsg = err.Error()

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -12,8 +12,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/pkg/errors"
+
+	"github.com/elastic/elastic-package/internal/elasticsearch"
 )
 
 // TestType represents the various supported test types
@@ -24,7 +25,7 @@ type TestOptions struct {
 	TestFolder         TestFolder
 	PackageRootPath    string
 	GenerateTestResult bool
-	ESClient           *elasticsearch.Client
+	API                *elasticsearch.API
 
 	DeferCleanup   time.Duration
 	ServiceVariant string


### PR DESCRIPTION
Along the code there are several places where we are importing these packages:
* `github.com/elastic/elastic-package/internal/elasticsearch`
* `github.com/elastic/go-elasticsearch/v7`
* `github.com/elastic/go-elasticsearch/v7/esapi`

The `elasticsearch` ones are ambiguous and need an alias, we are using `es`, but not consistently, sometimes for the internal package, and sometimes for `go-elasticsearch`.

This PR adds aliases of the required types of `go-elasticsearch` into the internal package, so other packages only need to import this one.

Also, elastic-package only needs the `API` part of the `Client`s, so this is the only part exposed now. We could use interfaces also for this but these objects are not easy to interface because functions are members and members of embedded objects.