### PR TITLE
Temporary workaround: rename Fleet Server policy to expected default

### DIFF
--- a/internal/profile/_static/kibana_config_8x.yml
+++ b/internal/profile/_static/kibana_config_8x.yml
@@ -35,7 +35,7 @@ xpack.fleet.agentPolicies:
         package:
           name: system
   - name: Fleet Server (elastic-package)
-    id: fleet-server-managed-ep
+    id: fleet-server-policy
     is_default_fleet_server: true
     is_managed: false
     namespace: default


### PR DESCRIPTION
This PR renames the Fleet Service policy in Kibana to the default name, expected by the Fleet Server application. It looks like a breaking change sneaked into Fleet Server.