### PR TITLE
Add support when kibana or registry are defined under a path

### DIFF
--- a/.ci/package-storage-publish.groovy
+++ b/.ci/package-storage-publish.groovy
@@ -51,8 +51,8 @@ pipeline {
     stage('Build package') {
       steps {
         cleanup()
-        withGoEnv() {
-          dir("${BASE_DIR}") {
+        dir("${BASE_DIR}") {
+          withGoEnv() {
             sh(label: 'Install elastic-package',script: "make install")
             // sh(label: 'Install elastic-package', script: 'go build github.com/elastic/elastic-package')
             dir("test/packages/package-storage/package_storage_candidate") {

--- a/internal/kibana/client.go
+++ b/internal/kibana/client.go
@@ -108,7 +108,8 @@ func (c *Client) sendRequest(method, resourcePath string, body []byte) (int, []b
 		return 0, nil, errors.Wrapf(err, "could not create relative URL from resource path: %v", resourcePath)
 	}
 
-	u := base.JoinPath(rel.String())
+	u := base.JoinPath(rel.EscapedPath())
+	u.RawQuery = rel.RawQuery
 
 	logger.Debugf("%s %s", method, u)
 

--- a/internal/kibana/client.go
+++ b/internal/kibana/client.go
@@ -108,7 +108,7 @@ func (c *Client) sendRequest(method, resourcePath string, body []byte) (int, []b
 		return 0, nil, errors.Wrapf(err, "could not create relative URL from resource path: %v", resourcePath)
 	}
 
-	u := base.ResolveReference(rel)
+	u := base.JoinPath(rel.String())
 
 	logger.Debugf("%s %s", method, u)
 

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 
 	"github.com/pkg/errors"
+
+	"github.com/elastic/elastic-package/internal/logger"
 )
 
 const (
@@ -50,7 +52,9 @@ func (c *Client) get(resourcePath string) (int, []byte, error) {
 		return 0, nil, errors.Wrapf(err, "could not create relative URL from resource path: %v", resourcePath)
 	}
 
-	u := base.ResolveReference(rel)
+	u := base.JoinPath(rel.String())
+
+	logger.Debugf("%s", u)
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -10,8 +10,6 @@ import (
 	"net/url"
 
 	"github.com/pkg/errors"
-
-	"github.com/elastic/elastic-package/internal/logger"
 )
 
 const (
@@ -52,9 +50,8 @@ func (c *Client) get(resourcePath string) (int, []byte, error) {
 		return 0, nil, errors.Wrapf(err, "could not create relative URL from resource path: %v", resourcePath)
 	}
 
-	u := base.JoinPath(rel.String())
-
-	logger.Debugf("%s", u)
+	u := base.JoinPath(rel.EscapedPath())
+	u.RawQuery = rel.RawQuery
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {


### PR DESCRIPTION
Fixes #1031 

This PR adds support when kibana is defined under a path like `https://localhost:5601/kibana`

Example of the queries performed when testing a package:
```
2022/11/23 10:20:40 DEBUG creating test policy...
2022/11/23 10:20:40 DEBUG POST https://127.0.0.1:5601/kibana/api/fleet/agent_policies
2022/11/23 10:20:43 DEBUG adding package data stream to test policy...
2022/11/23 10:20:43 DEBUG POST https://127.0.0.1:5601/kibana/api/fleet/package_policies
```


Changes needed to be able to reproduce:
- Update ELASTIC_PACKAGE_KIBANA_HOST environment variable
  ```bash
  export ELASTIC_PACKAGE_KIBANA_HOST=https://127.0.0.1:5601/kibana
  ``` 
- Update kibana healthcheck.sh used by elastic-package:
    - File: `~/.elastic-package/stack/healthcheck.sh`
      ```bash
      #!/bin/bash

      set -e

      curl -s --cacert /usr/share/kibana/config/certs/ca-cert.pem -f https://localhost:5601/kibana/login | grep kbn-injected-metadata 2>&1 >/dev/null
      curl -s --cacert /usr/share/kibana/config/certs/ca-cert.pem -f -u elastic:changeme "https://elasticsearch:9200/_cat/indices/.security-*?h=health" | grep -v red
      ```
- Update dockerfile used by the corresponding profile
    - let's consider it is used `default profile`
    - it is required to update/add environment variables to fleet-server, elastic-agent and kibana services:
  ```yaml
  version: '2.3'
  services:
    kibana:
      image: "${KIBANA_IMAGE_REF}"
      ...
      environment:
        # Is there a better way to add certificates to Kibana/Fleet?
        - "NODE_EXTRA_CA_CERTS=/usr/share/kibana/config/certs/ca-cert.pem"
        - "SERVER_BASEPATH=/kibana"
        - "SERVER_PUBLICBASEURL=https://localhost:5601/kibana"
        - "SERVER_REWRITEBASEPATH=true"

    fleet-server:
      image: "${ELASTIC_AGENT_IMAGE_REF}"
      environment:
      - ...
      - "KIBANA_FLEET_HOST=https://kibana:5601/kibana"
      - "KIBANA_HOST=https://kibana:5601/kibana"

    elastic-agent:
      image: "${ELASTIC_AGENT_IMAGE_REF}"
      ...
      env_file: "./elastic-agent.${STACK_VERSION_VARIANT}.env"
      environment:
      - "KIBANA_FLEET_HOST=https://kibana:5601/kibana"
      - "KIBANA_HOST=https://kibana:5601/kibana"
  ```