### PR TITLE
Use BUILD_TAG to tag cloud resources

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -6,7 +6,6 @@ pipeline {
   agent { label 'ubuntu-20 && immutable' }
   environment {
     REPO = "elastic-package"
-    REPO_BUILD_TAG = "${env.REPO}/${env.BUILD_TAG}"
 
     BASE_DIR="src/github.com/elastic/elastic-package"
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
   agent { label 'ubuntu-20 && immutable' }
   environment {
     REPO = "elastic-package"
+    REPO_BUILD_TAG = "${env.REPO}/${env.BUILD_TAG}"
 
     BASE_DIR="src/github.com/elastic/elastic-package"
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"

--- a/internal/install/_static/Dockerfile.terraform_deployer
+++ b/internal/install/_static/Dockerfile.terraform_deployer
@@ -20,6 +20,7 @@ HEALTHCHECK --timeout=3s CMD sh -c "[ -f /tmp/tf-applied ]"
 ENV TF_IN_AUTOMATION=true
 ENV TF_CLI_ARGS="-no-color"
 ADD run.sh /
+RUN chmod +x /run.sh
 WORKDIR /workspace
 
-ENTRYPOINT bash /run.sh
+ENTRYPOINT exec /run.sh

--- a/internal/install/_static/terraform_deployer.yml
+++ b/internal/install/_static/terraform_deployer.yml
@@ -3,6 +3,7 @@ services:
   terraform:
     build: .
     tty: true
+    stop_grace_period: 5m
     environment:
       - TF_VAR_TEST_RUN_ID=${TF_VAR_TEST_RUN_ID:-detached}
       - TF_VAR_BUILD_TAG=${REPO_NAME:-unknown}-pr-${CHANGE_ID:-unknown}-${BUILD_NUMBER:-unknown}

--- a/internal/install/_static/terraform_deployer.yml
+++ b/internal/install/_static/terraform_deployer.yml
@@ -5,6 +5,6 @@ services:
     tty: true
     environment:
       - TF_VAR_TEST_RUN_ID=${TF_VAR_TEST_RUN_ID:-detached}
-      - TF_VAR_BUILD_TAG="${REPO_NAME:-unknown}-${JOB_BASE_NAME:-unknown}-${BUILD_NUMBER:-unknown}"
+      - TF_VAR_BUILD_TAG=${REPO_NAME:-unknown}-${JOB_BASE_NAME:-unknown}-${BUILD_NUMBER:-unknown}
     volumes:
       - ${TF_DIR}:/stage

--- a/internal/install/_static/terraform_deployer.yml
+++ b/internal/install/_static/terraform_deployer.yml
@@ -5,5 +5,6 @@ services:
     tty: true
     environment:
       - TF_VAR_TEST_RUN_ID=${TF_VAR_TEST_RUN_ID:-detached}
+      - TF_VAR_REPO_BUILD_TAG=${REPO_BUILD_TAG:-unknown}
     volumes:
       - ${TF_DIR}:/stage

--- a/internal/install/_static/terraform_deployer.yml
+++ b/internal/install/_static/terraform_deployer.yml
@@ -6,6 +6,8 @@ services:
     stop_grace_period: 5m
     environment:
       - TF_VAR_TEST_RUN_ID=${TF_VAR_TEST_RUN_ID:-detached}
-      - TF_VAR_BUILD_TAG=${REPO_NAME:-unknown}-pr-${CHANGE_ID:-unknown}-${BUILD_NUMBER:-unknown}
+      - TF_VAR_REPO_NAME=${REPO_NAME:-unknown}
+      - TF_VAR_PULL_REQUEST=pr-${CHANGE_ID:-unknown}
+      - TF_VAR_CI_BUILD_NUMBER=${BUILD_NUMBER:-unknown}
     volumes:
       - ${TF_DIR}:/stage

--- a/internal/install/_static/terraform_deployer.yml
+++ b/internal/install/_static/terraform_deployer.yml
@@ -5,6 +5,6 @@ services:
     tty: true
     environment:
       - TF_VAR_TEST_RUN_ID=${TF_VAR_TEST_RUN_ID:-detached}
-      - TF_VAR_BUILD_TAG="${JOB_BASE_NAME:-unknown}-${BUILD_NUMBER:-unknown}"
+      - TF_VAR_BUILD_TAG="${REPO_NAME:-unknown}-${JOB_BASE_NAME:-unknown}-${BUILD_NUMBER:-unknown}"
     volumes:
       - ${TF_DIR}:/stage

--- a/internal/install/_static/terraform_deployer.yml
+++ b/internal/install/_static/terraform_deployer.yml
@@ -5,6 +5,6 @@ services:
     tty: true
     environment:
       - TF_VAR_TEST_RUN_ID=${TF_VAR_TEST_RUN_ID:-detached}
-      - TF_VAR_BUILD_TAG=${REPO_NAME:-unknown}-${JOB_BASE_NAME:-unknown}-${BUILD_NUMBER:-unknown}
+      - TF_VAR_BUILD_TAG=${REPO_NAME:-unknown}-pr-${CHANGE_ID:-unknown}-${BUILD_NUMBER:-unknown}
     volumes:
       - ${TF_DIR}:/stage

--- a/internal/install/_static/terraform_deployer.yml
+++ b/internal/install/_static/terraform_deployer.yml
@@ -5,6 +5,6 @@ services:
     tty: true
     environment:
       - TF_VAR_TEST_RUN_ID=${TF_VAR_TEST_RUN_ID:-detached}
-      - TF_VAR_REPO_BUILD_TAG=${REPO_BUILD_TAG:-unknown}
+      - TF_VAR_BUILD_TAG="${JOB_BASE_NAME:-unknown}-${BUILD_NUMBER:-unknown}"
     volumes:
       - ${TF_DIR}:/stage

--- a/test/packages/parallel/gcp/data_stream/compute/_dev/deploy/tf/compute.tf
+++ b/test/packages/parallel/gcp/data_stream/compute/_dev/deploy/tf/compute.tf
@@ -13,8 +13,8 @@ resource "google_compute_instance" "default" {
   zone         = var.zone
 
   labels = {
-    team   = "integrations"
     run_id = var.TEST_RUN_ID
+    repo_build_tag = var.REPO_BUILD_TAG
   }
 
   boot_disk {

--- a/test/packages/parallel/gcp/data_stream/compute/_dev/deploy/tf/compute.tf
+++ b/test/packages/parallel/gcp/data_stream/compute/_dev/deploy/tf/compute.tf
@@ -14,7 +14,7 @@ resource "google_compute_instance" "default" {
 
   labels = {
     run_id = var.TEST_RUN_ID
-    repo_build_tag = var.REPO_BUILD_TAG
+    repo_build_tag = var.BUILD_TAG
   }
 
   boot_disk {

--- a/test/packages/parallel/gcp/data_stream/compute/_dev/deploy/tf/compute.tf
+++ b/test/packages/parallel/gcp/data_stream/compute/_dev/deploy/tf/compute.tf
@@ -14,7 +14,7 @@ resource "google_compute_instance" "default" {
 
   labels = {
     run_id = var.TEST_RUN_ID
-    repo_build_tag = var.BUILD_TAG
+    build_tag = var.BUILD_TAG
   }
 
   boot_disk {

--- a/test/packages/parallel/gcp/data_stream/compute/_dev/deploy/tf/compute.tf
+++ b/test/packages/parallel/gcp/data_stream/compute/_dev/deploy/tf/compute.tf
@@ -14,7 +14,9 @@ resource "google_compute_instance" "default" {
 
   labels = {
     run_id = var.TEST_RUN_ID
-    build_tag = var.BUILD_TAG
+    repo_name = var.REPO_NAME
+    pull_request = var.PULL_REQUEST
+    ci_build_number = var.CI_BUILD_NUMBER
   }
 
   boot_disk {

--- a/test/packages/parallel/gcp/data_stream/compute/_dev/deploy/tf/vars.tf
+++ b/test/packages/parallel/gcp/data_stream/compute/_dev/deploy/tf/vars.tf
@@ -2,8 +2,8 @@ variable "TEST_RUN_ID" {
   default = "detached"
 }
 
-variable "REPO_BUILD_TAG" {
-  default = "unknown"
+variable "BUILD_TAG" {
+  default = "unknown-tag"
 }
 
 variable "gcp_project_id" {

--- a/test/packages/parallel/gcp/data_stream/compute/_dev/deploy/tf/vars.tf
+++ b/test/packages/parallel/gcp/data_stream/compute/_dev/deploy/tf/vars.tf
@@ -2,8 +2,16 @@ variable "TEST_RUN_ID" {
   default = "detached"
 }
 
-variable "BUILD_TAG" {
-  default = "unknown-tag"
+variable "REPO_NAME" {
+  default = "unknown-repo"
+}
+
+variable "PULL_REQUEST" {
+  default = "unknown-pr"
+}
+
+variable "CI_BUILD_NUMBER" {
+  default = "unknown-build"
 }
 
 variable "gcp_project_id" {

--- a/test/packages/parallel/gcp/data_stream/compute/_dev/deploy/tf/vars.tf
+++ b/test/packages/parallel/gcp/data_stream/compute/_dev/deploy/tf/vars.tf
@@ -2,6 +2,10 @@ variable "TEST_RUN_ID" {
   default = "detached"
 }
 
+variable "REPO_BUILD_TAG" {
+  default = "unknown"
+}
+
 variable "gcp_project_id" {
   type = string
 }


### PR DESCRIPTION
Close: https://github.com/elastic/elastic-package/issues/754

This PR introduces a new environment variable to tag created cloud resources with Terraform service deployer. 