### PR TITLE
Set metrics address and port for EPR container

### DIFF
--- a/internal/profile/_static/docker-compose-stack.yml
+++ b/internal/profile/_static/docker-compose-stack.yml
@@ -57,7 +57,7 @@ services:
       args:
         PROFILE: "${PROFILE_NAME}"
     healthcheck:
-      test: ["CMD", "curl", "--cacert", "/etc/ssl/package-registry/ca-cert.pem", "-f", "https://localhost:8080/health"]
+      test: ["CMD", "curl", "--cacert", "/etc/ssl/package-registry/ca-cert.pem", "-f", "https://localhost:8080"]
       retries: 300
       interval: 1s
     environment:

--- a/internal/profile/_static/docker-compose-stack.yml
+++ b/internal/profile/_static/docker-compose-stack.yml
@@ -57,17 +57,19 @@ services:
       args:
         PROFILE: "${PROFILE_NAME}"
     healthcheck:
-      test: ["CMD", "curl", "--cacert", "/etc/ssl/package-registry/ca-cert.pem", "-f", "https://localhost:8080"]
+      test: ["CMD", "curl", "--cacert", "/etc/ssl/package-registry/ca-cert.pem", "-f", "https://localhost:8080/health"]
       retries: 300
       interval: 1s
     environment:
       - "EPR_ADDRESS=0.0.0.0:8080"
+      - "EPR_METRICS_ADDRESS=0.0.0.0:9000"
       - "EPR_TLS_KEY=/etc/ssl/package-registry/key.pem"
       - "EPR_TLS_CERT=/etc/ssl/package-registry/cert.pem"
     volumes:
       - "../certs/package-registry:/etc/ssl/package-registry"
     ports:
       - "127.0.0.1:8080:8080"
+      - "127.0.0.1:9000:9000"
 
   package-registry_is_ready:
     image: tianon/true


### PR DESCRIPTION
Relates https://github.com/elastic/package-registry/issues/797
Blocked by https://github.com/elastic/package-registry/pull/827 , https://github.com/elastic/package-registry/pull/842

Set the required settings (URL and port) to be able to scrape metrics from the Package Registry.


