### PR TITLE
Add auto-approve for dependabot PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,6 +4,13 @@ queue_rules:
       - check-success=elastic-package/pr-merge
 
 pull_request_rules:
+  - name: automatic approval for Dependabot pull requests
+    conditions:
+      - author~=^dependabot(|-preview)\[bot\]$
+    actions:
+      review:
+        type: APPROVE
+        message: Automatically approving dependabot
   - name: automatic merge of bot 🤖
     conditions:
       - check-success=elastic-package/pr-merge


### PR DESCRIPTION
It [seems](https://github.com/elastic/elastic-package/pull/1035/checks?check_run_id=9416295947) that mergify still expects an approval before merging PRs even if it has permissions. Let it auto-approve dependabot PRs.