### PR TITLE
Use consistent dataset in input tests configuration

### DIFF
--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -611,13 +611,14 @@ func createInputPackageDatastream(
 	streamInput := policyTemplate.Input
 	r.Inputs[0].Type = streamInput
 
+	dataset := fmt.Sprintf("%s.%s", pkg.Name, policyTemplate.Name)
 	streams := []kibana.Stream{
 		{
 			ID:      fmt.Sprintf("%s-%s.%s", streamInput, pkg.Name, policyTemplate.Name),
 			Enabled: true,
 			DataStream: kibana.DataStream{
 				Type:    policyTemplate.Type,
-				Dataset: fmt.Sprintf("%s.%s", pkg.Name, policyTemplate.Name),
+				Dataset: dataset,
 			},
 		},
 	}
@@ -626,7 +627,7 @@ func createInputPackageDatastream(
 	vars := setKibanaVariables(policyTemplate.Vars, config.Vars)
 	if _, found := vars["data_stream.dataset"]; !found {
 		var value packages.VarValue
-		value.Unpack(pkg.Name + "_test")
+		value.Unpack(dataset)
 		vars["data_stream.dataset"] = kibana.Var{
 			Value: value,
 			Type:  "text",


### PR DESCRIPTION
It seems that when the agent policy template includes a dataset ([as is the case of the jolokia input](https://github.com/elastic/integrations/blob/99dcdbe8ca003435d800c1abde5e4493c1fe4122/packages/jolokia_input/agent/input/input.yml.hbs#L11-L12)), this is used as part of the data stream name. If names are not consistent there, `elastic-package` cannot find documents when running system tests.