### PR TITLE
Update Package Registry docker image

### DIFF
--- a/internal/profile/static.go
+++ b/internal/profile/static.go
@@ -124,7 +124,7 @@ func newPackageRegistryConfig(_ string, profilePath string) (*simpleFile, error)
 
 // PackageRegistryBaseImage is the base Docker image of the Elastic Package Registry.
 // commit SHA of enabled proxy mode (technical preview feature)
-const PackageRegistryBaseImage = "docker.elastic.co/package-registry/package-registry:14455fcb7e415d6b4aed48e00d2289718f056162"
+const PackageRegistryBaseImage = "docker.elastic.co/package-registry/package-registry:fbeed6de1a5872df95d25ab445e261d8912c22ba"
 
 // PackageRegistryDockerfileFile is the dockerfile for the Elastic package registry
 const PackageRegistryDockerfileFile configFile = "Dockerfile.package-registry"


### PR DESCRIPTION
Update Package Registry docker image used when booting up an Elastic stack.
This new docker image includes this change: https://github.com/elastic/package-registry/pull/873