### PR TITLE
render diff for readme checks

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -47,7 +47,7 @@ func lintCommandAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		for _, f := range readmeFiles {
 			if !f.UpToDate {
-				cmd.Printf("%s is outdated. Rebuild the package with 'elastic-package build'\n", f.FileName)
+				cmd.Printf("%s is outdated. Rebuild the package with 'elastic-package build'\n%s", f.FileName, f.Diff)
 			}
 			if f.Error != nil {
 				cmd.Printf("check if %s is up-to-date failed: %s\n", f.FileName, f.Error)

--- a/internal/docs/readme.go
+++ b/internal/docs/readme.go
@@ -11,8 +11,8 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	"github.com/pmezard/go-difflib/difflib"
 
 	"github.com/elastic/elastic-package/internal/builder"
 	"github.com/elastic/elastic-package/internal/logger"
@@ -81,7 +81,15 @@ func isReadmeUpToDate(fileName, packageRoot string) (bool, string, error) {
 	if bytes.Equal(existing, rendered) {
 		return true, "", nil
 	}
-	return false, cmp.Diff(string(existing), string(rendered)), nil
+	var buf bytes.Buffer
+	err = difflib.WriteUnifiedDiff(&buf, difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(existing)),
+		B:        difflib.SplitLines(string(rendered)),
+		FromFile: "want",
+		ToFile:   "got",
+		Context:  1,
+	})
+	return false, buf.String(), err
 }
 
 // UpdateReadmes function updates all .md readme files using a defined template


### PR DESCRIPTION
This renders the difference between the stored and rendered readme files. Like so:
```
[2022-09-27T07:35:28.126Z] README.md is outdated. Rebuild the package with 'elastic-package build'
[2022-09-27T07:35:28.126Z]   strings.Join({
[2022-09-27T07:35:28.126Z]   	... // 49896 identical bytes
[2022-09-27T07:35:28.126Z]   	"| host.os.name | Operating system name, without the version. | k",
[2022-09-27T07:35:28.126Z]   	"eyword |\n| host.os.name.text | Multi-field of `host.os.name`. | ",
[2022-09-27T07:35:28.126Z] - 	"match_only_",
[2022-09-27T07:35:28.126Z]   	"text |\n| host.os.platform | Operating system platform (such cent",
[2022-09-27T07:35:28.126Z]   	"os, ubuntu, windows). | keyword |\n| host.os.version | Operating ",
[2022-09-27T07:35:28.126Z]   	... // 10306 identical bytes
[2022-09-27T07:35:28.126Z]   }, "")
[2022-09-27T07:35:28.126Z] Error: checking package failed: checking readme files are up-to-date failed: files do not match
```
This is important due to differential behaviour between CI and local `elastic-package build`.