### PR TITLE
Remove STATE_PATH from agent/fleet-server containers

### DIFF
--- a/internal/profile/_static/docker-compose-stack.yml
+++ b/internal/profile/_static/docker-compose-stack.yml
@@ -81,7 +81,6 @@ services:
     - "KIBANA_FLEET_SETUP=1"
     - "KIBANA_FLEET_HOST=http://kibana:5601"
     - "FLEET_SERVER_HOST=0.0.0.0"
-    - "STATE_PATH=/usr/share/elastic-agent"
     ports:
       - "127.0.0.1:8220:8220"
 
@@ -105,7 +104,6 @@ services:
     - "FLEET_ENROLL=1"
     - "FLEET_INSECURE=1"
     - "FLEET_URL=http://fleet-server:8220"
-    - "STATE_PATH=/usr/share/elastic-agent"
     volumes:
     - type: bind
       source: ../../../tmp/service_logs/


### PR DESCRIPTION
In #329 a non-default STATE_PATH was set in the container environments
to make the elastic-agent status command function. That does not appear
to be necessary so let's remove it. Having this in our envionrment makes
us operate our tests differently than how users deploy the software.

Relates: elastic/beats#25204