### PR TITLE
Bump up default Elastic stack version to 8.3.2

### DIFF
--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "8.2.0"
+	DefaultStackVersion = "8.3.2"
 )


### PR DESCRIPTION
This PR bumps up the default Elastic stack version to v8.3.2. It looks like we missed the v8.3.0 release.