### PR TITLE
Re-enable AWS tests

### DIFF
--- a/test/packages/parallel/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
+++ b/test/packages/parallel/aws/data_stream/ec2_metrics/_dev/test/system/test-default-config.yml
@@ -1,7 +1,4 @@
 wait_for_data_timeout: 20m # AWS CloudWatch may delay metrics delivery for more than 10 minutes.
-skip:
-  reason: "EC2 module fails initialization (access_key_id undefined)"
-  link: "https://github.com/elastic/integrations/issues/2692"
 vars:
   access_key_id: '{{AWS_ACCESS_KEY_ID}}'
   secret_access_key: '{{AWS_SECRET_ACCESS_KEY}}'


### PR DESCRIPTION
This PR re-enables AWS system tests.