### PR TITLE
Use different namespace for elastic-agent

### DIFF
--- a/internal/install/application_configuration.go
+++ b/internal/install/application_configuration.go
@@ -19,12 +19,12 @@ import (
 
 const (
 	stackVersion715 = "7.15.0-SNAPSHOT"
-	stackVersion830 = "8.3.0-SNAPSHOT"
+	stackVersion820 = "8.2.0-SNAPSHOT"
 )
 
 var (
 	elasticAgentCompleteFirstSupportedVersion = semver.MustParse(stackVersion715)
-	elasticAgentCompleteOwnNamespaceVersion   = semver.MustParse(stackVersion830)
+	elasticAgentCompleteOwnNamespaceVersion   = semver.MustParse(stackVersion820)
 )
 
 // ApplicationConfiguration represents the configuration of the elastic-package.

--- a/internal/install/application_configuration.go
+++ b/internal/install/application_configuration.go
@@ -17,9 +17,15 @@ import (
 	"github.com/elastic/elastic-package/internal/logger"
 )
 
-const stackVersion715 = "7.15.0-SNAPSHOT"
+const (
+	stackVersion715 = "7.15.0-SNAPSHOT"
+	stackVersion830 = "8.3.0-SNAPSHOT"
+)
 
-var elasticAgentCompleteFirstSupportedVersion = semver.MustParse(stackVersion715)
+var (
+	elasticAgentCompleteFirstSupportedVersion = semver.MustParse(stackVersion715)
+	elasticAgentCompleteOwnNamespaceVersion   = semver.MustParse(stackVersion830)
+)
 
 // ApplicationConfiguration represents the configuration of the elastic-package.
 type ApplicationConfiguration struct {
@@ -83,7 +89,9 @@ func selectElasticAgentImageName(version string) string {
 	v, err := semver.NewVersion(version)
 	if err != nil {
 		logger.Errorf("stack version not in semver format (value: %s): %v", v, err)
-	} else if !v.LessThan(elasticAgentCompleteFirstSupportedVersion) {
+	} else if !v.LessThan(elasticAgentCompleteFirstSupportedVersion) && v.LessThan(elasticAgentCompleteOwnNamespaceVersion) {
+		return elasticAgentCompleteLegacyImageName
+	} else if !v.LessThan(elasticAgentCompleteOwnNamespaceVersion) {
 		return elasticAgentCompleteImageName
 	}
 	return elasticAgentImageName

--- a/internal/install/application_configuration.go
+++ b/internal/install/application_configuration.go
@@ -89,10 +89,13 @@ func selectElasticAgentImageName(version string) string {
 	v, err := semver.NewVersion(version)
 	if err != nil {
 		logger.Errorf("stack version not in semver format (value: %s): %v", v, err)
-	} else if !v.LessThan(elasticAgentCompleteFirstSupportedVersion) && v.LessThan(elasticAgentCompleteOwnNamespaceVersion) {
-		return elasticAgentCompleteLegacyImageName
-	} else if !v.LessThan(elasticAgentCompleteOwnNamespaceVersion) {
+		return elasticAgentImageName
+	}
+	if !v.LessThan(elasticAgentCompleteOwnNamespaceVersion) {
 		return elasticAgentCompleteImageName
+	}
+	if !v.LessThan(elasticAgentCompleteFirstSupportedVersion) {
+		return elasticAgentCompleteLegacyImageName
 	}
 	return elasticAgentImageName
 }

--- a/internal/install/application_configuration_test.go
+++ b/internal/install/application_configuration_test.go
@@ -25,11 +25,23 @@ func TestSelectElasticAgentImageName_OlderStack(t *testing.T) {
 func TestSelectElasticAgentImageName_FirstStackWithCompleteAgent(t *testing.T) {
 	version := stackVersion715
 	selected := selectElasticAgentImageName(version)
-	assert.Equal(t, selected, elasticAgentCompleteImageName)
+	assert.Equal(t, selected, elasticAgentCompleteLegacyImageName)
 }
 
 func TestSelectElasticAgentImageName_NextStackWithAgentComplete(t *testing.T) {
 	version := "7.16.0-SNAPSHOT"
+	selected := selectElasticAgentImageName(version)
+	assert.Equal(t, selected, elasticAgentCompleteLegacyImageName)
+}
+
+func TestSelectElasticAgentImageName_OwnNamespace(t *testing.T) {
+	version := "8.3.0-SNAPSHOT"
+	selected := selectElasticAgentImageName(version)
+	assert.Equal(t, selected, elasticAgentCompleteImageName)
+}
+
+func TestSelectElasticAgentImageName_NextStackInOwnNamespace(t *testing.T) {
+	version := "8.4.0-SNAPSHOT"
 	selected := selectElasticAgentImageName(version)
 	assert.Equal(t, selected, elasticAgentCompleteImageName)
 }

--- a/internal/install/application_configuration_test.go
+++ b/internal/install/application_configuration_test.go
@@ -40,6 +40,12 @@ func TestSelectElasticAgentImageName_OwnNamespace(t *testing.T) {
 	assert.Equal(t, selected, elasticAgentCompleteImageName)
 }
 
+func TestSelectElasticAgentImageName_OwnNamespace_Release(t *testing.T) {
+	version := "8.2.0"
+	selected := selectElasticAgentImageName(version)
+	assert.Equal(t, selected, elasticAgentCompleteImageName)
+}
+
 func TestSelectElasticAgentImageName_NextStackInOwnNamespace(t *testing.T) {
 	version := "8.4.0-SNAPSHOT"
 	selected := selectElasticAgentImageName(version)

--- a/internal/install/application_configuration_test.go
+++ b/internal/install/application_configuration_test.go
@@ -35,7 +35,7 @@ func TestSelectElasticAgentImageName_NextStackWithAgentComplete(t *testing.T) {
 }
 
 func TestSelectElasticAgentImageName_OwnNamespace(t *testing.T) {
-	version := "8.3.0-SNAPSHOT"
+	version := "8.2.0-SNAPSHOT"
 	selected := selectElasticAgentImageName(version)
 	assert.Equal(t, selected, elasticAgentCompleteImageName)
 }

--- a/internal/install/application_configuration_yml.go
+++ b/internal/install/application_configuration_yml.go
@@ -5,10 +5,11 @@
 package install
 
 const (
-	elasticAgentImageName         = "docker.elastic.co/beats/elastic-agent"
-	elasticAgentCompleteImageName = "docker.elastic.co/beats/elastic-agent-complete"
-	elasticsearchImageName        = "docker.elastic.co/elasticsearch/elasticsearch"
-	kibanaImageName               = "docker.elastic.co/kibana/kibana"
+	elasticAgentImageName               = "docker.elastic.co/beats/elastic-agent"
+	elasticAgentCompleteLegacyImageName = "docker.elastic.co/beats/elastic-agent-complete"
+	elasticAgentCompleteImageName       = "docker.elastic.co/elastic-agent/elastic-agent-complete"
+	elasticsearchImageName              = "docker.elastic.co/elasticsearch/elasticsearch"
+	kibanaImageName                     = "docker.elastic.co/kibana/kibana"
 )
 
 const applicationConfigurationYmlFile = "config.yml"


### PR DESCRIPTION
Fixes: https://github.com/elastic/elastic-package/issues/691

This PR updates the logic to select the right Docker image for Elastic Agent. Starting with the ~v8.3.0~v8.2.0 release, the `elastic-package` should use a different namespace for Elastic Agent.