### PR TITLE
Permissive validation of arrays of objects

### DIFF
--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -417,7 +417,14 @@ func (v *Validator) parseElementValue(key string, definition FieldDefinition, va
 	case "float", "long", "double":
 		_, valid = val.(float64)
 	case "group":
-		return fmt.Errorf("field %q is a group of fields, it cannot store values", key)
+		switch val.(type) {
+		case map[string]interface{}:
+			// TODO: This is probably an element from an array of objects,
+			// even if not recommended, it should be validated.
+			valid = true
+		default:
+			return fmt.Errorf("field %q is a group of fields, it cannot store values", key)
+		}
 	default:
 		valid = true // all other types are considered valid not blocking validation
 	}

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -237,6 +237,34 @@ func Test_parseElementValue(t *testing.T) {
 			},
 			fail: true,
 		},
+		// arrays of objects can be stored in groups, even if not recommended
+		{
+			key: "host",
+			value: []interface{}{
+				map[string]interface{}{
+					"id":       "somehost-id",
+					"hostname": "somehost",
+				},
+				map[string]interface{}{
+					"id":       "otherhost-id",
+					"hostname": "otherhost",
+				},
+			},
+			definition: FieldDefinition{
+				Name: "host",
+				Type: "group",
+				Fields: []FieldDefinition{
+					{
+						Name: "id",
+						Type: "keyword",
+					},
+					{
+						Name: "hostname",
+						Type: "keyword",
+					},
+				},
+			},
+		},
 	} {
 		v := Validator{disabledDependencyManagement: true}
 		t.Run(test.key, func(t *testing.T) {


### PR DESCRIPTION
Some integrations are storing arrays of objects in group types. This is
valid, even if not recommended. Be permissive on these cases by now.

Changes in #818 breaks validation of fields in some integrations that
store arrays of objects (https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations%2FPR-3348/detail/PR-3348/1/tests/).