### PR TITLE
Fix importing of ECS tracing fields

### DIFF
--- a/internal/fields/model.go
+++ b/internal/fields/model.go
@@ -128,10 +128,11 @@ func (fds *FieldDefinitions) UnmarshalYAML(value *yaml.Node) error {
 				return err
 			}
 
-			// "base" group is used by convention in ECS to include
+			// Some groups are used by convention in ECS to include
 			// fields that can appear in the root level of the document.
-			// Append its child fields directly instead.
-			if name == "base" {
+			// Append their child fields directly instead.
+			// TODO: Make this generic looking for groups whose children don't match.
+			if name == "base" || name == "tracing" {
 				fields = append(fields, field.Fields...)
 			} else {
 				field.Name = name


### PR DESCRIPTION
Some groups (`base` and `tracing` afaik) contains fields that are not intended to be nested, but belong to the top level.

`base` was already handled this way, add `tracing` to the exceptions.