### PR TITLE
Ignore missing files while loading profiles metadata

### DIFF
--- a/internal/profile/files.go
+++ b/internal/profile/files.go
@@ -56,7 +56,7 @@ func (cfg simpleFile) writeConfig() error {
 func (cfg *simpleFile) readConfig() error {
 	body, err := os.ReadFile(cfg.path)
 	if err != nil {
-		return errors.Wrapf(err, "reading filed failed (path: %s)", cfg.path)
+		return errors.Wrapf(err, "reading file failed (path: %s)", cfg.path)
 	}
 	cfg.body = string(body)
 	return nil

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+
+	"github.com/elastic/elastic-package/internal/logger"
 )
 
 // Profile manages a a given user config profile
@@ -278,6 +280,10 @@ func (profile Profile) localFilesChanged() (bool, error) {
 func (profile Profile) readProfileResources() error {
 	for _, cfgFile := range profile.configFiles {
 		err := cfgFile.readConfig()
+		if errors.Is(err, os.ErrNotExist) {
+			logger.Debugf("File %s not found while reading profile.", cfgFile.path)
+			continue
+		}
 		if err != nil {
 			return errors.Wrap(err, "error reading in profile")
 		}


### PR DESCRIPTION
While loading profiles, ignore missing files. These errors can be caused by old or corrupted profiles, and shouldn't prevent elastic-package to read the rest of the profile or its metadata.

Fixes https://github.com/elastic/elastic-package/issues/881.
Solves the part of https://github.com/elastic/elastic-package/issues/589 about broken profiles list.