### PR TITLE
Add support for dash in shellinit stack

### DIFF
--- a/internal/stack/shellinit.go
+++ b/internal/stack/shellinit.go
@@ -64,19 +64,15 @@ set -x %s %s;
 )
 
 // availableShellTypes list all available values for s in initTemplate
-var availableShellTypes = []string{"bash", "fish", "sh", "zsh"}
+var availableShellTypes = []string{"bash", "dash", "fish", "sh", "zsh"}
 
 // InitTemplate returns code templates for shell initialization
 func initTemplate(s string) (string, error) {
 	switch s {
-	case "bash":
+	case "bash", "dash", "sh", "zsh":
 		return posixTemplate, nil
 	case "fish":
 		return fishTemplate, nil
-	case "sh":
-		return posixTemplate, nil
-	case "zsh":
-		return posixTemplate, nil
 	default:
 		return "", errors.New("shell type is unknown, should be one of " + strings.Join(availableShellTypes, ", "))
 	}


### PR DESCRIPTION
`dash` is used in CI, add support for it.

Fixes current failures with `elastic-package stack shellinit` with elastic-package v0.66.0 https://fleet-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations%2FPR-4482/detail/PR-4482/1/pipeline/

Seen in https://github.com/elastic/integrations/pull/4482.