### PR TITLE
Adding kube resources required by cloudbeat

### DIFF
--- a/internal/testrunner/runners/system/servicedeployer/elastic-agent-managed.yaml.tmpl
+++ b/internal/testrunner/runners/system/servicedeployer/elastic-agent-managed.yaml.tmpl
@@ -171,6 +171,7 @@ rules:
       - pods
       - services
       - configmaps
+      - serviceaccounts
     verbs: ["get", "list", "watch"]
   # Enable this rule only if planing to use kubernetes_secrets provider
   #- apiGroups: [""]
@@ -203,6 +204,22 @@ rules:
       - "/metrics"
     verbs:
       - get
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - rolebindings
+      - roles
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingressclasses
+      - ingresses
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources:
+      - podsecuritypolicies
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
**what this RP does**
Following https://github.com/elastic/elastic-package/pull/795, adding required `kube-api` resources.

___

- Related: https://github.com/elastic/security-team/issues/3682