### PR TITLE
Refactor to remove global shell type for shellinit

### DIFF
--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -202,12 +202,9 @@ func setupStackCommand() *cobraext.Command {
 			if err != nil {
 				return cobraext.FlagParsingError(err, cobraext.ShellInitShellFlagName)
 			}
-
 			if shellName == cobraext.ShellInitShellDetect {
-				shellName = stack.AutodetectedShell()
+				shellName = stack.AutodetectShell()
 				fmt.Fprintf(cmd.OutOrStderr(), "Detected shell: %s\n", shellName)
-			} else {
-				stack.SelectShell(shellName)
 			}
 
 			profile, err := profile.LoadProfile(profileName)
@@ -215,7 +212,7 @@ func setupStackCommand() *cobraext.Command {
 				return errors.Wrap(err, "error loading profile")
 			}
 
-			shellCode, err := stack.ShellInit(profile)
+			shellCode, err := stack.ShellInit(profile, shellName)
 			if err != nil {
 				return errors.Wrap(err, "shellinit failed")
 			}

--- a/internal/stack/errors.go
+++ b/internal/stack/errors.go
@@ -9,5 +9,5 @@ import "fmt"
 // UndefinedEnvError formats an error reported for undefined variable.
 func UndefinedEnvError(envName string) error {
 	return fmt.Errorf("undefined environment variable: %s. If you have started the Elastic stack using the elastic-package tool, "+
-		`please load stack environment variables using '%s' or set their values manually`, envName, helpText(shellType))
+		`please load stack environment variables using '%s' or set their values manually`, envName, helpText(AutodetectShell()))
 }

--- a/internal/stack/shellinit.go
+++ b/internal/stack/shellinit.go
@@ -27,7 +27,7 @@ var (
 	CACertificateEnv         = environment.WithElasticPackagePrefix("CA_CERT")
 )
 
-// AutodetectShell returns an error if shell could not be detected.
+// AutodetectShell returns the detected shell used.
 func AutodetectShell() string {
 	return detectShell()
 }

--- a/internal/stack/shellinit.go
+++ b/internal/stack/shellinit.go
@@ -27,24 +27,13 @@ var (
 	CACertificateEnv         = environment.WithElasticPackagePrefix("CA_CERT")
 )
 
-var shellType string
-
-func init() {
-	shellType = detectShell()
-}
-
-// SelectShell selects the shell to use.
-func SelectShell(shell string) {
-	shellType = shell
-}
-
-// AutodetectedShell returns an error if shell could not be detected.
-func AutodetectedShell() string {
-	return shellType
+// AutodetectShell returns an error if shell could not be detected.
+func AutodetectShell() string {
+	return detectShell()
 }
 
 // ShellInit method exposes environment variables that can be used for testing purposes.
-func ShellInit(elasticStackProfile *profile.Profile) (string, error) {
+func ShellInit(elasticStackProfile *profile.Profile, shellType string) (string, error) {
 	config, err := StackInitConfig(elasticStackProfile)
 	if err != nil {
 		return "", nil


### PR DESCRIPTION
Small refactor to remove the global shell type used to provide the help text on related errors.