### PR TITLE
Fix: use correct Command while running action

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -21,10 +21,10 @@ func setupCheckCommand() *cobraext.Command {
 		Short: "Check the package",
 		Long:  checkLongDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := cobraext.ComposeCommandActions(cmd, args,
-				formatCommandAction,
-				lintCommandAction,
-				buildCommandAction,
+			err := cobraext.ComposeCommands(args,
+				setupFormatCommand(),
+				setupLintCommand(),
+				setupBuildCommand(),
 			)
 			if err != nil {
 				return errors.Wrap(err, "checking package failed")

--- a/internal/cobraext/action.go
+++ b/internal/cobraext/action.go
@@ -21,3 +21,14 @@ func ComposeCommandActions(cmd *cobra.Command, args []string, actions ...Command
 	}
 	return nil
 }
+
+// ComposeCommands runs given commands in order
+func ComposeCommands(args []string, composed ...*Command) error {
+	for _, cmd := range composed {
+		err := cmd.RunE(cmd.Command, args)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Spotted in: https://github.com/elastic/apm-server/pull/8717

This PR fixes the reference to the `cmd` while running a `CommandAction`. For composing commands, like `check`, the sub-command actions, `build`, `lint`, `format`, receive a pointer to the `check` command instead of corresponding build/lint/format ones. As result, none of these commands can read their flags (and their default values).

I spotted this bug while trying to `elastic-package check` the APM package, but the tool didn't create .zip files, even though the build-zip flag should be enabled by default. Due to the bug, the command action couldn't read the default value.