### PR TITLE
Implement minimal pipeline to publish a package

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -102,8 +102,7 @@ pipeline {
                     'check-packages-with-kind': generateTestCommandStage(command: 'test-check-packages-with-kind', artifacts: ['build/test-results/*.xml', 'build/kubectl-dump.txt', 'build/elastic-stack-dump/check-*/logs/*.log', 'build/elastic-stack-dump/check-*/logs/fleet-server-internal/*'], junitArtifacts: true, publishCoverage: true),
                     'check-packages-other': generateTestCommandStage(command: 'test-check-packages-other', artifacts: ['build/test-results/*.xml', 'build/elastic-stack-dump/check-*/logs/*.log', 'build/elastic-stack-dump/check-*/logs/fleet-server-internal/*'], junitArtifacts: true, publishCoverage: true),
                     'build-zip': generateTestCommandStage(command: 'test-build-zip', artifacts: ['build/elastic-stack-dump/build-zip/logs/*.log', 'build/integrations/*.sig']),
-                    'profiles-command': generateTestCommandStage(command: 'test-profiles-command'),
-                    'publish-to-package-storage': generateTestPublishToPackageStorageStage()
+                    'profiles-command': generateTestCommandStage(command: 'test-profiles-command')
                   ]
 
                   def checkSinglePackageTasks = generateTestCheckSinglePackageStage()
@@ -146,14 +145,6 @@ def cleanup(){
     deleteDir()
   }
   unstash 'source'
-}
-
-def generateTestPublishToPackageStorageStage() {
-  return {
-    withNode(sleepMax: 20, forceWorkspace: true) {
-      build(wait: true, propagate: true, job: "/Ingest-manager/elastic-package-package-storage-publish/${BRANCH_NAME}")
-    }
-  }
 }
 
 def generateTestCheckSinglePackageStage(Map args = [:]) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -3,7 +3,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'ubuntu-18 && immutable' }
+  agent { label 'ubuntu-20 && immutable' }
   environment {
     REPO = "elastic-package"
 

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -22,21 +22,6 @@ pipeline {
     JOB_GCS_EXT_CREDENTIALS = 'beats-ci-gcs-plugin-file-credentials'
     ELASTIC_PACKAGE_GCP_SECRET = 'secret/observability-team/ci/service-account/elastic-package-gcp'
     ELASTIC_OBSERVABILITY_PROJECT_ID = 'elastic-observability'
-
-    JOB_SIGNING_CREDENTIALS = 'sign-artifacts-with-gpg-job'
-    INTERNAL_CI_JOB_GCS_CREDENTIALS = 'internal-ci-gcs-plugin'
-
-    REPO_BUILD_TAG = "${env.REPO}/${env.BUILD_TAG}"
-    INFRA_SIGNING_BUCKET_NAME = 'internal-ci-artifacts'
-    INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER = "${env.REPO_BUILD_TAG}/signed-artifacts"
-    INFRA_SIGNING_BUCKET_ARTIFACTS_PATH = "gs://${env.INFRA_SIGNING_BUCKET_NAME}/${env.REPO_BUILD_TAG}"
-    INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH = "gs://${env.INFRA_SIGNING_BUCKET_NAME}/${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER}"
-
-    INTEGRATIONS_SIGNATURES_PATH = 'build/integrations-elastic-signatures' // different path not to override signatures archived in the "build-zip" step
-
-    PACKAGE_STORAGE_UPLOADER_CREDENTIALS = 'upload-package-to-package-storage'
-    PACKAGE_STORAGE_UPLOADER_GCP_SERVICE_ACCOUNT = 'secret/gce/elastic-bekitzur/service-account/package-storage-uploader'
-    PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH = "gs://elastic-bekitzur-package-storage-internal/queue-publishing/${env.REPO_BUILD_TAG}"
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -165,62 +150,10 @@ def cleanup(){
 
 def generateTestPublishToPackageStorageStage() {
   return {
-    withNode(labels: "ubuntu-20 && immutable", sleepMax: 20, forceWorkspace: true) {
-      cleanup()
-      dir("${BASE_DIR}"){
-        withMageEnv(){
-          sh(label: 'Install elastic-package',script: "make install")
-          dir("test/packages/package-storage/package_storage_candidate") {
-            sh(label: 'Lint package',script: "elastic-package lint")
-            sh(label: 'Build zipped package',script: "elastic-package build --zip")
-          }
-          signArtifactsWithElastic('build/integrations', env.INTEGRATIONS_SIGNATURES_PATH)
-
-          // Add the package candidate to the "queue-publishing"
-          withGCPEnv(secret: env.PACKAGE_STORAGE_UPLOADER_GCP_SERVICE_ACCOUNT) {
-            sh(label: 'Upload package .zip file', script: "gsutil cp ${env.INTEGRATIONS_SIGNATURES_PATH}/package_storage_candidate-0.0.1.zip ${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/")
-            sh(label: 'Upload package .sig file', script: "gsutil cp ${env.INTEGRATIONS_SIGNATURES_PATH}/package_storage_candidate-0.0.1.zip.sig ${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/")
-          }
-
-          // Call the publishing job
-          withCredentials([string(credentialsId: env.PACKAGE_STORAGE_UPLOADER_CREDENTIALS, variable: 'TOKEN')]) {
-            triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
-              job: 'https://internal-ci.elastic.co/job/package_storage/job/publishing-job-remote',
-              token: TOKEN,
-              parameters: """
-                dry_run=true
-                gs_package_build_zip_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/package_storage_candidate-0.0.1.zip
-                gs_package_signature_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/package_storage_candidate-0.0.1.zip.sig
-                """,
-              useCrumbCache: false,
-              useJobInfoCache: false)
-          }
-        }
-      }
+    withNode(sleepMax: 20, forceWorkspace: true) {
+      build(wait: true, propagate: true, job: "/Ingest-manager/elastic-package-package-storage-publish/${BRANCH_NAME}")
     }
   }
-}
-
-def signArtifactsWithElastic(artifactsSourcePath, signaturesDestinationPath) {
-  googleStorageUpload(bucket: env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH,
-    credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
-    pathPrefix: artifactsSourcePath + '/',
-    pattern: artifactsSourcePath + '/*.zip',
-    sharedPublicly: false,
-    showInline: true)
-  withCredentials([string(credentialsId: env.JOB_SIGNING_CREDENTIALS, variable: 'TOKEN')]) {
-    triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
-      job: 'https://internal-ci.elastic.co/job/elastic+unified-release+master+sign-artifacts-with-gpg',
-      token: TOKEN,
-      parameters: "gcs_input_path=${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
-      useCrumbCache: false,
-      useJobInfoCache: false)
-  }
-  googleStorageDownload(bucketUri: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH}/*",
-    credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
-    localDirectory: signaturesDestinationPath + '/',
-    pathPrefix: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER}")
-    sh(label: 'Rename .asc to .sig', script: 'for f in ' + signaturesDestinationPath + '/*.asc; do mv "$f" "${f%.asc}.sig"; done')
 }
 
 def generateTestCheckSinglePackageStage(Map args = [:]) {

--- a/.ci/package-storage-publish.groovy
+++ b/.ci/package-storage-publish.groovy
@@ -53,7 +53,7 @@ pipeline {
         cleanup()
         useElasticPackage()
         dir("${BASE_DIR}/test/packages/package_storage_candidate") {
-          sh(label: 'Build package',script: "elastic-package build")
+          sh(label: 'Build package',script: "../../../elastic-package build")
         }
         stash(allowEmpty: true, name: 'build-package', useDefaultExcludes: false)
       }

--- a/.ci/package-storage-publish.groovy
+++ b/.ci/package-storage-publish.groovy
@@ -51,9 +51,14 @@ pipeline {
     stage('Build package') {
       steps {
         cleanup()
-        useElasticPackage()
-        dir("${BASE_DIR}/test/packages/package_storage_candidate") {
-          sh(label: 'Build package',script: "../../../elastic-package build")
+        withGoEnv() {
+          dir("${BASE_DIR}") {
+            sh(label: 'Install elastic-package',script: "make install")
+            // sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
+            dir("test/packages/package_storage_candidate") {
+              sh(label: 'Build package',script: "elastic-package build")
+            }
+          }
         }
         stash(allowEmpty: true, name: 'build-package', useDefaultExcludes: false)
       }
@@ -75,15 +80,6 @@ pipeline {
   post {
     cleanup {
       notifyBuildResult(prComment: true)
-    }
-  }
-}
-
-def useElasticPackage() {
-  withGoEnv() {
-    dir("${BASE_DIR}") {
-      sh(label: 'Install elastic-package',script: "make install")
-      // sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
     }
   }
 }

--- a/.ci/package-storage-publish.groovy
+++ b/.ci/package-storage-publish.groovy
@@ -56,18 +56,18 @@ pipeline {
             sh(label: 'Install elastic-package',script: "make install")
             // sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
             dir("test/packages/package-storage/package_storage_candidate") {
-              sh(label: 'Build package',script: "elastic-package build")
+              sh(label: 'Build package', script: "elastic-package build")
             }
           }
         }
-        stash(allowEmpty: true, name: 'build-package', useDefaultExcludes: false)
+        stash(allowEmpty: true, name: 'build-package', includes: 'build/integrations', useDefaultExcludes: false)
       }
     }
     stage('Sign package') {
       steps {
         cleanup(source: 'build-package')
         signArtifactsWithElastic('build/integrations')
-        stash(allowEmpty: true, name: 'sign-package', useDefaultExcludes: false)
+        stash(allowEmpty: true, name: 'sign-package', includes: 'build/integrations', useDefaultExcludes: false)
       }
     }
     stage('Publish package') {

--- a/.ci/package-storage-publish.groovy
+++ b/.ci/package-storage-publish.groovy
@@ -102,7 +102,7 @@ def signArtifactsWithElastic(artifactsPath) {
     }
     googleStorageDownload(bucketUri: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH}/*",
       credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
-      localDirectory: signaturesDestinationPath + '/',
+      localDirectory: artifactsPath + '/',
       pathPrefix: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER}")
       sh(label: 'Rename .asc to .sig', script: 'for f in ' + artifactsPath + '/*.asc; do mv "$f" "${f%.asc}.sig"; done')
   }

--- a/.ci/package-storage-publish.groovy
+++ b/.ci/package-storage-publish.groovy
@@ -96,8 +96,7 @@ def signUnpublishedArtifactsWithElastic(builtPackagesPath) {
       unpublished = true
       googleStorageUpload(bucket: env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH,
         credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
-        pathPrefix: '/',
-        pattern: '/*.zip',
+        pattern: '*.zip',
         sharedPublicly: false,
         showInline: true)
     }

--- a/.ci/package-storage-publish.groovy
+++ b/.ci/package-storage-publish.groovy
@@ -56,11 +56,11 @@ pipeline {
             sh(label: 'Install elastic-package',script: "make install")
             // sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
             dir("test/packages/package-storage/package_storage_candidate") {
-              sh(label: 'Build package', script: "elastic-package build")
+              sh(label: 'Build package', script: "elastic-package build -v --zip")
             }
           }
         }
-        stash(allowEmpty: true, name: 'build-package', includes: "${BASE_DIR}/build/integrations/**", useDefaultExcludes: false)
+        stash(allowEmpty: true, name: 'build-package', includes: "${BASE_DIR}/build/integrations/*.zip", useDefaultExcludes: false)
       }
     }
     stage('Sign package') {

--- a/.ci/package-storage-publish.groovy
+++ b/.ci/package-storage-publish.groovy
@@ -55,7 +55,7 @@ pipeline {
           dir("${BASE_DIR}") {
             sh(label: 'Install elastic-package',script: "make install")
             // sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
-            dir("test/packages/package_storage_candidate") {
+            dir("test/packages/package-storage/package_storage_candidate") {
               sh(label: 'Build package',script: "elastic-package build")
             }
           }

--- a/.ci/package-storage-publish.groovy
+++ b/.ci/package-storage-publish.groovy
@@ -6,11 +6,23 @@ pipeline {
   agent { label 'ubuntu-20 && immutable' }
   environment {
     REPO = "elastic-package"
+    REPO_BUILD_TAG = "${env.REPO}/${env.BUILD_TAG}"
 
     BASE_DIR="src/github.com/elastic/elastic-package"
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     GITHUB_TOKEN_CREDENTIALS = "2a9602aa-ab9f-4e52-baf3-b71ca88469c7"
     PIPELINE_LOG_LEVEL='INFO'
+
+    // Signing
+    INFRA_SIGNING_BUCKET_NAME = 'internal-ci-artifacts'
+    INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER = "${env.REPO_BUILD_TAG}/signed-artifacts"
+    INFRA_SIGNING_BUCKET_ARTIFACTS_PATH = "gs://${env.INFRA_SIGNING_BUCKET_NAME}/${env.REPO_BUILD_TAG}"
+    INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH = "gs://${env.INFRA_SIGNING_BUCKET_NAME}/${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER}"
+
+    // Publishing
+    PACKAGE_STORAGE_UPLOADER_CREDENTIALS = 'upload-package-to-package-storage'
+    PACKAGE_STORAGE_UPLOADER_GCP_SERVICE_ACCOUNT = 'secret/gce/elastic-bekitzur/service-account/package-storage-uploader'
+    PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH = "gs://elastic-bekitzur-package-storage-internal/queue-publishing/${env.REPO_BUILD_TAG}"
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -31,7 +43,30 @@ pipeline {
         pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
-        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+        stash(allowEmpty: true, name: 'source', useDefaultExcludes: false)
+      }
+    }
+    stage('Build package') {
+      steps {
+        cleanup()
+        useElasticPackage()
+        dir("${BASE_DIR}/test/packages/package_storage_candidate") {
+          sh(label: 'Build package',script: "elastic-package build")
+        }
+        stash(allowEmpty: true, name: 'build-package', useDefaultExcludes: false)
+      }
+    }
+    stage('Sign package') {
+      steps {
+        cleanup(source: 'build-package')
+        signArtifactsWithElastic('build/integrations')
+        stash(allowEmpty: true, name: 'sign-package', useDefaultExcludes: false)
+      }
+    }
+    stage('Publish package') {
+      steps {
+        cleanup(source: 'sign-package')
+        publishToPackageStorage('build/integrations')
       }
     }
   }
@@ -42,9 +77,68 @@ pipeline {
   }
 }
 
-def cleanup(){
+def useElasticPackage() {
+  withGoEnv() {
+    dir("${BASE_DIR}") {
+      sh(label: 'Install elastic-package',script: "make install")
+      // sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
+    }
+  }
+}
+
+def signArtifactsWithElastic(artifactsPath) {
+  dir("${BASE_DIR}") {
+    googleStorageUpload(bucket: env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH,
+      credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
+      pathPrefix: artifactsPath + '/',
+      pattern: artifactsPath + '/*.zip',
+      sharedPublicly: false,
+      showInline: true)
+    withCredentials([string(credentialsId: env.JOB_SIGNING_CREDENTIALS, variable: 'TOKEN')]) {
+      triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
+        job: 'https://internal-ci.elastic.co/job/elastic+unified-release+master+sign-artifacts-with-gpg',
+        token: TOKEN,
+        parameters: "gcs_input_path=${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
+        useCrumbCache: false,
+        useJobInfoCache: false)
+    }
+    googleStorageDownload(bucketUri: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH}/*",
+      credentialsId: env.INTERNAL_CI_JOB_GCS_CREDENTIALS,
+      localDirectory: signaturesDestinationPath + '/',
+      pathPrefix: "${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER}")
+      sh(label: 'Rename .asc to .sig', script: 'for f in ' + artifactsPath + '/*.asc; do mv "$f" "${f%.asc}.sig"; done')
+  }
+}
+
+def publishToPackageStorage(artifactsPath) {
+  dir("${BASE_DIR}/${artifactsPath}") {
+    withGCPEnv(secret: env.PACKAGE_STORAGE_UPLOADER_GCP_SERVICE_ACCOUNT) {
+      withCredentials([string(credentialsId: env.PACKAGE_STORAGE_UPLOADER_CREDENTIALS, variable: 'TOKEN')]) {
+        findFiles()?.findAll{ it.name.endsWith('.zip') }?.collect{ it.name }?.sort()?.each {
+          def packageZip = it
+          sh(label: 'Upload package .zip file', script: "gsutil cp ${packageZip} ${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/")
+          sh(label: 'Upload package .sig file', script: "gsutil cp ${packageZip}.sig ${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/")
+
+          triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
+            job: 'https://internal-ci.elastic.co/job/package_storage/job/publishing-job-remote',
+            token: TOKEN,
+            parameters: """
+              dry_run=true
+              gs_package_build_zip_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}
+              gs_package_signature_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}.sig
+              """,
+              useCrumbCache: true,
+              useJobInfoCache: true)
+        }
+      }
+    }
+  }
+}
+
+def cleanup(Map args = [:]) {
+  def source = args.containsKey('source') ? args.source : 'source'
   dir("${BASE_DIR}"){
     deleteDir()
   }
-  unstash 'source'
+  unstash source
 }

--- a/.ci/package-storage-publish.groovy
+++ b/.ci/package-storage-publish.groovy
@@ -14,12 +14,14 @@ pipeline {
     PIPELINE_LOG_LEVEL='INFO'
 
     // Signing
+    JOB_SIGNING_CREDENTIALS = 'sign-artifacts-with-gpg-job'
     INFRA_SIGNING_BUCKET_NAME = 'internal-ci-artifacts'
     INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER = "${env.REPO_BUILD_TAG}/signed-artifacts"
     INFRA_SIGNING_BUCKET_ARTIFACTS_PATH = "gs://${env.INFRA_SIGNING_BUCKET_NAME}/${env.REPO_BUILD_TAG}"
     INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_PATH = "gs://${env.INFRA_SIGNING_BUCKET_NAME}/${env.INFRA_SIGNING_BUCKET_SIGNED_ARTIFACTS_SUBFOLDER}"
 
     // Publishing
+    INTERNAL_CI_JOB_GCS_CREDENTIALS = 'internal-ci-gcs-plugin'
     PACKAGE_STORAGE_UPLOADER_CREDENTIALS = 'upload-package-to-package-storage'
     PACKAGE_STORAGE_UPLOADER_GCP_SERVICE_ACCOUNT = 'secret/gce/elastic-bekitzur/service-account/package-storage-uploader'
     PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH = "gs://elastic-bekitzur-package-storage-internal/queue-publishing/${env.REPO_BUILD_TAG}"

--- a/.ci/package-storage-publish.groovy
+++ b/.ci/package-storage-publish.groovy
@@ -60,14 +60,14 @@ pipeline {
             }
           }
         }
-        stash(allowEmpty: true, name: 'build-package', includes: "${BASE_DIR}/build/integrations", useDefaultExcludes: false)
+        stash(allowEmpty: true, name: 'build-package', includes: "${BASE_DIR}/build/integrations/**", useDefaultExcludes: false)
       }
     }
     stage('Sign package') {
       steps {
         cleanup(source: 'build-package')
         signArtifactsWithElastic('build/integrations')
-        stash(allowEmpty: true, name: 'sign-package', includes: "${BASE_DIR}/build/integrations", useDefaultExcludes: false)
+        stash(allowEmpty: true, name: 'sign-package', includes: "${BASE_DIR}/build/integrations/**", useDefaultExcludes: false)
       }
     }
     stage('Publish package') {

--- a/.ci/package-storage-publish.groovy
+++ b/.ci/package-storage-publish.groovy
@@ -60,14 +60,14 @@ pipeline {
             }
           }
         }
-        stash(allowEmpty: true, name: 'build-package', includes: 'build/integrations', useDefaultExcludes: false)
+        stash(allowEmpty: true, name: 'build-package', includes: "${BASE_DIR}/build/integrations", useDefaultExcludes: false)
       }
     }
     stage('Sign package') {
       steps {
         cleanup(source: 'build-package')
         signArtifactsWithElastic('build/integrations')
-        stash(allowEmpty: true, name: 'sign-package', includes: 'build/integrations', useDefaultExcludes: false)
+        stash(allowEmpty: true, name: 'sign-package', includes: "${BASE_DIR}/build/integrations", useDefaultExcludes: false)
       }
     }
     stage('Publish package') {

--- a/.ci/package-storage-publish.groovy
+++ b/.ci/package-storage-publish.groovy
@@ -153,7 +153,7 @@ def uploadUnpublishedToPackageStorage(builtPackagesPath) {
 
 def isAlreadyPublished(packageZip) {
   def responseCode = httpRequest(method: "HEAD",
-    url: "https://package-storage.elastic.co/artifacts/packages/${it}",
+    url: "https://package-storage.elastic.co/artifacts/packages/${packageZip}",
     response_code_only: true)
   return responseCode == 200
 }


### PR DESCRIPTION
Related: https://github.com/elastic/elastic-package/pull/728

This PR implements the minimal pipeline required to publish a package to the Package Storage v2. I extracted the publishing part from the main Jenkinsfile and put it in a separate mini-pipeline. We can discuss if/what we should we push to the apm-pipeline-library.