### PR TITLE
Add cronjobs in clusterRole for k8s runner

### DIFF
--- a/internal/testrunner/runners/system/servicedeployer/elastic-agent-managed.yaml.tmpl
+++ b/internal/testrunner/runners/system/servicedeployer/elastic-agent-managed.yaml.tmpl
@@ -167,6 +167,7 @@ rules:
   - apiGroups: [ "batch" ]
     resources:
       - jobs
+      - cronjobs
     verbs: [ "get", "list", "watch" ]
   # required for apiserver
   - nonResourceURLs:


### PR DESCRIPTION
Fix https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/main/156/tests/.

We recently introduced metadata addition for `state_cronjob` but the manifest used in the tests was not updated properly.