### PR TITLE
Bump up default Elastic stack to v8.4

### DIFF
--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "8.3.3"
+	DefaultStackVersion = "8.4.1"
 )


### PR DESCRIPTION
This PR bumps up the default Elastic stack version to 8.4.1