### PR TITLE
Allow to override ECS fields type from keyword to constant_keyword

### DIFF
--- a/internal/fields/dependency_manager.go
+++ b/internal/fields/dependency_manager.go
@@ -160,8 +160,13 @@ func (dm *DependencyManager) injectFieldsWithRoot(root string, defs []common.Map
 
 			// Allow overrides of everything, except the imported type, for consistency.
 			transformed.DeepUpdate(def)
-			transformed["type"] = imported.Type
 			transformed.Delete("external")
+
+			// Allow to override the type only from keyword to constant_keyword,
+			// to support the case of setting the value already in the mappings.
+			if ttype, _ := transformed["type"].(string); ttype != "constant_keyword" || imported.Type != "keyword" {
+				transformed["type"] = imported.Type
+			}
 
 			def = transformed
 			changed = true

--- a/internal/fields/dependency_manager_test.go
+++ b/internal/fields/dependency_manager_test.go
@@ -58,6 +58,27 @@ func TestDependencyManagerInjectExternalFields(t *testing.T) {
 			valid:   true,
 		},
 		{
+			title: "keyword to constant_keyword override",
+			defs: []common.MapStr{
+				{
+					"name":     "event.dataset",
+					"type":     "constant_keyword",
+					"external": "test",
+					"value":    "nginx.access",
+				},
+			},
+			result: []common.MapStr{
+				{
+					"name":        "event.dataset",
+					"type":        "constant_keyword",
+					"description": "Dataset that collected this event",
+					"value":       "nginx.access",
+				},
+			},
+			changed: true,
+			valid:   true,
+		},
+		{
 			title: "external dimension",
 			defs: []common.MapStr{
 				{
@@ -361,6 +382,11 @@ func TestDependencyManagerInjectExternalFields(t *testing.T) {
 			Name:        "data_stream.dataset",
 			Description: "Data stream dataset.",
 			Type:        "constant_keyword",
+		},
+		{
+			Name:        "event.dataset",
+			Description: "Dataset that collected this event",
+			Type:        "keyword",
 		},
 		{
 			Name:        "process.command_line",


### PR DESCRIPTION
Support the case of defining the value of a constant_keyword for fields that are defined as keyword in ECS.

Current workaround is to define the whole field on each data stream instead of importing it, so the `constant_keyword` type can be set along with a value. Something like this:
```
- name: event.dataset
  type: constant_keyword
  description: Event dataset
  value: apache.access
```

With this change, it will be allowed to reuse the definition from ECS:
```
- name: event.dataset
  external: ecs
  type: constant_keyword
  value: apache.access
```

This is helpful to have consistent descriptions and other settings in more complex fields.