### PR TITLE
Fix expected dataset check in test runners

### DIFF
--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -254,6 +254,12 @@ func ReadDataStreamManifest(path string) (*DataStreamManifest, error) {
 	return &m, nil
 }
 
+// ReadDataStreamManifestFromPackageRoot reads and parses the manifest of the given
+// data stream from the given package root.
+func ReadDataStreamManifestFromPackageRoot(packageRoot string, name string) (*DataStreamManifest, error) {
+	return ReadDataStreamManifest(filepath.Join(packageRoot, "data_stream", name, DataStreamManifestFile))
+}
+
 // GetPipelineNameOrDefault returns the name of the data stream's pipeline, if one is explicitly defined in the
 // data stream manifest. If not, the default pipeline name is returned.
 func (dsm *DataStreamManifest) GetPipelineNameOrDefault() string {

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -99,6 +99,16 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 		return nil, errors.Wrap(err, "failed to read manifest")
 	}
 
+	dsManifest, err := packages.ReadDataStreamManifestFromPackageRoot(r.options.PackageRootPath, r.options.TestFolder.DataStream)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read data stream manifest")
+	}
+
+	expectedDataset := dsManifest.Dataset
+	if expectedDataset == "" {
+		expectedDataset = pkgManifest.Name + "." + r.options.TestFolder.DataStream
+	}
+
 	results := make([]testrunner.TestResult, 0)
 	for _, testCaseFile := range testCaseFiles {
 		tr := testrunner.TestResult{
@@ -140,7 +150,6 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 		result := &testResult{events: processedEvents}
 
 		tr.TimeElapsed = time.Since(startTime)
-		expectedDataset := pkgManifest.Name + "." + r.options.TestFolder.DataStream
 		fieldsValidator, err := fields.CreateValidatorForDirectory(dataStreamPath,
 			fields.WithSpecVersion(pkgManifest.SpecVersion),
 			fields.WithNumericKeywordFields(tc.config.NumericKeywordFields),

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -464,7 +464,7 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 	// Validate fields in docs
 	var expectedDataset string
 	if ds := r.options.TestFolder.DataStream; ds != "" {
-		expectedDataset = pkgManifest.Name + "." + ds
+		expectedDataset = getDataStreamDataset(*pkgManifest, *dataStreamManifest)
 	} else {
 		expectedDataset = pkgManifest.Name + "." + policyTemplateName
 	}

--- a/test/packages/other/with_dataset/changelog.yml
+++ b/test/packages/other/with_dataset/changelog.yml
@@ -1,4 +1,4 @@
-- version: "0.0.1"
+- version: "0.0.2"
   changes:
     - description: initial release
       type: enhancement

--- a/test/packages/other/with_dataset/manifest.yml
+++ b/test/packages/other/with_dataset/manifest.yml
@@ -1,15 +1,14 @@
-format_version: 1.0.0
+format_version: 2.2.0
 name: with_dataset
 title: With dataset test
-version: 0.0.1
+version: 0.0.2
 description: Package that defines system test for data streams with an overwriting dataset
 categories:
   - custom
-release: experimental
-license: basic
 type: integration
 conditions:
   kibana.version: '^8.0.0'
+  elastic.subscription: basic
 policy_templates:
   - name: sample
     title: Sample logs


### PR DESCRIPTION
Data stream manifests can override the dataset, this is configured in the policy, but then when checking generated documents, it fails with:
```
[0] field "data_stream.dataset" should have value "beat.stats", it has "beats.stack_monitoring.stats"
[1] field "event.dataset" should have value "beat.stats", it has "beats.stack_monitoring.stats"
```
Seen in https://github.com/elastic/integrations/pull/4708.

Also fix issue that was silently skipping static tests for input packages, because they were looking for the sample event in the wrong path.