### PR TITLE
Check cluster health before trying to run tests

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -151,6 +151,10 @@ func benchTypeCommandActionFactory(runner benchrunner.BenchRunner) cobraext.Comm
 		if err != nil {
 			return errors.Wrap(err, "can't create Elasticsearch client")
 		}
+		err = elasticsearch.CheckHealth(cmd.Context(), esClient.API)
+		if err != nil {
+			return err
+		}
 
 		var results []*benchrunner.Result
 		for _, folder := range benchFolders {

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -211,6 +211,10 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 		if err != nil {
 			return errors.Wrap(err, "can't create Elasticsearch client")
 		}
+		err = elasticsearch.CheckHealth(cmd.Context(), esClient.API)
+		if err != nil {
+			return err
+		}
 
 		var results []testrunner.TestResult
 		for _, folder := range testFolders {


### PR DESCRIPTION
Trying to run tests with an unhealthy cluster may lead to obscure failures. Explicitly check the status of the cluster before trying to run tests.