### PR TITLE
Fix fleet-server healthcheck for 8.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test-stack-command-7x:
 	./scripts/test-stack-command.sh 7.17.3-SNAPSHOT
 
 test-stack-command-8x:
-	./scripts/test-stack-command.sh 8.3.0-SNAPSHOT
+	./scripts/test-stack-command.sh 8.6.0-SNAPSHOT
 
 test-stack-command: test-stack-command-default test-stack-command-7x test-stack-command-800 test-stack-command-8x
 

--- a/internal/profile/_static/docker-compose-stack.yml
+++ b/internal/profile/_static/docker-compose-stack.yml
@@ -86,7 +86,7 @@ services:
       kibana:
         condition: service_healthy
     healthcheck:
-      test: "curl --cacert /etc/ssl/elastic-agent/ca-cert.pem -f https://localhost:8220/api/status | grep HEALTHY 2>&1 >/dev/null"
+      test: "curl --cacert /etc/ssl/elastic-agent/ca-cert.pem -f https://localhost:8220/api/status | grep -i healthy 2>&1 >/dev/null"
       retries: 60
       interval: 5s
     hostname: docker-fleet-server


### PR DESCRIPTION
Fleet server healthcheck has changed its capitalization, before 8.6, it was:
```
{"name":"fleet-server","status":"HEALTHY"}
```
In 8.6 it is:
```
{"name":"fleet-server","status":"healthy"}
```