### PR TITLE
ci: replace special chars

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -5,7 +5,7 @@
 pipeline {
   agent { label 'ubuntu-20 && immutable' }
   environment {
-    BRANCH_NAME_LOWER_CASE = "${env.BRANCH_NAME.toLowerCase().replaceAll('\\.', '_')}"
+    BRANCH_NAME_LOWER_CASE = "${env.BRANCH_NAME.toLowerCase().replaceAll('[^a-z0-9-]', '-')}"
     CREATED_DATE = "${new Date().getTime()}"
     ENVIRONMENT = "ci"
     REPO = "elastic-package"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -5,7 +5,7 @@
 pipeline {
   agent { label 'ubuntu-20 && immutable' }
   environment {
-    BRANCH_NAME_LOWER_CASE = "${env.BRANCH_NAME.toLowerCase()}"
+    BRANCH_NAME_LOWER_CASE = "${env.BRANCH_NAME.toLowerCase().replaceAll('\\.', '_')}"
     CREATED_DATE = "${new Date().getTime()}"
     ENVIRONMENT = "ci"
     REPO = "elastic-package"


### PR DESCRIPTION
Tag releases are not Google Naming compliance, so, therefore it's not possible to release a new version.


I'm not sure if we might need to move away from the branch_name and use something else instead
