### PR TITLE
Add IndexTemplate field under elasticsearch field

### DIFF
--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -139,9 +139,11 @@ type DataStreamManifest struct {
 	Hidden        bool   `config:"hidden" json:"hidden" yaml:"hidden"`
 	Release       string `config:"release" json:"release" yaml:"release"`
 	Elasticsearch *struct {
-		IngestPipeline *struct {
-			Name string `config:"name" json:"name" yaml:"name"`
-		} `config:"ingest_pipeline" json:"ingest_pipeline" yaml:"ingest_pipeline"`
+		IndexTemplate *struct {
+			IngestPipeline *struct {
+				Name string `config:"name" json:"name" yaml:"name"`
+			} `config:"ingest_pipeline" json:"ingest_pipeline" yaml:"ingest_pipeline"`
+		} `config:"index_template" json:"index_template" yaml:"index_template"`
 	} `config:"elasticsearch" json:"elasticsearch" yaml:"elasticsearch"`
 	Streams []struct {
 		Input string     `config:"input" json:"input" yaml:"input"`
@@ -255,8 +257,8 @@ func ReadDataStreamManifest(path string) (*DataStreamManifest, error) {
 // GetPipelineNameOrDefault returns the name of the data stream's pipeline, if one is explicitly defined in the
 // data stream manifest. If not, the default pipeline name is returned.
 func (dsm *DataStreamManifest) GetPipelineNameOrDefault() string {
-	if dsm.Elasticsearch != nil && dsm.Elasticsearch.IngestPipeline != nil && dsm.Elasticsearch.IngestPipeline.Name != "" {
-		return dsm.Elasticsearch.IngestPipeline.Name
+	if dsm.Elasticsearch != nil && dsm.Elasticsearch.IndexTemplate != nil && dsm.Elasticsearch.IndexTemplate.IngestPipeline != nil && dsm.Elasticsearch.IndexTemplate.IngestPipeline.Name != "" {
+		return dsm.Elasticsearch.IndexTemplate.IngestPipeline.Name
 	}
 	return defaultPipelineName
 }


### PR DESCRIPTION
According to the package-spec [data_stream manifest definition](https://github.com/elastic/package-spec/blob/40622f8/spec/integration/data_stream/manifest.spec.yml#L196-L230), the structure under `elasticsearch` field should be:

```yaml
elasticsearch:
  index_template:
    mappings:
      ...
    ingest_pipeline:
      name:
```

Currently, DataStreamManifest definition does not include `index_template` field https://github.com/elastic/elastic-package/blob/019ab37/internal/packages/packages.go#L141-L145

This PR adds the `index_template` key to be compliant with the package-spec. Currently, there is no package defining/using this key in the integrations repository.

This addition is also required if at some point `mappings` need to be taken into account too.

Relates https://github.com/elastic/elastic-package/issues/1018