### PR TITLE
Move package-spec check version for dynamic mappings import

### DIFF
--- a/internal/builder/dynamic_mappings.go
+++ b/internal/builder/dynamic_mappings.go
@@ -89,11 +89,6 @@ func shouldImportEcsMappings(specVersion, packageRoot string) (bool, error) {
 		return false, errors.Wrap(err, "invalid spec version")
 	}
 
-	if v.LessThan(semver2_3_0) {
-		logger.Debugf("Required spec version >= %s to import ECS mappings", semver2_3_0.String())
-		return false, nil
-	}
-
 	bm, ok, err := buildmanifest.ReadBuildManifest(packageRoot)
 	if err != nil {
 		return false, errors.Wrap(err, "can't read build manifest")
@@ -106,6 +101,12 @@ func shouldImportEcsMappings(specVersion, packageRoot string) (bool, error) {
 		logger.Debug("Package doesn't have to import ECS mappings")
 		return false, nil
 	}
+
+	if v.LessThan(semver2_3_0) {
+		logger.Debugf("Required spec version >= %s to import ECS mappings", semver2_3_0.String())
+		return false, nil
+	}
+
 	return true, nil
 }
 


### PR DESCRIPTION
This PR moves down the check performed to import dynamic mappings related to the package-spec version.
This check should just be applied in case it is defined `import_mappings` in the package, but they are not using at least `format_version: 2.3.0`

Before the following debug message was showed when building a package:
```
2023/01/18 10:34:42 DEBUG Required spec version >= 2.3.0 to import ECS mappings
```
but the package had no enable the import mappings feature.