### PR TITLE
Support overriding configuration folder

### DIFF
--- a/internal/configuration/locations/locations.go
+++ b/internal/configuration/locations/locations.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// elasticDataHomeEnv is the name of the environment variable used to override data folder for elastic-package
-	elasticDataHomeEnv = "ELASTIC_PACKAGE_DATA_HOME"
+	elasticPackageDataHome = "ELASTIC_PACKAGE_DATA_HOME"
 
 	elasticPackageDir = ".elastic-package"
 	stackDir          = "stack"

--- a/internal/configuration/locations/locations.go
+++ b/internal/configuration/locations/locations.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	// elasticDataHomeEnv is the name of the environment variable used to override data folder for elastic-package
+	// elasticPackageDataHome is the name of the environment variable used to override data folder for elastic-package
 	elasticPackageDataHome = "ELASTIC_PACKAGE_DATA_HOME"
 
 	elasticPackageDir = ".elastic-package"
@@ -107,10 +107,10 @@ func (loc LocationManager) FieldsCacheDir() string {
 }
 
 // configurationDir returns the configuration directory location
-// If a environment variable named as in elasticDataHomeEnv is present,
+// If a environment variable named as in elasticPackageDataHome is present,
 // the value is used as is, overriding the value of this function.
 func configurationDir() (string, error) {
-	customHome := os.Getenv(elasticDataHomeEnv)
+	customHome := os.Getenv(elasticPackageDataHome)
 	if customHome != "" {
 		return customHome, nil
 	}

--- a/internal/configuration/locations/locations.go
+++ b/internal/configuration/locations/locations.go
@@ -13,6 +13,9 @@ import (
 )
 
 const (
+	// elasticDataHomeEnv is the name of the environment variable used to override data folder for elastic-package
+	elasticDataHomeEnv = "ELASTIC_PACKAGE_DATA_HOME"
+
 	elasticPackageDir = ".elastic-package"
 	stackDir          = "stack"
 	packagesDir       = "development"
@@ -104,7 +107,14 @@ func (loc LocationManager) FieldsCacheDir() string {
 }
 
 // configurationDir returns the configuration directory location
+// If a environment variable named as in elasticDataHomeEnv is present,
+// the value is used as is, overriding the value of this function.
 func configurationDir() (string, error) {
+	customHome := os.Getenv(elasticDataHomeEnv)
+	if customHome != "" {
+		return customHome, nil
+	}
+
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", errors.Wrap(err, "reading home dir failed")

--- a/internal/configuration/locations/locations_internal_test.go
+++ b/internal/configuration/locations/locations_internal_test.go
@@ -47,11 +47,11 @@ func Test_configurationDirError(t *testing.T) {
 
 func Test_configurationDirOverride(t *testing.T) {
 	expected := "/tmp/foobar"
-	os.Setenv(elasticDataHomeEnv, expected)
+	os.Setenv(elasticPackageDataHome, expected)
 
 	actual, err := configurationDir()
 	assert.Nil(t, err)
 
 	assert.Equal(t, expected, actual)
-	os.Setenv(elasticDataHomeEnv, "")
+	os.Setenv(elasticPackageDataHome, "")
 }

--- a/internal/configuration/locations/locations_internal_test.go
+++ b/internal/configuration/locations/locations_internal_test.go
@@ -1,0 +1,57 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// Package locations manages base file and directory locations from within the elastic-package config
+package locations
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_configurationDir(t *testing.T) {
+	userHome, err := os.UserHomeDir()
+	assert.Nil(t, err)
+	expected := filepath.Join(userHome, elasticPackageDir)
+
+	actual, err := configurationDir()
+	assert.Nil(t, err)
+
+	assert.Equal(t, expected, actual)
+}
+
+func Test_configurationDirError(t *testing.T) {
+	var env string
+	// Copied from os.UserHomeDir()
+	switch runtime.GOOS {
+	case "windows":
+		env = "USERPROFILE"
+	case "plan9":
+		env = "home"
+	default:
+		env = "HOME"
+	}
+	homeEnv := os.Getenv(env)
+	os.Unsetenv(env)
+
+	_, err := configurationDir()
+	assert.Error(t, err)
+
+	os.Setenv(env, homeEnv)
+}
+
+func Test_configurationDirOverride(t *testing.T) {
+	expected := "/tmp/foobar"
+	os.Setenv(elasticDataHomeEnv, expected)
+
+	actual, err := configurationDir()
+	assert.Nil(t, err)
+
+	assert.Equal(t, expected, actual)
+	os.Setenv(elasticDataHomeEnv, "")
+}


### PR DESCRIPTION
Configuration folder path was hardcoded to `user home folder/.elastic-package`. For testing purposes or for development this created some issues, as any run of the binary would run `EnsureInstalled`, eventually failing or overriding data.

This commit introduce a new environment variable, `ELASTIC_PACKAGE_DATA_HOME`, that can be used to override the data folder where this CLI unpack it's configuration and data files.

The suffix `DATA_HOME` is taken from XDG spec and leaves room for splitting configuration and data in the future without introducing a breaking change.

Tests have been added to check `configurationDir` behaviour.
