### PR TITLE
Fix panic when checking service status

### DIFF
--- a/internal/stack/compose.go
+++ b/internal/stack/compose.go
@@ -220,8 +220,12 @@ func newServiceStatus(description *docker.ContainerDescription) (*ServiceStatus,
 		Status:  description.State.Status,
 		Version: getVersionFromDockerImage(description.Config.Image),
 	}
-	if description.State.Status == "running" && description.State.Health != nil {
-		service.Status = fmt.Sprintf("%v (%v)", service.Status, description.State.Health.Status)
+	if description.State.Status == "running" {
+		healthStatus := "unknown health"
+		if health := description.State.Health; health != nil {
+			healthStatus = health.Status
+		}
+		service.Status = fmt.Sprintf("%v (%v)", service.Status, healthStatus)
 	}
 	if description.State.Status == "exited" {
 		service.Status = fmt.Sprintf("%v (%v)", service.Status, description.State.ExitCode)

--- a/internal/stack/compose.go
+++ b/internal/stack/compose.go
@@ -220,7 +220,7 @@ func newServiceStatus(description *docker.ContainerDescription) (*ServiceStatus,
 		Status:  description.State.Status,
 		Version: getVersionFromDockerImage(description.Config.Image),
 	}
-	if description.State.Status == "running" {
+	if description.State.Status == "running" && description.State.Health != nil {
 		service.Status = fmt.Sprintf("%v (%v)", service.Status, description.State.Health.Status)
 	}
 	if description.State.Status == "exited" {


### PR DESCRIPTION
There seems to be a race condition since a container starts running, till its state
reports any health information. During this time the value obtained from the API
is nil. Don't try to get the status from the healtcheck if that's the case.

This fixes panics like this one:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x231d562]

goroutine 1 [running]:
github.com/elastic/elastic-package/internal/stack.newServiceStatus(0xc000541b40)
	/home/jaime/gocode/src/github.com/elastic/elastic-package/internal/stack/compose.go:224 +0x1a2
github.com/elastic/elastic-package/internal/stack.dockerComposeStatus()
	/home/jaime/gocode/src/github.com/elastic/elastic-package/internal/stack/compose.go:206 +0x165
github.com/elastic/elastic-package/internal/stack.Status()
	/home/jaime/gocode/src/github.com/elastic/elastic-package/internal/stack/status.go:16 +0x2b
github.com/elastic/elastic-package/internal/stack.(*composeProvider).Status(0x0, {0x0, {0x0, 0x0}, {0x0, 0x0, 0x0}, 0xc00045f0e0, {0x3f70698, 0xc000513800}})
	/home/jaime/gocode/src/github.com/elastic/elastic-package/internal/stack/providers.go:82 +0x17
github.com/elastic/elastic-package/cmd.setupStackCommand.func6(0xc000513800, {0x5892d28?, 0x0?, 0x0?})
	/home/jaime/gocode/src/github.com/elastic/elastic-package/cmd/stack.go:258 +0xa5
github.com/spf13/cobra.(*Command).execute(0xc000513800, {0x5892d28, 0x0, 0x0})
	/home/jaime/gocode/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:916 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0xc000729800)
	/home/jaime/gocode/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/home/jaime/gocode/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
main.main()
	/home/jaime/gocode/src/github.com/elastic/elastic-package/main.go:29 +0xe5
exit status 2
```
Seen while testing https://github.com/elastic/elastic-package/pull/1055, but looks like it may affect current code too.