### PR TITLE
Include path in pipeline errors

### DIFF
--- a/internal/elasticsearch/ingest/pipeline.go
+++ b/internal/elasticsearch/ingest/pipeline.go
@@ -12,10 +12,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Pipeline represents a pipeline resource loaded from a file
+// Pipeline represents a pipeline resource loaded from a file.
 type Pipeline struct {
-	Name    string // Name of the pipeline
-	Format  string // Format (extension) of the pipeline
+	Path    string // Path of the file with the pipeline definition.
+	Name    string // Name of the pipeline.
+	Format  string // Format (extension) of the pipeline.
 	Content []byte // Content is the original file contents.
 }
 


### PR DESCRIPTION
When packages contain multiple data streams with multiple pipelines it
may be difficult to identify the cause of the error.

Pipeline errors look like this now:
```
Error: error running package pipeline tests: could not complete test run: installing ingest pipelines failed: unexpected response status for PutPipeline (400): 400 Bad Request (pipelineName: default-1660737944632495538, path: /home/jaime/gocode/src/github.com/elastic/integrations/packages/apache/data_stream/access/elasticsearch/ingest_pipeline/default.yml): elasticsearch error (type=parse_exception): [field] required property is missing
```

Closes #925.
