### PR TITLE
ci: use the Jenkins Code Coverage Plug-in with source support

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -240,6 +240,8 @@ def publishCoverageReports() {
       def bucketUri = getCoverageBucketURI() + "*.xml"
       googleStorageDownload(bucketUri: bucketUri, credentialsId: "${JOB_GCS_CREDENTIALS}", localDirectory: 'build/test-coverage', pathPrefix: getCoveragePathPrefix())
       coverageReport('build/test-coverage')
+      publishCoverage(adapters: [coberturaAdapter("build/test-coverage/*.xml")],
+                      sourceFileResolver: sourceFiles('STORE_ALL_BUILD'))
     }
   }
 }


### PR DESCRIPTION
Trying to enrich the CI with the source integration as stated in https://github.com/elastic/elastic-package/pull/585#issuecomment-970071779

### Test

If you go to [here](https://beats-ci.elastic.co/job/Ingest-manager/job/elastic-package/job/PR-775/1/coverage/2071716863/)

Then you will see the code coverage.

There are some files that are not found, so no idea about the intrinsic behaviour for the codecoverage either for this project or in the CI.

Logs can be found [here](https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Felastic-package%2FPR-775/detail/PR-775/1/pipeline/2359#step-2365-log-187) 

Or see the below extract from the entire log output while using the new coverage step in the CI.

```
[2022-04-01T14:00:41.334Z] Copied cmd/promote.go. 
[2022-04-01T14:00:41.334Z] Starting copy source file internal/testrunner/testrunner.go. 
[2022-04-01T14:00:41.354Z] Copied internal/testrunner/testrunner.go. 
[2022-04-01T14:00:41.354Z] Starting copy source file internal/profile/profile.go. 
[2022-04-01T14:00:41.369Z] Copied internal/profile/profile.go. 
[2022-04-01T14:00:41.369Z] Starting copy source file multiinput/test. 
[2022-04-01T14:00:41.381Z] Unable to find source file multiinput/test in workspace /var/lib/jenkins/workspace/t-manager_elastic-package_PR-775/src/github.com/elastic/elastic-package
[2022-04-01T14:00:41.381Z] Starting copy source file apache/status. 
[2022-04-01T14:00:41.392Z] Unable to find source file apache/status in workspace /var/lib/jenkins/workspace/t-manager_elastic-package_PR-775/src/github.com/elastic/elastic-package
```

<img width="1305" alt="image" src="https://user-images.githubusercontent.com/2871786/161279595-e385415f-91bf-4846-b9dc-6ae63ec67bb6.png">

<img width="1260" alt="image" src="https://user-images.githubusercontent.com/2871786/161279655-ecaf7ce7-bb3e-4db5-a4c2-80e5b61de872.png">
