### PR TITLE
Add CA fingerprint to agents configuration in 8.x versions

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -10,8 +10,10 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -19,6 +21,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/elastic/elastic-package/internal/common"
@@ -255,7 +258,23 @@ func (c *Certificate) WriteCert(w io.Writer) error {
 	return nil
 }
 
-// WriteCertFile writes the PEM-encoded certificate in the given file.
+// WriteEnv writes the environment variables about the certificate in the given writer.
+func (c *Certificate) WriteEnv(w io.Writer) error {
+	fingerprint := c.Fingerprint()
+	_, err := fmt.Fprintf(w, "%s=%s\n",
+		"ELASTIC_PACKAGE_CA_SHA256",
+		strings.ToUpper(hex.EncodeToString(fingerprint)))
+	return err
+}
+
+// Fingerprint returns the fingerprint of the certificate. The fingerprint
+// of a CA can be used to verify certificates.
+func (c *Certificate) Fingerprint() []byte {
+	f := sha256.Sum256(c.cert.Raw)
+	return f[:]
+}
+
+// WriteCertFile writes the PEM-encoded certifiacte in the given file.
 func (c *Certificate) WriteCertFile(path string) error {
 	err := os.MkdirAll(filepath.Dir(path), 0755)
 	if err != nil {

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -262,7 +262,7 @@ func (c *Certificate) WriteCert(w io.Writer) error {
 func (c *Certificate) WriteEnv(w io.Writer) error {
 	fingerprint := c.Fingerprint()
 	_, err := fmt.Fprintf(w, "%s=%s\n",
-		"ELASTIC_PACKAGE_CA_SHA256",
+		"ELASTIC_PACKAGE_CA_TRUSTED_FINGERPRINT",
 		strings.ToUpper(hex.EncodeToString(fingerprint)))
 	return err
 }

--- a/internal/profile/_static/docker-compose-stack.yml
+++ b/internal/profile/_static/docker-compose-stack.yml
@@ -34,6 +34,8 @@ services:
       test: "sh /usr/share/kibana/healthcheck.sh"
       retries: 600
       interval: 1s
+    env_file:
+      - "../certs/ca.env"
     environment:
       # Is there a better way to add certificates to Kibana/Fleet?
       - "NODE_EXTRA_CA_CERTS=/usr/share/kibana/config/certs/ca-cert.pem"

--- a/internal/profile/_static/kibana_config_80.yml
+++ b/internal/profile/_static/kibana_config_80.yml
@@ -14,6 +14,7 @@ monitoring.ui.container.elasticsearch.enabled: true
 xpack.fleet.registryUrl: "https://package-registry:8080"
 xpack.fleet.agents.enabled: true
 xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch:9200"]
+xpack.fleet.agents.elasticsearch.ca_trusted_fingerprint: "${ELASTIC_PACKAGE_CA_TRUSTED_FINGERPRINT}"
 xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server:8220"]
 
 xpack.encryptedSavedObjects.encryptionKey: "12345678901234567890123456789012"

--- a/internal/profile/_static/kibana_config_80.yml
+++ b/internal/profile/_static/kibana_config_80.yml
@@ -14,7 +14,6 @@ monitoring.ui.container.elasticsearch.enabled: true
 xpack.fleet.registryUrl: "https://package-registry:8080"
 xpack.fleet.agents.enabled: true
 xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch:9200"]
-xpack.fleet.agents.elasticsearch.ca_trusted_fingerprint: "${ELASTIC_PACKAGE_CA_TRUSTED_FINGERPRINT}"
 xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server:8220"]
 
 xpack.encryptedSavedObjects.encryptionKey: "12345678901234567890123456789012"
@@ -50,3 +49,11 @@ xpack.fleet.agentPolicies:
         id: default-fleet-server
         package:
           name: fleet_server
+xpack.fleet.outputs:
+  - id: fleet-default-output
+    name: default
+    type: elasticsearch
+    hosts: [ https://elasticsearch:9200 ]
+    ca_trusted_fingerprint: "${ELASTIC_PACKAGE_CA_TRUSTED_FINGERPRINT}"
+    is_default: true
+    is_default_monitoring: true

--- a/internal/profile/_static/kibana_config_8x.yml
+++ b/internal/profile/_static/kibana_config_8x.yml
@@ -14,7 +14,6 @@ monitoring.ui.container.elasticsearch.enabled: true
 xpack.fleet.registryUrl: "https://package-registry:8080"
 xpack.fleet.agents.enabled: true
 xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch:9200"]
-xpack.fleet.agents.elasticsearch.ca_trusted_fingerprint: "${ELASTIC_PACKAGE_CA_TRUSTED_FINGERPRINT}"
 xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server:8220"]
 
 xpack.encryptedSavedObjects.encryptionKey: "12345678901234567890123456789012"
@@ -52,3 +51,11 @@ xpack.fleet.agentPolicies:
         id: default-fleet-server
         package:
           name: fleet_server
+xpack.fleet.outputs:
+  - id: fleet-default-output
+    name: default
+    type: elasticsearch
+    hosts: [ https://elasticsearch:9200 ]
+    ca_trusted_fingerprint: "${ELASTIC_PACKAGE_CA_TRUSTED_FINGERPRINT}"
+    is_default: true
+    is_default_monitoring: true

--- a/internal/profile/_static/kibana_config_8x.yml
+++ b/internal/profile/_static/kibana_config_8x.yml
@@ -14,7 +14,7 @@ monitoring.ui.container.elasticsearch.enabled: true
 xpack.fleet.registryUrl: "https://package-registry:8080"
 xpack.fleet.agents.enabled: true
 xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch:9200"]
-xpack.fleet.agents.elasticsearch.ca_sha256: "${ELASTIC_PACKAGE_CA_SHA256}"
+xpack.fleet.agents.elasticsearch.ca_trusted_fingerprint: "${ELASTIC_PACKAGE_CA_TRUSTED_FINGERPRINT}"
 xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server:8220"]
 
 xpack.encryptedSavedObjects.encryptionKey: "12345678901234567890123456789012"

--- a/internal/profile/_static/kibana_config_8x.yml
+++ b/internal/profile/_static/kibana_config_8x.yml
@@ -14,6 +14,7 @@ monitoring.ui.container.elasticsearch.enabled: true
 xpack.fleet.registryUrl: "https://package-registry:8080"
 xpack.fleet.agents.enabled: true
 xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch:9200"]
+xpack.fleet.agents.elasticsearch.ca_sha256: "${ELASTIC_PACKAGE_CA_SHA256}"
 xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server:8220"]
 
 xpack.encryptedSavedObjects.encryptionKey: "12345678901234567890123456789012"

--- a/internal/profile/certs.go
+++ b/internal/profile/certs.go
@@ -32,6 +32,9 @@ var (
 
 	// CAKeyFile is the path to the CA key file inside a profile.
 	CAKeyFile = configFile(filepath.Join(CertificatesDirectory, "ca-key.pem"))
+
+	// CAEnvFile is the path to the file with environment variables about the CA.
+	CAEnvFile = configFile(filepath.Join(CertificatesDirectory, "ca.env"))
 )
 
 // initTLSCertificates initializes all the certificates needed to run the services
@@ -41,6 +44,7 @@ func initTLSCertificates(profilePath string, configMap map[configFile]*simpleFil
 	certsDir := filepath.Join(profilePath, CertificatesDirectory)
 	caCertFile := filepath.Join(profilePath, string(CACertificateFile))
 	caKeyFile := filepath.Join(profilePath, string(CAKeyFile))
+	envFile := filepath.Join(profilePath, string(CAEnvFile))
 
 	ca, err := initCA(caCertFile, caKeyFile)
 	if err != nil {
@@ -51,6 +55,10 @@ func initTLSCertificates(profilePath string, configMap map[configFile]*simpleFil
 		return err
 	}
 	err = certWriterToSimpleFile(configMap, profilePath, caKeyFile, ca.WriteKey)
+	if err != nil {
+		return err
+	}
+	err = certWriterToSimpleFile(configMap, profilePath, envFile, ca.WriteEnv)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Try again something like https://github.com/elastic/elastic-package/pull/789/commits/bb84977ac4e3710587a26cbf3eb752483b5b65b9 for 8.x stacks.

Adding this setting was evaluated and discarded in https://github.com/elastic/elastic-package/pull/789 because it didn't help configuring SSL in agents started by `elastic-package stack up`, as it was not supported in all versions of the stack supported by `elastic-package`. More about this can be read in https://github.com/elastic/elastic-package/pull/789.

The option implemented then and being used now is to install the certificate in the Elastic Agent containers, in `/etc/ssl`. This works well for Agents managed by `elastic-package`, but is not enough for external Elastic Agents, where installing the CA in the system may be more cumbersome.

Try to add the fingerprint back, as it would be helpful in some testing scenarios using external Elastic Agents.

Fix https://github.com/elastic/elastic-package/issues/1083.