### PR TITLE
Add linux/amd64 platform specification to Terraform deployer Dockerfile

### DIFF
--- a/internal/install/_static/Dockerfile.terraform_deployer
+++ b/internal/install/_static/Dockerfile.terraform_deployer
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM --platform=linux/amd64 ubuntu:20.04
 ENV GCLOUD_SDK_VERSION 370.0.0-0
 ENV TERRAFORM_VERSION 1.1.4
 


### PR DESCRIPTION
System tests using the Terraform deployer fail on M1 Macbooks, due to the change of architecture from intel/x86 to M1/ARM. 

The installation of the google cloud SDK within the container fails with the following error:
```
#6 13.66 Preparing to unpack .../google-cloud-sdk_370.0.0-0_all.deb ...
#6 13.66 Unpacking google-cloud-sdk (370.0.0-0) ...
#6 22.80 Setting up google-cloud-sdk (370.0.0-0) ...
#6 22.81 qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
#6 22.81 dpkg: error processing package google-cloud-sdk (--configure):
```

The reason is that, since no platform version is specifically defined, an ARM-related image is downloaded, and they do not have that library (see also https://stackoverflow.com/a/71611002 for reference)

Forcing linux/amd64 as platform version in the Dockerfile fixes the issue. 