### PR TITLE
Use cluster status for elasticsearch health

### DIFF
--- a/internal/profile/_static/docker-compose-stack.yml
+++ b/internal/profile/_static/docker-compose-stack.yml
@@ -3,7 +3,7 @@ services:
   elasticsearch:
     image: "${ELASTICSEARCH_IMAGE_REF}"
     healthcheck:
-      test: ["CMD", "curl", "--cacert", "/usr/share/elasticsearch/config/certs/ca-cert.pem", "-f", "-u", "elastic:changeme", "https://127.0.0.1:9200/"]
+      test: "curl -s --cacert /usr/share/elasticsearch/config/certs/ca-cert.pem -f -u elastic:changeme https://127.0.0.1:9200/_cat/health | cut -f4 -d' ' | grep -E '(green|yellow)'"
       retries: 300
       interval: 1s
     environment:


### PR DESCRIPTION
Modify elasticsearch healthcheck in `elastic-package stack` to check the cluster status. If it is not green or yellow, ingestion won't work, and tests will fail.

Related to https://github.com/elastic/elastic-package/issues/856.