### PR TITLE
Import patterns from ECS

### DIFF
--- a/internal/fields/dependency_manager.go
+++ b/internal/fields/dependency_manager.go
@@ -229,6 +229,10 @@ func transformImportedField(fd FieldDefinition) common.MapStr {
 		m["description"] = fd.Description
 	}
 
+	if fd.Pattern != "" {
+		m["pattern"] = fd.Pattern
+	}
+
 	if fd.Index != nil {
 		m["index"] = *fd.Index
 	}

--- a/internal/fields/dependency_manager_test.go
+++ b/internal/fields/dependency_manager_test.go
@@ -161,6 +161,25 @@ func TestDependencyManagerInjectExternalFields(t *testing.T) {
 			valid:   true,
 		},
 		{
+			title: "external with pattern",
+			defs: []common.MapStr{
+				{
+					"name":     "source.mac",
+					"external": "test",
+				},
+			},
+			result: []common.MapStr{
+				{
+					"name":        "source.mac",
+					"type":        "keyword",
+					"description": "MAC address of the source.",
+					"pattern":     "^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$",
+				},
+			},
+			changed: true,
+			valid:   true,
+		},
+		{
 			title: "override not indexed external",
 			defs: []common.MapStr{
 				{
@@ -227,6 +246,12 @@ func TestDependencyManagerInjectExternalFields(t *testing.T) {
 			Type:        "text",
 			Index:       &indexFalse,
 			DocValues:   &indexFalse,
+		},
+		{
+			Name:        "source.mac",
+			Description: "MAC address of the source.",
+			Pattern:     "^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$",
+			Type:        "keyword",
 		},
 	}}
 	dm := &DependencyManager{schema: schema}


### PR DESCRIPTION
ECS fields can include patterns since https://github.com/elastic/ecs/pull/1834, import them when available.

Validation was already implemented in https://github.com/elastic/elastic-package/pull/162.

Requested in https://github.com/elastic/elastic-package/issues/615#issuecomment-1064270157.