### PR TITLE
Change make build to run go build and add install task

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -204,7 +204,7 @@ def generateTestCommandStage(Map args = [:]){
           withMageEnv(){
             withKubernetes() {
               withCloudTestEnv() {
-                sh(label: 'Check',script: "make build ${command} check-git-clean")
+                sh(label: 'Check',script: "make install ${command} check-git-clean")
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -161,7 +161,7 @@ def generateTestCheckSinglePackageStage(Map args = [:]) {
              dir("${BASE_DIR}"){
                withMageEnv(){
                  withCloudTestEnv() {
-                   sh(label: 'Build elastic-package',script: "make build")
+                   sh(label: 'Install elastic-package',script: "make install")
                    sh(label: 'Build elastic-package',script: "make PACKAGE_UNDER_TEST=${it} test-check-packages-parallel")
                  }
                }

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ VERSION_IMPORT_PATH = github.com/elastic/elastic-package/internal/version
 .PHONY: build
 
 build:
-	go install -ldflags \
+	go build -ldflags \
 	    "-X $(VERSION_IMPORT_PATH).CommitHash=`git describe --always --long --dirty` -X $(VERSION_IMPORT_PATH).BuildTime=`date +%s` -X $(VERSION_IMPORT_PATH).Tag=`(git describe --exact-match --tags 2>/dev/null || echo '') | tr -d '\n'`" \
-	    github.com/elastic/elastic-package
+	    -o elastic-package
 
 clean:
 	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,7 @@ VERSION_LDFLAGS = -X $(VERSION_IMPORT_PATH).CommitHash=$(VERSION_COMMIT_HASH) -X
 .PHONY: build
 
 build:
-	go build \
-			-ldflags "$(VERSION_LDFLAGS)" \
-	    -o elastic-package
+	go build -ldflags "$(VERSION_LDFLAGS)" -o elastic-package
 
 clean:
 	rm -rf build
@@ -20,9 +18,7 @@ format:
 	go run golang.org/x/tools/cmd/goimports -local github.com/elastic/elastic-package/ -w .
 
 install:
-	go install \
-			-ldflags "$(VERSION_LDFLAGS)" \
-	    github.com/elastic/elastic-package
+	go install -ldflags "$(VERSION_LDFLAGS)" github.com/elastic/elastic-package
 
 lint:
 	go run honnef.co/go/tools/cmd/staticcheck ./...

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 CODE_COVERAGE_REPORT_FOLDER = $(PWD)/build/test-coverage
 CODE_COVERAGE_REPORT_NAME_UNIT = $(CODE_COVERAGE_REPORT_FOLDER)/coverage-unit-report
 VERSION_IMPORT_PATH = github.com/elastic/elastic-package/internal/version
+VERSION_COMMIT_HASH = `git describe --always --long --dirty`
+VERSION_BUILD_TIME = `date +%s`
+VERSION_TAG = `(git describe --exact-match --tags 2>/dev/null || echo '') | tr -d '\n'`
+VERSION_LDFLAGS = -X $(VERSION_IMPORT_PATH).CommitHash=$(VERSION_COMMIT_HASH) -X $(VERSION_IMPORT_PATH).BuildTime=$(VERSION_BUILD_TIME) -X $(VERSION_IMPORT_PATH).Tag=$(VERSION_TAG)
 
 .PHONY: build
 
 build:
-	go build -ldflags \
-	    "-X $(VERSION_IMPORT_PATH).CommitHash=`git describe --always --long --dirty` -X $(VERSION_IMPORT_PATH).BuildTime=`date +%s` -X $(VERSION_IMPORT_PATH).Tag=`(git describe --exact-match --tags 2>/dev/null || echo '') | tr -d '\n'`" \
+	go build \
+			-ldflags "$(VERSION_LDFLAGS)" \
 	    -o elastic-package
 
 clean:
@@ -16,8 +20,8 @@ format:
 	go run golang.org/x/tools/cmd/goimports -local github.com/elastic/elastic-package/ -w .
 
 install:
-	go install -ldflags \
-	    "-X $(VERSION_IMPORT_PATH).CommitHash=`git describe --always --long --dirty` -X $(VERSION_IMPORT_PATH).BuildTime=`date +%s` -X $(VERSION_IMPORT_PATH).Tag=`(git describe --exact-match --tags 2>/dev/null || echo '') | tr -d '\n'`" \
+	go install \
+			-ldflags "$(VERSION_LDFLAGS)" \
 	    github.com/elastic/elastic-package
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ clean:
 format:
 	go run golang.org/x/tools/cmd/goimports -local github.com/elastic/elastic-package/ -w .
 
+install:
+	go install -ldflags \
+	    "-X $(VERSION_IMPORT_PATH).CommitHash=`git describe --always --long --dirty` -X $(VERSION_IMPORT_PATH).BuildTime=`date +%s` -X $(VERSION_IMPORT_PATH).Tag=`(git describe --exact-match --tags 2>/dev/null || echo '') | tr -d '\n'`" \
+	    github.com/elastic/elastic-package
+
 lint:
 	go run honnef.co/go/tools/cmd/staticcheck ./...
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ source code:
 
 `make format` - format the Go code
 
+`make install` - build the tool source and move binary to `$GOBIN`
+
 `make vendor` - vendor code of dependencies
 
 `make check` - one-liner, used by CI to verify if source code is ready to be pushed to the repository

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -99,6 +99,8 @@ source code:
 
 `make format` - format the Go code
 
+`make install` - build the tool source and move binary to `$GOBIN`
+
 `make vendor` - vendor code of dependencies
 
 `make check` - one-liner, used by CI to verify if source code is ready to be pushed to the repository


### PR DESCRIPTION
Follow-up for a conversation @jsoriano, @mtojek and me had about how `make build` works at the moment.

`make build` performs `go install` under the hood. This behaviour is unexpected as `go install` moves the built binary to `GOBIN` folder, which in most system is part of system `PATH`. While this is the purpose of `go install` in the context of `elastic-package` makes a bit troublesome to build binary for development and local testing.

The current workaround is to manually run `go build`, but we loose version information and is undocumented.

To improve the situation this PR moves the current `build` task logic to a separate `install` one and changes the `build` task to perform `go build`, creating the executable in the project folder.