### PR TITLE
Fetch tags for goreleaser

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -121,6 +121,8 @@ pipeline {
             dir("${BASE_DIR}"){
               withMageEnv(){
                 withCredentials([string(credentialsId: "${GITHUB_TOKEN_CREDENTIALS}", variable: 'GITHUB_TOKEN')]) {
+                  // Ensure that tags are present so goreleaser can build the changelog from the last release.
+                  gitCmd(cmd: 'fetch', args: '--tags')
                   sh 'curl -sL https://git.io/goreleaser | bash'
                 }
               }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -122,7 +122,7 @@ pipeline {
               withMageEnv(){
                 withCredentials([string(credentialsId: "${GITHUB_TOKEN_CREDENTIALS}", variable: 'GITHUB_TOKEN')]) {
                   // Ensure that tags are present so goreleaser can build the changelog from the last release.
-                  gitCmd(cmd: 'fetch', args: '--tags')
+                  gitCmd(cmd: 'fetch', args: '--unshallow --tags')
                   sh 'curl -sL https://git.io/goreleaser | bash'
                 }
               }


### PR DESCRIPTION
Fetch tags in the `Release` job.

Goreleaser can find what was the previously released tag if tags are
present, and then build the changelog from this tag.

Currently Goreleaser uses the available history, that is the last
[five](https://github.com/elastic/apm-pipeline-library/blob/2c364b4190942364312915258a792d8a2454a020/vars/gitCheckout.txt#L31) changesets retrieved by `gitCheckout`.

It complains about this ([sample build](https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Felastic-package/detail/v0.45.0/1/pipeline/2331#step-2376-log-6)):
```
[2022-04-01T14:03:32.869Z]    • getting and validating git state
[2022-04-01T14:03:33.070Z]       • couldn't find any tags before "v0.45.0"
[2022-04-01T14:03:33.071Z]       • building...               commit=f150e3835fd69b701016848a909b883b2dc6f75a latest tag=v0.45.0
[2022-04-01T14:03:33.071Z]       • running against a shallow clone - check your CI documentation at https://goreleaser.com/ci
```