### PR TITLE
Use Terraform Dependecy Lock in system tests

### DIFF
--- a/internal/install/_static/terraform_deployer_run.sh
+++ b/internal/install/_static/terraform_deployer_run.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 
 # Terraform code may rely on content from other files than .tf files (es json, zip, html, text), so we copy all the content over
 # See more: https://github.com/elastic/elastic-package/pull/603
-cp -r /stage/* /workspace
+# NOTE: must copy hidden files too (supported by "/.")
+# See more: https://github.com/elastic/package-spec/issues/269
+cp -r /stage/. /workspace
 
 cleanup() {
   r=$?


### PR DESCRIPTION
Terraform Lock File support has been added https://github.com/elastic/package-spec/issues/269
but was not used by Terraform Deployer as the file was not copied from
the stage folder to the workspace.

`cp *` does not copy hidden files.

This commit adds copy for .terraform.lock.hcl from the stage to the
workspace folder, so it's correctly picked up by Terraform in tests.
