### PR TITLE
Stop using legacy syntax for parameters on triggerRemoteJob

### DIFF
--- a/.ci/package-storage-publish.groovy
+++ b/.ci/package-storage-publish.groovy
@@ -110,7 +110,9 @@ def signUnpublishedArtifactsWithElastic(builtPackagesPath) {
     triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
       job: 'https://internal-ci.elastic.co/job/elastic+unified-release+master+sign-artifacts-with-gpg',
       token: TOKEN,
-      parameters: "gcs_input_path=${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
+      parameters2: [
+        gcs_input_path: env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH,
+      ],
       useCrumbCache: false,
       useJobInfoCache: false)
   }
@@ -137,13 +139,13 @@ def uploadUnpublishedToPackageStorage(builtPackagesPath) {
           triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
             job: 'https://internal-ci.elastic.co/job/package_storage/job/publishing-job-remote',
             token: TOKEN,
-            parameters: """
-              dry_run=true
-              gs_package_build_zip_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}
-              gs_package_signature_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}.sig
-              """,
-              useCrumbCache: true,
-              useJobInfoCache: true)
+            parameters2: [
+              dry_run: true,
+              gs_package_build_zip_path: "${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}",
+              gs_package_signature_path: "${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}.sig",
+            ],
+            useCrumbCache: true,
+            useJobInfoCache: true)
         }
       }
     }

--- a/.ci/package-storage-publish.groovy
+++ b/.ci/package-storage-publish.groovy
@@ -110,7 +110,7 @@ def signUnpublishedArtifactsWithElastic(builtPackagesPath) {
     triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
       job: 'https://internal-ci.elastic.co/job/elastic+unified-release+master+sign-artifacts-with-gpg',
       token: TOKEN,
-      parameters2: [
+      parameters: [
         gcs_input_path: env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH,
       ],
       useCrumbCache: false,
@@ -139,7 +139,7 @@ def uploadUnpublishedToPackageStorage(builtPackagesPath) {
           triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
             job: 'https://internal-ci.elastic.co/job/package_storage/job/publishing-job-remote',
             token: TOKEN,
-            parameters2: [
+            parameters: [
               dry_run: true,
               gs_package_build_zip_path: "${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}",
               gs_package_signature_path: "${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}.sig",


### PR DESCRIPTION
Fix issue seen in https://github.com/elastic/elastic-package/pull/928 after upgrade to Jenkins 2.346.3.