### PR TITLE
Update Stack default version to 8.1.0

### DIFF
--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "8.0.0"
+	DefaultStackVersion = "8.1.0"
 )

--- a/test/packages/with-kind/kubernetes/data_stream/pod/fields/base-fields.yml
+++ b/test/packages/with-kind/kubernetes/data_stream/pod/fields/base-fields.yml
@@ -59,6 +59,44 @@
       description: >
         Kubernetes annotations map
 
+    - name: node.labels.*
+      type: object
+      object_type: keyword
+      object_type_mapping_type: "*"
+      description: >
+        Kubernetes node labels map
+
+    - name: node.annotations.*
+      type: object
+      object_type: keyword
+      object_type_mapping_type: "*"
+      description: >
+        Kubernetes node annotations map
+
+    - name: node.uid
+      type: keyword
+      description: >
+        Kubernetes node UID
+
+    - name: namespace_uid
+      type: keyword
+      description: >
+        Kubernetes namespace UID
+
+    - name: namespace_labels.*
+      type: object
+      object_type: keyword
+      object_type_mapping_type: "*"
+      description: >
+        Kubernetes namespace labels map
+
+    - name: namespace_annotations.*
+      type: object
+      object_type: keyword
+      object_type_mapping_type: "*"
+      description: >
+        Kubernetes namespace annotations map
+
     - name: selectors.*
       type: object
       object_type: keyword
@@ -85,6 +123,16 @@
       type: keyword
       description: >
         Kubernetes statefulset name
+
+    - name: job.name
+      type: keyword
+      description: >
+        Name of the Job to which the Pod belongs
+
+    - name: cronjob.name
+      type: keyword
+      description: >
+        Name of the CronJob to which the Pod belongs
 
     - name: container.name
       type: keyword

--- a/test/packages/with-kind/kubernetes/data_stream/pod/fields/fields.yml
+++ b/test/packages/with-kind/kubernetes/data_stream/pod/fields/fields.yml
@@ -111,6 +111,14 @@
               metric_type: gauge
               description: |
                 Total working set memory
+            - name: limit.pct
+              type: scaled_float
+              format: percent
+              unit: percent
+              metric_type: gauge
+              description: >
+                Working set memory usage as a percentage of the defined limit for the pod containers (or total node allocatable memory if unlimited)
+
         - name: rss
           type: group
           fields:


### PR DESCRIPTION
This PR supersede #708 and updates default Stack version to `8.1.0` to align with latest release.
