### PR TITLE
ci: support for "skip-ci" github label in order to reduce what to run

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -73,10 +73,6 @@ pipeline {
                 sh(label: 'Check',script: 'make check-static')
               }
             }
-            // IMPORTANT: notify a build status in order to avoid GitHub checks with a wrong status.
-            whenTrue(matchesPrLabel(label: 'skip-ci')) {
-              error 'Pull Request has been configured to be disabled when there is a skip-ci label match'
-            }
           }
         }
         /**
@@ -157,6 +153,10 @@ pipeline {
   }
   post {
     always {
+      // IMPORTANT: notify a build status in order to avoid GitHub checks with a wrong status.
+      whenTrue(matchesPrLabel(label: 'skip-ci')) {
+        error 'Pull Request has been configured to be disabled when there is a skip-ci label match'
+      }
       publishCoverageReports()
     }
     cleanup {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -73,12 +73,20 @@ pipeline {
                 sh(label: 'Check',script: 'make check-static')
               }
             }
+            // IMPORTANT: notify a build status in order to avoid GitHub checks with a wrong status.
+            whenTrue(matchesPrLabel(label: 'skip-ci')) {
+              error 'Pull Request has been configured to be disabled when there is a skip-ci label match'
+            }
           }
         }
         /**
         Run the unit tests suite
         */
         stage('Unit tests') {
+          when {
+            beforeAgent true
+            not { expression { matchesPrLabel(label: 'skip-ci') } }
+          }
           steps {
             cleanup()
             dir("${BASE_DIR}"){
@@ -98,6 +106,10 @@ pipeline {
           }
         }
         stage('Integration tests') {
+          when {
+            beforeAgent true
+            not { expression { matchesPrLabel(label: 'skip-ci') } }
+          }
           failFast true
           options { skipDefaultCheckout() }
           steps {


### PR DESCRIPTION
## What

`skip-ci` label will only run the linting stage and then will stop doing anything else.

## Why

See the below use case:

> As a developer, I don't want to run CI because I'm sure is going to fail and will just waste CI cycles

## Issue

Similar to https://github.com/elastic/beats/pull/21377

## UX

See the below comment that points to the reason for the failure:

<img width="1026" alt="image" src="https://user-images.githubusercontent.com/2871786/156163789-59bd0c6c-5199-4a6c-bb59-cc4eebdfccf4.png">
