### PR TITLE
Add docs template language to `elastic-package create package`

### DIFF
--- a/internal/packages/archetype/package_docs_readme.go
+++ b/internal/packages/archetype/package_docs_readme.go
@@ -4,8 +4,87 @@
 
 package archetype
 
-const packageDocsReadme = `# {{.Manifest.Title}}
+const packageDocsReadme = `<!-- Use this template language as a starting point, replacing {placeholder text} with details about the integration. -->
+<!-- Find more detailed documentation guidelines in https://github.com/elastic/integrations/blob/main/docs/documentation_guidelines.md -->
 
-This is a new integration created using the [elastic-package](https://github.com/elastic/elastic-package) tool.
+# {{.Manifest.Title}}
 
-Consider using the README template file ` + "`_dev/build/docs/README.md`" + `to generate a list of exported fields or include a sample event.`
+<!-- The {{.Manifest.Title}} integration allows you to monitor {name of service}. {name of service} is {describe service}.
+
+Use the {{.Manifest.Title}} integration to {purpose}. Then visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference {data stream type} when troubleshooting an issue.
+
+For example, if you wanted to {sample use case} you could {action}. Then you can {visualize|alert|troubleshoot} by {action}. -->
+
+## Data streams
+
+<!-- The {{.Manifest.Title}} integration collects {one|two} type{s} of data streams: {logs and/or metrics}. -->
+
+<!-- If applicable -->
+<!-- **Logs** help you keep a record of events happening in {service}.
+Log data streams collected by the {name} integration include {sample data stream(s)} and more. See more details in the [Logs](#logs-reference). -->
+
+<!-- If applicable -->
+<!-- **Metrics** give you insight into the state of {service}.
+Metric data streams collected by the {name} integration include {sample data stream(s)} and more. See more details in the [Metrics](#metrics-reference). -->
+
+<!-- Optional: Any additional notes on data streams -->
+
+## Requirements
+
+You need Elasticsearch for storing and searching your data and Kibana for visualizing and managing it.
+You can use our hosted Elasticsearch Service on Elastic Cloud, which is recommended, or self-manage the Elastic Stack on your own hardware.
+
+<!--
+	Optional: Other requirements including:
+	* System compatibility
+	* Supported versions of third-party products
+	* Permissions needed
+	* Anything else that could block a user from successfully using the integration
+-->
+
+## Setup
+
+<!-- Any prerequisite instructions -->
+
+For step-by-step instructions on how to set up an integration, see the
+[Getting started](https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html) guide.
+
+<!-- Additional set up instructions -->
+
+<!-- If applicable -->
+<!-- ## Logs reference -->
+
+<!-- Repeat for each data stream of the current type -->
+<!-- ### {Data stream name}
+
+The ` + "`{data stream name}`" + ` data stream provides events from {source} of the following types: {list types}. -->
+
+<!-- Optional -->
+<!-- #### Example
+
+An example event for ` + "`{data stream name}`" + ` looks as following:
+
+{code block with example} -->
+
+<!-- #### Exported fields
+
+{insert table} -->
+
+<!-- If applicable -->
+<!-- ## Metrics reference -->
+
+<!-- Repeat for each data stream of the current type -->
+<!-- ### {Data stream name}
+
+The ` + "`{data stream name}`" + ` data stream provides events from {source} of the following types: {list types}. -->
+
+<!-- Optional -->
+<!-- #### Example
+
+An example event for ` + "`{data stream name}`" + ` looks as following:
+
+{code block with example} -->
+
+<!-- #### Exported fields
+
+{insert table} -->`

--- a/internal/packages/archetype/package_docs_readme.go
+++ b/internal/packages/archetype/package_docs_readme.go
@@ -64,11 +64,11 @@ The ` + "`{data stream name}`" + ` data stream provides events from {source} of 
 
 An example event for ` + "`{data stream name}`" + ` looks as following:
 
-{{event "{data stream}"}} -->
+{code block with example} -->
 
 <!-- #### Exported fields
 
-{{fields "{data stream}"}} -->
+{insert table} -->
 
 <!-- If applicable -->
 <!-- ## Metrics reference -->
@@ -83,8 +83,8 @@ The ` + "`{data stream name}`" + ` data stream provides events from {source} of 
 
 An example event for ` + "`{data stream name}`" + ` looks as following:
 
-{{event "{data stream}"}} -->
+{code block with example} -->
 
 <!-- #### Exported fields
 
-{{fields "{data stream}"}} -->`
+{insert table} -->`

--- a/internal/packages/archetype/package_docs_readme.go
+++ b/internal/packages/archetype/package_docs_readme.go
@@ -64,11 +64,11 @@ The ` + "`{data stream name}`" + ` data stream provides events from {source} of 
 
 An example event for ` + "`{data stream name}`" + ` looks as following:
 
-{code block with example} -->
+{{event "{data stream}"}} -->
 
 <!-- #### Exported fields
 
-{insert table} -->
+{{fields "{data stream}"}} -->
 
 <!-- If applicable -->
 <!-- ## Metrics reference -->
@@ -83,8 +83,8 @@ The ` + "`{data stream name}`" + ` data stream provides events from {source} of 
 
 An example event for ` + "`{data stream name}`" + ` looks as following:
 
-{code block with example} -->
+{{event "{data stream}"}} -->
 
 <!-- #### Exported fields
 
-{insert table} -->`
+{{fields "{data stream}"}} -->`


### PR DESCRIPTION
Closes https://github.com/elastic/elastic-package/issues/880

In elastic/integrations#3433, we added more detailed documentation guidelines for integrations (including template language). In that PR @jsoriano suggested:

>`elastic-package create package` can be used to create an initial scaffolding for new packages, as a follow up we could apply these recommendations in the templates there.

@jsoriano pointed me to [this directory](https://github.com/elastic/elastic-package/tree/main/internal/packages/archetype), but I'm not sure if I put the template language in the correct place. 🙃 Let me know if it should go somewhere else!

## To do

- [x] Confirm template language is in the correct place
- [x] Approval from @jsoriano 
- [x] [outside this repo] Update the script for building integration docs to reformat code comments to prevent build failures cc @bmorelli25 
- [ ] After ☝️ is complete, merge this PR