### PR TITLE
Re-add -x to Terraform deployer script

### DIFF
--- a/internal/install/_static/terraform_deployer_run.sh
+++ b/internal/install/_static/terraform_deployer_run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -euxo pipefail
 
 # Terraform code may rely on content from other files than .tf files (es json, zip, html, text), so we copy all the content over
 # See more: https://github.com/elastic/elastic-package/pull/603


### PR DESCRIPTION
In #665 we removed `-x` to debug an issue with script shebang, but the
intention wasn't to remove it entirely from the script.

This PR sets `-x` for the whole the script.
