### PR TITLE
Add docs to avoid issues with CRLF line endings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cd elastic-package
 make build
 ```
 
-When developing on Windows, please use the `core.autocrlf=input` option to avoid issues with CRLF line endings:
+When developing on Windows, please use the `core.autocrlf=input` or `core.autocrlf=false` option to avoid issues with CRLF line endings:
 ```bash
 git clone --config core.autocrlf=input https://github.com/elastic/elastic-package.git
 cd elastic-package

--- a/README.md
+++ b/README.md
@@ -42,7 +42,23 @@ Download and build the latest main of `elastic-package` binary:
 
 ```bash
 git clone https://github.com/elastic/elastic-package.git
+cd elastic-package
 make build
+```
+
+When developing on Windows, please use the `core.autocrlf=input` option to avoid issues with CRLF line endings:
+```bash
+git clone --config core.autocrlf=input https://github.com/elastic/elastic-package.git
+cd elastic-package
+make build
+```
+
+This option can be also configured on existing clones with the following commands. Be aware that these commands
+will remove uncommited changes.
+```bash
+git config core.autocrlf input
+git rm --cached -r .
+git reset --hard
 ```
 
 ## Commands

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -42,7 +42,23 @@ Download and build the latest main of `elastic-package` binary:
 
 ```bash
 git clone https://github.com/elastic/elastic-package.git
+cd elastic-package
 make build
+```
+
+When developing on Windows, please use the `core.autocrlf=input` or `core.autocrlf=false` option to avoid issues with CRLF line endings:
+```bash
+git clone --config core.autocrlf=input https://github.com/elastic/elastic-package.git
+cd elastic-package
+make build
+```
+
+This option can be also configured on existing clones with the following commands. Be aware that these commands
+will remove uncommited changes.
+```bash
+git config core.autocrlf input
+git rm --cached -r .
+git reset --hard
 ```
 
 ## Commands


### PR DESCRIPTION
When developing on Windows you may face issues because of CRLF line endings:
* If `core.autocrlf=true` is enabled in git (common in Windows), files included in binaries with `embed` may include CRLF line endings, causing issues when used in docker scenarios.
* If it is disabled, with `core.autocrlf=false` (usual default), file editors in Windows may add CRLF line endings in files.

With `core.autocrlf=input` git doesn't include CRLF when checking out files, and it removes the carriage return when commiting files, avoiding the unexpected presence of CRLF line endings.

For example, this issue was found when running the Kibana healthcheck with an `elastic-package` binary built on Windows:
```
$ bash -x healthcheck.sh
+ $'\r'
healthcheck.sh: line 2: $'\r': command not found
+ set $'-e\r'
: invalid optionline 3: set: -
...
```