### PR TITLE
Fix fleet managed spec

### DIFF
--- a/internal/testrunner/runners/system/servicedeployer/elastic-agent-managed.yaml.tmpl
+++ b/internal/testrunner/runners/system/servicedeployer/elastic-agent-managed.yaml.tmpl
@@ -171,6 +171,7 @@ rules:
       - pods
       - services
       - configmaps
+      - serviceaccounts
     verbs: ["get", "list", "watch"]
   # Enable this rule only if planing to use kubernetes_secrets provider
   #- apiGroups: [""]
@@ -203,6 +204,23 @@ rules:
       - "/metrics"
     verbs:
       - get
+  - apiGroups: ["rbac.authorization.k8s.io/v1"]
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - rolebindings
+      - roles
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io/v1"]
+    resources:
+      - ingressclasses
+      - ingresses
+      - networkpolicies
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy/v1beta1"]
+    resources:
+      - podsecuritypolicies
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
What does this pr do?

Updates the cluster role permissions required for cloudbeat's k8s API fetcher.

![image](https://user-images.githubusercontent.com/16253938/165349741-a6a3d303-9e59-4ad3-83d3-34849a6f1594.png)
