### PR TITLE
Add storageclass permissions in agent clusterrole

### DIFF
--- a/internal/testrunner/runners/system/servicedeployer/elastic-agent-managed.yaml.tmpl
+++ b/internal/testrunner/runners/system/servicedeployer/elastic-agent-managed.yaml.tmpl
@@ -236,6 +236,10 @@ rules:
     resources:
       - podsecuritypolicies
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - storageclasses
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
Add `get, list, watch` permissions for `storageclasses`  in kubernetes managed agent manifest