### PR TITLE
add cloudbeat mounts and volumes to elastic-managed manifest

### DIFF
--- a/internal/testrunner/runners/system/servicedeployer/elastic-agent-managed.yaml.tmpl
+++ b/internal/testrunner/runners/system/servicedeployer/elastic-agent-managed.yaml.tmpl
@@ -63,6 +63,11 @@ spec:
             - name: proc
               mountPath: /hostfs/proc
               readOnly: true
+            - name: etc-kubernetes
+              mountPath: /hostfs/etc/kubernetes
+            - name: var-lib
+              mountPath: /hostfs/var/lib
+              readOnly: true
             - name: cgroup
               mountPath: /hostfs/sys/fs/cgroup
               readOnly: true
@@ -72,10 +77,31 @@ spec:
             - name: varlog
               mountPath: /var/log
               readOnly: true
+            - name: passwd
+              mountPath: /hostfs/etc/passwd
+              readOnly: true
+            - name: group
+              mountPath: /hostfs/etc/group
+              readOnly: true
+            - name: etcsysmd
+              mountPath: /hostfs/etc/systemd
+              readOnly: true
       volumes:
         - name: proc
           hostPath:
             path: /proc
+        - name: etc-kubernetes
+          hostPath:
+            path: /etc/kubernetes
+        - name: var-lib
+          hostPath:
+            path: /var/lib
+        - name: passwd
+          hostPath:
+            path: /etc/passwd
+        - name: group
+          hostPath:
+            path: /etc/group
         - name: cgroup
           hostPath:
             path: /sys/fs/cgroup
@@ -85,6 +111,9 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
+        - name: etcsysmd
+          hostPath:
+            path: /etc/systemd
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
**What this PR does**
- adds mounts and volumes that are needed by [cloudbeat](https://github.com/elastic/cloudbeat)

**Why is this needed**

Our team uses elastic-agent to set up a stack locally and then by using `service up` to deploy an agent on some kind cluster in order to test our beat. This agent deployment manifest is missing some mounts that are needed by cloudbeat in order to work properly (collect the data).

____

- closes: https://github.com/elastic/security-team/issues/3656