### PR TITLE
internal/version: make version available when installed via go install github.com/elastic/elastic-package

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,6 +5,7 @@
 package version
 
 import (
+	"runtime/debug"
 	"strconv"
 	"time"
 )
@@ -19,6 +20,17 @@ var (
 	// Tag describes the semver version of the application (set externally with ldflags).
 	Tag string
 )
+
+// Set Tag to version stored in modinfo if it is not available from the builder.
+func init() {
+	if Tag != "" {
+		return
+	}
+	info, ok := debug.ReadBuildInfo()
+	if ok && info.Main.Version != "(devel)" {
+		Tag = info.Main.Version
+	}
+}
 
 // BuildTimeFormatted method returns the build time preserving the RFC3339 format.
 func BuildTimeFormatted() string {


### PR DESCRIPTION
This makes to output of elastic-package version informative when the go.mod-based install within integrations is used. It does not prevent the "CommitHash is undefined" warning since that is based on build-time var substitution. The logic required to properly handle update detection is reasonably involved, so I have not added this (see [here](https://github.com/kortschak/ugbt/blob/18ee59e607e8117ba0bf85621cf69203df511891/cmd.go#L658) for the general case — not all of that would be required here).

The output of `elastic-package version` when it has been installed using `go install github.com/elastic/elastic-package@latest` or by `go install github.com/elastic/elastic-package` from within a module with it written as a require would look something like this

```
elastic-package v0.43.1 version-hash 032f343 (build time: 2052-01-18T19:38:06+4:30)
```

Please take a look.