### PR TITLE
Add tags for added and removed content in jsondiff

### DIFF
--- a/internal/testrunner/runners/pipeline/test_result.go
+++ b/internal/testrunner/runners/pipeline/test_result.go
@@ -106,8 +106,8 @@ func diffJson(want, got []byte) (string, error) {
 	opts := jsondiff.DefaultConsoleOptions()
 
 	// Remove colored output.
-	opts.Added = jsondiff.Tag{}
-	opts.Removed = jsondiff.Tag{}
+	opts.Added = jsondiff.Tag{Begin: "+ "}
+	opts.Removed = jsondiff.Tag{Begin: "- "}
 	opts.Changed = jsondiff.Tag{}
 	opts.Skipped = jsondiff.Tag{}
 


### PR DESCRIPTION
It is not clear what is added and removed in jsondiff introduced in #743.

Add  `+`/`-` tags before content added or removed as indication of the reason
to appear in the diff.

Changes appear now like this:

Added:
```
{
    "expected": [
        {
            ...skipped 5 object properties...,
            "source": {
                + "address": "127.0.0.1",
                ...skipped 1 object property...
            },
            ...skipped 4 object properties...
        },
        ...skipped 8 array elements...
    ]
}
```
Removed:
```
{
    "expected": [
        {
            ...skipped 5 object properties...,
            "source": {
                ...skipped 2 object properties...,
                - "port": "33456"
            },
            ...skipped 4 object properties...
        },
        ...skipped 8 array elements...
    ]
}
```
Changed:
```
{
    "expected": [
        {
            ...skipped 5 object properties...,
            "source": {
                "address": "127.0.0.2" => "127.0.0.1",
                ...skipped 1 object property...
            },
            ...skipped 4 object properties...
        },
        ...skipped 8 array elements...
    ]
}
```
An object is renamed:
```
{
    "expected": [
        {
            ...skipped 5 object properties...,
            + "source": {
                + "address": "127.0.0.1",
                + "ip": "127.0.0.1"
            + },
            - "sources": {
                - "address": "127.0.0.1",
                - "ip": "127.0.0.1"
            - },
            ...skipped 4 object properties...
        },
        ...skipped 8 array elements...
    ]
}
```

Reported in https://github.com/elastic/elastic-package/pull/743#discussion_r839068836.