### PR TITLE
Collect service container logs if emergency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ build:
 
 clean:
 	rm -rf build
+	rm -f elastic-package
 
 format:
 	go run golang.org/x/tools/cmd/goimports -local github.com/elastic/elastic-package/ -w .

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -307,6 +307,11 @@ func (p *Project) WaitForHealthy(opts CommandOptions) error {
 				continue
 			}
 
+			// Container exited with code > 2
+			if containerDescription.State.Status == "exited" && containerDescription.State.ExitCode > 2 {
+				return fmt.Errorf("container (ID: %s) exited with code %d", containerDescription.ID, containerDescription.State.ExitCode)
+			}
+
 			// Any different status is considered unhealthy
 			healthy = false
 		}

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -307,8 +307,8 @@ func (p *Project) WaitForHealthy(opts CommandOptions) error {
 				continue
 			}
 
-			// Container exited with code > 2
-			if containerDescription.State.Status == "exited" && containerDescription.State.ExitCode > 2 {
+			// Container exited with code > 0
+			if containerDescription.State.Status == "exited" && containerDescription.State.ExitCode > 0 {
 				return fmt.Errorf("container (ID: %s) exited with code %d", containerDescription.ID, containerDescription.State.ExitCode)
 			}
 

--- a/internal/testrunner/runners/system/servicedeployer/compose.go
+++ b/internal/testrunner/runners/system/servicedeployer/compose.go
@@ -90,7 +90,9 @@ func (d *DockerComposeServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedSer
 
 	err = p.WaitForHealthy(opts)
 	if err != nil {
-		processServiceContainerLogs(p, opts, outCtxt.Name)
+		processServiceContainerLogs(p, compose.CommandOptions{
+			Env: opts.Env,
+		}, outCtxt.Name)
 		return nil, errors.Wrap(err, "service is unhealthy")
 	}
 

--- a/internal/testrunner/runners/system/servicedeployer/terraform.go
+++ b/internal/testrunner/runners/system/servicedeployer/terraform.go
@@ -78,7 +78,9 @@ func (tsd TerraformServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedServic
 
 	err = p.WaitForHealthy(opts)
 	if err != nil {
-		processServiceContainerLogs(p, opts, outCtxt.Name)
+		processServiceContainerLogs(p, compose.CommandOptions{
+			Env: opts.Env,
+		}, outCtxt.Name)
 		return nil, errors.Wrap(err, "Terraform deployer is unhealthy")
 	}
 

--- a/internal/testrunner/runners/system/servicedeployer/terraform.go
+++ b/internal/testrunner/runners/system/servicedeployer/terraform.go
@@ -78,6 +78,7 @@ func (tsd TerraformServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedServic
 
 	err = p.WaitForHealthy(opts)
 	if err != nil {
+		processServiceContainerLogs(p, opts, outCtxt.Name)
 		return nil, errors.Wrap(err, "Terraform deployer is unhealthy")
 	}
 


### PR DESCRIPTION
This PR fixes a problem with not collecting logs for Docker and Terraform service deployers when the container doesn't boot correctly.