### PR TITLE
Add CI checks for the oldest GA version of fleet

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -92,6 +92,7 @@ pipeline {
                 script {
                   def basicTasks = [
                     'stack-command-default': generateTestCommandStage(command: 'test-stack-command-default', artifacts: ['build/elastic-stack-dump/stack/*/logs/*.log', 'build/elastic-stack-dump/stack/*/logs/fleet-server-internal/*']),
+                    'stack-command-oldest': generateTestCommandStage(command: 'test-stack-command-oldest', artifacts: ['build/elastic-stack-dump/stack/*/logs/*.log', 'build/elastic-stack-dump/stack/*/logs/fleet-server-internal/*']),
                     'stack-command-7x': generateTestCommandStage(command: 'test-stack-command-7x', artifacts: ['build/elastic-stack-dump/stack/*/logs/*.log', 'build/elastic-stack-dump/stack/*/logs/fleet-server-internal/*']),
                     'stack-command-800': generateTestCommandStage(command: 'test-stack-command-800', artifacts: ['build/elastic-stack-dump/stack/*/logs/*.log', 'build/elastic-stack-dump/stack/*/logs/fleet-server-internal/*']),
                     'stack-command-8x': generateTestCommandStage(command: 'test-stack-command-8x', artifacts: ['build/elastic-stack-dump/stack/*/logs/*.log', 'build/elastic-stack-dump/stack/*/logs/fleet-server-internal/*']),

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ test-go-ci: $(CODE_COVERAGE_REPORT_NAME_UNIT)
 test-stack-command-default:
 	./scripts/test-stack-command.sh
 
+# Oldest minor where fleet is GA.
+test-stack-command-oldest:
+	./scripts/test-stack-command.sh 7.14.2
+
 test-stack-command-7x:
 	./scripts/test-stack-command.sh 7.16.3-SNAPSHOT
 


### PR DESCRIPTION
Keeping support for oldest GA version of fleet.

Tried for https://github.com/elastic/package-spec/pull/256#discussion_r788703707, but failed locally.