### PR TITLE
Fix: do not comment on notifyBuildResult

### DIFF
--- a/.ci/package-storage-publish.groovy
+++ b/.ci/package-storage-publish.groovy
@@ -74,7 +74,7 @@ pipeline {
   }
   post {
     cleanup {
-      notifyBuildResult(prComment: true)
+      notifyBuildResult(prComment: false)
     }
   }
 }


### PR DESCRIPTION
Related: https://github.com/elastic/elastic-package/commit/8a8e3d214988370320e6051c7bde29a9e1de2439#r70180022


This PR modifies the minimal publishing pipeline so that it doesn't update the relevant Github comment. Currently, there is a race condition between two pipelines and the same comment is randomly updated.