### PR TITLE
Fix: use share dir to collect logs

### DIFF
--- a/internal/stack/logs.go
+++ b/internal/stack/logs.go
@@ -44,7 +44,7 @@ func copyDockerInternalLogs(serviceName, outputPath string) error {
 
 	outputPath = filepath.Join(outputPath, serviceName+"-internal")
 	serviceContainer := p.ContainerName(serviceName)
-	err = docker.Copy(serviceContainer, "/usr/share/elastic-agent/data/logs/default", outputPath)
+	err = docker.Copy(serviceContainer, "/usr/share/elastic-agent/state/data/logs/default", outputPath)
 	if err != nil {
 		return errors.Wrap(err, "docker copy failed")
 	}


### PR DESCRIPTION
This PR modifies the "stack dump" logic to collect elastic-agent logs from a different directory.

Tested with: `elastic-package stack dump -v`

CI did the same thing and logs showed up under Artifacts tab.