### PR TITLE
Bump up default stack version to 7.17.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ test-stack-command-oldest:
 	./scripts/test-stack-command.sh 7.14.2
 
 test-stack-command-7x:
-	./scripts/test-stack-command.sh 7.16.3-SNAPSHOT
+	./scripts/test-stack-command.sh 7.17.1-SNAPSHOT
 
 test-stack-command-800:
 	./scripts/test-stack-command.sh 8.0.0-SNAPSHOT

--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "7.16.2"
+	DefaultStackVersion = "7.17.0"
 )


### PR DESCRIPTION
This PR bumps up the default stack version to 7.17.0.