### PR TITLE
Update package-registry to use EPR production as proxy

### DIFF
--- a/internal/profile/_static/Dockerfile.package-registry
+++ b/internal/profile/_static/Dockerfile.package-registry
@@ -5,6 +5,7 @@ ARG PROFILE
 ENV EPR_DISABLE_PACKAGE_VALIDATION=true
 
 ENV EPR_FEATURE_PROXY_MODE=true
+ENV EPR_PROXY_TO=https://epr.elastic.co
 
 COPY profiles/${PROFILE}/stack/package-registry.config.yml /package-registry/config.yml
 COPY stack/development/ /packages/development


### PR DESCRIPTION
This PR updates the Dockerfile that creates the Elastic Package Registry image to configure the Elastic Package Registry production DNS (https://epr.elastic.co) to be used as proxy. Currently, the default value used is the snapshot one (https://epr-snapshot.elastic.co)