### PR TITLE
Fix: jenkins.JenkinsException: create[Ingest-manager/elastic-package/…

### DIFF
--- a/.ci/jobs/package-storage-publish.yml
+++ b/.ci/jobs/package-storage-publish.yml
@@ -1,7 +1,7 @@
 ---
 - job:
-    name: Ingest-manager/elastic-package/package-storage-publish
-    display-name: Publish a package to Package Storage v2
+    name: Ingest-manager/elastic-package-package-storage-publish
+    display-name: Publish a package to Package Storage v2 (for testing only)
     description: Minimal Jenkins pipeline to exercise publishing a package to Package Storage
     view: Beats
     project-type: multibranch


### PR DESCRIPTION
…package-storage-publish] failed.

Error spotted in JJBB logs:

```
09:08:30 2022-03-16 08:08:30,779 [jjbb.jenkins_server] [ERROR] create[Ingest-manager/elastic-package/package-storage-publish] failed
09:08:30 Traceback (most recent call last):
[redacted]
``` 

It looks like the `elastic-package` is considered to be a folder, so I replaced the `/` with `-`.

I can share link to the failed job over slack.