### PR TITLE
Bump up stack version to 7.16.0

### DIFF
--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "7.15.1"
+	DefaultStackVersion = "7.16.0"
 )


### PR DESCRIPTION
This PR bumps up the stack version to 7.16.0 (stable).