### PR TITLE
Find overrides of variables with names in their dots

### DIFF
--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -12,9 +12,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/elastic/elastic-package/internal/common"
 	"github.com/elastic/go-ucfg"
 	"github.com/elastic/go-ucfg/yaml"
+
+	"github.com/elastic/elastic-package/internal/common"
 )
 
 const (

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -644,7 +644,7 @@ func setKibanaVariables(definitions []packages.Variable, values map[string]packa
 	for _, definition := range definitions {
 		val := definition.Default
 
-		value, exists := values[definition.Name]
+		value, exists := getConfigValue(values, definition.Name)
 		if exists {
 			val = value
 		}
@@ -655,6 +655,26 @@ func setKibanaVariables(definitions []packages.Variable, values map[string]packa
 		}
 	}
 	return vars
+}
+
+func getConfigValue(values map[string]packages.VarValue, name string) (packages.VarValue, bool) {
+	value, found := values[name]
+	if found {
+		return value, true
+	}
+
+	// Workaround when the value has been expanded.
+	root, leaf, found := strings.Cut(name, ".")
+	if !found {
+		return packages.VarValue{}, false
+	}
+
+	parent, found := values[root]
+	if !found {
+		return packages.VarValue{}, false
+	}
+
+	return parent.GetChildValue(leaf)
 }
 
 // getDataStreamIndex returns the index of the data stream whose input name

--- a/internal/testrunner/runners/system/test_config.go
+++ b/internal/testrunner/runners/system/test_config.go
@@ -78,18 +78,27 @@ func newConfig(configFilePath string, ctxt servicedeployer.ServiceContext, servi
 		return nil, errors.Wrapf(err, "could not apply context to test configuration file: %s", configFilePath)
 	}
 
-	var c testConfig
-	cfg, err := yaml.NewConfig(data, ucfg.PathSep("."))
+	c, err := parseConfig(configFilePath, data)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to load system test configuration file: %s", configFilePath)
+		return nil, err
 	}
-	if err := cfg.Unpack(&c); err != nil {
-		return nil, errors.Wrapf(err, "unable to unpack system test configuration file: %s", configFilePath)
-	}
+
 	// Save path
 	c.Path = configFilePath
 	c.ServiceVariantName = serviceVariantName
 	return &c, nil
+}
+
+func parseConfig(configFilePath string, data []byte) (testConfig, error) {
+	var c testConfig
+	cfg, err := yaml.NewConfig(data, ucfg.PathSep("."))
+	if err != nil {
+		return c, errors.Wrapf(err, "unable to load system test configuration file: %s", configFilePath)
+	}
+	if err := cfg.Unpack(&c); err != nil {
+		return c, errors.Wrapf(err, "unable to unpack system test configuration file: %s", configFilePath)
+	}
+	return c, nil
 }
 
 func listConfigFiles(systemTestFolderPath string) (files []string, err error) {

--- a/internal/testrunner/runners/system/test_config_test.go
+++ b/internal/testrunner/runners/system/test_config_test.go
@@ -1,0 +1,29 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package system
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetExpandedConfigValue(t *testing.T) {
+	const configData = `
+vars:
+  jmx.mappings: |
+    - mbean: 'java.lang:type=Runtime'
+      attributes:
+        - attr: Uptime
+          field: uptime
+`
+
+	config, err := parseConfig("test", []byte(configData))
+	require.NoError(t, err)
+
+	_, found := getConfigValue(config.Vars, "jmx.mappings")
+	assert.True(t, found)
+}


### PR DESCRIPTION
Variables in policy templates can have dots in their names. This names are defined as plain strings in yaml files. For example like this:
```
      - name: jmx.mappings
        type: yaml
        title: JMX Mappings
        multi: false
        required: true
        show_user: true
```
These variables can be overridden in system tests configuration files, for example like this:
```
vars:
  hosts:
    - {{Hostname}}:{{Port}}
  jmx.mappings: |
    - mbean: 'java.lang:type=Runtime'
      attributes:
        - attr: Uptime
          field: uptime
```
These configuration files are parsed with go-ucfg, configured to use `.` as path separator, so variable names containing dots are expanded. Also, when parsed, they are parsed into an opaque `VarVariable` structure, so it is not possible to access their content, so overrides cannot be defined for variables with dots in their names.
This happens for example in https://github.com/elastic/integrations/pull/4706.

This issue could be easily solved if `ucfg` would support `preserve` as defined in https://github.com/elastic/go-ucfg/issues/124.

This change introduces a hacky workaround to give access to child elements, so they can be also used for overrides.

Alternatives considered:
* Completely disable variable expansion when parsing this configuration. This could produce breaking changes, and could be misleading, as developers are used to this kind of configurations where handling of objects structure is transparent for them.
* Implement `preserve` as defined in https://github.com/elastic/go-ucfg/issues/124. Probably a rabbit hole.
* Parse the configuration as `common.MapStr` instead of `map[string]VarValue`, and generate the `VarValue`s later. This could be cleaner, but require some refactors. I may give it a try though.