### PR TITLE
Fix validation of histograms and fields with object_type

### DIFF
--- a/internal/fields/model.go
+++ b/internal/fields/model.go
@@ -18,6 +18,7 @@ type FieldDefinition struct {
 	Name           string            `yaml:"name"`
 	Description    string            `yaml:"description"`
 	Type           string            `yaml:"type"`
+	ObjectType     string            `yaml:"object_type"`
 	Value          string            `yaml:"value"` // The value to associate with a constant_keyword field.
 	AllowedValues  AllowedValues     `yaml:"allowed_values"`
 	ExpectedValues []string          `yaml:"expected_values"`
@@ -40,6 +41,9 @@ func (orig *FieldDefinition) Update(fd FieldDefinition) {
 	}
 	if fd.Type != "" {
 		orig.Type = fd.Type
+	}
+	if fd.ObjectType != "" {
+		orig.ObjectType = fd.ObjectType
 	}
 	if fd.Value != "" {
 		orig.Value = fd.Value

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -527,8 +527,38 @@ func TestCompareKeys(t *testing.T) {
 		},
 		{
 			key:         "example.*",
+			def:         FieldDefinition{Type: "object", ObjectType: "geo_point"},
+			searchedKey: "example.geo.lon",
+			expected:    true,
+		},
+		{
+			key:         "example.*",
 			def:         FieldDefinition{Type: "geo_point"},
 			searchedKey: "example.geo.foo",
+			expected:    false,
+		},
+		{
+			key:         "example.histogram",
+			def:         FieldDefinition{Type: "histogram"},
+			searchedKey: "example.histogram.counts",
+			expected:    true,
+		},
+		{
+			key:         "example.*",
+			def:         FieldDefinition{Type: "histogram"},
+			searchedKey: "example.histogram.counts",
+			expected:    true,
+		},
+		{
+			key:         "example.*",
+			def:         FieldDefinition{Type: "histogram"},
+			searchedKey: "example.histogram.values",
+			expected:    true,
+		},
+		{
+			key:         "example.*",
+			def:         FieldDefinition{Type: "histogram"},
+			searchedKey: "example.histogram.foo",
 			expected:    false,
 		},
 	}

--- a/test/packages/other/fields_tests/data_stream/first/fields/histogram-fields.yml
+++ b/test/packages/other/fields_tests/data_stream/first/fields/histogram-fields.yml
@@ -1,0 +1,3 @@
+- name: service.status.*.histogram
+  type: object
+  object_type: histogram

--- a/test/packages/other/fields_tests/data_stream/first/sample_event.json
+++ b/test/packages/other/fields_tests/data_stream/first/sample_event.json
@@ -4,5 +4,9 @@
         "lon": "2.0"
     },
     "destination.geo.location.lat": 3.0,
-    "destination.geo.location.lon": 4.0
+    "destination.geo.location.lon": 4.0,
+    "service.status.duration.histogram": {
+        "counts": [8, 17, 8, 7, 6, 2],
+        "values": [0.1, 0.25, 0.35, 0.4, 0.45, 0.5]
+    }
 }

--- a/test/packages/other/fields_tests/data_stream/first/sample_event.json
+++ b/test/packages/other/fields_tests/data_stream/first/sample_event.json
@@ -6,7 +6,21 @@
     "destination.geo.location.lat": 3.0,
     "destination.geo.location.lon": 4.0,
     "service.status.duration.histogram": {
-        "counts": [8, 17, 8, 7, 6, 2],
-        "values": [0.1, 0.25, 0.35, 0.4, 0.45, 0.5]
+        "counts": [
+            8,
+            17,
+            8,
+            7,
+            6,
+            2
+        ],
+        "values": [
+            0.1,
+            0.25,
+            0.35,
+            0.4,
+            0.45,
+            0.5
+        ]
     }
 }

--- a/test/packages/other/fields_tests/docs/README.md
+++ b/test/packages/other/fields_tests/docs/README.md
@@ -9,7 +9,25 @@ An example event for `first` looks as following:
         "lon": "2.0"
     },
     "destination.geo.location.lat": 3.0,
-    "destination.geo.location.lon": 4.0
+    "destination.geo.location.lon": 4.0,
+    "service.status.duration.histogram": {
+        "counts": [
+            8,
+            17,
+            8,
+            7,
+            6,
+            2
+        ],
+        "values": [
+            0.1,
+            0.25,
+            0.35,
+            0.4,
+            0.45,
+            0.5
+        ]
+    }
 }
 ```
 
@@ -22,4 +40,5 @@ An example event for `first` looks as following:
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
 | destination.geo.location | Longitude and latitude. | geo_point |
+| service.status.\*.histogram |  | object |
 | source.geo.location | Longitude and latitude. | geo_point |


### PR DESCRIPTION
Fields of [type histogram](https://www.elastic.co/guide/en/elasticsearch/reference/8.1/histogram.html) contain (and can only contain) `values` and `counters` sub-fields in a similar fashion to `lat` and `long` sub-fields of the `geo_point` type.

Fix validation of sample events including histograms.

Fix also validation of geo points and histograms defined as dynamic mappings with `object_type`, like:
```
- name: service.status.*.histogram
  type: object
  object_type: histogram
```

Thanks @ritalwar for reporting!

Fixes https://github.com/elastic/elastic-package/issues/905.