### PR TITLE
Add required subscription on package creation

### DIFF
--- a/cmd/create_package.go
+++ b/cmd/create_package.go
@@ -19,13 +19,14 @@ const createPackageLongDescription = `Use this command to create a new package.
 The command can bootstrap the first draft of a package using embedded package template and wizard.`
 
 type newPackageAnswers struct {
-	Name          string
-	Version       string
-	Title         string
-	Description   string
-	Categories    []string
-	KibanaVersion string `survey:"kibana_version"`
-	GithubOwner   string `survey:"github_owner"`
+	Name                string
+	Version             string
+	Title               string
+	Description         string
+	Categories          []string
+	KibanaVersion       string `survey:"kibana_version"`
+	ElasticSubscription string `survey:"elastic_subscription"`
+	GithubOwner         string `survey:"github_owner"`
 }
 
 func createPackageCommandAction(cmd *cobra.Command, args []string) error {
@@ -81,9 +82,18 @@ func createPackageCommandAction(cmd *cobra.Command, args []string) error {
 			Name: "kibana_version",
 			Prompt: &survey.Input{
 				Message: "Kibana version constraint:",
-				Default: surveyext.DefaultConstraintValue(),
+				Default: surveyext.DefaultKibanaVersionConditionValue(),
 			},
 			Validate: survey.ComposeValidators(survey.Required, surveyext.ConstraintValidator),
+		},
+		{
+			Name: "elastic_subscription",
+			Prompt: &survey.Select{
+				Message: "Required Elastic subscription:",
+				Options: []string{"basic", "gold", "platinum", "enterprise"},
+				Default: "basic",
+			},
+			Validate: survey.Required,
 		},
 		{
 			Name: "github_owner",
@@ -122,12 +132,15 @@ func createPackageDescriptorFromAnswers(answers newPackageAnswers) archetype.Pac
 				Kibana: packages.KibanaConditions{
 					Version: answers.KibanaVersion,
 				},
+				Elastic: packages.ElasticConditions{
+					Subscription: answers.ElasticSubscription,
+				},
 			},
 			Owner: packages.Owner{
 				Github: answers.GithubOwner,
 			},
+			License:     answers.ElasticSubscription,
 			Description: answers.Description,
-			License:     "basic",
 			Categories:  answers.Categories,
 		},
 	}

--- a/internal/packages/archetype/package_manifest.go
+++ b/internal/packages/archetype/package_manifest.go
@@ -16,6 +16,7 @@ categories:{{range $category := .Manifest.Categories}}
 {{- end}}
 conditions:
   kibana.version: "{{.Manifest.Conditions.Kibana.Version}}"
+  elastic.subscription: "{{.Manifest.Conditions.Elastic.Subscription}}"
 screenshots:
   - src: /img/sample-screenshot.png
     title: Sample screenshot

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -78,9 +78,15 @@ type KibanaConditions struct {
 	Version string `config:"version" json:"version" yaml:"version"`
 }
 
+// ElasticConditions defines conditions related to Elastic subscriptions or partnerships.
+type ElasticConditions struct {
+	Subscription string `config:"subscription" json:"subscription" yaml:"subscription"`
+}
+
 // Conditions define requirements for different parts of the Elastic stack.
 type Conditions struct {
-	Kibana KibanaConditions `config:"kibana" json:"kibana" yaml:"kibana"`
+	Kibana  KibanaConditions  `config:"kibana" json:"kibana" yaml:"kibana"`
+	Elastic ElasticConditions `config:"elastic" json:"elastic" yaml:"elastic"`
 }
 
 // PolicyTemplate is a configuration of inputs responsible for collecting log or metric data.

--- a/internal/surveyext/default.go
+++ b/internal/surveyext/default.go
@@ -10,8 +10,8 @@ import (
 	"github.com/elastic/elastic-package/internal/install"
 )
 
-// DefaultConstraintValue function returns a constraint
-func DefaultConstraintValue() string {
+// DefaultKibanaVersionConditionValue function returns a constraint
+func DefaultKibanaVersionConditionValue() string {
 	ver := semver.MustParse(install.DefaultStackVersion)
 	v, _ := ver.SetPrerelease("")
 	return "^" + v.String()


### PR DESCRIPTION
It adds by now the old `license` field and the new `elastic.subscription` condition.