### PR TITLE
Fix creation of coverage report folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,16 +35,16 @@ update-readme:
 
 update: update-readme
 
-$(CODE_COVERAGE_REPORT_NAME_UNIT):
+$(CODE_COVERAGE_REPORT_FOLDER):
 	mkdir -p $@
 
-test-go: $(CODE_COVERAGE_REPORT_NAME_UNIT)
+test-go: $(CODE_COVERAGE_REPORT_FOLDER)
 	# -count=1 is included to invalidate the test cache. This way, if you run "make test-go" multiple times
 	# you will get fresh test results each time. For instance, changing the source of mocked packages
 	# does not invalidate the cache so having the -count=1 to invalidate the test cache is useful.
 	go run gotest.tools/gotestsum --format standard-verbose -- -count 1 -coverprofile=$(CODE_COVERAGE_REPORT_NAME_UNIT).out ./...
 
-test-go-ci: $(CODE_COVERAGE_REPORT_NAME_UNIT)
+test-go-ci: $(CODE_COVERAGE_REPORT_FOLDER)
 	mkdir -p $(PWD)/build/test-results
 	mkdir -p $(PWD)/build/test-coverage
 	go run gotest.tools/gotestsum --junitfile "$(PWD)/build/test-results/TEST-unit.xml" -- -count=1 -coverprofile=$(CODE_COVERAGE_REPORT_NAME_UNIT).out ./...


### PR DESCRIPTION
Current code is creating the `build/test-coverage/coverage-unit-report` folder that is never used. Create `build/test-coverage` instead.