### PR TITLE
Test against the stack 8.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ test-stack-command-800:
 	./scripts/test-stack-command.sh 8.0.0-SNAPSHOT
 
 test-stack-command-8x:
-	./scripts/test-stack-command.sh 8.1.0-SNAPSHOT
+	./scripts/test-stack-command.sh 8.2.0-SNAPSHOT
 
 test-stack-command: test-stack-command-default test-stack-command-7x test-stack-command-800 test-stack-command-8x
 


### PR DESCRIPTION
This PR updates the testing stack version to 8.2.0, so that we can verify if it boots up correctly.