### PR TITLE
Reduce terraform deployer build verbosity

### DIFF
--- a/internal/install/_static/Dockerfile.terraform_deployer
+++ b/internal/install/_static/Dockerfile.terraform_deployer
@@ -18,6 +18,7 @@ RUN echo "deb [arch=amd64] https://apt.releases.hashicorp.com focal main" | tee 
 HEALTHCHECK --timeout=3s CMD sh -c "[ -f /tmp/tf-applied ]"
 
 ENV TF_IN_AUTOMATION=true
+ENV TF_CLI_ARGS="-no-color"
 ADD run.sh /
 WORKDIR /workspace
 

--- a/internal/install/_static/Dockerfile.terraform_deployer
+++ b/internal/install/_static/Dockerfile.terraform_deployer
@@ -1,14 +1,14 @@
 FROM hashicorp/terraform:light as terraform
 
 FROM ubuntu:20.04
-
-RUN apt-get -q update && apt-get install -yq curl apt-transport-https ca-certificates gnupg && apt-get clean
-
 ENV GCLOUD_SDK_VERSION 370.0.0-0
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+
+RUN apt-get -q update \
+  && apt-get install -yq curl apt-transport-https ca-certificates gnupg \
+  && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - \
-  && apt-get update -y \
-  && apt-get install google-cloud-sdk=${GCLOUD_SDK_VERSION} -y
+  && apt-get update -yq \
+  && apt-get install google-cloud-sdk=${GCLOUD_SDK_VERSION} -yq
 
 HEALTHCHECK --timeout=3s CMD sh -c "[ -f /tmp/tf-applied ]"
 

--- a/internal/install/_static/Dockerfile.terraform_deployer
+++ b/internal/install/_static/Dockerfile.terraform_deployer
@@ -3,11 +3,12 @@ FROM hashicorp/terraform:light as terraform
 FROM ubuntu:20.04
 ENV GCLOUD_SDK_VERSION 370.0.0-0
 
-RUN apt-get -q update \
-  && apt-get install -yq curl apt-transport-https ca-certificates gnupg \
-  && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+RUN apt-get -qq update \
+  && apt-get install -yq curl apt-transport-https ca-certificates gnupg
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - \
-  && apt-get update -yq \
+  && apt-get update -qq \
   && apt-get install google-cloud-sdk=${GCLOUD_SDK_VERSION} -yq
 
 HEALTHCHECK --timeout=3s CMD sh -c "[ -f /tmp/tf-applied ]"

--- a/internal/install/_static/Dockerfile.terraform_deployer
+++ b/internal/install/_static/Dockerfile.terraform_deployer
@@ -10,7 +10,7 @@ ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 RUN curl --silent "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_SDK_VERSION-linux-x86_64.tar.gz" > /tmp/google-cloud-sdk.tar.gz \
   && mkdir -p /usr/local/gcloud \
   && tar -C /usr/local/gcloud -xf /tmp/google-cloud-sdk.tar.gz \
-  && /usr/local/gcloud/google-cloud-sdk/install.sh -q --override-components="bq" --disable-prompts \
+  && /usr/local/gcloud/google-cloud-sdk/install.sh -q --override-components="bq" &>/dev/null \
   && rm /tmp/google-cloud-sdk.tar.gz
 
 HEALTHCHECK --timeout=3s CMD sh -c "[ -f /tmp/tf-applied ]"

--- a/internal/install/_static/Dockerfile.terraform_deployer
+++ b/internal/install/_static/Dockerfile.terraform_deployer
@@ -22,4 +22,4 @@ ENV TF_CLI_ARGS="-no-color"
 ADD run.sh /
 WORKDIR /workspace
 
-ENTRYPOINT sh /run.sh
+ENTRYPOINT bash /run.sh

--- a/internal/install/_static/Dockerfile.terraform_deployer
+++ b/internal/install/_static/Dockerfile.terraform_deployer
@@ -1,17 +1,14 @@
 FROM hashicorp/terraform:light as terraform
 
-FROM python:3-alpine
+FROM ubuntu:20.04
 
-RUN apk add --no-cache git openssh curl
+RUN apt-get -q update && apt-get install -yq curl apt-transport-https ca-certificates gnupg && apt-get clean
 
-# Announcements for new releases: https://groups.google.com/g/google-cloud-sdk-announce
-ENV GCLOUD_SDK_VERSION 369.0.0
-ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
-RUN curl --silent "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_SDK_VERSION-linux-x86_64.tar.gz" > /tmp/google-cloud-sdk.tar.gz \
-  && mkdir -p /usr/local/gcloud \
-  && tar -C /usr/local/gcloud -xf /tmp/google-cloud-sdk.tar.gz \
-  && /usr/local/gcloud/google-cloud-sdk/install.sh -q --override-components="bq" &>/dev/null \
-  && rm /tmp/google-cloud-sdk.tar.gz
+ENV GCLOUD_SDK_VERSION 370.0.0-0
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+  && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - \
+  && apt-get update -y \
+  && apt-get install google-cloud-sdk=${GCLOUD_SDK_VERSION} -y
 
 HEALTHCHECK --timeout=3s CMD sh -c "[ -f /tmp/tf-applied ]"
 

--- a/internal/install/_static/Dockerfile.terraform_deployer
+++ b/internal/install/_static/Dockerfile.terraform_deployer
@@ -1,7 +1,6 @@
-FROM hashicorp/terraform:light as terraform
-
 FROM ubuntu:20.04
 ENV GCLOUD_SDK_VERSION 370.0.0-0
+ENV TERRAFORM_VERSION 1.1.4
 
 RUN apt-get -qq update \
   && apt-get install -yq curl apt-transport-https ca-certificates gnupg
@@ -11,9 +10,12 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
   && apt-get update -qq \
   && apt-get install google-cloud-sdk=${GCLOUD_SDK_VERSION} -yq
 
-HEALTHCHECK --timeout=3s CMD sh -c "[ -f /tmp/tf-applied ]"
+RUN echo "deb [arch=amd64] https://apt.releases.hashicorp.com focal main" | tee -a /etc/apt/sources.list.d/hashicorp.list \
+  && curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - \
+  && apt-get -qq update \
+  && apt-get install -yq terraform=${TERRAFORM_VERSION}
 
-COPY --from=terraform /bin/terraform /usr/bin/terraform
+HEALTHCHECK --timeout=3s CMD sh -c "[ -f /tmp/tf-applied ]"
 
 ENV TF_IN_AUTOMATION=true
 ADD run.sh /

--- a/internal/install/_static/Dockerfile.terraform_deployer
+++ b/internal/install/_static/Dockerfile.terraform_deployer
@@ -2,15 +2,15 @@ FROM hashicorp/terraform:light as terraform
 
 FROM python:3-alpine
 
-# required by gcloud SDK
 RUN apk add --no-cache git openssh curl
 
+# Announcements for new releases: https://groups.google.com/g/google-cloud-sdk-announce
 ENV GCLOUD_SDK_VERSION 369.0.0
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
-RUN curl "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_SDK_VERSION-linux-x86_64.tar.gz" > /tmp/google-cloud-sdk.tar.gz \
+RUN curl --silent "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_SDK_VERSION-linux-x86_64.tar.gz" > /tmp/google-cloud-sdk.tar.gz \
   && mkdir -p /usr/local/gcloud \
-  && tar -C /usr/local/gcloud -xvf /tmp/google-cloud-sdk.tar.gz \
-  && /usr/local/gcloud/google-cloud-sdk/install.sh -q --override-components="bq" \
+  && tar -C /usr/local/gcloud -xf /tmp/google-cloud-sdk.tar.gz \
+  && /usr/local/gcloud/google-cloud-sdk/install.sh -q --override-components="bq" &>/dev/null \
   && rm /tmp/google-cloud-sdk.tar.gz
 
 HEALTHCHECK --timeout=3s CMD sh -c "[ -f /tmp/tf-applied ]"

--- a/internal/install/_static/Dockerfile.terraform_deployer
+++ b/internal/install/_static/Dockerfile.terraform_deployer
@@ -10,7 +10,7 @@ ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 RUN curl --silent "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_SDK_VERSION-linux-x86_64.tar.gz" > /tmp/google-cloud-sdk.tar.gz \
   && mkdir -p /usr/local/gcloud \
   && tar -C /usr/local/gcloud -xf /tmp/google-cloud-sdk.tar.gz \
-  && /usr/local/gcloud/google-cloud-sdk/install.sh -q --override-components="bq" &>/dev/null \
+  && /usr/local/gcloud/google-cloud-sdk/install.sh -q --override-components="bq" --disable-prompts \
   && rm /tmp/google-cloud-sdk.tar.gz
 
 HEALTHCHECK --timeout=3s CMD sh -c "[ -f /tmp/tf-applied ]"

--- a/internal/install/_static/terraform_deployer_run.sh
+++ b/internal/install/_static/terraform_deployer_run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euxo pipefail
+set -euo pipefail
 
 # Terraform code may rely on content from other files than .tf files (es json, zip, html, text), so we copy all the content over
 # See more: https://github.com/elastic/elastic-package/pull/603

--- a/internal/install/_static/terraform_deployer_run.sh
+++ b/internal/install/_static/terraform_deployer_run.sh
@@ -1,4 +1,4 @@
-#!sh
+#!/usr/bin/env bash
 
 set -euxo pipefail
 


### PR DESCRIPTION
Reduce output from gcloud SDK installation process, by silencing the various steps.

This is needed to reduce image build log verbosity; gcloud SDK installation output is also difficult to read on terminal that do not support colours.
