### PR TITLE
[mergify] use merge queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,8 @@
+queue_rules:
+  - name: default
+    conditions:
+      - check-success=elastic-package/pr-merge
+
 pull_request_rules:
   - name: automatic merge of bot 🤖
     conditions:
@@ -6,6 +11,6 @@ pull_request_rules:
       - base=master
       - author~=^dependabot(|-preview)\[bot\]$
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart+fasttrack
+        name: default


### PR DESCRIPTION
### What

Migrate from the `merge action` to the `queue action`.

See https://docs.mergify.io/actions/queue/#queue-rules to know more about how the `queue` command works.

### Why

We use the merge action to automerge automated PRs, so we cannot use this approach from January 2022

```
The configuration uses the deprecated strict mode of the merge action.
A brownout is planned for the whole December 6th, 2021 day.
This option will be removed on January 10th, 2022.
For more information: https://blog.mergify.io/strict-mode-deprecation/
```
