### PR TITLE
Use bash as shell in shellinit when detection is not implemented

### DIFF
--- a/internal/stack/shellinit.go
+++ b/internal/stack/shellinit.go
@@ -137,7 +137,7 @@ func detectShell() (string, error) {
 		// This mainly affects osx when building without CGO.
 		// Assume bash in that case.
 		// See https://github.com/elastic/elastic-package/issues/1030.
-		logger.Debugf("Failed to determine parent process info while detecting shell, will assume bash")
+		logger.Debug("Failed to determine parent process info while detecting shell, will assume bash")
 		return "bash", nil
 	}
 	if err != nil {


### PR DESCRIPTION
Elastic Package relies on sysinfo to get information about the running shell. This relies on features that are not implemented for all platforms. This is a frequent issue with some builds for Mac users. Assume bash when detection relies on unimplemented features.

Fixes https://github.com/elastic/elastic-package/issues/1030.