### PR TITLE
Fix: use correct index template name for hidden data streams

### DIFF
--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -242,6 +242,8 @@ func (dsm *DataStreamManifest) GetPipelineNameOrDefault() string {
 
 // IndexTemplateName returns the name of the Elasticsearch index template that would be installed
 // for this data stream.
+// The template name starts with dot "." if the datastream is hidden which is consistent with kibana implementation
+// https://github.com/elastic/kibana/blob/3955d0dc819fec03f68cd1d931f64da8472e34b2/x-pack/plugins/fleet/server/services/epm/elasticsearch/index.ts#L14
 func (dsm *DataStreamManifest) IndexTemplateName(pkgName string) string {
 	if dsm.Dataset == "" {
 		return dsm.IndexTemplateNamePrefix() + fmt.Sprintf("%s-%s.%s", dsm.Type, pkgName, dsm.Name)

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -246,13 +246,13 @@ func (dsm *DataStreamManifest) GetPipelineNameOrDefault() string {
 // https://github.com/elastic/kibana/blob/3955d0dc819fec03f68cd1d931f64da8472e34b2/x-pack/plugins/fleet/server/services/epm/elasticsearch/index.ts#L14
 func (dsm *DataStreamManifest) IndexTemplateName(pkgName string) string {
 	if dsm.Dataset == "" {
-		return dsm.IndexTemplateNamePrefix() + fmt.Sprintf("%s-%s.%s", dsm.Type, pkgName, dsm.Name)
+		return fmt.Sprintf("%s%s-%s.%s", dsm.indexTemplateNamePrefix(), dsm.Type, pkgName, dsm.Name)
 	}
 
-	return dsm.IndexTemplateNamePrefix() + fmt.Sprintf("%s-%s", dsm.Type, dsm.Dataset)
+	return fmt.Sprintf("%s%s-%s", dsm.indexTemplateNamePrefix(), dsm.Type, dsm.Dataset)
 }
 
-func (dsm *DataStreamManifest) IndexTemplateNamePrefix() string {
+func (dsm *DataStreamManifest) indexTemplateNamePrefix() string {
 	if dsm.Hidden {
 		return "."
 	}

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -115,6 +115,7 @@ type DataStreamManifest struct {
 	Title         string `config:"title" json:"title" yaml:"title"`
 	Type          string `config:"type" json:"type" yaml:"type"`
 	Dataset       string `config:"dataset" json:"dataset" yaml:"dataset"`
+	Hidden        bool   `config:"hidden" json:"hidden" yaml:"hidden"`
 	Release       string `config:"release" json:"release" yaml:"release"`
 	Elasticsearch *struct {
 		IngestPipeline *struct {
@@ -243,10 +244,17 @@ func (dsm *DataStreamManifest) GetPipelineNameOrDefault() string {
 // for this data stream.
 func (dsm *DataStreamManifest) IndexTemplateName(pkgName string) string {
 	if dsm.Dataset == "" {
-		return fmt.Sprintf("%s-%s.%s", dsm.Type, pkgName, dsm.Name)
+		return dsm.IndexTemplateNamePrefix() + fmt.Sprintf("%s-%s.%s", dsm.Type, pkgName, dsm.Name)
 	}
 
-	return fmt.Sprintf("%s-%s", dsm.Type, dsm.Dataset)
+	return dsm.IndexTemplateNamePrefix() + fmt.Sprintf("%s-%s", dsm.Type, dsm.Dataset)
+}
+
+func (dsm *DataStreamManifest) IndexTemplateNamePrefix() string {
+	if dsm.Hidden {
+		return "."
+	}
+	return ""
 }
 
 // FindInputByType returns the input for the provided type.

--- a/internal/packages/packages_test.go
+++ b/internal/packages/packages_test.go
@@ -57,6 +57,15 @@ func TestDataStreamManifest_IndexTemplateName(t *testing.T) {
 			"pkg",
 			dataStreamTypeLogs + "-pkg.foo",
 		},
+		"no_dataset_hidden": {
+			DataStreamManifest{
+				Name:   "foo",
+				Type:   dataStreamTypeLogs,
+				Hidden: true,
+			},
+			"pkg",
+			"." + dataStreamTypeLogs + "-pkg.foo",
+		},
 		"with_dataset": {
 			DataStreamManifest{
 				Name:    "foo",
@@ -65,6 +74,16 @@ func TestDataStreamManifest_IndexTemplateName(t *testing.T) {
 			},
 			"pkg",
 			dataStreamTypeLogs + "-custom",
+		},
+		"with_dataset_hidden": {
+			DataStreamManifest{
+				Name:    "foo",
+				Type:    dataStreamTypeLogs,
+				Dataset: "custom",
+				Hidden:  true,
+			},
+			"pkg",
+			"." + dataStreamTypeLogs + "-custom",
 		},
 	}
 


### PR DESCRIPTION
Fix elastic-package where it was not correctly deriving the index template name for the ```hidden``` datastreams 
and failing in CI:

For example PR https://github.com/elastic/integrations/pull/2563

resulting in error:
```
asset test: index_template logs-osquery_manager.actions is loaded – osquery_manager.actions
no error details
Expand to view the stacktrace
 could not find expected asset: could not find index_template asset "logs-osquery_manager.actions". Assets loaded:
- .logs-osquery_manager.action_results (type: index_template)
- .logs-osquery_manager.action_results@mappings (type: component_template)
- .logs-osquery_manager.action_results@settings (type: component_template)
- .logs-osquery_manager.action_results@custom (type: component_template)
- .logs-osquery_manager.actions (type: index_template)
- .logs-osquery_manager.actions@mappings (type: component_template)
- .logs-osquery_manager.actions@settings (type: component_template)
- .logs-osquery_manager.actions@custom (type: component_template)
- logs-osquery_manager.result (type: index_template)
- logs-osquery_manager.result@mappings (type: component_template)
- logs-osquery_manager.result@settings (type: component_template)
- logs-osquery_manager.result@custom (type: component_template)
```

Screenshot after this change, showing it passes the tests now:

<img width="1113" alt="Screen Shot 2022-01-27 at 2 29 29 PM" src="https://user-images.githubusercontent.com/872351/151431412-2f266bf2-f33c-4a79-bd0c-98c91cd8b984.png">

