### PR TITLE
Allow cancellation of clean-up wait

### DIFF
--- a/internal/signal/sigint.go
+++ b/internal/signal/sigint.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/elastic/elastic-package/internal/logger"
 )
@@ -28,5 +29,17 @@ func SIGINT() bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// Sleep is the equivalent of time.Sleep with the exception
+// that is will end the sleep if ctrl+c is pressed.
+func Sleep(d time.Duration) {
+	timer := time.NewTimer(d)
+	select {
+	case <-ch:
+		logger.Info("Signal caught!")
+		timer.Stop()
+	case <-timer.C:
 	}
 }

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -21,6 +21,7 @@ import (
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/multierror"
 	"github.com/elastic/elastic-package/internal/packages"
+	"github.com/elastic/elastic-package/internal/signal"
 	"github.com/elastic/elastic-package/internal/testrunner"
 )
 
@@ -58,7 +59,7 @@ func (r *runner) Run(options testrunner.TestOptions) ([]testrunner.TestResult, e
 func (r *runner) TearDown() error {
 	if r.options.DeferCleanup > 0 {
 		logger.Debugf("Waiting for %s before cleanup...", r.options.DeferCleanup)
-		time.Sleep(r.options.DeferCleanup)
+		signal.Sleep(r.options.DeferCleanup)
 	}
 
 	err := uninstallIngestPipelines(r.options.API, r.pipelines)

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -95,7 +95,7 @@ func (r *runner) TearDown() error {
 func (r *runner) tearDownTest() error {
 	if r.options.DeferCleanup > 0 {
 		logger.Debugf("waiting for %s before tearing down...", r.options.DeferCleanup)
-		time.Sleep(r.options.DeferCleanup)
+		signal.Sleep(r.options.DeferCleanup)
 	}
 
 	if r.resetAgentPolicyHandler != nil {
@@ -437,7 +437,6 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 		docs, err = r.getDocs(dataStream)
 		return len(docs) > 0, err
 	}, waitForDataTimeout)
-
 	if err != nil {
 		return result.WithError(err)
 	}


### PR DESCRIPTION
This allows waits to hear signals and uses this capacity in deferred clean-up waits.

Please take a look.