### PR TITLE
Deprecate publish and promote

### DIFF
--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -50,6 +50,7 @@ func setupPromoteCommand() *cobraext.Command {
 
 func promoteCommandAction(cmd *cobra.Command, _ []string) error {
 	cmd.Println("Promote packages")
+	cmd.Println("DEPRECATED: Packages stored in the Package Storage v2 won't require to be promoted. This command will be removed soon. README: https://github.com/elastic/elastic-package/blob/main/docs/howto/use_package_storage_v2.md")
 
 	// Setup GitHub
 	err := github.EnsureAuthConfigured()

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -37,6 +37,7 @@ func setupPublishCommand() *cobraext.Command {
 
 func publishCommandAction(cmd *cobra.Command, args []string) error {
 	cmd.Println("Publish the package")
+	cmd.Println("DEPRECATED: Package candidates to the Package Storage v2 will be published using Jenkins jobs. This command will be removed soon. README: https://github.com/elastic/elastic-package/blob/main/docs/howto/use_package_storage_v2.md")
 
 	fork, err := cmd.Flags().GetBool(cobraext.ForkFlagName)
 	if err != nil {


### PR DESCRIPTION
Issue: https://github.com/elastic/ingest-dev/issues/1040

This PR deprecates `publish` and `promote` commands. They will be removed once we switch to the Package Storage v2.