### PR TITLE
Build command: skip package validation

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -37,6 +37,7 @@ func setupBuildCommand() *cobraext.Command {
 	}
 	cmd.Flags().Bool(cobraext.BuildZipFlagName, true, cobraext.BuildZipFlagDescription)
 	cmd.Flags().Bool(cobraext.SignPackageFlagName, false, cobraext.SignPackageFlagDescription)
+	cmd.Flags().Bool(cobraext.BuildSkipValidationFlagName, false, cobraext.BuildSkipValidationFlagDescription)
 	return cobraext.NewCommand(cmd, cobraext.ContextPackage)
 }
 

--- a/internal/cobraext/flags.go
+++ b/internal/cobraext/flags.go
@@ -26,8 +26,10 @@ const (
 	AgentPolicyFlagName    = "agent-policy"
 	AgentPolicyDescription = "name of the agent policy"
 
-	BuildZipFlagName        = "zip"
-	BuildZipFlagDescription = "archive the built package"
+	BuildZipFlagName                   = "zip"
+	BuildZipFlagDescription            = "archive the built package"
+	BuildSkipValidationFlagName        = "skip-validation"
+	BuildSkipValidationFlagDescription = "skip validation of the built package, use only if all validation issues have been acknowledged"
 
 	ChangelogAddNextFlagName        = "next"
 	ChangelogAddNextFlagDescription = "changelog entry is added in the next `major`, `minor` or `patch` version"

--- a/internal/cobraext/flags.go
+++ b/internal/cobraext/flags.go
@@ -26,10 +26,11 @@ const (
 	AgentPolicyFlagName    = "agent-policy"
 	AgentPolicyDescription = "name of the agent policy"
 
-	BuildZipFlagName                   = "zip"
-	BuildZipFlagDescription            = "archive the built package"
 	BuildSkipValidationFlagName        = "skip-validation"
 	BuildSkipValidationFlagDescription = "skip validation of the built package, use only if all validation issues have been acknowledged"
+
+	BuildZipFlagName        = "zip"
+	BuildZipFlagDescription = "archive the built package"
 
 	ChangelogAddNextFlagName        = "next"
 	ChangelogAddNextFlagDescription = "changelog entry is added in the next `major`, `minor` or `patch` version"


### PR DESCRIPTION
Related: https://github.com/elastic/endpoint-package/pull/272

The goal of this PR is to expose an option to disable validation of built packages if we have acknowledged all spec issues. It blocks endpoint-package to publish artifacts to Package Storage v2.