### PR TITLE
Include licenses in packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -152,3 +152,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/elastic/package-spec => github.com/elastic/package-spec v1.12.2-0.20220629092545-9ee240e557a5

--- a/go.sum
+++ b/go.sum
@@ -414,8 +414,8 @@ github.com/elastic/go-ucfg v0.8.6 h1:stUeyh2goTgGX+/wb9gzKvTv0YB0231LTpKUgCKj4U0
 github.com/elastic/go-ucfg v0.8.6/go.mod h1:4E8mPOLSUV9hQ7sgLEJ4bvt0KhMuDJa8joDT2QGAEKA=
 github.com/elastic/gojsonschema v1.2.1 h1:cUMbgsz0wyEB4x7xf3zUEvUVDl6WCz2RKcQPul8OsQc=
 github.com/elastic/gojsonschema v1.2.1/go.mod h1:biw5eBS2Z4T02wjATMRSfecfjCmwaDPvuaqf844gLrg=
-github.com/elastic/package-spec v1.12.1 h1:L/DNYJ+QIjN0PDYpgVXhmB0zDXI+T0N84b7/bzimq0E=
-github.com/elastic/package-spec v1.12.1/go.mod h1:423uVkiND51q9oAhlXPxp5vmdUZ3D0bqWf9+idM0yu0=
+github.com/elastic/package-spec v1.12.2-0.20220629092545-9ee240e557a5 h1:UYdpfTCvKrtf5QDwr/Y2OFMGt+/u/ILW7K3Mq1YSSns=
+github.com/elastic/package-spec v1.12.2-0.20220629092545-9ee240e557a5/go.mod h1:423uVkiND51q9oAhlXPxp5vmdUZ3D0bqWf9+idM0yu0=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/internal/builder/packages.go
+++ b/internal/builder/packages.go
@@ -71,18 +71,14 @@ func findBuildDirectory() (string, bool, error) {
 }
 
 // BuildPackagesDirectory function locates the target build directory for the package.
-func BuildPackagesDirectory(packageRoot string) (string, error) {
-	buildDir, err := buildPackagesRootDirectory()
-	if err != nil {
-		return "", errors.Wrap(err, "can't locate build packages root directory")
+func BuildPackagesDirectory(buildDir, packageRoot string) (string, error) {
+	var err error
+	if buildDir == "" {
+		buildDir, err = buildPackagesRootDirectory()
+		if err != nil {
+			return "", errors.Wrap(err, "can't locate build packages root directory")
+		}
 	}
-
-	return buildPackagesDirectory(buildDir, packageRoot)
-}
-
-// buildPackagesDirectory is used internaly to locate the target build directory for a package
-// inside a given build directory.
-func buildPackagesDirectory(buildDir, packageRoot string) (string, error) {
 	m, err := packages.ReadPackageManifestFromPackageRoot(packageRoot)
 	if err != nil {
 		return "", errors.Wrapf(err, "reading package manifest failed (path: %s)", packageRoot)
@@ -152,18 +148,9 @@ func FindBuildPackagesDirectory() (string, bool, error) {
 
 // BuildPackage function builds the package.
 func BuildPackage(options BuildOptions) (string, error) {
-	var err error
-	var destinationDir string
-	if options.buildDir == "" {
-		destinationDir, err = BuildPackagesDirectory(options.PackageRoot)
-		if err != nil {
-			return "", errors.Wrap(err, "can't locate build directory")
-		}
-	} else {
-		destinationDir, err = buildPackagesDirectory(options.buildDir, options.PackageRoot)
-		if err != nil {
-			return "", errors.Wrap(err, "can't locate build directory")
-		}
+	destinationDir, err := BuildPackagesDirectory(options.buildDir, options.PackageRoot)
+	if err != nil {
+		return "", errors.Wrap(err, "can't locate build directory")
 	}
 	logger.Debugf("Build directory: %s\n", destinationDir)
 

--- a/internal/builder/packages.go
+++ b/internal/builder/packages.go
@@ -14,6 +14,7 @@ import (
 	"github.com/elastic/package-spec/code/go/pkg/validator"
 
 	"github.com/elastic/elastic-package/internal/files"
+	"github.com/elastic/elastic-package/internal/licenses"
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/packages"
 )
@@ -148,6 +149,18 @@ func BuildPackage(options BuildOptions) (string, error) {
 	err = files.ClearDir(destinationDir)
 	if err != nil {
 		return "", errors.Wrap(err, "clearing package contents failed")
+	}
+
+	m, err := packages.ReadPackageManifestFromPackageRoot(options.PackageRoot)
+	if err != nil {
+		return "", errors.Wrapf(err, "reading package manifest failed (path: %s)", options.PackageRoot)
+	}
+	if license := m.Source.License; license != "" {
+		logger.Debugf("Write license text for %q", license)
+		err := licenses.WriteTextToFile(license, filepath.Join(destinationDir, "LICENSE.txt"))
+		if err != nil {
+			return "", errors.Wrap(err, "writing license text failed")
+		}
 	}
 
 	logger.Debugf("Copy package content (source: %s)", options.PackageRoot)

--- a/internal/builder/packages_test.go
+++ b/internal/builder/packages_test.go
@@ -25,11 +25,11 @@ func TestLicensesOnBuiltPackage(t *testing.T) {
 		t.Run(path.Base(packageRoot), func(t *testing.T) {
 			options := BuildOptions{
 				PackageRoot: packageRoot,
-				buildDir:    t.TempDir(),
 			}
-			buildPath, err := BuildPackage(options)
+			buildDir := t.TempDir()
+			buildPath, err := buildPackageWithBuildDir(options, buildDir)
 			require.NoError(t, err)
-			assertRelativePath(t, options.buildDir, buildPath)
+			assertRelativePath(t, buildDir, buildPath)
 			assert.FileExists(t, filepath.Join(buildPath, "LICENSE.txt"))
 		})
 
@@ -37,11 +37,11 @@ func TestLicensesOnBuiltPackage(t *testing.T) {
 			options := BuildOptions{
 				PackageRoot: packageRoot,
 				CreateZip:   true,
-				buildDir:    t.TempDir(),
 			}
-			buildPath, err := BuildPackage(options)
+			buildDir := t.TempDir()
+			buildPath, err := buildPackageWithBuildDir(options, buildDir)
 			require.NoError(t, err)
-			assertRelativePath(t, options.buildDir, buildPath)
+			assertRelativePath(t, buildDir, buildPath)
 
 			r, err := zip.OpenReader(buildPath)
 			require.NoError(t, err)

--- a/internal/builder/packages_test.go
+++ b/internal/builder/packages_test.go
@@ -1,0 +1,62 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package builder
+
+import (
+	"archive/zip"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLicensesOnBuiltPackage(t *testing.T) {
+	packagePaths := []string{
+		"../../test/packages/parallel/apache",
+		"../../test/packages/other/sql_input",
+	}
+
+	for _, packageRoot := range packagePaths {
+		t.Run(path.Base(packageRoot), func(t *testing.T) {
+			options := BuildOptions{
+				PackageRoot: packageRoot,
+				buildDir:    t.TempDir(),
+			}
+			buildPath, err := BuildPackage(options)
+			require.NoError(t, err)
+			assertRelativePath(t, options.buildDir, buildPath)
+			assert.FileExists(t, filepath.Join(buildPath, "LICENSE.txt"))
+		})
+
+		t.Run(path.Base(packageRoot)+".zip", func(t *testing.T) {
+			options := BuildOptions{
+				PackageRoot: packageRoot,
+				CreateZip:   true,
+				buildDir:    t.TempDir(),
+			}
+			buildPath, err := BuildPackage(options)
+			require.NoError(t, err)
+			assertRelativePath(t, options.buildDir, buildPath)
+
+			r, err := zip.OpenReader(buildPath)
+			require.NoError(t, err)
+			defer r.Close()
+
+			rootDir := strings.TrimSuffix(filepath.Base(buildPath), ".zip")
+			f, err := r.Open(path.Join(rootDir, "LICENSE.txt"))
+			require.NoError(t, err)
+			defer f.Close()
+		})
+	}
+}
+
+func assertRelativePath(t *testing.T, basepath, path string) {
+	t.Helper()
+	isRelativePath := strings.HasPrefix(filepath.Clean(path), filepath.Clean(basepath))
+	assert.Truef(t, isRelativePath, "%q should be a path under %q", path, basepath)
+}

--- a/internal/docs/readme.go
+++ b/internal/docs/readme.go
@@ -117,7 +117,7 @@ func updateReadme(fileName, packageRoot string) (string, error) {
 		return "", errors.Wrapf(err, "writing %s file failed", fileName)
 	}
 
-	packageBuildRoot, err := builder.BuildPackagesDirectory(packageRoot)
+	packageBuildRoot, err := builder.BuildPackagesDirectory("", packageRoot)
 	if err != nil {
 		return "", errors.Wrap(err, "package build root not found")
 	}

--- a/internal/docs/readme.go
+++ b/internal/docs/readme.go
@@ -117,7 +117,7 @@ func updateReadme(fileName, packageRoot string) (string, error) {
 		return "", errors.Wrapf(err, "writing %s file failed", fileName)
 	}
 
-	packageBuildRoot, err := builder.BuildPackagesDirectory("", packageRoot)
+	packageBuildRoot, err := builder.BuildPackagesDirectory(packageRoot)
 	if err != nil {
 		return "", errors.Wrap(err, "package build root not found")
 	}

--- a/internal/licenses/_static/Apache-2.0.txt
+++ b/internal/licenses/_static/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/internal/licenses/_static/Elastic-2.0.txt
+++ b/internal/licenses/_static/Elastic-2.0.txt
@@ -1,0 +1,93 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/internal/licenses/licenses.go
+++ b/internal/licenses/licenses.go
@@ -1,0 +1,57 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package licenses
+
+import (
+	_ "embed"
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	// Licenses supported by package-spec, as specified in https://spdx.org/licenses/
+	Apache20  = "Apache-2.0"
+	Elastic20 = "Elastic-2.0"
+)
+
+//go:embed _static/Apache-2.0.txt
+var apache20text []byte
+
+//go:embed _static/Elastic-2.0.txt
+var elastic20text []byte
+
+func getText(license string) ([]byte, error) {
+	switch license {
+	case Apache20:
+		return apache20text, nil
+	case Elastic20:
+		return elastic20text, nil
+	}
+	return nil, fmt.Errorf("unknown license %q", license)
+}
+
+// WriteText writes the text of a license to the given writer.
+func WriteText(license string, w io.Writer) error {
+	text, err := getText(license)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(text)
+	if err != nil {
+		return fmt.Errorf("failed to write license text: %w", err)
+	}
+	return nil
+}
+
+// WriteTextToFile writes the text of a license to a file in the given path.
+func WriteTextToFile(license string, path string) error {
+	w, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create license file (%q): %w", path, err)
+	}
+	defer w.Close()
+	return WriteText(license, w)
+}

--- a/internal/licenses/licenses_test.go
+++ b/internal/licenses/licenses_test.go
@@ -1,0 +1,46 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package licenses
+
+import (
+	"bytes"
+	_ "embed"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteText(t *testing.T) {
+	cases := []struct {
+		license  string
+		expected []byte
+		fail     bool
+	}{
+		{
+			license:  Apache20,
+			expected: apache20text,
+		},
+		{
+			license:  Elastic20,
+			expected: elastic20text,
+		},
+		{
+			license: "not-existing-license",
+			fail:    true,
+		},
+	}
+
+	for _, c := range cases {
+		var w bytes.Buffer
+		err := WriteText(c.license, &w)
+		if c.fail {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			assert.Equal(t, string(c.expected), w.String())
+		}
+	}
+}

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -110,7 +110,10 @@ type PackageManifest struct {
 	Owner           Owner            `config:"owner" json:"owner" yaml:"owner"`
 	Description     string           `config:"description" json:"description" yaml:"description"`
 	License         string           `config:"license" json:"license" yaml:"license"`
-	Categories      []string         `config:"categories" json:"categories" yaml:"categories"`
+	Source          struct {
+		License string `config:"license" json:"license" yaml:"license"`
+	} `config:"source" json:"source" yaml: "source`
+	Categories []string `config:"categories" json:"categories" yaml:"categories"`
 }
 
 // DataStreamManifest represents the structure of a data stream's manifest

--- a/test/packages/other/number_formats/manifest.yml
+++ b/test/packages/other/number_formats/manifest.yml
@@ -2,13 +2,15 @@ format_version: 1.0.0
 name: number_formats
 title: "Number formats"
 version: 0.1.0
-license: basic
-description: "Package to tes pipelines with documents with different formats of numbers"
+source:
+  license: Apache-2.0
+description: "Package to test pipelines with documents with different formats of numbers"
 type: integration
 categories:
   - custom
 conditions:
   kibana.version: "^8.1.0"
+  elastic.subscription: "basic"
 screenshots:
   - src: /img/sample-screenshot.png
     title: Sample screenshot

--- a/test/packages/other/sql_input/manifest.yml
+++ b/test/packages/other/sql_input/manifest.yml
@@ -5,7 +5,10 @@ description: >-
   Execute custom queries against an SQL database and store the results in Elasticsearch.
 type: input
 version: 0.2.0
-license: basic
+source:
+  license: Elastic-2.0
+conditions:
+  elastic.subscription: basic
 categories:
   - custom
   - datastore

--- a/test/packages/parallel/apache/manifest.yml
+++ b/test/packages/parallel/apache/manifest.yml
@@ -5,7 +5,8 @@ title: Apache HTTP Server
 # be installed in the package registry regardless of the version of
 # the actual apache package in the registry at any given time.
 version: 999.999.999
-license: basic
+source:
+  license: Apache-2.0
 description: Collect logs and metrics from Apache servers with Elastic Agent.
 type: integration
 categories:
@@ -13,6 +14,7 @@ categories:
 release: ga
 conditions:
   kibana.version: "^7.14.0 || ^8.0.0"
+  elastic.subscription: basic
 screenshots:
   - src: /img/apache-metrics-overview.png
     title: Apache metrics overview


### PR DESCRIPTION
Include a new `LICENSE.txt` file when building packages that include the `source.license` field in their manifests.

Follow up of https://github.com/elastic/package-spec/pull/355.
Part of https://github.com/elastic/package-spec/issues/298.