### PR TITLE
copy all files for terraform system tests

### DIFF
--- a/internal/install/_static/terraform_deployer_run.sh
+++ b/internal/install/_static/terraform_deployer_run.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-cp -r /stage/*.tf /workspace
+cp -r /stage/* /workspace
 
 cleanup() {
   r=$?

--- a/internal/install/_static/terraform_deployer_run.sh
+++ b/internal/install/_static/terraform_deployer_run.sh
@@ -2,6 +2,8 @@
 
 set -euxo pipefail
 
+# Terraform code may rely on content from other files than .tf files (es json, zip, html, text), so we copy all the content over
+# See more: https://github.com/elastic/elastic-package/pull/603
 cp -r /stage/* /workspace
 
 cleanup() {


### PR DESCRIPTION
Terraform allows using files from the local folder for different use cases.

The current implementation of the deployer prevents this by copying only `*.tf` files from the stage folder to the workspace folder.

This PR update the script to copy all files.

I have a use case behind this change: to test GCP BigQuery a schema and some test data must be provided. The schema and data are in JSON format, but with the current implementation is not possible to use them as they do not get copied over.