### PR TITLE
[Kubernetes] Add support for 1.26 K8s version and update kind version

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -15,8 +15,8 @@ pipeline {
     PIPELINE_LOG_LEVEL='INFO'
     AWS_ACCOUNT_SECRET = 'secret/observability-team/ci/elastic-observability-aws-account-auth'
     HOME = "${env.WORKSPACE}"
-    KIND_VERSION = 'v0.14.0'
-    K8S_VERSION = 'v1.25.0'
+    KIND_VERSION = 'v0.17.0'
+    K8S_VERSION = 'v1.26.0'
     JOB_GCS_BUCKET = 'fleet-ci-temp'
     JOB_GCS_BUCKET_INTERNAL = 'fleet-ci-temp-internal'
     JOB_GCS_CREDENTIALS = 'fleet-ci-gcs-plugin'


### PR DESCRIPTION
## What does this PR do?
Adds support for Kubernetes 1.26.x version and update kind version to 0.17.0


## Related issues

- Relates to https://github.com/elastic/observability-dev/issues/2345