### PR TITLE
Document build tags for cloud resources

### DIFF
--- a/docs/howto/system_testing.md
+++ b/docs/howto/system_testing.md
@@ -169,6 +169,16 @@ Terraform is often used to interact with Cloud Providers. This require Cloud Pro
 
 Injecting credentials can be achieved with functions from the [`apm-pipeline-library`](https://github.com/elastic/apm-pipeline-library/tree/main/vars) Jenkins library. For example look for `withAzureCredentials`, `withAWSEnv` or `withGCPEnv`.
 
+#### Tagging/labelling created Cloud Provider resources
+
+Leveraging Terraform to create cloud resources is useful but risks creating leftovers resources that are difficult to remove.
+
+There are 4 environment variables that should be leveraged to overcome this issue; these variables are already injected to be used by Terraform (through `TF_VAR_`):
+- `TEST_RUN_ID`: an unique ID for the test run, allows to distinguish each run
+- `REPO_NAME`: the repository name the CI run is linked to
+- `CHANGE_ID`: the PR number the CI run is linked to
+- `BUILD_NUMBER`: incremental number providing the current CI run number
+
 ### Kubernetes service deployer
 
 The Kubernetes service deployer requires the `_dev/deploy/k8s` directory to be present. It can include additional `*.yaml` files to deploy

--- a/docs/howto/system_testing.md
+++ b/docs/howto/system_testing.md
@@ -171,10 +171,10 @@ Injecting credentials can be achieved with functions from the [`apm-pipeline-lib
 
 #### Tagging/labelling created Cloud Provider resources
 
-Leveraging Terraform to create cloud resources is useful but risks creating leftovers resources that are difficult to remove.
+Leveraging Terraform to create cloud resources is useful but risks creating leftover resources that are difficult to remove.
 
 There are 4 environment variables that should be leveraged to overcome this issue; these variables are already injected to be used by Terraform (through `TF_VAR_`):
-- `TEST_RUN_ID`: an unique ID for the test run, allows to distinguish each run
+- `TF_VAR_TEST_RUN_ID`: an unique ID for the test run, allows to distinguish each run
 - `REPO_NAME`: the repository name the CI run is linked to
 - `CHANGE_ID`: the PR number the CI run is linked to
 - `BUILD_NUMBER`: incremental number providing the current CI run number

--- a/docs/howto/system_testing.md
+++ b/docs/howto/system_testing.md
@@ -174,7 +174,7 @@ Injecting credentials can be achieved with functions from the [`apm-pipeline-lib
 Leveraging Terraform to create cloud resources is useful but risks creating leftover resources that are difficult to remove.
 
 There are 4 environment variables that should be leveraged to overcome this issue; these variables are already injected to be used by Terraform (through `TF_VAR_`):
-- `TF_VAR_TEST_RUN_ID`: an unique ID for the test run, allows to distinguish each run
+- `TF_VAR_TEST_RUN_ID`: a unique identifier for the test run, allows to distinguish each run
 - `REPO_NAME`: the repository name the CI run is linked to
 - `CHANGE_ID`: the PR number the CI run is linked to
 - `BUILD_NUMBER`: incremental number providing the current CI run number


### PR DESCRIPTION
Following https://github.com/elastic/elastic-package/pull/755/ is possible to use a set of environment variables to tag cloud resources created for system tests through Terraform.

The available vars were not documented, this PR aims to fix that.
