### PR TITLE
Set version var during make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 CODE_COVERAGE_REPORT_FOLDER = $(PWD)/build/test-coverage
 CODE_COVERAGE_REPORT_NAME_UNIT = $(CODE_COVERAGE_REPORT_FOLDER)/coverage-unit-report
+VERSION_IMPORT_PATH = github.com/elastic/elastic-package/internal/version
 
 .PHONY: build
 
 build:
-	go get -ldflags "-X github.com/elastic/elastic-package/internal/version.CommitHash=`git describe --always --long --dirty` -X github.com/elastic/elastic-package/internal/version.BuildTime=`date +%s`" \
+	go install -ldflags \
+	    "-X $(VERSION_IMPORT_PATH).CommitHash=`git describe --always --long --dirty` -X $(VERSION_IMPORT_PATH).BuildTime=`date +%s` -X $(VERSION_IMPORT_PATH).Tag=`(git describe --exact-match --tags 2>/dev/null || echo '') | tr -d '\n'`" \
 	    github.com/elastic/elastic-package
 
 clean:


### PR DESCRIPTION
This is a follow up from #648, @mtojek please take a look.

The change bakes in the current version tag during `make build` if the repo is checked out at a tagged version.

Prior to this a user building `elastic-package` using `make` would be given an executable that is unaware of its version. Now `make` will leave an executable that renders `elastic-package version` similar to this when the source tree is checked out at a tagged version:
```
elastic-package v0.42.2 version-hash 3478ac7 (build time: 2022-01-20T09:11:07+4:30
```
If not at a tagged version, no semver version is output.