### PR TITLE
Ignore stack profile for geoip db

### DIFF
--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -165,26 +165,24 @@ func writeStackResources(elasticPackagePath *locations.LocationManager) error {
 
 	// Install GeoIP database
 	ingestGeoIPDir := filepath.Join(elasticPackagePath.StackDir(), "ingest-geoip")
-
-	ingestGeoIPDefaultDir := filepath.Join(ingestGeoIPDir, "default")
-	err = os.MkdirAll(ingestGeoIPDefaultDir, 0755)
+	err = os.MkdirAll(ingestGeoIPDir, 0755)
 	if err != nil {
-		return errors.Wrapf(err, "creating directory failed (path: %s)", ingestGeoIPDefaultDir)
+		return errors.Wrapf(err, "creating directory failed (path: %s)", ingestGeoIPDir)
 	}
 
-	geoIpAsnMmdbPath := filepath.Join(ingestGeoIPDefaultDir, "GeoLite2-ASN.mmdb")
+	geoIpAsnMmdbPath := filepath.Join(ingestGeoIPDir, "GeoLite2-ASN.mmdb")
 	err = writeStaticResource(err, geoIpAsnMmdbPath, geoIpAsnMmdb)
 	if err != nil {
 		return errors.Wrapf(err, "copying GeoIP ASN database failed (%s)", geoIpAsnMmdbPath)
 	}
 
-	geoIpCityMmdbPath := filepath.Join(ingestGeoIPDefaultDir, "GeoLite2-City.mmdb")
+	geoIpCityMmdbPath := filepath.Join(ingestGeoIPDir, "GeoLite2-City.mmdb")
 	err = writeStaticResource(err, geoIpCityMmdbPath, geoIpCityMmdb)
 	if err != nil {
 		return errors.Wrapf(err, "copying GeoIP city database failed (%s)", geoIpCityMmdbPath)
 	}
 
-	geoIpCountryMmdbPath := filepath.Join(ingestGeoIPDefaultDir, "GeoLite2-Country.mmdb")
+	geoIpCountryMmdbPath := filepath.Join(ingestGeoIPDir, "GeoLite2-Country.mmdb")
 	err = writeStaticResource(err, geoIpCountryMmdbPath, geoIpCountryMmdb)
 	if err != nil {
 		return errors.Wrapf(err, "copying GeoIP country database failed (%s)", geoIpCountryMmdbPath)

--- a/internal/profile/_static/docker-compose-stack.yml
+++ b/internal/profile/_static/docker-compose-stack.yml
@@ -11,7 +11,7 @@ services:
       - "ELASTIC_PASSWORD=changeme"
     volumes:
       - "./elasticsearch.config.${STACK_VERSION_VARIANT}.yml:/usr/share/elasticsearch/config/elasticsearch.yml"
-      - "../../../stack/ingest-geoip/${STACK_VERSION_VARIANT}/:/usr/share/elasticsearch/config/ingest-geoip"
+      - "../../../stack/ingest-geoip:/usr/share/elasticsearch/config/ingest-geoip"
     ports:
       - "127.0.0.1:9200:9200"
 


### PR DESCRIPTION
Ignores the stack version to set the geoip database, since we want to use the same for any stack available.