### PR TITLE
Show version instead of error in debug message

### DIFF
--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -175,7 +175,7 @@ func NewProject(name string, paths ...string) (*Project, error) {
 		return &c, nil
 	}
 	if ver.Major() == 1 {
-		logger.Debugf("Determined Docker Compose version: %v, the tool will use Compose V1", err)
+		logger.Debugf("Determined Docker Compose version: %v, the tool will use Compose V1", ver)
 		c.dockerComposeV1 = true
 	}
 	return &c, nil


### PR DESCRIPTION
Fix debug message to show the version instead of the error (`<nil>`):

Before:

```
2022/07/22 17:08:06 DEBUG running command: /usr/local/bin/docker-compose version --short
2022/07/22 17:08:06 DEBUG Determined Docker Compose version: <nil>, the tool will use Compose V1
```

After:
```
2022/07/22 17:56:10 DEBUG running command: /usr/local/bin/docker-compose version --short
2022/07/22 17:56:10 DEBUG Determined Docker Compose version: 1.29.2, the tool will use Compose V1
```