### PR TITLE
Enable APM tracing by default for stack up

### DIFF
--- a/internal/profile/_static/docker-compose-stack.yml
+++ b/internal/profile/_static/docker-compose-stack.yml
@@ -37,6 +37,7 @@ services:
     environment:
       # Is there a better way to add certificates to Kibana/Fleet?
       - "NODE_EXTRA_CA_CERTS=/usr/share/kibana/config/certs/ca-cert.pem"
+      - "ELASTIC_APM_ENVIRONMENT=dev"
     volumes:
       - "./kibana.config.${STACK_VERSION_VARIANT}.yml:/usr/share/kibana/config/kibana.yml"
       - "../certs/kibana:/usr/share/kibana/config/certs"
@@ -66,6 +67,9 @@ services:
       - "EPR_METRICS_ADDRESS=0.0.0.0:9000"
       - "EPR_TLS_KEY=/etc/ssl/package-registry/key.pem"
       - "EPR_TLS_CERT=/etc/ssl/package-registry/cert.pem"
+      - "ELASTIC_APM_SERVER_URL=http://fleet-server:8200"
+      - "ELASTIC_APM_SECRET_TOKEN=changeme"
+      - "ELASTIC_APM_ENVIRONMENT=dev"
     volumes:
       - "../certs/package-registry:/etc/ssl/package-registry"
     ports:
@@ -107,7 +111,8 @@ services:
       - "../certs/ca-cert.pem:/etc/ssl/certs/elastic-package.pem"
       - "../certs/fleet-server:/etc/ssl/elastic-agent"
     ports:
-      - "127.0.0.1:8220:8220"
+      - "127.0.0.1:8220:8220" # Fleet Server
+      - "127.0.0.1:8200:8200" # APM
 
   fleet-server_is_ready:
     image: tianon/true

--- a/internal/profile/_static/elasticsearch_config_8x.yml
+++ b/internal/profile/_static/elasticsearch_config_8x.yml
@@ -13,3 +13,9 @@ xpack.security.http.ssl.key: "certs/key.pem"
 xpack.security.http.ssl.certificate: "certs/cert.pem"
 
 ingest.geoip.downloader.enabled: false
+
+tracing.apm.enabled: true
+tracing.apm.agent:
+  server_url: http://fleet-server:8200
+  secret_token: changeme
+  environment: dev

--- a/internal/profile/_static/kibana_config_8x.yml
+++ b/internal/profile/_static/kibana_config_8x.yml
@@ -20,12 +20,25 @@ xpack.encryptedSavedObjects.encryptionKey: "12345678901234567890123456789012"
 
 xpack.cloudSecurityPosture.enabled: true
 
+elastic.apm.active: true
+elastic.apm.serverUrl: http://fleet-server:8200
+elastic.apm.secretToken: changeme
+# elastic.apm.environment: dev # this doesn't work?
+elastic.apm.verifyServerCert: false
+elastic.apm.transactionSampleRate: 1.0
+elastic.apm.breakdownMetrics: true
+elastic.apm.captureSpanStackTraces: true
+elastic.apm.propagateTracestate: true
+elastic.apm.contextPropagationOnly: false
+
 xpack.fleet.packages:
   - name: system
     version: latest
   - name: elastic_agent
     version: latest
   - name: fleet_server
+    version: latest
+  - name: apm
     version: latest
 xpack.fleet.agentPolicies:
   - name: Elastic-Agent (elastic-package)
@@ -51,3 +64,26 @@ xpack.fleet.agentPolicies:
         id: default-fleet-server
         package:
           name: fleet_server
+        inputs:
+          - type: fleet-server
+            vars:
+              - name: custom
+                value: |
+                  server.runtime:
+                    gc_percent: 20
+                  server.instrumentation:
+                    enabled: true
+                    hosts:
+                    - "http://fleet-server:8200"
+                    environment: dev
+                    secret_token: changeme
+      - name: apm-1
+        package:
+          name: apm
+        inputs:
+          - type: apm
+            vars:
+              - name: host
+                value: "0.0.0.0:8200"
+              - name: secret_token
+                value: changeme


### PR DESCRIPTION
Turns on tracing by default for all components

<img width="1532" alt="image" src="https://user-images.githubusercontent.com/1813008/208213883-b37e9d33-1584-4b51-b595-0f0167c0eb61.png">


TODO:
- [ ] Figure out how to enable tracing for managed Agent
	- Setting `agent.monitoring.tracing` and `agent.monitoring.apm` settings in `elastic-agent.yml` didn't work
- [ ] Cleanup Kibana configs, prefer env vars over yaml if possible
- [ ] Log correlation for Fleet Server and Agent logs (which are already collected)
- [ ] Setup certs & https for APM for RUM support

Things that could be improved in future PRs:
- Agent and Fleet Server should allow enabling tracing via env vars, rather than depending on yaml or policy configuration
- Trace context propagation from Agent to Fleet Server
- Log collection and correlation for Kibana, Elasticsearch, and Package Registry