### PR TITLE
Improve Docker Compose container execution

### DIFF
--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -23,7 +23,8 @@ import (
 	"github.com/elastic/elastic-package/internal/signal"
 )
 
-const waitForHealthyTimeout = 10 * time.Minute
+// waitForHealthyTimeout is the maximum duration for WaitForHealthy().
+var waitForHealthyTimeout = time.Duration(10 * time.Minute)
 
 // Project represents a Docker Compose project.
 type Project struct {
@@ -277,14 +278,13 @@ func (p *Project) WaitForHealthy(opts CommandOptions) error {
 		return err
 	}
 
-	timeout := time.Duration(waitForHealthyTimeout)
 	startTime := time.Now()
-	timeoutTime := startTime.Add(timeout)
+	timeout := startTime.Add(waitForHealthyTimeout)
 	interval := time.Duration(1 * time.Second)
 	healthy := true
 
 	containerIDs := strings.Split(strings.TrimSpace(b.String()), "\n")
-	for time.Now().Before(timeoutTime) {
+	for time.Now().Before(timeout) {
 		if signal.SIGINT() {
 			return errors.New("SIGINT: cancel waiting for policy assigned")
 		}

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -26,6 +26,9 @@ import (
 // waitForHealthyTimeout is the maximum duration for WaitForHealthy().
 var waitForHealthyTimeout = time.Duration(10 * time.Minute)
 
+// waitForHealthyInterval is the check interval for WaitForHealthy().
+const waitForHealthyInterval = time.Duration(1 * time.Second)
+
 // Project represents a Docker Compose project.
 type Project struct {
 	name             string
@@ -280,7 +283,6 @@ func (p *Project) WaitForHealthy(opts CommandOptions) error {
 
 	startTime := time.Now()
 	timeout := startTime.Add(waitForHealthyTimeout)
-	interval := time.Duration(1 * time.Second)
 
 	containerIDs := strings.Split(strings.TrimSpace(b.String()), "\n")
 	for time.Now().Before(timeout) {
@@ -329,7 +331,7 @@ func (p *Project) WaitForHealthy(opts CommandOptions) error {
 		}
 
 		// NOTE: using sleep does not guarantee interval but it's ok for this use case
-		time.Sleep(interval)
+		time.Sleep(waitForHealthyInterval)
 	}
 
 	if time.Now().After(timeout) {

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -275,54 +275,58 @@ func (p *Project) WaitForHealthy(opts CommandOptions) error {
 		return err
 	}
 
+	timeout := time.After(10 * time.Minute)
+	ticker := time.NewTicker(1 * time.Second)
+
 	containerIDs := strings.Split(strings.TrimSpace(b.String()), "\n")
 	for {
 		if signal.SIGINT() {
 			return errors.New("SIGINT: cancel waiting for policy assigned")
 		}
 
-		healthy := true
+		select {
+		case <-timeout:
+			return errors.New("time out waiting for healthy container")
+		case <-ticker.C:
+			healthy := true
 
-		logger.Debugf("Wait for healthy containers: %s", strings.Join(containerIDs, ","))
-		descriptions, err := docker.InspectContainers(containerIDs...)
-		if err != nil {
-			return err
+			logger.Debugf("Wait for healthy containers: %s", strings.Join(containerIDs, ","))
+			descriptions, err := docker.InspectContainers(containerIDs...)
+			if err != nil {
+				return err
+			}
+			for _, containerDescription := range descriptions {
+				logger.Debugf("Container status: %s", containerDescription.String())
+
+				// No healthcheck defined for service
+				if containerDescription.State.Status == "running" && containerDescription.State.Health == nil {
+					continue
+				}
+
+				// Service is up and running and it's healthy
+				if containerDescription.State.Status == "running" && containerDescription.State.Health.Status == "healthy" {
+					continue
+				}
+
+				// Container started and finished with exit code 0
+				if containerDescription.State.Status == "exited" && containerDescription.State.ExitCode == 0 {
+					continue
+				}
+
+				// Container exited with code > 0
+				if containerDescription.State.Status == "exited" && containerDescription.State.ExitCode > 0 {
+					return fmt.Errorf("container (ID: %s) exited with code %d", containerDescription.ID, containerDescription.State.ExitCode)
+				}
+
+				// Any different status is considered unhealthy
+				healthy = false
+			}
+
+			if healthy {
+				return nil
+			}
 		}
-
-		for _, containerDescription := range descriptions {
-			logger.Debugf("Container status: %s", containerDescription.String())
-
-			// No healthcheck defined for service
-			if containerDescription.State.Status == "running" && containerDescription.State.Health == nil {
-				continue
-			}
-
-			// Service is up and running and it's healthy
-			if containerDescription.State.Status == "running" && containerDescription.State.Health.Status == "healthy" {
-				continue
-			}
-
-			// Container started and finished with exit code 0
-			if containerDescription.State.Status == "exited" && containerDescription.State.ExitCode == 0 {
-				continue
-			}
-
-			// Container exited with code > 0
-			if containerDescription.State.Status == "exited" && containerDescription.State.ExitCode > 0 {
-				return fmt.Errorf("container (ID: %s) exited with code %d", containerDescription.ID, containerDescription.State.ExitCode)
-			}
-
-			// Any different status is considered unhealthy
-			healthy = false
-		}
-
-		if healthy {
-			break
-		}
-
-		time.Sleep(time.Second)
 	}
-	return nil
 }
 
 func (p *Project) baseArgs() []string {


### PR DESCRIPTION
This PR has been extracted from https://github.com/elastic/elastic-package/pull/665.

When `elastic-package` runs docker containers it relies on [`WaitForHealthy()`](https://github.com/endorama/elastic-package/blob/89161065b946c1531132f0e20c03b4f48210f0b7/internal/compose/compose.go#L267) to ensure expected containers are running.

This functions has a missing feature: timing out if the condition is not met.

This PR adds this feature, adding a 10 minute timeout after which an error is returned.

To prevent waiting time waiting for a condition that can never be met a check is added for unrecoverable termination condition (container is reported as exited and with an exit code greater than 0) to immediately exit with an error, skipping waiting until timeout expiration.