### PR TITLE
Collect unsafe logs

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -113,7 +113,7 @@ pipeline {
                     'sign-with-elastic': generateTestSignWithElasticStage()
                   ]
 
-                  def checkSinglePackageTasks = generateTestCheckSinglePackageStage(artifacts: ['build/test-results/*.xml', 'build/elastic-stack-dump/check-*/logs/*.log', 'build/elastic-stack-dump/check-*/logs/fleet-server-internal/*'], junitArtifacts: true, publishCoverage: true)
+                  def checkSinglePackageTasks = generateTestCheckSinglePackageStage()
                   def tasks = basicTasks + checkSinglePackageTasks
                   parallel tasks
                 }
@@ -190,9 +190,7 @@ def generateTestSignWithElasticStage() {
 }
 
 def generateTestCheckSinglePackageStage(Map args = [:]) {
-  def artifacts = args.get('artifacts') ? args.get('artifacts') : []
-  def junitArtifacts = args.get('junitArtifacts') ? args.get('junitArtifacts') : false
-  def publishCoverage = args.get('publishCoverage') ? args.get('publishCoverage') : false
+  def artifacts = ['build/test-results/*.xml', 'build/elastic-stack-dump/check-*/logs/*.log', 'build/elastic-stack-dump/check-*/logs/fleet-server-internal/*']
 
   def integrations = [:]
   dir("test/packages/parallel") {
@@ -216,16 +214,11 @@ def generateTestCheckSinglePackageStage(Map args = [:]) {
                artifacts.each { artifact ->
                  archiveArtifacts(allowEmptyArchive: true, artifacts: "${artifact}")
                }
+               archiveArtifactsSafe("insecure-logs/${it}", "build/elastic-stack-dump/check-${it}/logs/elastic-agent-internal/*")
+               archiveArtifactsSafe("insecure-logs/${it}/container-logs", "build/container-logs/*.log")
 
-               if (junitArtifacts) {
-                 junit(allowEmptyResults: true,
-                  keepLongStdio: true,
-                  testResults: "build/test-results/*.xml")
-               }
-
-               if (publishCoverage) {
-                 stashCoverageReport()
-               }
+               junit(allowEmptyResults: true, keepLongStdio: true, testResults: "build/test-results/*.xml")
+               stashCoverageReport()
              }
            }
          }
@@ -338,4 +331,17 @@ def withCloudTestEnv(Closure body) {
   withEnvMask(vars: maskedVars) {
     body()
   }
+}
+
+def archiveArtifactsSafe(remotePath, artifacts) {
+  r = sh(label: "areArtifactsPresent", script: "ls ${artifacts}", returnStatus: true)
+  if (r != 0) {
+    echo "areArtifactsPresent: artifacts files not found, nothing will be archived"
+    return
+  }
+
+  googleStorageUploadExt(
+    bucket: "gs://${JOB_GCS_BUCKET_INTERNAL}/${env.JOB_NAME}-${env.BUILD_ID}/${remotePath}",
+    credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",
+    pattern: artifacts)
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -16,6 +16,7 @@ pipeline {
     KIND_VERSION = 'v0.11.1'
     K8S_VERSION = 'v1.23.0'
     JOB_GCS_BUCKET = 'beats-ci-temp'
+    JOB_GCS_BUCKET_INTERNAL = 'beats-ci-temp-internal'
     JOB_GCS_CREDENTIALS = 'beats-ci-gcs-plugin'
     JOB_GCS_EXT_CREDENTIALS = 'beats-ci-gcs-plugin-file-credentials'
     JOB_SIGNING_CREDENTIALS = 'sign-artifacts-with-gpg-job'


### PR DESCRIPTION
This PR modifies the Jenkinsfile to collect unsafe artifacts. We plan to use it to dump Terraform service deployer logs, useful to debug https://github.com/elastic/elastic-package/pull/665 and https://github.com/elastic/elastic-package/pull/662.

Logs are saved in this place/bucket: `beats-ci-temp-internal/Ingest-manager/elastic-package/PR-679-2`