### PR TITLE
internal/testrunner/runners/pipeline: use diff with limited context lines when rendering failures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2
+	github.com/google/go-cmp v0.5.7
 	github.com/google/go-github/v32 v32.1.0
 	github.com/google/go-querystring v1.1.0
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
@@ -72,7 +73,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.3 // indirect
 	github.com/google/btree v1.0.1 // indirect
-	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -592,8 +592,9 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-containerregistry v0.5.1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
 github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
 github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=

--- a/internal/testrunner/runners/pipeline/runner_test.go
+++ b/internal/testrunner/runners/pipeline/runner_test.go
@@ -109,7 +109,8 @@ e
   c
   d
 - e change
-+ e`,
++ e
+  `,
 	},
 	{
 		name: "middle",
@@ -240,7 +241,8 @@ m
   k
 - l
 + l change
-  m`,
+  m
+  `,
 	},
 	{
 		name: "far pair addition",
@@ -301,7 +303,8 @@ m
   k
 - l
 + l change
-  m`,
+  m
+  `,
 	},
 }
 
@@ -310,7 +313,7 @@ func TestDiffUlite(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := diffUlite(test.a, test.b, test.u)
 			if got != test.want {
-				t.Errorf("unexpected result for\n%s", cmp.Diff(got, test.want))
+				t.Errorf("unexpected result\n%s", cmp.Diff(got, test.want))
 			}
 		})
 	}

--- a/internal/testrunner/runners/pipeline/runner_test.go
+++ b/internal/testrunner/runners/pipeline/runner_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,4 +40,278 @@ func TestStripEmptyTestResults(t *testing.T) {
 	require.Equal(t, actual.events[1], json.RawMessage(emptyTestResult))
 	require.Equal(t, actual.events[2], json.RawMessage(secondTestResult))
 	require.Equal(t, actual.events[3], json.RawMessage(thirdTestResult))
+}
+
+var diffUliteTests = []struct {
+	name string
+	a, b string
+	u    int
+	want string
+}{
+	{
+		name: "no diff",
+		u:    3,
+		a: `a
+b
+c
+d
+`,
+		b: `a
+b
+c
+d
+`,
+		want: "",
+	},
+	{
+		name: "first line",
+		u:    3,
+		a: `a change
+b
+c
+d
+e
+`,
+		b: `a
+b
+c
+d
+e
+`,
+		want: `--- want
++++ got
+@@ -1 +1 @@
+- a change
++ a
+  b
+  c
+  d`,
+	},
+	{
+		name: "last line",
+		u:    3,
+		a: `a
+b
+c
+d
+e change
+`,
+		b: `a
+b
+c
+d
+e
+`,
+		want: `--- want
++++ got
+@@ -2 +2 @@
+  b
+  c
+  d
+- e change
++ e`,
+	},
+	{
+		name: "middle",
+		u:    3,
+		a: `a
+b
+c
+d change
+e
+f
+g
+h
+`,
+		b: `a
+b
+c
+d
+e
+f
+g
+h
+`,
+		want: `--- want
++++ got
+@@ -1 +1 @@
+  a
+  b
+  c
+- d change
++ d
+  e
+  f
+  g`,
+	},
+	{
+		name: "close pair",
+		u:    3,
+		a: `a
+b
+c
+d change
+e
+f
+g
+h
+i
+j
+k
+l
+m
+`,
+		b: `a
+b
+c
+d
+e
+f
+g
+h
+i change
+j
+k
+l
+m
+`,
+		want: `--- want
++++ got
+@@ -1 +1 @@
+  a
+  b
+  c
+- d change
++ d
+  e
+  f
+  g
+  h
+- i
++ i change
+  j
+  k
+  l`,
+	},
+	{
+		name: "far pair",
+		u:    3,
+		a: `a
+b
+c change
+d
+e
+f
+g
+h
+i
+j
+k
+l
+m
+`,
+		b: `a
+b
+c
+d
+e
+f
+g
+h
+i
+j
+k
+l change
+m
+`,
+		want: `--- want
++++ got
+@@ -1 +1 @@
+  a
+  b
+- c change
++ c
+  d
+  e
+  f
+@@ -9 +9 @@
+  i
+  j
+  k
+- l
++ l change
+  m`,
+	},
+	{
+		name: "far pair addition",
+		u:    3,
+		a: `a
+b
+c change
+d
+e
+f
+g
+a
+b
+c
+d
+e
+f
+g
+h
+i
+j
+k
+l
+m
+`,
+		b: `a
+b
+c
+d
+e
+f
+g
+h
+i
+j
+k
+l change
+m
+`,
+		want: `--- want
++++ got
+@@ -1 +1 @@
+  a
+  b
+- c change
+- d
+- e
+- f
+- g
+- a
+- b
+  c
+  d
+  e
+@@ -16 +9 @@
+  i
+  j
+  k
+- l
++ l change
+  m`,
+	},
+}
+
+func TestDiffUlite(t *testing.T) {
+	for _, test := range diffUliteTests {
+		t.Run(test.name, func(t *testing.T) {
+			got := diffUlite(test.a, test.b, test.u)
+			if got != test.want {
+				t.Errorf("unexpected result for\n%s", cmp.Diff(got, test.want))
+			}
+		})
+	}
 }

--- a/internal/testrunner/runners/pipeline/test_result.go
+++ b/internal/testrunner/runners/pipeline/test_result.go
@@ -5,10 +5,12 @@
 package pipeline
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/kylelemons/godebug/diff"
 	"github.com/pkg/errors"
@@ -63,7 +65,7 @@ func compareResults(testCasePath string, config *testConfig, result *testResult)
 		return errors.Wrap(err, "marshalling expected test results failed")
 	}
 
-	report := diff.Diff(string(expected), string(actual))
+	report := diffUlite(string(expected), string(actual), 3)
 	if report != "" {
 		return testrunner.ErrTestCaseFailed{
 			Reason:  "Expected results are different from actual ones",
@@ -71,6 +73,81 @@ func compareResults(testCasePath string, config *testConfig, result *testResult)
 		}
 	}
 	return nil
+}
+
+// diffUlite implements a unified diff-like rendering with u lines of context.
+// It differs from a complete unified diff in that it does not provide the length
+// of the chunk, so it cannot be used to generate patches, but can be used for
+// human inspection.
+func diffUlite(a, b string, u int) string {
+	chunks := diff.DiffChunks(strings.Split(a, "\n"), strings.Split(b, "\n"))
+	if len(chunks) == 0 {
+		return ""
+	}
+
+	buf := new(bytes.Buffer)
+	fmt.Fprintf(buf, "--- want\n+++ got\n")
+	gotLine := 1
+	wantLine := 1
+
+	for i, c := range chunks {
+		if i == 0 && (len(c.Added) != 0 || len(c.Deleted) != 0) {
+			fmt.Fprintf(buf, "@@ -%d +%d @@\n", wantLine, gotLine)
+		}
+		var change bool
+		for _, line := range c.Added {
+			change = true
+			fmt.Fprintf(buf, "+ %s\n", line)
+		}
+		gotLine += len(c.Added)
+
+		for _, line := range c.Deleted {
+			change = true
+			fmt.Fprintf(buf, "- %s\n", line)
+		}
+		wantLine += len(c.Deleted)
+
+		var used int
+		if change {
+			used = min(len(c.Equal), u)
+			for j, line := range c.Equal[:used] {
+				if j < used-1 || line != "" {
+					fmt.Fprintf(buf, "  %s\n", line)
+				}
+			}
+		}
+		if i < len(chunks)-1 {
+			next := chunks[i+1]
+			if len(next.Added) != 0 || len(next.Deleted) != 0 {
+				off := max(used, len(c.Equal)-u)
+				if off < len(c.Equal) {
+					if i == 0 || 2*u < len(c.Equal) {
+						fmt.Fprintf(buf, "@@ -%d +%d @@\n", wantLine+off, gotLine+off)
+					}
+					for _, line := range c.Equal[off:] {
+						fmt.Fprintf(buf, "  %s\n", line)
+					}
+				}
+			}
+		}
+		gotLine += len(c.Equal)
+		wantLine += len(c.Equal)
+	}
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func readExpectedTestResult(testCasePath string, config *testConfig) (*testResult, error) {

--- a/internal/testrunner/runners/pipeline/test_result.go
+++ b/internal/testrunner/runners/pipeline/test_result.go
@@ -114,10 +114,8 @@ func diffUlite(a, b string, u int) string {
 		var used int
 		if change {
 			used = min(len(c.Equal), u)
-			for j, line := range c.Equal[:used] {
-				if j < used-1 || line != "" {
-					fmt.Fprintf(buf, "  %s\n", line)
-				}
+			for _, line := range c.Equal[:used] {
+				fmt.Fprintf(buf, "  %s\n", line)
 			}
 		}
 		if i < len(chunks)-1 {

--- a/internal/testrunner/runners/pipeline/test_result.go
+++ b/internal/testrunner/runners/pipeline/test_result.go
@@ -21,6 +21,10 @@ import (
 
 const expectedTestResultSuffix = "-expected.json"
 
+// diffContext is the number of context lines to show for diffs in test case
+// mismatches. It is the equivalent of -U in a unified diff.
+const diffContext = 3
+
 type testResult struct {
 	events []json.RawMessage
 }
@@ -65,7 +69,7 @@ func compareResults(testCasePath string, config *testConfig, result *testResult)
 		return errors.Wrap(err, "marshalling expected test results failed")
 	}
 
-	report := diffUlite(string(expected), string(actual), 3)
+	report := diffUlite(string(expected), string(actual), diffContext)
 	if report != "" {
 		return testrunner.ErrTestCaseFailed{
 			Reason:  "Expected results are different from actual ones",


### PR DESCRIPTION
This implements a lightweight diff -Un function to use when rendering differences
reducing the amount of text needed to read through to get to informative differences.

Please take a look.

Example output:
```
FAILURE DETAILS:
panw/panos test-panw-panos-globalprotect-sample.log:
--- want
+++ got
@@ -983 +983 @@
              },
              "panw": {
                  "panos": {
-                     "act ion_flags": "true",
+                     "action_flags": "true",
                      "client_ver": "5.2.8",
                      "description": "Pre-tunnel latency: 35ms, Post-tunnel latency: 16ms",
                      "error_code": "0",
                      "repeat_count": 1,
                      "sequence_number": 1041590,
-                     "seri al_number": "SERIALNR",
+                     "serial_number": "SERIALNR",
                      "source": {
                          "nat": {
                              "ip": "fc00::1234"
@@ -1008 +1008 @@
                  ],
                  "ip": [
                      "fc00::abcd",
-                     "fc 00::1234"
+                     "fc00::1234"
                  ],
                  "user": [
-                     "us er"
+                     "user"
                  ]
              },
              "source": {
-                 "ip": "fc 00::abcd",
+                 "ip": "fc00::abcd",
                  "nat": {
-                     "ip": "fc00 ::1234"
+                     "ip": "fc00::1234"
                  },
                  "user": {
-                     "name": "us er"
+                     "name": "user"
                  }
              },
              "tags": [
```