### PR TITLE
Don't import ECS fields of type group

### DIFF
--- a/internal/fields/dependency_manager.go
+++ b/internal/fields/dependency_manager.go
@@ -241,15 +241,6 @@ func transformImportedField(fd FieldDefinition) common.MapStr {
 		m["doc_values"] = *fd.DocValues
 	}
 
-	if len(fd.Fields) > 0 {
-		var t []common.MapStr
-		for _, f := range fd.Fields {
-			i := transformImportedField(f)
-			t = append(t, i)
-		}
-		m.Put("fields", t)
-	}
-
 	if len(fd.MultiFields) > 0 {
 		var t []common.MapStr
 		for _, f := range fd.MultiFields {

--- a/internal/fields/dependency_manager_test.go
+++ b/internal/fields/dependency_manager_test.go
@@ -277,7 +277,7 @@ func TestDependencyManagerInjectExternalFields(t *testing.T) {
 			changed: true,
 		},
 		{
-			title: "import group but not subfields",
+			title: "keep group for docs but not for fields",
 			defs: []common.MapStr{
 				{
 					"name":     "host",
@@ -289,11 +289,6 @@ func TestDependencyManagerInjectExternalFields(t *testing.T) {
 				},
 			},
 			result: []common.MapStr{
-				{
-					"name":        "host",
-					"description": "A general computing instance",
-					"type":        "group",
-				},
 				{
 					"name":        "host.hostname",
 					"description": "Hostname of the host",

--- a/internal/fields/dependency_manager_test.go
+++ b/internal/fields/dependency_manager_test.go
@@ -210,6 +210,99 @@ func TestDependencyManagerInjectExternalFields(t *testing.T) {
 			},
 			valid: false,
 		},
+		{
+			title: "import nested fields",
+			defs: []common.MapStr{
+				{
+					"name":     "host.id",
+					"external": "test",
+				},
+				{
+					"name":     "host.hostname",
+					"external": "test",
+				},
+			},
+			result: []common.MapStr{
+				{
+					"name":        "host.id",
+					"description": "Unique host id",
+					"type":        "keyword",
+				},
+				{
+					"name":        "host.hostname",
+					"description": "Hostname of the host",
+					"type":        "keyword",
+				},
+			},
+			valid:   true,
+			changed: true,
+		},
+		{
+			title: "import nested definitions",
+			defs: []common.MapStr{
+				{
+					"name": "host",
+					"type": "group",
+					"fields": []interface{}{
+						common.MapStr{
+							"name":     "id",
+							"external": "test",
+						},
+						common.MapStr{
+							"name":     "hostname",
+							"external": "test",
+						},
+					},
+				},
+			},
+			result: []common.MapStr{
+				{
+					"name": "host",
+					"type": "group",
+					"fields": []common.MapStr{
+						{
+							"name":        "id",
+							"description": "Unique host id",
+							"type":        "keyword",
+						},
+						{
+							"name":        "hostname",
+							"description": "Hostname of the host",
+							"type":        "keyword",
+						},
+					},
+				},
+			},
+			valid:   true,
+			changed: true,
+		},
+		{
+			title: "import group but not subfields",
+			defs: []common.MapStr{
+				{
+					"name":     "host",
+					"external": "test",
+				},
+				{
+					"name":     "host.hostname",
+					"external": "test",
+				},
+			},
+			result: []common.MapStr{
+				{
+					"name":        "host",
+					"description": "A general computing instance",
+					"type":        "group",
+				},
+				{
+					"name":        "host.hostname",
+					"description": "Hostname of the host",
+					"type":        "keyword",
+				},
+			},
+			valid:   true,
+			changed: true,
+		},
 	}
 
 	indexFalse := false
@@ -252,6 +345,23 @@ func TestDependencyManagerInjectExternalFields(t *testing.T) {
 			Description: "MAC address of the source.",
 			Pattern:     "^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$",
 			Type:        "keyword",
+		},
+		{
+			Name:        "host",
+			Description: "A general computing instance",
+			Type:        "group",
+			Fields: []FieldDefinition{
+				{
+					Name:        "id",
+					Description: "Unique host id",
+					Type:        "keyword",
+				},
+				{
+					Name:        "hostname",
+					Description: "Hostname of the host",
+					Type:        "keyword",
+				},
+			},
 		},
 	}}
 	dm := &DependencyManager{schema: schema}

--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -416,6 +416,8 @@ func (v *Validator) parseElementValue(key string, definition FieldDefinition, va
 		}
 	case "float", "long", "double":
 		_, valid = val.(float64)
+	case "group":
+		return fmt.Errorf("field %q is a group of fields, it cannot store values", key)
 	default:
 		valid = true // all other types are considered valid not blocking validation
 	}

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -228,6 +228,15 @@ func Test_parseElementValue(t *testing.T) {
 			},
 			fail: true,
 		},
+		// fields shouldn't be stored in groups
+		{
+			key:   "host",
+			value: "42",
+			definition: FieldDefinition{
+				Type: "group",
+			},
+			fail: true,
+		},
 	} {
 		v := Validator{disabledDependencyManagement: true}
 		t.Run(test.key, func(t *testing.T) {


### PR DESCRIPTION
`elastic-package build` doesn't import anymore fields of type group, or groups without subfields.

Before this change, it imported fields of type group and all its subfields, what was unexpected (see https://github.com/elastic/package-spec/issues/331).

A check is also added to don't allow to store values in names of fields of type group. 
