### PR TITLE
Check values against list of expected values

### DIFF
--- a/internal/fields/model.go
+++ b/internal/fields/model.go
@@ -15,19 +15,20 @@ import (
 
 // FieldDefinition describes a single field with its properties.
 type FieldDefinition struct {
-	Name          string            `yaml:"name"`
-	Description   string            `yaml:"description"`
-	Type          string            `yaml:"type"`
-	Value         string            `yaml:"value"` // The value to associate with a constant_keyword field.
-	AllowedValues AllowedValues     `yaml:"allowed_values"`
-	Pattern       string            `yaml:"pattern"`
-	Unit          string            `yaml:"unit"`
-	MetricType    string            `yaml:"metric_type"`
-	External      string            `yaml:"external"`
-	Index         *bool             `yaml:"index"`
-	DocValues     *bool             `yaml:"doc_values"`
-	Fields        FieldDefinitions  `yaml:"fields,omitempty"`
-	MultiFields   []FieldDefinition `yaml:"multi_fields,omitempty"`
+	Name           string            `yaml:"name"`
+	Description    string            `yaml:"description"`
+	Type           string            `yaml:"type"`
+	Value          string            `yaml:"value"` // The value to associate with a constant_keyword field.
+	AllowedValues  AllowedValues     `yaml:"allowed_values"`
+	ExpectedValues []string          `yaml:"expected_values"`
+	Pattern        string            `yaml:"pattern"`
+	Unit           string            `yaml:"unit"`
+	MetricType     string            `yaml:"metric_type"`
+	External       string            `yaml:"external"`
+	Index          *bool             `yaml:"index"`
+	DocValues      *bool             `yaml:"doc_values"`
+	Fields         FieldDefinitions  `yaml:"fields,omitempty"`
+	MultiFields    []FieldDefinition `yaml:"multi_fields,omitempty"`
 }
 
 func (orig *FieldDefinition) Update(fd FieldDefinition) {
@@ -45,6 +46,9 @@ func (orig *FieldDefinition) Update(fd FieldDefinition) {
 	}
 	if len(fd.AllowedValues) > 0 {
 		orig.AllowedValues = fd.AllowedValues
+	}
+	if len(fd.ExpectedValues) > 0 {
+		orig.ExpectedValues = fd.ExpectedValues
 	}
 	if fd.Pattern != "" {
 		orig.Pattern = fd.Pattern

--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -391,7 +391,7 @@ func (v *Validator) parseSingleElementValue(key string, definition FieldDefiniti
 		if err := ensurePatternMatches(key, valStr, definition.Pattern); err != nil {
 			return err
 		}
-		if err := ensureAllowedValues(key, valStr, definition.AllowedValues); err != nil {
+		if err := ensureAllowedValues(key, valStr, definition); err != nil {
 			return err
 		}
 	// Normal text fields should be of type string.
@@ -405,7 +405,7 @@ func (v *Validator) parseSingleElementValue(key string, definition FieldDefiniti
 		if err := ensurePatternMatches(key, valStr, definition.Pattern); err != nil {
 			return err
 		}
-		if err := ensureAllowedValues(key, valStr, definition.AllowedValues); err != nil {
+		if err := ensureAllowedValues(key, valStr, definition); err != nil {
 			return err
 		}
 	// Dates are expected to be formatted as strings or as seconds or milliseconds
@@ -540,9 +540,12 @@ func ensureConstantKeywordValueMatches(key, value, constantKeywordValue string) 
 
 // ensureAllowedValues validates that the document's field value
 // is one of the allowed values.
-func ensureAllowedValues(key, value string, allowedValues AllowedValues) error {
-	if !allowedValues.IsAllowed(value) {
-		return fmt.Errorf("field %q's value %q is not one of the allowed values (%s)", key, value, strings.Join(allowedValues.Values(), ", "))
+func ensureAllowedValues(key, value string, definition FieldDefinition) error {
+	if !definition.AllowedValues.IsAllowed(value) {
+		return fmt.Errorf("field %q's value %q is not one of the allowed values (%s)", key, value, strings.Join(definition.AllowedValues.Values(), ", "))
+	}
+	if e := definition.ExpectedValues; len(e) > 0 && !common.StringSliceContains(e, value) {
+		return fmt.Errorf("field %q's value %q is not one of the expected values (%s)", key, value, strings.Join(e, ", "))
 	}
 	return nil
 }

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -348,6 +348,24 @@ func Test_parseElementValue(t *testing.T) {
 			},
 			fail: true,
 		},
+		// expected values
+		{
+			key:   "expected values",
+			value: "linux",
+			definition: FieldDefinition{
+				Type:           "keyword",
+				ExpectedValues: []string{"linux", "windows"},
+			},
+		},
+		{
+			key:   "not expected values",
+			value: "bsd",
+			definition: FieldDefinition{
+				Type:           "keyword",
+				ExpectedValues: []string{"linux", "windows"},
+			},
+			fail: true,
+		},
 		// fields shouldn't be stored in groups
 		{
 			key:   "host",


### PR DESCRIPTION
Since https://github.com/elastic/ecs/pull/1952, ECS fields can contain a list of expected values.

Check that imported fields comply with these values.

Similar to https://github.com/elastic/elastic-package/pull/771, but for `expected_values`.

It won't affect current integrations because no ECS version has been released yet with `expected_values`.

Fixes https://github.com/elastic/elastic-package/issues/864.