### PR TITLE
Report error root cause if available

### DIFF
--- a/internal/elasticsearch/error.go
+++ b/internal/elasticsearch/error.go
@@ -13,19 +13,64 @@ import (
 // NewError returns a new error constructed from the given response body.
 // This assumes the body contains a JSON encoded error. If the body cannot
 // be parsed then an error is returned that contains the raw body.
-func NewError(body []byte) error {
-	type ErrorBody struct {
-		Error struct {
-			Type   string `json:"type"`
-			Reason string `json:"reason"`
-		} `json:"error"`
-	}
+type ErrorBody struct {
+	Error struct {
+		RootCause []struct {
+			Type          string   `json:"type"`
+			Reason        string   `json:"reason"`
+			ProcessorType string   `json:"processor_type"`
+			ScriptStack   []string `json:"script_stack"`
+			Script        string   `json:"script"`
+			Lang          string   `json:"lang"`
+			Position      struct {
+				Offset int `json:"offset"`
+				Start  int `json:"start"`
+				End    int `json:"end"`
+			} `json:"position"`
+			Suppressed []struct {
+				Type          string `json:"type"`
+				Reason        string `json:"reason"`
+				ProcessorType string `json:"processor_type"`
+			} `json:"suppressed"`
+		} `json:"root_cause"`
+		Type          string   `json:"type"`
+		Reason        string   `json:"reason"`
+		ProcessorType string   `json:"processor_type"`
+		ScriptStack   []string `json:"script_stack"`
+		Script        string   `json:"script"`
+		Lang          string   `json:"lang"`
+		Position      struct {
+			Offset int `json:"offset"`
+			Start  int `json:"start"`
+			End    int `json:"end"`
+		} `json:"position"`
+		CausedBy struct {
+			Type     string `json:"type"`
+			Reason   string `json:"reason"`
+			CausedBy struct {
+				Type   string      `json:"type"`
+				Reason interface{} `json:"reason"`
+			} `json:"caused_by"`
+		} `json:"caused_by"`
+		Suppressed []struct {
+			Type          string `json:"type"`
+			Reason        string `json:"reason"`
+			ProcessorType string `json:"processor_type"`
+		} `json:"suppressed"`
+	} `json:"error"`
+	Status int `json:"status"`
+}
 
+func NewError(body []byte) error {
 	var errBody ErrorBody
 	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&errBody); err == nil {
+		if len(errBody.Error.RootCause) > 0 {
+			rootCause, _ := json.MarshalIndent(errBody.Error.RootCause, "", "  ")
+			return fmt.Errorf("elasticsearch error (type=%v): %v\nRoot cause:\n%v", errBody.Error.Type,
+				errBody.Error.Reason, string(rootCause))
+		}
 		return fmt.Errorf("elasticsearch error (type=%v): %v", errBody.Error.Type, errBody.Error.Reason)
 	}
-
 	// Fall back to including to raw body if it cannot be parsed.
 	return fmt.Errorf("elasticsearch error: %v", string(body))
 }

--- a/internal/elasticsearch/error.go
+++ b/internal/elasticsearch/error.go
@@ -18,45 +18,45 @@ type ErrorBody struct {
 		RootCause []struct {
 			Type          string   `json:"type"`
 			Reason        string   `json:"reason"`
-			ProcessorType string   `json:"processor_type"`
-			ScriptStack   []string `json:"script_stack"`
-			Script        string   `json:"script"`
-			Lang          string   `json:"lang"`
+			ProcessorType string   `json:"processor_type,omitempty"`
+			ScriptStack   []string `json:"script_stack,omitempty"`
+			Script        string   `json:"script,omitempty"`
+			Lang          string   `json:"lang,omitempty"`
 			Position      struct {
 				Offset int `json:"offset"`
 				Start  int `json:"start"`
 				End    int `json:"end"`
-			} `json:"position"`
+			} `json:"position,omitempty"`
 			Suppressed []struct {
 				Type          string `json:"type"`
 				Reason        string `json:"reason"`
 				ProcessorType string `json:"processor_type"`
-			} `json:"suppressed"`
-		} `json:"root_cause"`
+			} `json:"suppressed,omitempty"`
+		} `json:"root_cause,omitempty"`
 		Type          string   `json:"type"`
 		Reason        string   `json:"reason"`
-		ProcessorType string   `json:"processor_type"`
-		ScriptStack   []string `json:"script_stack"`
-		Script        string   `json:"script"`
-		Lang          string   `json:"lang"`
+		ProcessorType string   `json:"processor_type,omitempty"`
+		ScriptStack   []string `json:"script_stack,omitempty"`
+		Script        string   `json:"script,omitempty"`
+		Lang          string   `json:"lang,omitempty"`
 		Position      struct {
 			Offset int `json:"offset"`
 			Start  int `json:"start"`
 			End    int `json:"end"`
-		} `json:"position"`
+		} `json:"position,omitempty"`
 		CausedBy struct {
 			Type     string `json:"type"`
 			Reason   string `json:"reason"`
 			CausedBy struct {
 				Type   string      `json:"type"`
 				Reason interface{} `json:"reason"`
-			} `json:"caused_by"`
-		} `json:"caused_by"`
+			} `json:"caused_by,omitempty"`
+		} `json:"caused_by,omitempty"`
 		Suppressed []struct {
 			Type          string `json:"type"`
 			Reason        string `json:"reason"`
 			ProcessorType string `json:"processor_type"`
-		} `json:"suppressed"`
+		} `json:"suppressed,omitempty"`
 	} `json:"error"`
 	Status int `json:"status"`
 }

--- a/internal/elasticsearch/error_test.go
+++ b/internal/elasticsearch/error_test.go
@@ -29,6 +29,20 @@ func TestNewError(t *testing.T) {
   "status" : 400
 }`
 
+	const expected = `elasticsearch error (type=parse_exception): processor [set] doesn't support one or more provided configuration parameters [fail]
+Root cause:
+[
+  {
+    "type": "parse_exception",
+    "reason": "processor [set] doesn't support one or more provided configuration parameters [fail]",
+    "processor_type": "set",
+    "position": {
+      "offset": 0,
+      "start": 0,
+      "end": 0
+    }
+  }
+]`
 	err := elasticsearch.NewError([]byte(resp))
-	assert.Equal(t, err.Error(), "elasticsearch error (type=parse_exception): processor [set] doesn't support one or more provided configuration parameters [fail]")
+	assert.Equal(t, err.Error(), expected)
 }


### PR DESCRIPTION
Return root cause (if available) for errors returned from Elasticsearch. This helps debugging errors with respect to ingest pipelines or other errors reported when interacting with Elasticsearch. Example - 

**Before:**

```
$ elastic-package test pipeline
Run pipeline tests for the package
Error: error running package pipeline tests: could not complete test run: installing ingest pipelines failed: installing pipelines failed: unexpected response status for PutPipeline (400): 400 Bad Request (pipelineName: default-1638926343429676922): elasticsearch error (type=script_exception): compile error
```

**After:**
```
$ elastic-package test pipeline
Run pipeline tests for the package
Error: error running package pipeline tests: could not complete test run: installing ingest pipelines failed: installing pipelines failed: unexpected response status for PutPipeline (400): 400 Bad Request (pipelineName: default-1638926754640971882): elasticsearch error (type=script_exception): compile error
Root cause:
[
  {
    "type": "script_exception",
    "reason": "compile error",
    "processor_type": "dissect",
    "script_stack": [
      "... _principal_name.contains('\\')",
      "                             ^---- HERE"
    ],
    "script": "ctx?.sqlserver?.audit?.server_principal_name != null \u0026\u0026 ctx?.sqlserver?.audit?.server_principal_name.contains('\\')",
    "lang": "painless",
    "position": {
      "offset": 110,
      "start": 85,
      "end": 114
    },
    "suppressed": [
      {
        "type": "parse_exception",
        "reason": "processor [set] doesn't support one or more provided configuration parameters [ignore_missing]",
        "processor_type": "set"
      },
      {
        "type": "parse_exception",
        "reason": "processor [set] doesn't support one or more provided configuration parameters [ignore_missing]",
        "processor_type": "set"
      },
      {
        "type": "parse_exception",
        "reason": "processor [set] doesn't support one or more provided configuration parameters [ignore_missing]",
        "processor_type": "set"
      },
      {
        "type": "parse_exception",
        "reason": "processor [set] doesn't support one or more provided configuration parameters [ignore_missing]",
        "processor_type": "set"
      }
    ]
  }
]
```
