### PR TITLE
Revert "Generate documentation for imported external nested fields"

### DIFF
--- a/internal/docs/exported_fields.go
+++ b/internal/docs/exported_fields.go
@@ -125,22 +125,21 @@ func visitFields(namePrefix string, f fields.FieldDefinition, records []fieldsTa
 	}
 	name += f.Name
 
-	if f.External != "" {
-		imported, err := fdm.ImportField(f.External, name)
-		if err != nil {
-			return nil, errors.Wrap(err, "can't import field")
-		}
-
-		// Override imported fields with the definition, except for the type and external.
-		var updated fields.FieldDefinition
-		updated.Update(imported)
-		updated.Update(f)
-		updated.Type = imported.Type
-		updated.External = ""
-		f = updated
-	}
-
 	if len(f.Fields) == 0 && f.Type != "group" {
+		if f.External != "" {
+			imported, err := fdm.ImportField(f.External, name)
+			if err != nil {
+				return nil, errors.Wrap(err, "can't import field")
+			}
+
+			// Override imported fields with the definition, except for the type and external.
+			var updated fields.FieldDefinition
+			updated.Update(imported)
+			updated.Update(f)
+			updated.Type = imported.Type
+			updated.External = ""
+			f = updated
+		}
 		records = append(records, fieldsTableRecord{
 			name:        name,
 			description: f.Description,

--- a/test/packages/parallel/gcp/docs/compute.md
+++ b/test/packages/parallel/gcp/docs/compute.md
@@ -98,17 +98,16 @@ An example event for `compute` looks as following:
 | Field | Description | Type |
 |---|---|---|
 | @timestamp | Event timestamp. | date |
+| cloud | Fields related to the cloud or infrastructure the events are coming from. | group |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |
 | cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
 | cloud.instance.id | Instance ID of the host machine. | keyword |
 | cloud.instance.name | Instance name of the host machine. | keyword |
 | cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | The cloud project identifier. Examples: Google Cloud Project id, Azure Project id. | keyword |
-| cloud.project.name | The cloud project name. Examples: Google Cloud Project name, Azure Project name. | keyword |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host, resource, or service is located. | keyword |
-| cloud.service.name | The cloud service name is intended to distinguish services running on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs App Engine, Azure VM vs App Server. Examples: app engine, app service, cloud run, fargate, lambda. | keyword |
+| cloud.region | Region in which this host is running. | keyword |
 | container.id | Unique container id. | keyword |
 | container.image.name | Name of the image the container was built on. | keyword |
 | container.labels | Image labels. | object |
@@ -117,12 +116,8 @@ An example event for `compute` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
-| error.code | Error code describing the error. | keyword |
-| error.id | Unique identifier for the error. | keyword |
+| error | These fields can represent errors of any kind. Use them for errors that happen while fetching events or in cases where the event itself contains an error. | group |
 | error.message | Error message. | match_only_text |
-| error.stack_trace | The stack trace of this error in plain text. | wildcard |
-| error.stack_trace.text | Multi-field of `error.stack_trace`. | match_only_text |
-| error.type | The type of the error, for example the class name of the exception. | keyword |
 | event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |
 | gcp.compute.firewall.dropped.bytes | Incoming bytes dropped by the firewall | long |


### PR DESCRIPTION
Revert "Generate documentation for imported external nested fields" (#814)

This reverts commit 6b03219d2c0b373d4639f268c7634d0c0019b7c6.

See https://github.com/elastic/package-spec/issues/331 for more context.