### PR TITLE
Print kibana and elasticsearch information on boot-up

### DIFF
--- a/internal/stack/boot.go
+++ b/internal/stack/boot.go
@@ -59,6 +59,7 @@ func BootUp(options Options) error {
 	if err != nil {
 		return errors.Wrap(err, "running docker-compose failed")
 	}
+
 	return nil
 }
 

--- a/internal/stack/initconfig.go
+++ b/internal/stack/initconfig.go
@@ -1,0 +1,77 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package stack
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+
+	"github.com/elastic/elastic-package/internal/compose"
+	"github.com/elastic/elastic-package/internal/install"
+	"github.com/elastic/elastic-package/internal/profile"
+)
+
+type InitConfig struct {
+	ElasticsearchHostPort string
+	ElasticsearchUsername string
+	ElasticsearchPassword string
+	KibanaHostPort        string
+}
+
+func StackInitConfig(elasticStackProfile *profile.Profile) (*InitConfig, error) {
+	// Read Elasticsearch username and password from Kibana configuration file.
+	// FIXME read credentials from correct Kibana config file, not default
+	body, err := os.ReadFile(elasticStackProfile.FetchPath(profile.KibanaConfigDefaultFile))
+	if err != nil {
+		return nil, errors.Wrap(err, "error reading Kibana config file")
+	}
+
+	var kibanaCfg struct {
+		ElasticsearchUsername string `yaml:"elasticsearch.username"`
+		ElasticsearchPassword string `yaml:"elasticsearch.password"`
+	}
+	err = yaml.Unmarshal(body, &kibanaCfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshalling Kibana configuration failed")
+	}
+
+	// Read Elasticsearch and Kibana hostnames from Elastic Stack Docker Compose configuration file.
+	p, err := compose.NewProject(DockerComposeProjectName, elasticStackProfile.FetchPath(profile.SnapshotFile))
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create docker compose project")
+	}
+
+	appConfig, err := install.Configuration()
+	if err != nil {
+		return nil, errors.Wrap(err, "can't read application configuration")
+	}
+
+	serviceComposeConfig, err := p.Config(compose.CommandOptions{
+		Env: newEnvBuilder().
+			withEnvs(appConfig.StackImageRefs(install.DefaultStackVersion).AsEnv()).
+			withEnvs(elasticStackProfile.ComposeEnvVars()).
+			withEnv(stackVariantAsEnv(install.DefaultStackVersion)).
+			build(),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get Docker Compose configuration for service")
+	}
+
+	kib := serviceComposeConfig.Services["kibana"]
+	kibHostPort := fmt.Sprintf("http://%s:%d", kib.Ports[0].ExternalIP, kib.Ports[0].ExternalPort)
+
+	es := serviceComposeConfig.Services["elasticsearch"]
+	esHostPort := fmt.Sprintf("http://%s:%d", es.Ports[0].ExternalIP, es.Ports[0].ExternalPort)
+
+	return &InitConfig{
+		ElasticsearchHostPort: esHostPort,
+		ElasticsearchUsername: kibanaCfg.ElasticsearchUsername,
+		ElasticsearchPassword: kibanaCfg.ElasticsearchPassword,
+		KibanaHostPort:        kibHostPort,
+	}, nil
+}

--- a/internal/stack/shellinit.go
+++ b/internal/stack/shellinit.go
@@ -6,13 +6,7 @@ package stack
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/pkg/errors"
-	"gopkg.in/yaml.v3"
-
-	"github.com/elastic/elastic-package/internal/compose"
-	"github.com/elastic/elastic-package/internal/install"
 	"github.com/elastic/elastic-package/internal/profile"
 )
 
@@ -32,57 +26,16 @@ var (
 var shellInitFormat = "export " + ElasticsearchHostEnv + "=%s\nexport " + ElasticsearchUsernameEnv + "=%s\nexport " +
 	ElasticsearchPasswordEnv + "=%s\nexport " + KibanaHostEnv + "=%s"
 
-type kibanaConfiguration struct {
-	ElasticsearchUsername string `yaml:"elasticsearch.username"`
-	ElasticsearchPassword string `yaml:"elasticsearch.password"`
-}
-
 // ShellInit method exposes environment variables that can be used for testing purposes.
 func ShellInit(elasticStackProfile *profile.Profile) (string, error) {
-	// Read Elasticsearch username and password from Kibana configuration file.
-	// FIXME read credentials from correct Kibana config file, not default
-	body, err := os.ReadFile(elasticStackProfile.FetchPath(profile.KibanaConfigDefaultFile))
+	config, err := StackInitConfig(elasticStackProfile)
 	if err != nil {
-		return "", errors.Wrap(err, "error reading Kibana config file")
+		return "", nil
 	}
-
-	var kibanaCfg kibanaConfiguration
-	err = yaml.Unmarshal(body, &kibanaCfg)
-	if err != nil {
-		return "", errors.Wrap(err, "unmarshalling Kibana configuration failed")
-	}
-
-	// Read Elasticsearch and Kibana hostnames from Elastic Stack Docker Compose configuration file.
-	p, err := compose.NewProject(DockerComposeProjectName, elasticStackProfile.FetchPath(profile.SnapshotFile))
-	if err != nil {
-		return "", errors.Wrap(err, "could not create docker compose project")
-	}
-
-	appConfig, err := install.Configuration()
-	if err != nil {
-		return "", errors.Wrap(err, "can't read application configuration")
-	}
-
-	serviceComposeConfig, err := p.Config(compose.CommandOptions{
-		Env: newEnvBuilder().
-			withEnvs(appConfig.StackImageRefs(install.DefaultStackVersion).AsEnv()).
-			withEnvs(elasticStackProfile.ComposeEnvVars()).
-			withEnv(stackVariantAsEnv(install.DefaultStackVersion)).
-			build(),
-	})
-	if err != nil {
-		return "", errors.Wrap(err, "could not get Docker Compose configuration for service")
-	}
-
-	kib := serviceComposeConfig.Services["kibana"]
-	kibHostPort := fmt.Sprintf("http://%s:%d", kib.Ports[0].ExternalIP, kib.Ports[0].ExternalPort)
-
-	es := serviceComposeConfig.Services["elasticsearch"]
-	esHostPort := fmt.Sprintf("http://%s:%d", es.Ports[0].ExternalIP, es.Ports[0].ExternalPort)
 
 	return fmt.Sprintf(shellInitFormat,
-		esHostPort,
-		kibanaCfg.ElasticsearchUsername,
-		kibanaCfg.ElasticsearchPassword,
-		kibHostPort), nil
+		config.ElasticsearchHostPort,
+		config.ElasticsearchUsername,
+		config.ElasticsearchPassword,
+		config.KibanaHostPort), nil
 }


### PR DESCRIPTION
Print kibana and elasticsearch information on `elastic-package stack up` output, so users know what endpoints to use to reach these services. This is the same information as the available in `elastic-package shellinit`, but in a more human-friendly format.

Done in the context of https://github.com/elastic/elastic-package/pull/789, so users know that they have to use https when this change is applied.

This is the output now:
```
Boot up the Elastic stack
Using profile /home/jaime/.elastic-package/profiles/default.
Remember to load stack environment variables using 'eval "$(elastic-package stack shellinit)"'.
Packages from the following directories will be loaded into the package-registry:
- built-in packages (package-storage:snapshot Docker image)
Elasticsearch host: http://127.0.0.1:9200
Kibana host: http://127.0.0.1:5601
Username: elastic
Password: changeme
Done
```