### PR TITLE
Fix override of variables with dots in their names in system tests

### DIFF
--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -639,14 +639,15 @@ func createInputPackageDatastream(
 	return r
 }
 
-func setKibanaVariables(definitions []packages.Variable, values map[string]packages.VarValue) kibana.Vars {
+func setKibanaVariables(definitions []packages.Variable, values common.MapStr) kibana.Vars {
 	vars := kibana.Vars{}
 	for _, definition := range definitions {
 		val := definition.Default
 
-		value, exists := values[definition.Name]
-		if exists {
-			val = value
+		value, err := values.GetValue(definition.Name)
+		if err == nil {
+			val = packages.VarValue{}
+			val.Unpack(value)
 		}
 
 		vars[definition.Name] = kibana.Var{

--- a/internal/testrunner/runners/system/test_config.go
+++ b/internal/testrunner/runners/system/test_config.go
@@ -17,7 +17,7 @@ import (
 	"github.com/elastic/go-ucfg"
 	"github.com/elastic/go-ucfg/yaml"
 
-	"github.com/elastic/elastic-package/internal/packages"
+	"github.com/elastic/elastic-package/internal/common"
 	"github.com/elastic/elastic-package/internal/testrunner"
 	"github.com/elastic/elastic-package/internal/testrunner/runners/system/servicedeployer"
 )
@@ -33,9 +33,9 @@ type testConfig struct {
 	ServiceNotifySignal string        `config:"service_notify_signal"` // Signal to send when the agent policy is applied.
 	WaitForDataTimeout  time.Duration `config:"wait_for_data_timeout"`
 
-	Vars       map[string]packages.VarValue `config:"vars"`
+	Vars       common.MapStr `config:"vars"`
 	DataStream struct {
-		Vars map[string]packages.VarValue `config:"vars"`
+		Vars common.MapStr `config:"vars"`
 	} `config:"data_stream"`
 
 	// NumericKeywordFields holds a list of fields that have keyword


### PR DESCRIPTION
Use `common.MapStr` to be able to get variables independently of them being expanded because of having dots or not.

Variables in policy templates can have dots in their names. This names are defined as plain strings in yaml files. For example like this:
```
      - name: jmx.mappings
        type: yaml
        title: JMX Mappings
        multi: false
        required: true
        show_user: true
```
These variables can be overridden in system tests configuration files, for example like this:
```
vars:
  hosts:
    - {{Hostname}}:{{Port}}
  jmx.mappings: |
    - mbean: 'java.lang:type=Runtime'
      attributes:
        - attr: Uptime
          field: uptime
```
These configuration files are parsed with go-ucfg, configured to use `.` as path separator, so variable names containing dots are expanded. Also, when parsed, they are parsed into an opaque `VarVariable` structure, so it is not possible to access their content, so overrides cannot be defined for variables with dots in their names.
This happens for example in https://github.com/elastic/integrations/pull/4706.

This issue could be easily solved if `ucfg` would support `preserve` as defined in https://github.com/elastic/go-ucfg/issues/124.
