### PR TITLE
Add GCP Cloud SDK to Terraform deployer image

### DIFF
--- a/internal/install/_static/Dockerfile.terraform_deployer
+++ b/internal/install/_static/Dockerfile.terraform_deployer
@@ -3,7 +3,7 @@ FROM hashicorp/terraform:light as terraform
 FROM python:3-alpine
 
 # required by gcloud SDK
-RUN apk add git openssh curl
+RUN apk add --no-cache git openssh curl
 
 ENV GCLOUD_SDK_VERSION 367.0.0
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin

--- a/internal/install/_static/Dockerfile.terraform_deployer
+++ b/internal/install/_static/Dockerfile.terraform_deployer
@@ -3,7 +3,7 @@ FROM hashicorp/terraform:light as terraform
 FROM python:3-alpine
 
 # required by gcloud SDK
-RUN apk add curl
+RUN apk add git openssh curl
 
 ENV GCLOUD_SDK_VERSION 367.0.0
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin

--- a/internal/install/_static/Dockerfile.terraform_deployer
+++ b/internal/install/_static/Dockerfile.terraform_deployer
@@ -1,6 +1,23 @@
-FROM hashicorp/terraform:light
-ENV TF_IN_AUTOMATION=true
+FROM hashicorp/terraform:light as terraform
+
+FROM python:3-alpine
+
+# required by gcloud SDK
+RUN apk add curl
+
+ENV GCLOUD_SDK_VERSION 367.0.0
+ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
+RUN curl "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_SDK_VERSION-linux-x86_64.tar.gz" > /tmp/google-cloud-sdk.tar.gz \
+  && mkdir -p /usr/local/gcloud \
+  && tar -C /usr/local/gcloud -xvf /tmp/google-cloud-sdk.tar.gz \
+  && /usr/local/gcloud/google-cloud-sdk/install.sh -q --override-components="bq"
+
 HEALTHCHECK --timeout=3s CMD sh -c "[ -f /tmp/tf-applied ]"
+
+COPY --from=terraform /bin/terraform /usr/bin/terraform
+
+ENV TF_IN_AUTOMATION=true
 ADD run.sh /
 WORKDIR /workspace
+
 ENTRYPOINT sh /run.sh

--- a/internal/install/_static/Dockerfile.terraform_deployer
+++ b/internal/install/_static/Dockerfile.terraform_deployer
@@ -10,7 +10,8 @@ ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 RUN curl "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_SDK_VERSION-linux-x86_64.tar.gz" > /tmp/google-cloud-sdk.tar.gz \
   && mkdir -p /usr/local/gcloud \
   && tar -C /usr/local/gcloud -xvf /tmp/google-cloud-sdk.tar.gz \
-  && /usr/local/gcloud/google-cloud-sdk/install.sh -q --override-components="bq"
+  && /usr/local/gcloud/google-cloud-sdk/install.sh -q --override-components="bq" \
+  && rm /tmp/google-cloud-sdk.tar.gz
 
 HEALTHCHECK --timeout=3s CMD sh -c "[ -f /tmp/tf-applied ]"
 


### PR DESCRIPTION
Terraform deployer image may need some additional Cloud Service Provider specific tooling to handle corner cases not handled by Terraform itself.

In this case this commits adds support for `bq` tool from GCP Cloud SDK.

As `bq` and the entire GCP Cloud SDK requires python, is easy to add AWS or Azure dedicated tooling in the future (as both are Python-based).

This PR is a follow-up for thread we started in https://github.com/elastic/integrations/pull/2312/files/f9557ea229de629c78ccb5d736efec2ab8ae104b#diff-6f3fb9692206fe5de2c5656d237ad692e6772234331ed60d7c91e674072d417e, where more CSP dedicated tools where needed in the Terraform deployer Docker image.