### PR TITLE
[Fleet] Enable experimental toggles in Fleet UI from Kibana config

### DIFF
--- a/internal/profile/_static/kibana_config_8x.yml
+++ b/internal/profile/_static/kibana_config_8x.yml
@@ -5,7 +5,7 @@ server.ssl.certificate: "/usr/share/kibana/config/certs/cert.pem"
 server.ssl.key: "/usr/share/kibana/config/certs/key.pem"
 server.ssl.certificateAuthorities: ["/usr/share/kibana/config/certs/ca-cert.pem"]
 
-elasticsearch.hosts: [ "https://elasticsearch:9200" ]
+elasticsearch.hosts: ["https://elasticsearch:9200"]
 elasticsearch.ssl.certificateAuthorities: "/usr/share/kibana/config/certs/ca-cert.pem"
 elasticsearch.serviceAccountToken: "AAEAAWVsYXN0aWMva2liYW5hL2VsYXN0aWMtcGFja2FnZS1raWJhbmEtdG9rZW46b2x4b051SWNRa0tYMHdXazdLWmFBdw"
 
@@ -15,6 +15,7 @@ xpack.fleet.registryUrl: "https://package-registry:8080"
 xpack.fleet.agents.enabled: true
 xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch:9200"]
 xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server:8220"]
+xpack.fleet.enableExperimental: ["experimentalDataStreamSettings"] # Enable experimental toggles in Fleet UI
 
 xpack.encryptedSavedObjects.encryptionKey: "12345678901234567890123456789012"
 
@@ -55,7 +56,7 @@ xpack.fleet.outputs:
   - id: fleet-default-output
     name: default
     type: elasticsearch
-    hosts: [ https://elasticsearch:9200 ]
+    hosts: [https://elasticsearch:9200]
     ca_trusted_fingerprint: "${ELASTIC_PACKAGE_CA_TRUSTED_FINGERPRINT}"
     is_default: true
     is_default_monitoring: true

--- a/internal/profile/_static/kibana_config_8x.yml
+++ b/internal/profile/_static/kibana_config_8x.yml
@@ -56,7 +56,7 @@ xpack.fleet.outputs:
   - id: fleet-default-output
     name: default
     type: elasticsearch
-    hosts: [https://elasticsearch:9200]
+    hosts: ["https://elasticsearch:9200"]
     ca_trusted_fingerprint: "${ELASTIC_PACKAGE_CA_TRUSTED_FINGERPRINT}"
     is_default: true
     is_default_monitoring: true

--- a/internal/profile/_static/kibana_config_default.yml
+++ b/internal/profile/_static/kibana_config_default.yml
@@ -17,6 +17,5 @@ xpack.fleet.registryUrl: "https://package-registry:8080"
 xpack.fleet.agents.enabled: true
 xpack.fleet.agents.elasticsearch.host: "https://elasticsearch:9200"
 xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server:8220"]
-xpack.fleet.enableExperimental: ["experimentalDataStreamSettings"] # Enable experimental toggles in Fleet UI
 
 xpack.encryptedSavedObjects.encryptionKey: "12345678901234567890123456789012"

--- a/internal/profile/_static/kibana_config_default.yml
+++ b/internal/profile/_static/kibana_config_default.yml
@@ -5,7 +5,7 @@ server.ssl.certificate: "/usr/share/kibana/config/certs/cert.pem"
 server.ssl.key: "/usr/share/kibana/config/certs/key.pem"
 server.ssl.certificateAuthorities: ["/usr/share/kibana/config/certs/ca-cert.pem"]
 
-elasticsearch.hosts: [ "https://elasticsearch:9200" ]
+elasticsearch.hosts: ["https://elasticsearch:9200"]
 elasticsearch.ssl.certificateAuthorities: "/usr/share/kibana/config/certs/ca-cert.pem"
 elasticsearch.username: elastic
 elasticsearch.password: changeme
@@ -17,5 +17,6 @@ xpack.fleet.registryUrl: "https://package-registry:8080"
 xpack.fleet.agents.enabled: true
 xpack.fleet.agents.elasticsearch.host: "https://elasticsearch:9200"
 xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server:8220"]
+xpack.fleet.enableExperimental: ["experimentalDataStreamSettings"] # Enable experimental toggles in Fleet UI
 
 xpack.encryptedSavedObjects.encryptionKey: "12345678901234567890123456789012"


### PR DESCRIPTION
Enable the experimental data stream toggles (synthetic source, TSDB, doc-values-only) in Fleet's policy editor by toggling a feature flag in the Kibana config used for launching the local Kibana instance.

Ref https://github.com/elastic/kibana/pull/148418
Ref https://github.com/elastic/kibana/issues/148317

Not sure if this should also be turned on in the other Kibana config files:
- `kibana_config_8x.yml`
- `kibana_config_80.yml`

If they should be edited too, let me know and I'll happily make the changes. 