### PR TITLE
Allow multicast and broadcast IPs in test documents

### DIFF
--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -451,7 +451,13 @@ func (v *Validator) isAllowedIPValue(s string) bool {
 		}
 	}
 
-	if ip.IsUnspecified() || ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+	if ip.IsUnspecified() ||
+		ip.IsPrivate() ||
+		ip.IsLoopback() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.Equal(net.IPv4bcast) {
 		return true
 	}
 

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -216,6 +216,34 @@ func Test_parseElementValue(t *testing.T) {
 			},
 		},
 		{
+			key:   "unspecified ipv4",
+			value: "0.0.0.0",
+			definition: FieldDefinition{
+				Type: "ip",
+			},
+		},
+		{
+			key:   "ipv4 broadcast address",
+			value: "255.255.255.255",
+			definition: FieldDefinition{
+				Type: "ip",
+			},
+		},
+		{
+			key:   "ipv6 min multicast",
+			value: "ff00::",
+			definition: FieldDefinition{
+				Type: "ip",
+			},
+		},
+		{
+			key:   "ipv6 max multicast",
+			value: "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+			definition: FieldDefinition{
+				Type: "ip",
+			},
+		},
+		{
 			key:   "abbreviated ipv6 in allowed list with leading 0",
 			value: "2a02:cf40:0add:0::1",
 			definition: FieldDefinition{


### PR DESCRIPTION
Another fix for #826.