### PR TITLE
Remove packages from bucket dry-run execution

### DIFF
--- a/.ci/package-storage-publish.groovy
+++ b/.ci/package-storage-publish.groovy
@@ -146,6 +146,10 @@ def uploadUnpublishedToPackageStorage(builtPackagesPath) {
             ],
             useCrumbCache: true,
             useJobInfoCache: true)
+
+          // As publishing job remote is triggered in dry-run mode, uploaded files (*.zip and *.zig.sig) should be deleted from the bucket
+          sh(label: 'Remove package .zip file', script: "gsutil rm ${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}")
+          sh(label: 'Remove package .sig file', script: "gsutil rm ${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}.sig")
         }
       }
     }


### PR DESCRIPTION
As publishing-job-remote is executed in dry-run mode, zip package and its signature files that were uploaded to the publishing queue are not being deleted from there when this job is run.
Therefore, it has been added the needed commands needed to ensure that there are no left files in the publishing queue (bucket).