### PR TITLE
internal/testrunner/runners/pipeline: output documents with fields in a normalized order

### DIFF
--- a/internal/testrunner/runners/pipeline/test_result.go
+++ b/internal/testrunner/runners/pipeline/test_result.go
@@ -146,11 +146,27 @@ func unmarshalTestResult(body []byte) (*testResult, error) {
 func marshalTestResultDefinition(result *testResult) ([]byte, error) {
 	var trd testResultDefinition
 	trd.Expected = result.events
-	body, err := json.MarshalIndent(&trd, "", "    ")
+	body, err := marshalNormalizedJSON(trd)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshalling test result definition failed")
 	}
 	return body, nil
+}
+
+// marshalNormalizedJSON marshals test results ensuring that field
+// order remains consistent independent of field order returned by
+// ES to minimize diff noise during changes.
+func marshalNormalizedJSON(v testResultDefinition) ([]byte, error) {
+	msg, err := json.Marshal(v)
+	if err != nil {
+		return msg, err
+	}
+	var obj interface{}
+	err = json.Unmarshal(msg, &obj)
+	if err != nil {
+		return msg, err
+	}
+	return json.MarshalIndent(obj, "", "    ")
 }
 
 func expectedTestResultFile(testFile string) string {


### PR DESCRIPTION
The unstable order of fields output by ES commonly results in unrelated diff noise in changes to packages. This change normalises the order of fields lexically to reduce that problem over time. There will be an initial increase in diff noise as each package is brought into the canonical order.

For example with the sophos xg test set.

Before:
```
{
    "expected": [
        {
            "server": {
                "port": 0,
                "bytes": 0
            },
            "log": {
                "level": "informational"
            },
            "destination": {
                "port": 0,
                "user": {
                    "email": "Sysadmin@elasticuser.com"
                },
                "bytes": 0
            },
            "source": {
                "port": 0,
                "user": {
                    "email": "firewall@firewallgate.com"
                },
                "bytes": 0,
                "domain": "elasticuser.com"
            },
            "tags": [
                "preserve_original_event"
            ],
            "network": {
                "transport": "TCP"
            },
            "observer": {
                "product": "XG",
                "serial_number": "1234567890123456",
                "type": "firewall",
                "vendor": "Sophos"
            },
            "@timestamp": "2020-05-18T14:38:48.000Z",
            "ecs": {
                "version": "1.12.0"
            },
            "related": {
                "hosts": [
                    "testhost.local"
                ]
            },
            "sophos": {
                "xg": {
                    "fw_rule_id": "0",
                    ...
```

After:

```
{
    "expected": [
        {
            "@timestamp": "2020-05-18T14:38:48.000Z",
            "client": {
                "bytes": 0,
                "port": 0
            },
            "destination": {
                "bytes": 0,
                "port": 0,
                "user": {
                    "email": "Sysadmin@elasticuser.com"
                }
            },
            "ecs": {
                "version": "1.12.0"
            },
            "event": {
                "action": "Allowed",
                "category": [
                    "network"
                ],
                "code": "041101618035",
                "ingested": "2022-01-13T06:37:18.072532500Z",
                "kind": "event",
                "original": "device=\"SFW\" date=2020-05-18 time=14:38:48 timezone=\"CEST\" device_name=\"XG230\" device_id=1234567890123456 log_id=041101618035 log_type=\"Anti-Spam\" log_component=\"SMTP\" log_subtype=\"Allowed\" status=\"\" priority=Information fw_rule_id=0 user_name=\"\" av_policy_name=\"None\" from_email_address=\"firewall@firewallgate.com\" to_email_address=\"Sysadmin@elasticuser.com\" email_subject=\"*ALERT* Sophos XG Firewall\" mailid=\"qkW2Y6-LxBk6U-vH-1590055245\" mailsize=19728 spamaction=\"QUEUED\" reason=\"Email has been accepted by Device and queued for scanning.\" src_domainname=\"elasticuser.com\" dst_domainname=\"\" src_ip=\"\" src_country_code=\"\" dst_ip=\"\" dst_country_code=\"\" protocol=\"TCP\" src_port=0 dst_port=0 sent_bytes=0 recv_bytes=0 quarantine_reason=\"Other\"",
                "outcome": "success",
                "severity": 6,
                "type": [
                    "allowed",
                    "connection"
                ]
            },
            "host": {
                "name": "testhost.local"
            },
            "log": {
                "level": "informational"
            },
            "network": {
                "transport": "TCP"
            },
            "observer": {
                "product": "XG",
                "serial_number": "1234567890123456",
                "type": "firewall",
                "vendor": "Sophos"
            },
            ...
```

Please take a look.