### PR TITLE
Flaky: increase boot timeout

### DIFF
--- a/internal/profile/_static/docker-compose-stack.yml
+++ b/internal/profile/_static/docker-compose-stack.yml
@@ -72,7 +72,7 @@ services:
         condition: service_healthy
     healthcheck:
       test: "curl -f http://127.0.0.1:8220/api/status | grep HEALTHY 2>&1 >/dev/null"
-      retries: 12
+      retries: 60
       interval: 5s
     hostname: docker-fleet-server
     environment:
@@ -97,7 +97,7 @@ services:
         condition: service_healthy
     healthcheck:
       test: "elastic-agent status"
-      retries: 90
+      retries: 180
       interval: 1s
     hostname: docker-fleet-agent
     environment:


### PR DESCRIPTION
The [main build job](https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Felastic-package/detail/master/295/) just failed because of slow agent startup. This PR increases the boot timeout.