### PR TITLE
Update GCP SDK in Terraform deployer to 369.0.0

### DIFF
--- a/internal/install/_static/Dockerfile.terraform_deployer
+++ b/internal/install/_static/Dockerfile.terraform_deployer
@@ -5,7 +5,7 @@ FROM python:3-alpine
 # required by gcloud SDK
 RUN apk add --no-cache git openssh curl
 
-ENV GCLOUD_SDK_VERSION 367.0.0
+ENV GCLOUD_SDK_VERSION 369.0.0
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 RUN curl "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_SDK_VERSION-linux-x86_64.tar.gz" > /tmp/google-cloud-sdk.tar.gz \
   && mkdir -p /usr/local/gcloud \


### PR DESCRIPTION
Small PR to update GCP Cloud SDK installed in Terraform Deployer to latest version.

Release notes: https://cloud.google.com/sdk/docs/release-notes#36900_2022-01-19
