### PR TITLE
Bump up version stack to 8.0.1

### DIFF
--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "8.0.1-SNAPSHOT"
+	DefaultStackVersion = "8.0.1"
 )

--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "8.0.0"
+	DefaultStackVersion = "8.0.1-SNAPSHOT"
 )

--- a/test/packages/parallel/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
+++ b/test/packages/parallel/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
@@ -1,7 +1,4 @@
 wait_for_data_timeout: 20m # AWS CloudWatch may delay metrics delivery for more than 10 minutes.
-skip:
-  reason: "EC2 module fails initialization (access_key_id undefined)"
-  link: "https://github.com/elastic/integrations/issues/2692"
 vars:
   access_key_id: '{{AWS_ACCESS_KEY_ID}}'
   secret_access_key: '{{AWS_SECRET_ACCESS_KEY}}'


### PR DESCRIPTION
Related:
https://github.com/elastic/integrations/issues/2692

The reason why we have to bump up the version stack is bugfix for: https://github.com/elastic/kibana/issues/125625

