### PR TITLE
Handle error for 0 doc hits for a data stream

### DIFF
--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -651,7 +651,6 @@ func writeSampleEvent(path string, doc common.MapStr) error {
 
 func validateFields(docs []common.MapStr, fieldsValidator *fields.Validator, dataStream string) error {
 	var multiErr multierror.Error
-
 	for _, doc := range docs {
 		if message, err := doc.GetValue("error.message"); err != common.ErrKeyNotFound {
 			multiErr = append(multiErr, fmt.Errorf("found error.message in event: %v", message))

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -655,19 +655,18 @@ func validateFields(docs []common.MapStr, fieldsValidator *fields.Validator, dat
 	// no hits were found for a data stream
 	if len(docs) == 0 {
 		multiErr = append(multiErr, fmt.Errorf("no documents found in %s data stream", dataStream))
-		return multiErr
-	}
+	} else {
+		for _, doc := range docs {
+			if message, err := doc.GetValue("error.message"); err != common.ErrKeyNotFound {
+				multiErr = append(multiErr, fmt.Errorf("found error.message in event: %v", message))
+				continue
+			}
 
-	for _, doc := range docs {
-		if message, err := doc.GetValue("error.message"); err != common.ErrKeyNotFound {
-			multiErr = append(multiErr, fmt.Errorf("found error.message in event: %v", message))
-			continue
-		}
-
-		errs := fieldsValidator.ValidateDocumentMap(doc)
-		if errs != nil {
-			multiErr = append(multiErr, errs...)
-			continue
+			errs := fieldsValidator.ValidateDocumentMap(doc)
+			if errs != nil {
+				multiErr = append(multiErr, errs...)
+				continue
+			}
 		}
 	}
 

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -653,7 +653,7 @@ func validateFields(docs []common.MapStr, fieldsValidator *fields.Validator, dat
 
 	// prevents panic and performs cleanup/teardown for cases where
 	// no hits were found for a data stream
-	if docs == nil || len(docs) == 0 {
+	if len(docs) == 0 {
 		multiErr = append(multiErr, fmt.Errorf("no documents found in %s data stream", dataStream))
 		return multiErr
 	}

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -650,6 +650,14 @@ func writeSampleEvent(path string, doc common.MapStr) error {
 
 func validateFields(docs []common.MapStr, fieldsValidator *fields.Validator, dataStream string) error {
 	var multiErr multierror.Error
+
+	// prevents panic and performs cleanup/teardown for cases where
+	// no hits were found for a data stream
+	if docs == nil || len(docs) == 0 {
+		multiErr = append(multiErr, fmt.Errorf("no documents found in %s data stream", dataStream))
+		return multiErr
+	}
+
 	for _, doc := range docs {
 		if message, err := doc.GetValue("error.message"); err != common.ErrKeyNotFound {
 			multiErr = append(multiErr, fmt.Errorf("found error.message in event: %v", message))


### PR DESCRIPTION
Return error for system test cases where zero or no doc hits were found on a particular data stream. Without this error check the code panics and prevents proper cleanup of the system test containers which prevents subsequent system test runs.

**Error before this fix:**

```
....
2022/03/21 12:32:47 DEBUG found 0 hits in logs-cisco_meraki.events-ep data stream
2022/03/21 12:32:48 DEBUG found 0 hits in logs-cisco_meraki.events-ep data stream
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/elastic/elastic-package/internal/testrunner/runners/system.(*runner).runTest(0xc000142d80, 0xc000654480, {{0xc0001623d8, 0x14}, {0xc000444000, 0x2e}, {0x7bcce78, 0x0, 0x0}, 0x0, ...}, ...)
        /Users/saikiran/go/src/github.com/r00tu53r/elastic-package/internal/testrunner/runners/system/runner.go:454 +0x184f
github.com/elastic/elastic-package/internal/testrunner/runners/system.(*runner).runTestPerVariant(0xc000142d80, 0xc00011a0f0, 0x64b3520, {0xc00065c102, 0x1c}, {0xc00017c100, 0x0}, {0x0, 0x0})
        /Users/saikiran/go/src/github.com/r00tu53r/elastic-package/internal/testrunner/runners/system/runner.go:206 +0x5d8
github.com/elastic/elastic-package/internal/testrunner/runners/system.(*runner).run(0xc000142d80)
        /Users/saikiran/go/src/github.com/r00tu53r/elastic-package/internal/testrunner/runners/system/runner.go:176 +0x4fd
github.com/elastic/elastic-package/internal/testrunner/runners/system.(*runner).Run(0x0, {{{0xc00017c100, 0x71}, {0xc00005c0a5, 0xc}, {0xc00017c15a, 0x6}}, {0xc00005c064, 0x4d}, 0x1, ...})
        /Users/saikiran/go/src/github.com/r00tu53r/elastic-package/internal/testrunner/runners/system/runner.go:87 +0x65                                                                                                      github.com/elastic/elastic-package/internal/testrunner.Run({0x615a975, 0x6}, {{{0xc00017c100, 0x71}, {0xc00005c0a5, 0xc}, {0xc00017c15a, 0x6}}, {0xc00005c064, 0x4d}, ...})
        /Users/saikiran/go/src/github.com/r00tu53r/elastic-package/internal/testrunner/testrunner.go:250 +0x99
<... snipped ... >
main.main()
```

**Messages after the fix:**

```
2022/03/25 17:37:59 DEBUG found 0 hits in logs-cisco_meraki.events-ep data stream
2022/03/25 17:38:00 DEBUG found 0 hits in logs-cisco_meraki.events-ep data stream
2022/03/25 17:38:01 DEBUG reassigning original policy back to agent...
2022/03/25 17:38:01 DEBUG PUT http://127.0.0.1:5601/api/fleet/agents/a9acf647-b4a4-494a-b24a-c0eb661a315c/reassign
2022/03/25 17:38:03 DEBUG GET http://127.0.0.1:5601/api/fleet/agents/a9acf647-b4a4-494a-b24a-c0eb661a315c
2022/03/25 17:38:03 DEBUG Agent data: {"id":"a9acf647-b4a4-494a-b24a-c0eb661a315c","policy_id":"2016d7cc-135e-5583-9758-3ba01f5a06e5","local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2022/03/25 17:38:03 DEBUG Wait until the policy (ID: 2016d7cc-135e-5583-9758-3ba01f5a06e5, revision: 1) is assigned to the agent (ID: a9acf647-b4a4-494a-b24a-c0eb661a315c)...
2022/03/25 17:38:05 DEBUG GET http://127.0.0.1:5601/api/fleet/agents/a9acf647-b4a4-494a-b24a-c0eb661a315c
2022/03/25 17:38:05 DEBUG Agent data: {"id":"a9acf647-b4a4-494a-b24a-c0eb661a315c","policy_id":"2016d7cc-135e-5583-9758-3ba01f5a06e5","local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2022/03/25 17:38:05 DEBUG Wait until the policy (ID: 2016d7cc-135e-5583-9758-3ba01f5a06e5, revision: 1) is assigned to the agent (ID: a9acf647-b4a4-494a-b24a-c0eb661a315c)...
2022/03/25 17:38:07 DEBUG GET http://127.0.0.1:5601/api/fleet/agents/a9acf647-b4a4-494a-b24a-c0eb661a315c
2022/03/25 17:38:07 DEBUG Agent data: {"id":"a9acf647-b4a4-494a-b24a-c0eb661a315c","policy_id":"2016d7cc-135e-5583-9758-3ba01f5a06e5","local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2022/03/25 17:38:07 DEBUG Wait until the policy (ID: 2016d7cc-135e-5583-9758-3ba01f5a06e5, revision: 1) is assigned to the agent (ID: a9acf647-b4a4-494a-b24a-c0eb661a315c)...
2022/03/25 17:38:09 DEBUG GET http://127.0.0.1:5601/api/fleet/agents/a9acf647-b4a4-494a-b24a-c0eb661a315c
2022/03/25 17:38:09 DEBUG Agent data: {"id":"a9acf647-b4a4-494a-b24a-c0eb661a315c","policy_id":"2016d7cc-135e-5583-9758-3ba01f5a06e5","policy_revision":1,"local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2022/03/25 17:38:09 DEBUG Policy revision assigned to the agent (ID: a9acf647-b4a4-494a-b24a-c0eb661a315c)...
2022/03/25 17:38:09 DEBUG deleting test policy...
2022/03/25 17:38:09 DEBUG POST http://127.0.0.1:5601/api/fleet/agent_policies/delete
2022/03/25 17:38:12 DEBUG tearing down service...
...
...
2022/03/25 17:38:13 DEBUG deleting data in data stream...
Error: error running package system tests: could not complete test run: could not find hits in logs-cisco_meraki.events-ep data stream
```