### PR TITLE
Check values in arrays

### DIFF
--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -352,85 +352,83 @@ func compareKeys(key string, def FieldDefinition, searchedKey string) bool {
 }
 
 func (v *Validator) parseElementValue(key string, definition FieldDefinition, val interface{}) error {
-	val, ok := ensureSingleElementValue(val)
-	if !ok {
-		return nil // it's an array, but it's not possible to extract the single value.
-	}
+	return forEachElementValue(val, func(val interface{}) error {
+		var valid bool
+		switch definition.Type {
+		case "constant_keyword":
+			var valStr string
+			valStr, valid = val.(string)
+			if !valid {
+				break
+			}
 
-	var valid bool
-	switch definition.Type {
-	case "constant_keyword":
-		var valStr string
-		valStr, valid = val.(string)
-		if !valid {
-			break
-		}
-
-		if err := ensureConstantKeywordValueMatches(key, valStr, definition.Value); err != nil {
-			return err
-		}
-		if err := ensurePatternMatches(key, valStr, definition.Pattern); err != nil {
-			return err
-		}
-	case "keyword", "text":
-		var valStr string
-		valStr, valid = val.(string)
-		if !valid {
-			break
-		}
-
-		if err := ensurePatternMatches(key, valStr, definition.Pattern); err != nil {
-			return err
-		}
-	case "date":
-		switch val := val.(type) {
-		case string:
-			if err := ensurePatternMatches(key, val, definition.Pattern); err != nil {
+			if err := ensureConstantKeywordValueMatches(key, valStr, definition.Value); err != nil {
 				return err
 			}
-			valid = true
-		case float64:
-			// date as seconds or milliseconds since epoch
-			if definition.Pattern != "" {
-				return fmt.Errorf("numeric date in field %q, but pattern defined", key)
+			if err := ensurePatternMatches(key, valStr, definition.Pattern); err != nil {
+				return err
 			}
-			valid = true
+		case "keyword", "text":
+			var valStr string
+			valStr, valid = val.(string)
+			if !valid {
+				break
+			}
+
+			if err := ensurePatternMatches(key, valStr, definition.Pattern); err != nil {
+				return err
+			}
+		case "date":
+			switch val := val.(type) {
+			case string:
+				if err := ensurePatternMatches(key, val, definition.Pattern); err != nil {
+					return err
+				}
+				valid = true
+			case float64:
+				// date as seconds or milliseconds since epoch
+				if definition.Pattern != "" {
+					return fmt.Errorf("numeric date in field %q, but pattern defined", key)
+				}
+				valid = true
+			default:
+				valid = false
+			}
+		case "ip":
+			var valStr string
+			valStr, valid = val.(string)
+			if !valid {
+				break
+			}
+
+			if err := ensurePatternMatches(key, valStr, definition.Pattern); err != nil {
+				return err
+			}
+
+			if v.enabledAllowedIPCheck && !v.isAllowedIPValue(valStr) {
+				return fmt.Errorf("the IP %q is not one of the allowed test IPs (see: https://github.com/elastic/elastic-package/blob/main/internal/fields/_static/allowed_geo_ips.txt)", valStr)
+			}
+		case "group":
+			switch val.(type) {
+			case map[string]interface{}:
+				// TODO: This is probably an element from an array of objects,
+				// even if not recommended, it should be validated.
+				valid = true
+			default:
+				return fmt.Errorf("field %q is a group of fields, it cannot store values", key)
+			}
+		case "float", "long", "double":
+			_, valid = val.(float64)
 		default:
-			valid = false
+			valid = true // all other types are considered valid not blocking validation
 		}
-	case "ip":
-		var valStr string
-		valStr, valid = val.(string)
+
 		if !valid {
-			break
+			return fmt.Errorf("field %q's Go type, %T, does not match the expected field type: %s (field value: %v)", key, val, definition.Type, val)
 		}
 
-		if err := ensurePatternMatches(key, valStr, definition.Pattern); err != nil {
-			return err
-		}
-
-		if v.enabledAllowedIPCheck && !v.isAllowedIPValue(valStr) {
-			return fmt.Errorf("the IP %q is not one of the allowed test IPs (see: https://github.com/elastic/elastic-package/blob/main/internal/fields/_static/allowed_geo_ips.txt)", valStr)
-		}
-	case "float", "long", "double":
-		_, valid = val.(float64)
-	case "group":
-		switch val.(type) {
-		case map[string]interface{}:
-			// TODO: This is probably an element from an array of objects,
-			// even if not recommended, it should be validated.
-			valid = true
-		default:
-			return fmt.Errorf("field %q is a group of fields, it cannot store values", key)
-		}
-	default:
-		valid = true // all other types are considered valid not blocking validation
-	}
-
-	if !valid {
-		return fmt.Errorf("field %q's Go type, %T, does not match the expected field type: %s (field value: %v)", key, val, definition.Type, val)
-	}
-	return nil
+		return nil
+	})
 }
 
 // isAllowedIPValue checks if the provided IP is allowed for testing
@@ -464,17 +462,20 @@ func (v *Validator) isAllowedIPValue(s string) bool {
 	return false
 }
 
-// ensureSingleElementValue extracts single entity from a potential array, which is a valid field representation
-// in Elasticsearch. For type assertion we need a single value.
-func ensureSingleElementValue(val interface{}) (interface{}, bool) {
+// forEachElementValue visits a function for each element in the given value if
+// it is an array. If it is not an array, it calls the function with it.
+func forEachElementValue(val interface{}, fn func(interface{}) error) error {
 	arr, isArray := val.([]interface{})
 	if !isArray {
-		return val, true
+		return fn(val)
 	}
-	if len(arr) > 0 {
-		return arr[0], true
+	for _, element := range arr {
+		err := fn(element)
+		if err != nil {
+			return err
+		}
 	}
-	return nil, false // false: empty array, can't deduce single value type
+	return nil
 }
 
 // ensurePatternMatches validates the document's field value matches the field

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -98,7 +98,7 @@ func Test_parseElementValue(t *testing.T) {
 		definition FieldDefinition
 		fail       bool
 	}{
-		// Arrays (only first value checked)
+		// Arrays
 		{
 			key:   "string array to keyword",
 			value: []interface{}{"hello", "world"},
@@ -109,6 +109,14 @@ func Test_parseElementValue(t *testing.T) {
 		{
 			key:   "numeric string array to long",
 			value: []interface{}{"123", "42"},
+			definition: FieldDefinition{
+				Type: "long",
+			},
+			fail: true,
+		},
+		{
+			key:   "mixed numbers and strings in number array",
+			value: []interface{}{123, "hi"},
 			definition: FieldDefinition{
 				Type: "long",
 			},


### PR DESCRIPTION
Add validation for all values in arrays.

This is needed when some validation of the values is desired, apart of type validation. This is the case with IPs (https://github.com/elastic/integrations/issues/3408) or event types (https://github.com/elastic/elastic-package/issues/615#issuecomment-1021884406).

This change was part of https://github.com/elastic/elastic-package/pull/771, but this is being delayed due to https://github.com/elastic/integrations/issues/3016.