### PR TITLE
all: replace github.com/pkg/errors with errors

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -5,9 +5,9 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/builder"
@@ -49,30 +49,30 @@ func buildCommandAction(cmd *cobra.Command, args []string) error {
 	skipValidation, _ := cmd.Flags().GetBool(cobraext.BuildSkipValidationFlagName)
 
 	if signPackage && !createZip {
-		return errors.New("can't sign the unzipped package, please use also the --zip switch")
+		return fmt.Errorf("can't sign the unzipped package, please use also the --zip switch")
 	}
 
 	if signPackage {
 		err := files.VerifySignerConfiguration()
 		if err != nil {
-			return errors.Wrap(err, "can't verify signer configuration")
+			return fmt.Errorf("can't verify signer configuration: %s", err)
 		}
 	}
 
 	packageRoot, err := packages.MustFindPackageRoot()
 	if err != nil {
-		return errors.Wrap(err, "locating package root failed")
+		return fmt.Errorf("locating package root failed: %s", err)
 	}
 
 	buildDir, err := builder.BuildDirectory()
 	if err != nil {
-		return errors.Wrap(err, "can't prepare build directory")
+		return fmt.Errorf("can't prepare build directory: %s", err)
 	}
 	logger.Debugf("Use build directory: %s", buildDir)
 
 	targets, err := docs.UpdateReadmes(packageRoot)
 	if err != nil {
-		return errors.Wrap(err, "updating files failed")
+		return fmt.Errorf("updating files failed: %s", err)
 	}
 
 	for _, target := range targets {
@@ -87,7 +87,7 @@ func buildCommandAction(cmd *cobra.Command, args []string) error {
 		SkipValidation: skipValidation,
 	})
 	if err != nil {
-		return errors.Wrap(err, "building package failed")
+		return fmt.Errorf("building package failed: %s", err)
 	}
 	cmd.Printf("Package built: %s\n", target)
 

--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -5,11 +5,11 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cobraext"
@@ -61,13 +61,13 @@ func setupChangelogCommand() *cobraext.Command {
 func changelogAddCmd(cmd *cobra.Command, args []string) error {
 	packageRoot, err := packages.MustFindPackageRoot()
 	if err != nil {
-		return errors.Wrap(err, "locating package root failed")
+		return fmt.Errorf("locating package root failed: %s", err)
 	}
 
 	version, _ := cmd.Flags().GetString(cobraext.ChangelogAddVersionFlagName)
 	nextMode, _ := cmd.Flags().GetString(cobraext.ChangelogAddNextFlagName)
 	if version != "" && nextMode != "" {
-		return errors.Errorf("flags %q and %q cannot be used at the same time",
+		return fmt.Errorf("flags %q and %q cannot be used at the same time",
 			cobraext.ChangelogAddVersionFlagName,
 			cobraext.ChangelogAddNextFlagName)
 	}
@@ -110,7 +110,7 @@ func changelogAddCmd(cmd *cobra.Command, args []string) error {
 func changelogCmdVersion(nextMode, packageRoot string) (*semver.Version, error) {
 	revisions, err := changelog.ReadChangelogFromPackageRoot(packageRoot)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to read current changelog")
+		return nil, fmt.Errorf("failed to read current changelog: %s", err)
 	}
 	if len(revisions) == 0 {
 		return semver.MustParse("0.0.0"), nil
@@ -118,7 +118,7 @@ func changelogCmdVersion(nextMode, packageRoot string) (*semver.Version, error) 
 
 	version, err := semver.NewVersion(revisions[0].Version)
 	if err != nil {
-		return nil, errors.Wrapf(err, "invalid version in changelog %q", revisions[0].Version)
+		return nil, fmt.Errorf("invalid version in changelog %q: %s", revisions[0].Version, err)
 	}
 
 	switch nextMode {
@@ -134,8 +134,9 @@ func changelogCmdVersion(nextMode, packageRoot string) (*semver.Version, error) 
 		v := version.IncPatch()
 		version = &v
 	default:
-		return nil, errors.Errorf("invalid value for %q: %s",
+		return nil, fmt.Errorf("invalid value for %q: %s",
 			cobraext.ChangelogAddNextFlagName, nextMode)
+
 	}
 
 	return version, nil

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -5,7 +5,8 @@
 package cmd
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cobraext"
@@ -27,7 +28,7 @@ func setupCheckCommand() *cobraext.Command {
 				setupBuildCommand(),
 			)
 			if err != nil {
-				return errors.Wrap(err, "checking package failed")
+				return fmt.Errorf("checking package failed: %s", err)
 			}
 			return nil
 		},

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -5,7 +5,8 @@
 package cmd
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cleanup"
@@ -32,7 +33,7 @@ func cleanCommandAction(cmd *cobra.Command, args []string) error {
 
 	target, err := cleanup.Build()
 	if err != nil {
-		return errors.Wrap(err, "can't clean build resources")
+		return fmt.Errorf("can't clean build resources: %s", err)
 	}
 
 	if target != "" {
@@ -41,7 +42,7 @@ func cleanCommandAction(cmd *cobra.Command, args []string) error {
 
 	target, err = cleanup.Stack()
 	if err != nil {
-		return errors.Wrap(err, "can't clean the development stack")
+		return fmt.Errorf("can't clean the development stack: %s", err)
 	}
 	if target != "" {
 		cmd.Printf("Package removed from the development stack: %s\n", target)
@@ -49,7 +50,7 @@ func cleanCommandAction(cmd *cobra.Command, args []string) error {
 
 	target, err = cleanup.ServiceLogs()
 	if err != nil {
-		return errors.Wrap(err, "can't clean temporary service logs")
+		return fmt.Errorf("can't clean temporary service logs: %s", err)
 	}
 	if target != "" {
 		cmd.Printf("Temporary service logs removed: %s\n", target)

--- a/cmd/create_data_stream.go
+++ b/cmd/create_data_stream.go
@@ -5,8 +5,9 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/packages"
@@ -29,10 +30,10 @@ func createDataStreamCommandAction(cmd *cobra.Command, args []string) error {
 
 	packageRoot, found, err := packages.FindPackageRoot()
 	if err != nil {
-		return errors.Wrap(err, "locating package root failed")
+		return fmt.Errorf("locating package root failed: %s", err)
 	}
 	if !found {
-		return errors.New("package root not found, you can only create new data stream in the package context")
+		return fmt.Errorf("package root not found, you can only create new data stream in the package context")
 	}
 
 	qs := []*survey.Question{
@@ -65,13 +66,13 @@ func createDataStreamCommandAction(cmd *cobra.Command, args []string) error {
 	var answers newDataStreamAnswers
 	err = survey.Ask(qs, &answers)
 	if err != nil {
-		return errors.Wrap(err, "prompt failed")
+		return fmt.Errorf("prompt failed: %s", err)
 	}
 
 	descriptor := createDataStreamDescriptorFromAnswers(answers, packageRoot)
 	err = archetype.CreateDataStream(descriptor)
 	if err != nil {
-		return errors.Wrap(err, "can't create new data stream")
+		return fmt.Errorf("can't create new data stream: %s", err)
 	}
 
 	cmd.Println("Done")

--- a/cmd/create_package.go
+++ b/cmd/create_package.go
@@ -5,8 +5,9 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/licenses"
@@ -133,13 +134,13 @@ func createPackageCommandAction(cmd *cobra.Command, args []string) error {
 	var answers newPackageAnswers
 	err := survey.Ask(qs, &answers)
 	if err != nil {
-		return errors.Wrap(err, "prompt failed")
+		return fmt.Errorf("prompt failed: %s", err)
 	}
 
 	descriptor := createPackageDescriptorFromAnswers(answers)
 	err = archetype.CreatePackage(descriptor)
 	if err != nil {
-		return errors.Wrap(err, "can't create new package")
+		return fmt.Errorf("can't create new package: %s", err)
 	}
 
 	cmd.Println("Done")

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cobraext"
@@ -82,13 +81,13 @@ func dumpInstalledObjectsCmdAction(cmd *cobra.Command, args []string) error {
 	}
 	client, err := elasticsearch.NewClient(clientOptions...)
 	if err != nil {
-		return errors.Wrap(err, "failed to initialize Elasticsearch client")
+		return fmt.Errorf("failed to initialize Elasticsearch client: %s", err)
 	}
 
 	dumper := dump.NewInstalledObjectsDumper(client.API, packageName)
 	n, err := dumper.DumpAll(cmd.Context(), outputPath)
 	if err != nil {
-		return errors.Wrap(err, "dump failed")
+		return fmt.Errorf("dump failed: %s", err)
 	}
 	if n == 0 {
 		cmd.Printf("No objects were dumped for package %s, is it installed?\n", packageName)
@@ -122,7 +121,7 @@ func dumpAgentPoliciesCmdAction(cmd *cobra.Command, args []string) error {
 	}
 	kibanaClient, err := kibana.NewClient(clientOptions...)
 	if err != nil {
-		return errors.Wrap(err, "failed to initialize Kibana client")
+		return fmt.Errorf("failed to initialize Kibana client: %s", err)
 	}
 
 	switch {
@@ -132,14 +131,14 @@ func dumpAgentPoliciesCmdAction(cmd *cobra.Command, args []string) error {
 		dumper := dump.NewAgentPoliciesDumper(kibanaClient)
 		err = dumper.DumpByName(cmd.Context(), outputPath, agentPolicy)
 		if err != nil {
-			return errors.Wrap(err, "dump failed")
+			return fmt.Errorf("dump failed: %s", err)
 		}
 		cmd.Printf("Dumped agent policy %s to %s\n", agentPolicy, outputPath)
 	case packageName != "":
 		dumper := dump.NewAgentPoliciesDumper(kibanaClient)
 		count, err := dumper.DumpByPackage(cmd.Context(), outputPath, packageName)
 		if err != nil {
-			return errors.Wrap(err, "dump failed")
+			return fmt.Errorf("dump failed: %s", err)
 		}
 		if count != 0 {
 			cmd.Printf("Dumped %d agent policies filtering by package name %s to %s\n", count, packageName, outputPath)
@@ -150,7 +149,7 @@ func dumpAgentPoliciesCmdAction(cmd *cobra.Command, args []string) error {
 		dumper := dump.NewAgentPoliciesDumper(kibanaClient)
 		count, err := dumper.DumpAll(cmd.Context(), outputPath)
 		if err != nil {
-			return errors.Wrap(err, "dump failed")
+			return fmt.Errorf("dump failed: %s", err)
 		}
 		if count != 0 {
 			cmd.Printf("Dumped %d agent policies to %s\n", count, outputPath)

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cobraext"
@@ -67,18 +66,18 @@ func exportDashboardsCmd(cmd *cobra.Command, args []string) error {
 
 	kibanaClient, err := kibana.NewClient(opts...)
 	if err != nil {
-		return errors.Wrap(err, "can't create Kibana client")
+		return fmt.Errorf("can't create Kibana client: %s", err)
 	}
 
 	kibanaVersion, err := kibanaClient.Version()
 	if err != nil {
-		return errors.Wrap(err, "can't get Kibana status information")
+		return fmt.Errorf("can't get Kibana status information: %s", err)
 	}
 
 	if kibanaVersion.IsSnapshot() {
 		message := fmt.Sprintf("exporting dashboards from a SNAPSHOT version of Kibana (%s) is discouraged. It could lead to invalid dashboards (for example if they use features that are reverted or modified before the final release)", kibanaVersion.Version())
 		if !allowSnapshot {
-			return errors.Errorf("%s. --%s flag can be used to ignore this error", message, cobraext.AllowSnapshotFlagName)
+			return fmt.Errorf("%s. --%s flag can be used to ignore this error", message, cobraext.AllowSnapshotFlagName)
 		}
 		fmt.Printf("Warning: %s\n", message)
 	}
@@ -86,7 +85,7 @@ func exportDashboardsCmd(cmd *cobra.Command, args []string) error {
 	if len(dashboardIDs) == 0 {
 		dashboardIDs, err = promptDashboardIDs(kibanaClient)
 		if err != nil {
-			return errors.Wrap(err, "prompt for dashboard selection failed")
+			return fmt.Errorf("prompt for dashboard selection failed: %s", err)
 		}
 
 		if len(dashboardIDs) == 0 {
@@ -97,7 +96,7 @@ func exportDashboardsCmd(cmd *cobra.Command, args []string) error {
 
 	err = export.Dashboards(kibanaClient, dashboardIDs)
 	if err != nil {
-		return errors.Wrap(err, "dashboards export failed")
+		return fmt.Errorf("dashboards export failed: %s", err)
 	}
 
 	cmd.Println("Done")
@@ -107,7 +106,7 @@ func exportDashboardsCmd(cmd *cobra.Command, args []string) error {
 func promptDashboardIDs(kibanaClient *kibana.Client) ([]string, error) {
 	savedDashboards, err := kibanaClient.FindDashboards()
 	if err != nil {
-		return nil, errors.Wrap(err, "finding dashboards failed")
+		return nil, fmt.Errorf("finding dashboards failed: %s", err)
 	}
 
 	if len(savedDashboards) == 0 {

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -5,7 +5,8 @@
 package cmd
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cobraext"
@@ -34,10 +35,10 @@ func formatCommandAction(cmd *cobra.Command, args []string) error {
 
 	packageRoot, found, err := packages.FindPackageRoot()
 	if err != nil {
-		return errors.Wrap(err, "locating package root failed")
+		return fmt.Errorf("locating package root failed: %s", err)
 	}
 	if !found {
-		return errors.New("package root not found")
+		return fmt.Errorf("package root not found")
 	}
 
 	ff, err := cmd.Flags().GetBool(cobraext.FailFastFlagName)
@@ -47,7 +48,7 @@ func formatCommandAction(cmd *cobra.Command, args []string) error {
 
 	err = formatter.Format(packageRoot, ff)
 	if err != nil {
-		return errors.Wrapf(err, "formatting the integration failed (path: %s, failFast: %t)", packageRoot, ff)
+		return fmt.Errorf("formatting the integration failed (path: %s, failFast: %t): %s", packageRoot, ff, err)
 	}
 
 	cmd.Println("Done")

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -5,7 +5,8 @@
 package cmd
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cobraext"
@@ -39,28 +40,28 @@ func installCommandAction(cmd *cobra.Command, _ []string) error {
 		var found bool
 		packageRootPath, found, err = packages.FindPackageRoot()
 		if !found {
-			return errors.New("package root not found")
+			return fmt.Errorf("package root not found")
 		}
 		if err != nil {
-			return errors.Wrap(err, "locating package root failed")
+			return fmt.Errorf("locating package root failed: %s", err)
 		}
 	}
 
 	m, err := packages.ReadPackageManifestFromPackageRoot(packageRootPath)
 	if err != nil {
-		return errors.Wrapf(err, "reading package manifest failed (path: %s)", packageRootPath)
+		return fmt.Errorf("reading package manifest failed (path: %s): %s", packageRootPath, err)
 	}
 
 	// Check conditions
 	keyValuePairs, err := cmd.Flags().GetStringSlice(cobraext.CheckConditionFlagName)
 	if err != nil {
-		return errors.Wrap(err, "can't process check-condition flag")
+		return fmt.Errorf("can't process check-condition flag: %s", err)
 	}
 	if len(keyValuePairs) > 0 {
 		cmd.Println("Check conditions for package")
 		err = packages.CheckConditions(*m, keyValuePairs)
 		if err != nil {
-			return errors.Wrap(err, "checking conditions failed")
+			return fmt.Errorf("checking conditions failed: %s", err)
 		}
 		cmd.Println("Requirements satisfied - the package can be installed.")
 		cmd.Println("Done")
@@ -69,14 +70,14 @@ func installCommandAction(cmd *cobra.Command, _ []string) error {
 
 	packageInstaller, err := installer.CreateForManifest(*m)
 	if err != nil {
-		return errors.Wrap(err, "can't create the package installer")
+		return fmt.Errorf("can't create the package installer: %s", err)
 	}
 
 	// Install the package
 	cmd.Println("Install the package")
 	installedPackage, err := packageInstaller.Install()
 	if err != nil {
-		return errors.Wrap(err, "can't install the package")
+		return fmt.Errorf("can't install the package: %s", err)
 	}
 
 	cmd.Println("Installed assets:")

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -5,7 +5,8 @@
 package cmd
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/package-spec/v2/code/go/pkg/validator"
@@ -53,7 +54,7 @@ func lintCommandAction(cmd *cobra.Command, args []string) error {
 				cmd.Printf("check if %s is up-to-date failed: %s\n", f.FileName, f.Error)
 			}
 		}
-		return errors.Wrap(err, "checking readme files are up-to-date failed")
+		return fmt.Errorf("checking readme files are up-to-date failed: %s", err)
 	}
 	return nil
 }
@@ -61,14 +62,14 @@ func lintCommandAction(cmd *cobra.Command, args []string) error {
 func validateSourceCommandAction(cmd *cobra.Command, args []string) error {
 	packageRootPath, found, err := packages.FindPackageRoot()
 	if !found {
-		return errors.New("package root not found")
+		return fmt.Errorf("package root not found")
 	}
 	if err != nil {
-		return errors.Wrap(err, "locating package root failed")
+		return fmt.Errorf("locating package root failed: %s", err)
 	}
 	err = validator.ValidateFromPath(packageRootPath)
 	if err != nil {
-		return errors.Wrap(err, "linting package failed")
+		return fmt.Errorf("linting package failed: %s", err)
 	}
 
 	return nil

--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/olekukonko/tablewriter"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cobraext"
@@ -48,7 +47,7 @@ User profiles are not overwritten on upgrade of elastic-stack, and can be freely
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if len(args) == 0 {
-				return errors.New("create requires an argument")
+				return fmt.Errorf("create requires an argument")
 			}
 			newProfileName := args[0]
 
@@ -62,7 +61,7 @@ User profiles are not overwritten on upgrade of elastic-stack, and can be freely
 			}
 			err = profile.CreateProfile(options)
 			if err != nil {
-				return errors.Wrapf(err, "error creating profile %s from profile %s", newProfileName, fromName)
+				return fmt.Errorf("error creating profile %s from profile %s: %s", newProfileName, fromName, err)
 			}
 
 			fmt.Printf("Created profile %s from %s.\n", newProfileName, fromName)
@@ -77,13 +76,13 @@ User profiles are not overwritten on upgrade of elastic-stack, and can be freely
 		Short: "Delete a profile",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return errors.New("delete requires an argument")
+				return fmt.Errorf("delete requires an argument")
 			}
 			profileName := args[0]
 
 			err := profile.DeleteProfile(profileName)
 			if err != nil {
-				return errors.Wrap(err, "error deleting profile")
+				return fmt.Errorf("error deleting profile: %s", err)
 			}
 
 			fmt.Printf("Deleted profile %s\n", profileName)
@@ -98,11 +97,11 @@ User profiles are not overwritten on upgrade of elastic-stack, and can be freely
 		RunE: func(cmd *cobra.Command, args []string) error {
 			loc, err := locations.NewLocationManager()
 			if err != nil {
-				return errors.Wrap(err, "error fetching profile")
+				return fmt.Errorf("error fetching profile: %s", err)
 			}
 			profileList, err := profile.FetchAllProfiles(loc.ProfileDir())
 			if err != nil {
-				return errors.Wrap(err, "error listing all profiles")
+				return fmt.Errorf("error listing all profiles: %s", err)
 			}
 
 			format, err := cmd.Flags().GetString(cobraext.ProfileFormatFlagName)
@@ -130,7 +129,7 @@ User profiles are not overwritten on upgrade of elastic-stack, and can be freely
 func formatJSON(profileList []profile.Metadata) error {
 	data, err := json.Marshal(profileList)
 	if err != nil {
-		return errors.Wrap(err, "error listing all profiles in JSON format")
+		return fmt.Errorf("error listing all profiles in JSON format: %s", err)
 	}
 
 	fmt.Print(string(data))
@@ -187,13 +186,13 @@ func lookupEnv() string {
 func availableProfilesAsAList() ([]string, error) {
 	loc, err := locations.NewLocationManager()
 	if err != nil {
-		return []string{}, errors.Wrap(err, "error fetching profile path")
+		return []string{}, fmt.Errorf("error fetching profile path: %s", err)
 	}
 
 	profileNames := []string{}
 	profileList, err := profile.FetchAllProfiles(loc.ProfileDir())
 	if err != nil {
-		return profileNames, errors.Wrap(err, "error fetching all profiles")
+		return profileNames, fmt.Errorf("error fetching all profiles: %s", err)
 	}
 	for _, prof := range profileList {
 		profileNames = append(profileNames, prof.Name)

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -5,9 +5,9 @@
 package cmd
 
 import (
+	"fmt"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cobraext"
@@ -43,10 +43,10 @@ func upCommandAction(cmd *cobra.Command, args []string) error {
 
 	packageRoot, found, err := packages.FindPackageRoot()
 	if err != nil {
-		return errors.Wrap(err, "locating package root failed")
+		return fmt.Errorf("locating package root failed: %s", err)
 	}
 	if !found {
-		return errors.New("package root not found")
+		return fmt.Errorf("package root not found")
 	}
 
 	var dataStreamPath string
@@ -65,7 +65,7 @@ func upCommandAction(cmd *cobra.Command, args []string) error {
 		Variant:            variantFlag,
 	})
 	if err != nil {
-		return errors.Wrap(err, "up command failed")
+		return fmt.Errorf("up command failed: %s", err)
 	}
 	return nil
 }

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -5,11 +5,11 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/jedib0t/go-pretty/table"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cobraext"
@@ -65,7 +65,7 @@ func setupStackCommand() *cobraext.Command {
 
 			err = validateServicesFlag(services)
 			if err != nil {
-				return errors.Wrap(err, "validating services failed")
+				return fmt.Errorf("validating services failed: %s", err)
 			}
 
 			stackVersion, err := cmd.Flags().GetString(cobraext.StackVersionFlagName)
@@ -82,12 +82,12 @@ func setupStackCommand() *cobraext.Command {
 			if errors.Is(err, profile.ErrNotAProfile) {
 				pList, err := availableProfilesAsAList()
 				if err != nil {
-					return errors.Wrap(err, "error listing known profiles")
+					return fmt.Errorf("error listing known profiles: %s", err)
 				}
 				return fmt.Errorf("%s is not a valid profile, known profiles are: %s", profileName, pList)
 			}
 			if err != nil {
-				return errors.Wrap(err, "error loading profile")
+				return fmt.Errorf("error loading profile: %s", err)
 			}
 
 			// Print information before starting the stack, for cases where
@@ -106,7 +106,7 @@ func setupStackCommand() *cobraext.Command {
 				Profile:      userProfile,
 			})
 			if err != nil {
-				return errors.Wrap(err, "booting up the stack failed")
+				return fmt.Errorf("booting up the stack failed: %s", err)
 			}
 
 			cmd.Println("Done")
@@ -133,20 +133,20 @@ func setupStackCommand() *cobraext.Command {
 			if errors.Is(err, profile.ErrNotAProfile) {
 				pList, err := availableProfilesAsAList()
 				if err != nil {
-					return errors.Wrap(err, "error listing known profiles")
+					return fmt.Errorf("error listing known profiles: %s", err)
 				}
 				return fmt.Errorf("%s is not a valid profile, known profiles are: %s", profileName, pList)
 			}
 
 			if err != nil {
-				return errors.Wrap(err, "error loading profile")
+				return fmt.Errorf("error loading profile: %s", err)
 			}
 
 			err = stack.TearDown(stack.Options{
 				Profile: userProfile,
 			})
 			if err != nil {
-				return errors.Wrap(err, "tearing down the stack failed")
+				return fmt.Errorf("tearing down the stack failed: %s", err)
 			}
 
 			cmd.Println("Done")
@@ -167,7 +167,7 @@ func setupStackCommand() *cobraext.Command {
 
 			profile, err := profile.LoadProfile(profileName)
 			if err != nil {
-				return errors.Wrap(err, "error loading profile")
+				return fmt.Errorf("error loading profile: %s", err)
 			}
 
 			stackVersion, err := cmd.Flags().GetString(cobraext.StackVersionFlagName)
@@ -180,7 +180,7 @@ func setupStackCommand() *cobraext.Command {
 				Profile:      profile,
 			})
 			if err != nil {
-				return errors.Wrap(err, "failed updating the stack images")
+				return fmt.Errorf("failed updating the stack images: %s", err)
 			}
 
 			cmd.Println("Done")
@@ -209,12 +209,12 @@ func setupStackCommand() *cobraext.Command {
 
 			profile, err := profile.LoadProfile(profileName)
 			if err != nil {
-				return errors.Wrap(err, "error loading profile")
+				return fmt.Errorf("error loading profile: %s", err)
 			}
 
 			shellCode, err := stack.ShellInit(profile, shellName)
 			if err != nil {
-				return errors.Wrap(err, "shellinit failed")
+				return fmt.Errorf("shellinit failed: %s", err)
 			}
 			fmt.Println(shellCode)
 			return nil
@@ -239,7 +239,7 @@ func setupStackCommand() *cobraext.Command {
 
 			profile, err := profile.LoadProfile(profileName)
 			if err != nil {
-				return errors.Wrap(err, "error loading profile")
+				return fmt.Errorf("error loading profile: %s", err)
 			}
 
 			target, err := stack.Dump(stack.DumpOptions{
@@ -247,7 +247,7 @@ func setupStackCommand() *cobraext.Command {
 				Profile: profile,
 			})
 			if err != nil {
-				return errors.Wrap(err, "dump failed")
+				return fmt.Errorf("dump failed: %s", err)
 			}
 
 			cmd.Printf("Path to stack dump: %s\n", target)
@@ -264,7 +264,7 @@ func setupStackCommand() *cobraext.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			servicesStatus, err := stack.Status()
 			if err != nil {
-				return errors.Wrap(err, "failed getting stack status")
+				return fmt.Errorf("failed getting stack status: %s", err)
 			}
 
 			cmd.Println("Status of Elastic stack services:")

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/fatih/color"
 	"github.com/olekukonko/tablewriter"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cobraext"
@@ -79,10 +78,10 @@ func getPackageStatus(packageName string, options registry.SearchOptions) (*stat
 	}
 	packageRootPath, found, err := packages.FindPackageRoot()
 	if !found {
-		return nil, errors.New("no package specified and package root not found")
+		return nil, fmt.Errorf("no package specified and package root not found")
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "locating package root failed")
+		return nil, fmt.Errorf("locating package root failed: %s", err)
 	}
 	return status.LocalPackage(packageRootPath, options)
 }

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -37,7 +37,7 @@ func TestStatusFormatAndPrint(t *testing.T) {
 	localPendingChanges := changelog.Revision{
 		Version: "2.0.0-rc2",
 		Changes: []changelog.Entry{
-			changelog.Entry{
+			{
 				Description: "New feature",
 				Type:        "enhancement",
 				Link:        "http:github.com/org/repo/pull/2",

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -5,7 +5,8 @@
 package cmd
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cobraext"
@@ -31,27 +32,27 @@ func setupUninstallCommand() *cobraext.Command {
 func uninstallCommandAction(cmd *cobra.Command, args []string) error {
 	packageRootPath, found, err := packages.FindPackageRoot()
 	if !found {
-		return errors.New("package root not found")
+		return fmt.Errorf("package root not found")
 	}
 	if err != nil {
-		return errors.Wrap(err, "locating package root failed")
+		return fmt.Errorf("locating package root failed: %s", err)
 	}
 
 	m, err := packages.ReadPackageManifestFromPackageRoot(packageRootPath)
 	if err != nil {
-		return errors.Wrapf(err, "reading package manifest failed (path: %s)", packageRootPath)
+		return fmt.Errorf("reading package manifest failed (path: %s): %s", packageRootPath, err)
 	}
 
 	packageInstaller, err := installer.CreateForManifest(*m)
 	if err != nil {
-		return errors.Wrap(err, "can't create the package installer")
+		return fmt.Errorf("can't create the package installer: %s", err)
 	}
 
 	// Uninstall the package
 	cmd.Println("Uninstall the package")
 	err = packageInstaller.Uninstall()
 	if err != nil {
-		return errors.Wrap(err, "can't uninstall the package")
+		return fmt.Errorf("can't uninstall the package: %s", err)
 	}
 	cmd.Println("Done")
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/magefile/mage v1.14.0
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/shirou/gopsutil/v3 v3.22.12
 	github.com/spf13/cobra v1.6.1
@@ -113,6 +112,7 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect
 	github.com/pjbgf/sha1cd v0.2.3 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/rivo/uniseg v0.4.3 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/internal/benchrunner/runners/pipeline/benchmark.go
+++ b/internal/benchrunner/runners/pipeline/benchmark.go
@@ -6,7 +6,6 @@ package pipeline
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -240,7 +239,7 @@ func (agg aggregation) collect(fn mapFn) ([]benchrunner.BenchmarkValue, error) {
 
 func (r *runner) runSingleBenchmark(entryPipeline string, docs []json.RawMessage) (ingestResult, error) {
 	if len(docs) == 0 {
-		return ingestResult{}, errors.New("no docs supplied for benchmark")
+		return ingestResult{}, fmt.Errorf("no docs supplied for benchmark")
 	}
 
 	if _, err := ingest.SimulatePipeline(r.options.API, entryPipeline, docs); err != nil {

--- a/internal/benchrunner/runners/pipeline/runner.go
+++ b/internal/benchrunner/runners/pipeline/runner.go
@@ -6,7 +6,6 @@ package pipeline
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -61,7 +60,7 @@ func (r *runner) run() (*benchrunner.Result, error) {
 		return nil, fmt.Errorf("locating data_stream root failed: %w", err)
 	}
 	if !found {
-		return nil, errors.New("data stream root not found")
+		return nil, fmt.Errorf("data stream root not found")
 	}
 
 	var entryPipeline string

--- a/internal/benchrunner/runners/pipeline/test_case.go
+++ b/internal/benchrunner/runners/pipeline/test_case.go
@@ -8,7 +8,6 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -106,7 +105,7 @@ func jsonUnmarshalUsingNumber(data []byte, v interface{}) error {
 	err := dec.Decode(v)
 	if err != nil {
 		if err == io.EOF {
-			return errors.New("unexpected end of JSON input")
+			return fmt.Errorf("unexpected end of JSON input")
 		}
 		return err
 	}

--- a/internal/builder/dashboards.go
+++ b/internal/builder/dashboards.go
@@ -6,10 +6,9 @@ package builder
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/common"
 )
@@ -58,7 +57,7 @@ func encodedSavedObject(data []byte) ([]byte, bool, error) {
 	savedObject := common.MapStr{}
 	err := json.Unmarshal(data, &savedObject)
 	if err != nil {
-		return nil, false, errors.Wrapf(err, "unmarshalling saved object failed")
+		return nil, false, fmt.Errorf("unmarshalling saved object failed: %s", err)
 	}
 
 	var changed bool
@@ -83,7 +82,7 @@ func encodedSavedObject(data []byte) ([]byte, bool, error) {
 		}
 		_, err = savedObject.Put(v, string(r))
 		if err != nil {
-			return nil, false, errors.Wrapf(err, "can't put value to the saved object")
+			return nil, false, fmt.Errorf("can't put value to the saved object: %s", err)
 		}
 		changed = true
 	}

--- a/internal/builder/dynamic_mappings.go
+++ b/internal/builder/dynamic_mappings.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/elastic-package/internal/formatter"
@@ -86,12 +85,12 @@ func addDynamicMappings(packageRoot, destinationDir string) error {
 func shouldImportEcsMappings(specVersion, packageRoot string) (bool, error) {
 	v, err := semver.NewVersion(specVersion)
 	if err != nil {
-		return false, errors.Wrap(err, "invalid spec version")
+		return false, fmt.Errorf("invalid spec version: %s", err)
 	}
 
 	bm, ok, err := buildmanifest.ReadBuildManifest(packageRoot)
 	if err != nil {
-		return false, errors.Wrap(err, "can't read build manifest")
+		return false, fmt.Errorf("can't read build manifest: %s", err)
 	}
 	if !ok {
 		logger.Debug("Build manifest hasn't been defined for the package")
@@ -113,12 +112,12 @@ func shouldImportEcsMappings(specVersion, packageRoot string) (bool, error) {
 func addDynamicMappingElements(path string) ([]byte, error) {
 	ecsMappings, err := loadEcsMappings()
 	if err != nil {
-		return nil, errors.New("can't load ecs mappings template")
+		return nil, fmt.Errorf("can't load ecs mappings template")
 	}
 
 	contents, err := os.ReadFile(path)
 	if err != nil {
-		return nil, errors.New("can't read manifest")
+		return nil, fmt.Errorf("can't read manifest")
 	}
 
 	var doc yaml.Node
@@ -153,14 +152,14 @@ func addEcsMappings(doc *yaml.Node, mappings ecsTemplates) error {
 	var templates yaml.Node
 	err := templates.Encode(mappings.Mappings.DynamicTemplates)
 	if err != nil {
-		return errors.Wrap(err, "failed to encode dynamic templates")
+		return fmt.Errorf("failed to encode dynamic templates: %s", err)
 	}
 
 	renameMappingsNames(&templates)
 
 	err = appendElements(doc, []string{"elasticsearch", "index_template", "mappings", "dynamic_templates"}, &templates)
 	if err != nil {
-		return errors.Wrap(err, "failed to append dynamic templates")
+		return fmt.Errorf("failed to append dynamic templates: %s", err)
 	}
 
 	return nil
@@ -214,7 +213,7 @@ func appendElements(root *yaml.Node, path []string, values *yaml.Node) error {
 			return err
 		}
 		if len(root.Content) >= index {
-			return errors.Errorf("index out of range in nodes from key %s", key)
+			return fmt.Errorf("index out of range in nodes from key %s", key)
 		}
 
 		return appendElements(root.Content[index], rest, values)
@@ -237,11 +236,11 @@ func newYamlNode(key string) []*yaml.Node {
 func formatResult(result interface{}) ([]byte, error) {
 	d, err := yaml.Marshal(result)
 	if err != nil {
-		return nil, errors.New("failed to encode")
+		return nil, fmt.Errorf("failed to encode")
 	}
 	d, _, err = formatter.YAMLFormatter(d)
 	if err != nil {
-		return nil, errors.New("failed to format")
+		return nil, fmt.Errorf("failed to format")
 	}
 	return d, nil
 }

--- a/internal/builder/external_fields.go
+++ b/internal/builder/external_fields.go
@@ -5,10 +5,10 @@
 package builder
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/elastic-package/internal/common"
@@ -20,7 +20,7 @@ import (
 func resolveExternalFields(packageRoot, destinationDir string) error {
 	bm, ok, err := buildmanifest.ReadBuildManifest(packageRoot)
 	if err != nil {
-		return errors.Wrap(err, "can't read build manifest")
+		return fmt.Errorf("can't read build manifest: %s", err)
 	}
 	if !ok {
 		logger.Debugf("Build manifest hasn't been defined for the package")
@@ -34,7 +34,7 @@ func resolveExternalFields(packageRoot, destinationDir string) error {
 	logger.Debugf("Package has external dependencies defined")
 	fdm, err := fields.CreateFieldDependencyManager(bm.Dependencies)
 	if err != nil {
-		return errors.Wrap(err, "can't create field dependency manager")
+		return fmt.Errorf("can't create field dependency manager: %s", err)
 	}
 
 	dataStreamFieldsFiles, err := filepath.Glob(filepath.Join(destinationDir, "data_stream", "*", "fields", "*.yml"))
@@ -76,12 +76,12 @@ func injectFields(fdm *fields.DependencyManager, content []byte) ([]byte, bool, 
 	var f []common.MapStr
 	err := yaml.Unmarshal(content, &f)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "can't unmarshal source file")
+		return nil, false, fmt.Errorf("can't unmarshal source file: %s", err)
 	}
 
 	f, changed, err := fdm.InjectFields(f)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "can't resolve fields")
+		return nil, false, fmt.Errorf("can't resolve fields: %s", err)
 	}
 	if !changed {
 		return content, false, nil
@@ -89,7 +89,7 @@ func injectFields(fdm *fields.DependencyManager, content []byte) ([]byte, bool, 
 
 	content, err = yaml.Marshal(&f)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "can't marshal source file")
+		return nil, false, fmt.Errorf("can't marshal source file: %s", err)
 	}
 	return content, true, nil
 }

--- a/internal/builder/packages.go
+++ b/internal/builder/packages.go
@@ -5,12 +5,12 @@
 package builder
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/magefile/mage/sh"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/package-spec/v2/code/go/pkg/validator"
 
@@ -37,12 +37,12 @@ type BuildOptions struct {
 func BuildDirectory() (string, error) {
 	buildDir, found, err := findBuildDirectory()
 	if err != nil {
-		return "", errors.Wrap(err, "can't locate build directory")
+		return "", fmt.Errorf("can't locate build directory: %s", err)
 	}
 	if !found {
 		buildDir, err = createBuildDirectory()
 		if err != nil {
-			return "", errors.Wrap(err, "can't create new build directory")
+			return "", fmt.Errorf("can't create new build directory: %s", err)
 		}
 	}
 	return buildDir, nil
@@ -51,7 +51,7 @@ func BuildDirectory() (string, error) {
 func findBuildDirectory() (string, bool, error) {
 	workDir, err := os.Getwd()
 	if err != nil {
-		return "", false, errors.Wrap(err, "can't locate build directory")
+		return "", false, fmt.Errorf("can't locate build directory: %s", err)
 	}
 
 	dir := workDir
@@ -76,11 +76,11 @@ func findBuildDirectory() (string, bool, error) {
 func BuildPackagesDirectory(packageRoot string) (string, error) {
 	buildDir, err := buildPackagesRootDirectory()
 	if err != nil {
-		return "", errors.Wrap(err, "can't locate build packages root directory")
+		return "", fmt.Errorf("can't locate build packages root directory: %s", err)
 	}
 	m, err := packages.ReadPackageManifestFromPackageRoot(packageRoot)
 	if err != nil {
-		return "", errors.Wrapf(err, "reading package manifest failed (path: %s)", packageRoot)
+		return "", fmt.Errorf("reading package manifest failed (path: %s): %s", packageRoot, err)
 	}
 	return filepath.Join(buildDir, m.Name, m.Version), nil
 }
@@ -89,11 +89,11 @@ func BuildPackagesDirectory(packageRoot string) (string, error) {
 func buildPackagesZipPath(packageRoot string) (string, error) {
 	buildDir, err := buildPackagesRootDirectory()
 	if err != nil {
-		return "", errors.Wrap(err, "can't locate build packages root directory")
+		return "", fmt.Errorf("can't locate build packages root directory: %s", err)
 	}
 	m, err := packages.ReadPackageManifestFromPackageRoot(packageRoot)
 	if err != nil {
-		return "", errors.Wrapf(err, "reading package manifest failed (path: %s)", packageRoot)
+		return "", fmt.Errorf("reading package manifest failed (path: %s): %s", packageRoot, err)
 	}
 	return ZippedBuiltPackagePath(buildDir, *m), nil
 }
@@ -106,12 +106,12 @@ func ZippedBuiltPackagePath(buildDir string, m packages.PackageManifest) string 
 func buildPackagesRootDirectory() (string, error) {
 	buildDir, found, err := FindBuildPackagesDirectory()
 	if err != nil {
-		return "", errors.Wrap(err, "can't locate build directory")
+		return "", fmt.Errorf("can't locate build directory: %s", err)
 	}
 	if !found {
 		buildDir, err = createBuildDirectory(builtPackagesFolder)
 		if err != nil {
-			return "", errors.Wrap(err, "can't create new build directory")
+			return "", fmt.Errorf("can't create new build directory: %s", err)
 		}
 	}
 	return buildDir, nil
@@ -146,43 +146,43 @@ func FindBuildPackagesDirectory() (string, bool, error) {
 func BuildPackage(options BuildOptions) (string, error) {
 	destinationDir, err := BuildPackagesDirectory(options.PackageRoot)
 	if err != nil {
-		return "", errors.Wrap(err, "can't locate build directory")
+		return "", fmt.Errorf("can't locate build directory: %s", err)
 	}
 	logger.Debugf("Build directory: %s\n", destinationDir)
 
 	logger.Debugf("Clear target directory (path: %s)", destinationDir)
 	err = files.ClearDir(destinationDir)
 	if err != nil {
-		return "", errors.Wrap(err, "clearing package contents failed")
+		return "", fmt.Errorf("clearing package contents failed: %s", err)
 	}
 
 	logger.Debugf("Copy package content (source: %s)", options.PackageRoot)
 	err = files.CopyWithoutDev(options.PackageRoot, destinationDir)
 	if err != nil {
-		return "", errors.Wrap(err, "copying package contents failed")
+		return "", fmt.Errorf("copying package contents failed: %s", err)
 	}
 
 	logger.Debug("Copy license file if needed")
 	err = copyLicenseTextFile(filepath.Join(destinationDir, licenseTextFileName))
 	if err != nil {
-		return "", errors.Wrap(err, "copying license text file")
+		return "", fmt.Errorf("copying license text file: %s", err)
 	}
 
 	logger.Debug("Encode dashboards")
 	err = encodeDashboards(destinationDir)
 	if err != nil {
-		return "", errors.Wrap(err, "encoding dashboards failed")
+		return "", fmt.Errorf("encoding dashboards failed: %s", err)
 	}
 
 	logger.Debug("Resolve external fields")
 	err = resolveExternalFields(options.PackageRoot, destinationDir)
 	if err != nil {
-		return "", errors.Wrap(err, "resolving external fields failed")
+		return "", fmt.Errorf("resolving external fields failed: %s", err)
 	}
 
 	err = addDynamicMappings(options.PackageRoot, destinationDir)
 	if err != nil {
-		return "", errors.Wrap(err, "adding dynamic mappings")
+		return "", fmt.Errorf("adding dynamic mappings: %s", err)
 	}
 
 	if options.CreateZip {
@@ -197,7 +197,7 @@ func BuildPackage(options BuildOptions) (string, error) {
 	logger.Debugf("Validating built package (path: %s)", destinationDir)
 	err = validator.ValidateFromPath(destinationDir)
 	if err != nil {
-		return "", errors.Wrap(err, "invalid content found in built package")
+		return "", fmt.Errorf("invalid content found in built package: %s", err)
 	}
 	return destinationDir, nil
 }
@@ -206,12 +206,12 @@ func buildZippedPackage(options BuildOptions, destinationDir string) (string, er
 	logger.Debug("Build zipped package")
 	zippedPackagePath, err := buildPackagesZipPath(options.PackageRoot)
 	if err != nil {
-		return "", errors.Wrap(err, "can't evaluate path for the zipped package")
+		return "", fmt.Errorf("can't evaluate path for the zipped package: %s", err)
 	}
 
 	err = files.Zip(destinationDir, zippedPackagePath)
 	if err != nil {
-		return "", errors.Wrapf(err, "can't compress the built package (compressed file path: %s)", zippedPackagePath)
+		return "", fmt.Errorf("can't compress the built package (compressed file path: %s): %s", zippedPackagePath, err)
 	}
 
 	if options.SkipValidation {
@@ -220,7 +220,7 @@ func buildZippedPackage(options BuildOptions, destinationDir string) (string, er
 		logger.Debugf("Validating built .zip package (path: %s)", zippedPackagePath)
 		err = validator.ValidateFromZip(zippedPackagePath)
 		if err != nil {
-			return "", errors.Wrapf(err, "invalid content found in built zip package")
+			return "", fmt.Errorf("invalid content found in built zip package: %s", err)
 		}
 	}
 
@@ -238,7 +238,7 @@ func signZippedPackage(options BuildOptions, zippedPackagePath string) error {
 	logger.Debug("Sign the package")
 	m, err := packages.ReadPackageManifestFromPackageRoot(options.PackageRoot)
 	if err != nil {
-		return errors.Wrapf(err, "reading package manifest failed (path: %s)", options.PackageRoot)
+		return fmt.Errorf("reading package manifest failed (path: %s): %s", options.PackageRoot, err)
 	}
 
 	err = files.Sign(zippedPackagePath, files.SignOptions{
@@ -246,7 +246,7 @@ func signZippedPackage(options BuildOptions, zippedPackagePath string) error {
 		PackageVersion: m.Version,
 	})
 	if err != nil {
-		return errors.Wrapf(err, "can't sign the zipped package (path: %s)", zippedPackagePath)
+		return fmt.Errorf("can't sign the zipped package (path: %s): %s", zippedPackagePath, err)
 	}
 	return nil
 }
@@ -269,13 +269,13 @@ func copyLicenseTextFile(licensePath string) error {
 		return nil
 	}
 	if err != nil {
-		return errors.Wrapf(err, "failure while looking for license %q in repository", repositoryLicenseTextFileName)
+		return fmt.Errorf("failure while looking for license %q in repository: %s", repositoryLicenseTextFileName, err)
 	}
 
 	logger.Infof("License text found in %q will be included in package", sourceLicensePath)
 	err = sh.Copy(licensePath, sourceLicensePath)
 	if err != nil {
-		return errors.Wrap(err, "can't copy license from repository")
+		return fmt.Errorf("can't copy license from repository: %s", err)
 	}
 
 	return nil
@@ -284,7 +284,7 @@ func copyLicenseTextFile(licensePath string) error {
 func createBuildDirectory(dirs ...string) (string, error) {
 	dir, err := files.FindRepositoryRootDirectory()
 	if errors.Is(err, os.ErrNotExist) {
-		return "", errors.New("package can be only built inside of a Git repository (.git folder is used as reference point)")
+		return "", fmt.Errorf("package can be only built inside of a Git repository (.git folder is used as reference point)")
 	}
 	if err != nil {
 		return "", err
@@ -297,7 +297,7 @@ func createBuildDirectory(dirs ...string) (string, error) {
 	buildDir := filepath.Join(p...)
 	err = os.MkdirAll(buildDir, 0755)
 	if err != nil {
-		return "", errors.Wrapf(err, "mkdir failed (path: %s)", buildDir)
+		return "", fmt.Errorf("mkdir failed (path: %s): %s", buildDir, err)
 	}
 	return buildDir, nil
 }
@@ -311,7 +311,7 @@ func findRepositoryLicense(licenseTextFileName string) (string, error) {
 	sourceFileName := filepath.Join(dir, licenseTextFileName)
 	_, err = os.Stat(sourceFileName)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to find repository license")
+		return "", fmt.Errorf("failed to find repository license: %s", err)
 	}
 
 	return sourceFileName, nil

--- a/internal/cleanup/build.go
+++ b/internal/cleanup/build.go
@@ -5,10 +5,10 @@
 package cleanup
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/builder"
 	"github.com/elastic/elastic-package/internal/logger"
@@ -21,17 +21,17 @@ func Build() (string, error) {
 
 	packageRoot, err := packages.MustFindPackageRoot()
 	if err != nil {
-		return "", errors.Wrap(err, "locating package root failed")
+		return "", fmt.Errorf("locating package root failed: %s", err)
 	}
 
 	m, err := packages.ReadPackageManifestFromPackageRoot(packageRoot)
 	if err != nil {
-		return "", errors.Wrapf(err, "reading package manifest failed (path: %s)", packageRoot)
+		return "", fmt.Errorf("reading package manifest failed (path: %s): %s", packageRoot, err)
 	}
 
 	buildDir, found, err := builder.FindBuildPackagesDirectory()
 	if err != nil {
-		return "", errors.Wrap(err, "locating build directory failed")
+		return "", fmt.Errorf("locating build directory failed: %s", err)
 	}
 
 	if !found {
@@ -44,7 +44,7 @@ func Build() (string, error) {
 
 	_, err = os.Stat(destinationDir)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return "", errors.Wrapf(err, "stat file failed: %s", destinationDir)
+		return "", fmt.Errorf("stat file failed: %s: %s", destinationDir, err)
 	}
 	if errors.Is(err, os.ErrNotExist) {
 		logger.Debugf("Package hasn't been built (missing path: %s)", destinationDir)
@@ -54,14 +54,14 @@ func Build() (string, error) {
 	logger.Debugf("Remove directory (path: %s)", destinationDir)
 	err = os.RemoveAll(destinationDir)
 	if err != nil {
-		return "", errors.Wrapf(err, "can't remove directory (path: %s)", destinationDir)
+		return "", fmt.Errorf("can't remove directory (path: %s): %s", destinationDir, err)
 	}
 
 	zippedBuildPackagePath := builder.ZippedBuiltPackagePath(buildDir, *m)
 	logger.Debugf("Remove zipped built package (path: %s)", zippedBuildPackagePath)
 	err = os.RemoveAll(zippedBuildPackagePath)
 	if err != nil {
-		return "", errors.Wrapf(err, "can't remove zipped built package (path: %s)", zippedBuildPackagePath)
+		return "", fmt.Errorf("can't remove zipped built package (path: %s): %s", zippedBuildPackagePath, err)
 	}
 	return destinationDir, nil
 }

--- a/internal/cleanup/service_logs.go
+++ b/internal/cleanup/service_logs.go
@@ -5,7 +5,7 @@
 package cleanup
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/elastic/elastic-package/internal/configuration/locations"
 	"github.com/elastic/elastic-package/internal/files"
@@ -18,13 +18,13 @@ func ServiceLogs() (string, error) {
 
 	locationManager, err := locations.NewLocationManager()
 	if err != nil {
-		return "", errors.Wrap(err, "can't find service logs dir")
+		return "", fmt.Errorf("can't find service logs dir: %s", err)
 	}
 
 	logger.Debugf("Remove folder content (path: %s)", locationManager.ServiceLogDir())
 	err = files.RemoveContent(locationManager.ServiceLogDir())
 	if err != nil {
-		return "", errors.Wrapf(err, "can't remove content (path: %s)", locationManager.ServiceLogDir())
+		return "", fmt.Errorf("can't remove content (path: %s): %s", locationManager.ServiceLogDir(), err)
 	}
 	return locationManager.ServiceLogDir(), nil
 }

--- a/internal/cleanup/stack.go
+++ b/internal/cleanup/stack.go
@@ -5,10 +5,10 @@
 package cleanup
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/configuration/locations"
 	"github.com/elastic/elastic-package/internal/packages"
@@ -22,23 +22,23 @@ func Stack() (string, error) {
 
 	packageRoot, err := packages.MustFindPackageRoot()
 	if err != nil {
-		return "", errors.Wrap(err, "locating package root failed")
+		return "", fmt.Errorf("locating package root failed: %s", err)
 	}
 
 	m, err := packages.ReadPackageManifestFromPackageRoot(packageRoot)
 	if err != nil {
-		return "", errors.Wrapf(err, "reading package manifest failed (path: %s)", packageRoot)
+		return "", fmt.Errorf("reading package manifest failed (path: %s): %s", packageRoot, err)
 	}
 
 	locationManager, err := locations.NewLocationManager()
 	if err != nil {
-		return "", errors.Wrap(err, "can't find stack packages dir")
+		return "", fmt.Errorf("can't find stack packages dir: %s", err)
 	}
 	destinationDir := filepath.Join(locationManager.PackagesDir(), m.Name)
 
 	_, err = os.Stat(destinationDir)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return "", errors.Wrapf(err, "stat file failed: %s", destinationDir)
+		return "", fmt.Errorf("stat file failed: %s: %s", destinationDir, err)
 	}
 	if errors.Is(err, os.ErrNotExist) {
 		logger.Debugf("Stack package is not part of the development stack (missing path: %s)", destinationDir)
@@ -48,7 +48,7 @@ func Stack() (string, error) {
 	logger.Debugf("Remove folder (path: %s)", destinationDir)
 	err = os.RemoveAll(destinationDir)
 	if err != nil {
-		return "", errors.Wrapf(err, "can't remove directory (path: %s)", destinationDir)
+		return "", fmt.Errorf("can't remove directory (path: %s): %s", destinationDir, err)
 	}
 	return destinationDir, nil
 }

--- a/internal/cobraext/errors.go
+++ b/internal/cobraext/errors.go
@@ -4,9 +4,9 @@
 
 package cobraext
 
-import "github.com/pkg/errors"
+import "fmt"
 
 // FlagParsingError method wraps the original error with parsing error.
 func FlagParsingError(err error, flagName string) error {
-	return errors.Wrapf(err, "error parsing --%s flag", flagName)
+	return fmt.Errorf("error parsing --%s flag: %s", flagName, err)
 }

--- a/internal/common/mapstr.go
+++ b/internal/common/mapstr.go
@@ -12,13 +12,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 var (
 	// ErrKeyNotFound indicates that the specified key was not found.
-	ErrKeyNotFound = errors.New("key not found")
+	ErrKeyNotFound = fmt.Errorf("key not found")
 )
 
 // MapStr is a map[string]interface{} wrapper with utility methods for common
@@ -148,7 +146,7 @@ func ToMapStrSlice(slice interface{}) ([]MapStr, error) {
 	for _, v := range sliceI {
 		m, err := toMapStr(v)
 		if err != nil {
-			return nil, errors.Wrap(err, "can't convert element to MapStr")
+			return nil, fmt.Errorf("can't convert element to MapStr: %s", err)
 		}
 		mapStrs = append(mapStrs, m)
 	}
@@ -161,7 +159,7 @@ func ToMapStrSlice(slice interface{}) ([]MapStr, error) {
 func toMapStr(v interface{}) (MapStr, error) {
 	m, ok := tryToMapStr(v)
 	if !ok {
-		return nil, errors.Errorf("expected map but type is %T", v)
+		return nil, fmt.Errorf("expected map but type is %T", v)
 	}
 	return m, nil
 }

--- a/internal/configuration/locations/locations.go
+++ b/internal/configuration/locations/locations.go
@@ -6,10 +6,9 @@
 package locations
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/environment"
 )
@@ -49,7 +48,7 @@ type LocationManager struct {
 func NewLocationManager() (*LocationManager, error) {
 	cfg, err := configurationDir()
 	if err != nil {
-		return nil, errors.Wrap(err, "error getting config dir")
+		return nil, fmt.Errorf("error getting config dir: %s", err)
 	}
 
 	return &LocationManager{stackPath: cfg}, nil
@@ -132,7 +131,7 @@ func configurationDir() (string, error) {
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return "", errors.Wrap(err, "reading home dir failed")
+		return "", fmt.Errorf("reading home dir failed: %s", err)
 	}
 	return filepath.Join(homeDir, elasticPackageDir), nil
 }

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/logger"
 )
 
@@ -67,7 +65,7 @@ func Pull(image string) error {
 	logger.Debugf("run command: %s", cmd)
 	err := cmd.Run()
 	if err != nil {
-		return errors.Wrap(err, "running docker command failed")
+		return fmt.Errorf("running docker command failed: %s", err)
 	}
 	return nil
 }
@@ -81,7 +79,7 @@ func ContainerID(containerName string) (string, error) {
 	logger.Debugf("output command: %s", cmd)
 	output, err := cmd.Output()
 	if err != nil {
-		return "", errors.Wrapf(err, "could not find \"%s\" container (stderr=%q)", containerName, errOutput.String())
+		return "", fmt.Errorf("could not find \"%s\" container (stderr=%q): %s", containerName, errOutput.String(), err)
 	}
 	containerIDs := strings.Fields(string(output))
 	if len(containerIDs) != 1 {
@@ -100,7 +98,7 @@ func ContainerIDsWithLabel(key, value string) ([]string, error) {
 	logger.Debugf("output command: %s", cmd)
 	output, err := cmd.Output()
 	if err != nil {
-		return []string{}, errors.Wrapf(err, "error getting containers with label \"%s\" (stderr=%q)", label, errOutput.String())
+		return []string{}, fmt.Errorf("error getting containers with label \"%s\" (stderr=%q): %s", label, errOutput.String(), err)
 	}
 	containerIDs := strings.Fields(string(output))
 	return containerIDs, nil
@@ -115,13 +113,13 @@ func InspectNetwork(network string) ([]NetworkDescription, error) {
 	logger.Debugf("output command: %s", cmd)
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not inspect the network (stderr=%q)", errOutput.String())
+		return nil, fmt.Errorf("could not inspect the network (stderr=%q): %s", errOutput.String(), err)
 	}
 
 	var networkDescriptions []NetworkDescription
 	err = json.Unmarshal(output, &networkDescriptions)
 	if err != nil {
-		return nil, errors.Wrapf(err, "can't unmarshal network inspect for %s (stderr=%q)", network, errOutput.String())
+		return nil, fmt.Errorf("can't unmarshal network inspect for %s (stderr=%q): %s", network, errOutput.String(), err)
 	}
 	return networkDescriptions, nil
 }
@@ -134,7 +132,7 @@ func ConnectToNetwork(containerID, network string) error {
 
 	logger.Debugf("run command: %s", cmd)
 	if err := cmd.Run(); err != nil {
-		return errors.Wrapf(err, "could not attach container to the stack network (stderr=%q)", errOutput.String())
+		return fmt.Errorf("could not attach container to the stack network (stderr=%q): %s", errOutput.String(), err)
 	}
 	return nil
 }
@@ -151,13 +149,13 @@ func InspectContainers(containerIDs ...string) ([]ContainerDescription, error) {
 	logger.Debugf("output command: %s", cmd)
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not inspect containers (stderr=%q)", errOutput.String())
+		return nil, fmt.Errorf("could not inspect containers (stderr=%q): %s", errOutput.String(), err)
 	}
 
 	var containerDescriptions []ContainerDescription
 	err = json.Unmarshal(output, &containerDescriptions)
 	if err != nil {
-		return nil, errors.Wrapf(err, "can't unmarshal container inspect for %s (stderr=%q)", strings.Join(containerIDs, ","), errOutput.String())
+		return nil, fmt.Errorf("can't unmarshal container inspect for %s (stderr=%q): %s", strings.Join(containerIDs, ","), errOutput.String(), err)
 	}
 	return containerDescriptions, nil
 }
@@ -170,7 +168,7 @@ func Copy(containerName, containerPath, localPath string) error {
 
 	logger.Debugf("run command: %s", cmd)
 	if err := cmd.Run(); err != nil {
-		return errors.Wrapf(err, "could not copy files from the container (stderr=%q)", errOutput.String())
+		return fmt.Errorf("could not copy files from the container (stderr=%q): %s", errOutput.String(), err)
 	}
 	return nil
 }

--- a/internal/docs/exported_fields.go
+++ b/internal/docs/exported_fields.go
@@ -9,8 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/fields"
 )
 
@@ -27,12 +25,12 @@ var escaper = strings.NewReplacer("*", "\\*", "{", "\\{", "}", "\\}", "<", "\\<"
 func renderExportedFields(fieldsParentDir string) (string, error) {
 	validator, err := fields.CreateValidatorForDirectory(fieldsParentDir)
 	if err != nil {
-		return "", errors.Wrapf(err, "can't create fields validator instance (path: %s)", fieldsParentDir)
+		return "", fmt.Errorf("can't create fields validator instance (path: %s): %s", fieldsParentDir, err)
 	}
 
 	collected, err := collectFieldsFromDefinitions(validator)
 	if err != nil {
-		return "", errors.Wrap(err, "collecting fields files failed")
+		return "", fmt.Errorf("collecting fields files failed: %s", err)
 	}
 
 	var builder strings.Builder
@@ -110,7 +108,7 @@ func collectFieldsFromDefinitions(validator *fields.Validator) ([]fieldsTableRec
 	for _, f := range root {
 		records, err = visitFields("", f, records, validator.FieldDependencyManager)
 		if err != nil {
-			return nil, errors.Wrapf(err, "visiting fields failed")
+			return nil, fmt.Errorf("visiting fields failed: %s", err)
 		}
 	}
 	return uniqueTableRecords(records), nil
@@ -127,7 +125,7 @@ func visitFields(namePrefix string, f fields.FieldDefinition, records []fieldsTa
 		if f.External != "" {
 			imported, err := fdm.ImportField(f.External, name)
 			if err != nil {
-				return nil, errors.Wrap(err, "can't import field")
+				return nil, fmt.Errorf("can't import field: %s", err)
 			}
 
 			// Override imported fields with the definition, except for the type and external.
@@ -160,7 +158,7 @@ func visitFields(namePrefix string, f fields.FieldDefinition, records []fieldsTa
 	for _, fieldEntry := range f.Fields {
 		records, err = visitFields(name, fieldEntry, records, fdm)
 		if err != nil {
-			return nil, errors.Wrapf(err, "recursive visiting fields failed (namePrefix: %s)", namePrefix)
+			return nil, fmt.Errorf("recursive visiting fields failed (namePrefix: %s): %s", namePrefix, err)
 		}
 	}
 	return records, nil

--- a/internal/docs/links_map.go
+++ b/internal/docs/links_map.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/elastic-package/internal/environment"
@@ -39,12 +38,12 @@ func (l linkMap) Get(key string) (string, error) {
 	if url, ok := l.Links[key]; ok {
 		return url, nil
 	}
-	return "", errors.Errorf("link key not found: %s", key)
+	return "", fmt.Errorf("link key not found: %s", key)
 }
 
 func (l linkMap) Add(key, value string) error {
 	if _, ok := l.Links[key]; ok {
-		return errors.Errorf("link key already present: %s", key)
+		return fmt.Errorf("link key already present: %s", key)
 	}
 	l.Links[key] = value
 	return nil
@@ -53,7 +52,7 @@ func (l linkMap) Add(key, value string) error {
 func readLinksMap() (linkMap, error) {
 	linksFilePath, err := linksDefinitionsFilePath()
 	if err != nil {
-		return linkMap{}, errors.Wrap(err, "locating links file failed")
+		return linkMap{}, fmt.Errorf("locating links file failed: %s", err)
 	}
 
 	links := newLinkMap()
@@ -64,7 +63,7 @@ func readLinksMap() (linkMap, error) {
 	logger.Debugf("Using links definitions file: %s", linksFilePath)
 	contents, err := os.ReadFile(linksFilePath)
 	if err != nil {
-		return linkMap{}, errors.Wrapf(err, "readfile failed (path: %s)", linksFilePath)
+		return linkMap{}, fmt.Errorf("readfile failed (path: %s): %s", linksFilePath, err)
 	}
 
 	err = yaml.Unmarshal(contents, &links)

--- a/internal/docs/readme.go
+++ b/internal/docs/readme.go
@@ -6,12 +6,12 @@ package docs
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"text/template"
 
-	"github.com/pkg/errors"
 	"github.com/pmezard/go-difflib/difflib"
 
 	"github.com/elastic/elastic-package/internal/builder"
@@ -31,12 +31,12 @@ type ReadmeFile struct {
 func AreReadmesUpToDate() ([]ReadmeFile, error) {
 	packageRoot, err := packages.MustFindPackageRoot()
 	if err != nil {
-		return nil, errors.Wrap(err, "package root not found")
+		return nil, fmt.Errorf("package root not found: %s", err)
 	}
 
 	files, err := filepath.Glob(filepath.Join(packageRoot, "_dev", "build", "docs", "*.md"))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, errors.Wrap(err, "reading directory entries failed")
+		return nil, fmt.Errorf("reading directory entries failed: %s", err)
 	}
 
 	var readmeFiles []ReadmeFile
@@ -65,7 +65,7 @@ func isReadmeUpToDate(fileName, packageRoot string) (bool, string, error) {
 
 	rendered, shouldBeRendered, err := generateReadme(fileName, packageRoot)
 	if err != nil {
-		return false, "", errors.Wrap(err, "generating readme file failed")
+		return false, "", fmt.Errorf("generating readme file failed: %s", err)
 	}
 	if !shouldBeRendered {
 		return true, "", nil // README file is static and doesn't use template.
@@ -73,7 +73,7 @@ func isReadmeUpToDate(fileName, packageRoot string) (bool, string, error) {
 
 	existing, found, err := readReadme(fileName, packageRoot)
 	if err != nil {
-		return false, "", errors.Wrap(err, "reading README file failed")
+		return false, "", fmt.Errorf("reading README file failed: %s", err)
 	}
 	if !found {
 		return false, "", nil
@@ -97,7 +97,7 @@ func isReadmeUpToDate(fileName, packageRoot string) (bool, string, error) {
 func UpdateReadmes(packageRoot string) ([]string, error) {
 	readmeFiles, err := filepath.Glob(filepath.Join(packageRoot, "_dev", "build", "docs", "*.md"))
 	if err != nil {
-		return nil, errors.Wrap(err, "reading directory entries failed")
+		return nil, fmt.Errorf("reading directory entries failed: %s", err)
 	}
 
 	var targets []string
@@ -105,7 +105,7 @@ func UpdateReadmes(packageRoot string) ([]string, error) {
 		fileName := filepath.Base(filePath)
 		target, err := updateReadme(fileName, packageRoot)
 		if err != nil {
-			return nil, errors.Wrapf(err, "updating readme file %s failed", fileName)
+			return nil, fmt.Errorf("updating readme file %s failed: %s", fileName, err)
 		}
 
 		if target != "" {
@@ -128,17 +128,17 @@ func updateReadme(fileName, packageRoot string) (string, error) {
 
 	target, err := writeReadme(fileName, packageRoot, rendered)
 	if err != nil {
-		return "", errors.Wrapf(err, "writing %s file failed", fileName)
+		return "", fmt.Errorf("writing %s file failed: %s", fileName, err)
 	}
 
 	packageBuildRoot, err := builder.BuildPackagesDirectory(packageRoot)
 	if err != nil {
-		return "", errors.Wrap(err, "package build root not found")
+		return "", fmt.Errorf("package build root not found: %s", err)
 	}
 
 	_, err = writeReadme(fileName, packageBuildRoot, rendered)
 	if err != nil {
-		return "", errors.Wrapf(err, "writing %s file failed", fileName)
+		return "", fmt.Errorf("writing %s file failed: %s", fileName, err)
 	}
 	return target, nil
 }
@@ -147,7 +147,7 @@ func generateReadme(fileName, packageRoot string) ([]byte, bool, error) {
 	logger.Debugf("Generate %s file (package: %s)", fileName, packageRoot)
 	templatePath, found, err := findReadmeTemplatePath(fileName, packageRoot)
 	if err != nil {
-		return nil, false, errors.Wrapf(err, "can't locate %s template file", fileName)
+		return nil, false, fmt.Errorf("can't locate %s template file: %s", fileName, err)
 	}
 	if !found {
 		logger.Debug("README file is static, can't be generated from the template file")
@@ -162,7 +162,7 @@ func generateReadme(fileName, packageRoot string) ([]byte, bool, error) {
 
 	rendered, err := renderReadme(fileName, packageRoot, templatePath, linksMap)
 	if err != nil {
-		return nil, true, errors.Wrap(err, "rendering Readme failed")
+		return nil, true, fmt.Errorf("rendering Readme failed: %s", err)
 	}
 	return rendered, true, nil
 }
@@ -174,7 +174,7 @@ func findReadmeTemplatePath(fileName, packageRoot string) (string, bool, error) 
 		return "", false, nil // README.md file not found
 	}
 	if err != nil {
-		return "", false, errors.Wrapf(err, "can't stat the %s file", fileName)
+		return "", false, fmt.Errorf("can't stat the %s file: %s", fileName, err)
 	}
 	return templatePath, true, nil
 }
@@ -203,13 +203,13 @@ func renderReadme(fileName, packageRoot, templatePath string, linksMap linkMap) 
 		},
 	}).ParseFiles(templatePath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "parsing README template failed (path: %s)", templatePath)
+		return nil, fmt.Errorf("parsing README template failed (path: %s): %s", templatePath, err)
 	}
 
 	var rendered bytes.Buffer
 	err = t.Execute(&rendered, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "executing template failed")
+		return nil, fmt.Errorf("executing template failed: %s", err)
 	}
 	return rendered.Bytes(), nil
 }
@@ -223,7 +223,7 @@ func readReadme(fileName, packageRoot string) ([]byte, bool, error) {
 		return nil, false, nil
 	}
 	if err != nil {
-		return nil, false, errors.Wrapf(err, "readfile failed (path: %s)", readmePath)
+		return nil, false, fmt.Errorf("readfile failed (path: %s): %s", readmePath, err)
 	}
 	return b, true, err
 }
@@ -235,7 +235,7 @@ func writeReadme(fileName, packageRoot string, content []byte) (string, error) {
 	logger.Debugf("Create directories: %s", docsPath)
 	err := os.MkdirAll(docsPath, 0o755)
 	if err != nil {
-		return "", errors.Wrapf(err, "mkdir failed (path: %s)", docsPath)
+		return "", fmt.Errorf("mkdir failed (path: %s): %s", docsPath, err)
 	}
 
 	aReadmePath := readmePath(fileName, packageRoot)
@@ -243,7 +243,7 @@ func writeReadme(fileName, packageRoot string, content []byte) (string, error) {
 
 	err = os.WriteFile(aReadmePath, content, 0o644)
 	if err != nil {
-		return "", errors.Wrapf(err, "writing file failed (path: %s)", aReadmePath)
+		return "", fmt.Errorf("writing file failed (path: %s): %s", aReadmePath, err)
 	}
 	return aReadmePath, nil
 }

--- a/internal/docs/sample_event.go
+++ b/internal/docs/sample_event.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 
 	"github.com/elastic/elastic-package/internal/formatter"
-
-	"github.com/pkg/errors"
 )
 
 const sampleEventFile = "sample_event.json"
@@ -22,12 +20,12 @@ func renderSampleEvent(packageRoot, dataStreamName string) (string, error) {
 
 	body, err := os.ReadFile(eventPath)
 	if err != nil {
-		return "", errors.Wrapf(err, "reading sample event file failed (path: %s)", eventPath)
+		return "", fmt.Errorf("reading sample event file failed (path: %s): %s", eventPath, err)
 	}
 
 	formatted, _, err := formatter.JSONFormatter(body)
 	if err != nil {
-		return "", errors.Wrapf(err, "formatting sample event file failed (path: %s)", eventPath)
+		return "", fmt.Errorf("formatting sample event file failed (path: %s): %s", eventPath, err)
 	}
 
 	var builder strings.Builder

--- a/internal/dump/agentpolicies_test.go
+++ b/internal/dump/agentpolicies_test.go
@@ -24,7 +24,7 @@ func TestDumpAgentPolicies(t *testing.T) {
 	// - Run tests.
 	// - Check that recorded files make sense and commit them.
 	suites := []*agentPoliciesDumpSuite{
-		&agentPoliciesDumpSuite{
+		{
 			AgentPolicy:        "499b5aa7-d214-5b5d-838b-3cd76469844e",
 			PackageName:        "nginx",
 			RecordDir:          "./testdata/fleet-7-mock-dump-all",
@@ -32,7 +32,7 @@ func TestDumpAgentPolicies(t *testing.T) {
 			DumpDirPackage:     "./testdata/fleet-7-dump/package",
 			DumpDirAgentPolicy: "./testdata/fleet-7-dump/agentpolicy",
 		},
-		&agentPoliciesDumpSuite{
+		{
 			AgentPolicy:        "fleet-server-policy",
 			PackageName:        "nginx",
 			RecordDir:          "./testdata/fleet-8-mock-dump-all",

--- a/internal/dump/installedobjects_test.go
+++ b/internal/dump/installedobjects_test.go
@@ -31,12 +31,12 @@ func TestDumpInstalledObjects(t *testing.T) {
 	// - Run tests.
 	// - Check that recorded files make sense and commit them.
 	suites := []*installedObjectsDumpSuite{
-		&installedObjectsDumpSuite{
+		{
 			PackageName: "apache",
 			RecordDir:   "./testdata/elasticsearch-7-mock-dump-apache",
 			DumpDir:     "./testdata/elasticsearch-7-apache-dump-all",
 		},
-		&installedObjectsDumpSuite{
+		{
 			PackageName: "apache",
 			RecordDir:   "./testdata/elasticsearch-8-mock-dump-apache",
 			DumpDir:     "./testdata/elasticsearch-8-apache-dump-all",

--- a/internal/elasticsearch/ingest/datastream.go
+++ b/internal/elasticsearch/ingest/datastream.go
@@ -16,8 +16,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/elasticsearch"
 	"github.com/elastic/elastic-package/internal/packages"
 )
@@ -27,7 +25,7 @@ var ingestPipelineTag = regexp.MustCompile(`{{\s*IngestPipeline.+}}`)
 func InstallDataStreamPipelines(api *elasticsearch.API, dataStreamPath string) (string, []Pipeline, error) {
 	dataStreamManifest, err := packages.ReadDataStreamManifest(filepath.Join(dataStreamPath, packages.DataStreamManifestFile))
 	if err != nil {
-		return "", nil, errors.Wrap(err, "reading data stream manifest failed")
+		return "", nil, fmt.Errorf("reading data stream manifest failed: %s", err)
 	}
 
 	nonce := time.Now().UnixNano()
@@ -35,7 +33,7 @@ func InstallDataStreamPipelines(api *elasticsearch.API, dataStreamPath string) (
 	mainPipeline := getPipelineNameWithNonce(dataStreamManifest.GetPipelineNameOrDefault(), nonce)
 	pipelines, err := loadIngestPipelineFiles(dataStreamPath, nonce)
 	if err != nil {
-		return "", nil, errors.Wrap(err, "loading ingest pipeline files failed")
+		return "", nil, fmt.Errorf("loading ingest pipeline files failed: %s", err)
 	}
 
 	err = installPipelinesInElasticsearch(api, pipelines)
@@ -52,7 +50,7 @@ func loadIngestPipelineFiles(dataStreamPath string, nonce int64) ([]Pipeline, er
 	for _, pattern := range []string{"*.json", "*.yml"} {
 		files, err := filepath.Glob(filepath.Join(elasticsearchPath, pattern))
 		if err != nil {
-			return nil, errors.Wrapf(err, "listing '%s' in '%s'", pattern, elasticsearchPath)
+			return nil, fmt.Errorf("listing '%s' in '%s': %s", pattern, elasticsearchPath, err)
 		}
 		pipelineFiles = append(pipelineFiles, files...)
 	}
@@ -61,7 +59,7 @@ func loadIngestPipelineFiles(dataStreamPath string, nonce int64) ([]Pipeline, er
 	for _, path := range pipelineFiles {
 		c, err := os.ReadFile(path)
 		if err != nil {
-			return nil, errors.Wrapf(err, "reading ingest pipeline failed (path: %s)", path)
+			return nil, fmt.Errorf("reading ingest pipeline failed (path: %s): %s", path, err)
 		}
 
 		c = ingestPipelineTag.ReplaceAllFunc(c, func(found []byte) []byte {
@@ -98,7 +96,7 @@ func pipelineError(err error, pipeline Pipeline, format string, args ...interfac
 		context += ", path: " + pipeline.Path
 	}
 
-	return errors.Wrapf(err, format+" ("+context+")", args...)
+	return fmt.Errorf(fmt.Sprintf(format+" ("+context+")", args...), err)
 }
 
 func installPipeline(api *elasticsearch.API, pipeline Pipeline) error {

--- a/internal/elasticsearch/ingest/pipeline.go
+++ b/internal/elasticsearch/ingest/pipeline.go
@@ -7,11 +7,11 @@ package ingest
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/elastic-package/internal/elasticsearch"
@@ -59,13 +59,13 @@ func (p *Pipeline) MarshalJSON() (asJSON []byte, err error) {
 		var node map[string]interface{}
 		err = yaml.Unmarshal(p.Content, &node)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unmarshalling pipeline content failed (pipeline: %s)", p.Name)
+			return nil, fmt.Errorf("unmarshalling pipeline content failed (pipeline: %s): %s", p.Name, err)
 		}
 		if asJSON, err = json.Marshal(node); err != nil {
-			return nil, errors.Wrapf(err, "marshalling pipeline content failed (pipeline: %s)", p.Name)
+			return nil, fmt.Errorf("marshalling pipeline content failed (pipeline: %s): %s", p.Name, err)
 		}
 	default:
-		return nil, errors.Errorf("unsupported pipeline format '%s' (pipeline: %s)", p.Format, p.Name)
+		return nil, fmt.Errorf("unsupported pipeline format '%s' (pipeline: %s)", p.Format, p.Name)
 	}
 	return asJSON, nil
 }
@@ -80,30 +80,30 @@ func SimulatePipeline(api *elasticsearch.API, pipelineName string, events []json
 
 	requestBody, err := json.Marshal(&request)
 	if err != nil {
-		return nil, errors.Wrap(err, "marshalling simulate request failed")
+		return nil, fmt.Errorf("marshalling simulate request failed: %s", err)
 	}
 
 	r, err := api.Ingest.Simulate(bytes.NewReader(requestBody), func(request *elasticsearch.IngestSimulateRequest) {
 		request.PipelineID = pipelineName
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "Simulate API call failed (pipelineName: %s)", pipelineName)
+		return nil, fmt.Errorf("simulate API call failed (pipelineName: %s): %s", pipelineName, err)
 	}
 	defer r.Body.Close()
 
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to read Simulate API response body")
+		return nil, fmt.Errorf("failed to read Simulate API response body: %s", err)
 	}
 
 	if r.StatusCode != http.StatusOK {
-		return nil, errors.Wrapf(elasticsearch.NewError(body), "unexpected response status for Simulate (%d): %s", r.StatusCode, r.Status())
+		return nil, fmt.Errorf("unexpected response status for Simulate (%d): %s: %s", r.StatusCode, r.Status(), elasticsearch.NewError(body))
 	}
 
 	var response simulatePipelineResponse
 	err = json.Unmarshal(body, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "unmarshalling simulate request failed")
+		return nil, fmt.Errorf("unmarshalling simulate request failed: %s", err)
 	}
 
 	processedEvents := make([]json.RawMessage, len(response.Docs))
@@ -117,7 +117,7 @@ func UninstallPipelines(api *elasticsearch.API, pipelines []Pipeline) error {
 	for _, p := range pipelines {
 		resp, err := api.Ingest.DeletePipeline(p.Name)
 		if err != nil {
-			return errors.Wrapf(err, "DeletePipeline API call failed (pipelineName: %s)", p.Name)
+			return fmt.Errorf("DeletePipeline API call failed (pipelineName: %s): %s", p.Name, err)
 		}
 		resp.Body.Close()
 	}

--- a/internal/elasticsearch/ingest/processors.go
+++ b/internal/elasticsearch/ingest/processors.go
@@ -5,7 +5,8 @@
 package ingest
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -27,9 +28,12 @@ func (p Pipeline) Processors() (procs []Processor, err error) {
 	case "yaml", "yml", "json":
 		procs, err = processorsFromYAML(p.Content)
 	default:
-		return nil, errors.Errorf("unsupported pipeline format: %s", p.Format)
+		return nil, fmt.Errorf("unsupported pipeline format: %s", p.Format)
 	}
-	return procs, errors.Wrapf(err, "failure processing %s pipeline '%s'", p.Format, p.Filename())
+	if err != nil {
+		err = fmt.Errorf("failure processing %s pipeline '%s': %s", p.Format, p.Filename(), err)
+	}
+	return procs, err
 }
 
 // extract a list of processors from a pipeline definition in YAML format.
@@ -42,14 +46,14 @@ func processorsFromYAML(content []byte) (procs []Processor, err error) {
 	}
 	for idx, entry := range p.Processors {
 		if entry.Kind != yaml.MappingNode || len(entry.Content) != 2 {
-			return nil, errors.Errorf("processor#%d is not a single-key map (kind:%v content:%d)", idx, entry.Kind, len(entry.Content))
+			return nil, fmt.Errorf("processor#%d is not a single-key map (kind:%v content:%d)", idx, entry.Kind, len(entry.Content))
 		}
 		var proc Processor
 		if err := entry.Content[1].Decode(&proc); err != nil {
-			return nil, errors.Wrapf(err, "error decoding processor#%d configuration", idx)
+			return nil, fmt.Errorf("error decoding processor#%d configuration: %s", idx, err)
 		}
 		if err := entry.Content[0].Decode(&proc.Type); err != nil {
-			return nil, errors.Wrapf(err, "error decoding processor#%d type", idx)
+			return nil, fmt.Errorf("error decoding processor#%d type: %s", idx, err)
 		}
 		proc.FirstLine = entry.Line
 		proc.LastLine = lastLine(&entry)

--- a/internal/export/dashboards.go
+++ b/internal/export/dashboards.go
@@ -6,10 +6,9 @@ package export
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/common"
 	"github.com/elastic/elastic-package/internal/kibana"
@@ -22,18 +21,18 @@ import (
 func Dashboards(kibanaClient *kibana.Client, dashboardsIDs []string) error {
 	packageRoot, err := packages.MustFindPackageRoot()
 	if err != nil {
-		return errors.Wrap(err, "locating package root failed")
+		return fmt.Errorf("locating package root failed: %s", err)
 	}
 	logger.Debugf("Package root found: %s", packageRoot)
 
 	m, err := packages.ReadPackageManifestFromPackageRoot(packageRoot)
 	if err != nil {
-		return errors.Wrapf(err, "reading package manifest failed (path: %s)", packageRoot)
+		return fmt.Errorf("reading package manifest failed (path: %s): %s", packageRoot, err)
 	}
 
 	objects, err := kibanaClient.Export(dashboardsIDs)
 	if err != nil {
-		return errors.Wrap(err, "exporting dashboards using Kibana client failed")
+		return fmt.Errorf("exporting dashboards using Kibana client failed: %s", err)
 	}
 
 	ctx := &transformationContext{
@@ -42,12 +41,12 @@ func Dashboards(kibanaClient *kibana.Client, dashboardsIDs []string) error {
 
 	objects, err = applyTransformations(ctx, objects)
 	if err != nil {
-		return errors.Wrap(err, "can't transform Kibana objects")
+		return fmt.Errorf("can't transform Kibana objects: %s", err)
 	}
 
 	err = saveObjectsToFiles(packageRoot, objects)
 	if err != nil {
-		return errors.Wrap(err, "can't save Kibana objects")
+		return fmt.Errorf("can't save Kibana objects: %s", err)
 	}
 	return nil
 }
@@ -73,21 +72,21 @@ func saveObjectsToFiles(packageRoot string, objects []common.MapStr) error {
 		// Marshal object to byte content
 		b, err := json.MarshalIndent(&object, "", "    ")
 		if err != nil {
-			return errors.Wrapf(err, "marshalling Kibana object failed (ID: %s)", id.(string))
+			return fmt.Errorf("marshalling Kibana object failed (ID: %s): %s", id.(string), err)
 		}
 
 		// Create target directory
 		targetDir := filepath.Join(packageRoot, "kibana", aType.(string))
 		err = os.MkdirAll(targetDir, 0755)
 		if err != nil {
-			return errors.Wrapf(err, "creating target directory failed (path: %s)", targetDir)
+			return fmt.Errorf("creating target directory failed (path: %s): %s", targetDir, err)
 		}
 
 		// Save object to file
 		objectPath := filepath.Join(targetDir, id.(string)+".json")
 		err = os.WriteFile(objectPath, b, 0644)
 		if err != nil {
-			return errors.Wrap(err, "writing to file failed")
+			return fmt.Errorf("writing to file failed: %s", err)
 		}
 	}
 	return nil

--- a/internal/export/object_transformer.go
+++ b/internal/export/object_transformer.go
@@ -5,7 +5,7 @@
 package export
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/elastic/elastic-package/internal/common"
 )
@@ -36,7 +36,7 @@ func (ot *objectTransformer) transform(objects []common.MapStr) ([]common.MapStr
 			object, err = fn(ot.ctx, object)
 			if err != nil {
 				id, _ := object.GetValue("id")
-				return nil, errors.Wrapf(err, "object transformation failed (ID: %s)", id)
+				return nil, fmt.Errorf("object transformation failed (ID: %s): %s", id, err)
 			}
 		}
 

--- a/internal/export/transform_decode.go
+++ b/internal/export/transform_decode.go
@@ -6,8 +6,7 @@ package export
 
 import (
 	"encoding/json"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/elastic/elastic-package/internal/common"
 )
@@ -30,7 +29,7 @@ func decodeObject(ctx *transformationContext, object common.MapStr) (common.MapS
 		if err == common.ErrKeyNotFound {
 			continue
 		} else if err != nil {
-			return nil, errors.Wrapf(err, "retrieving value failed (key: %s)", fieldToDecode)
+			return nil, fmt.Errorf("retrieving value failed (key: %s): %s", fieldToDecode, err)
 		}
 
 		var target interface{}
@@ -43,13 +42,13 @@ func decodeObject(ctx *transformationContext, object common.MapStr) (common.MapS
 		} else {
 			err = json.Unmarshal([]byte(v.(string)), &array)
 			if err != nil {
-				return nil, errors.Wrapf(err, "can't unmarshal encoded field (key: %s)", fieldToDecode)
+				return nil, fmt.Errorf("can't unmarshal encoded field (key: %s): %s", fieldToDecode, err)
 			}
 			target = array
 		}
 		_, err = object.Put(fieldToDecode, target)
 		if err != nil {
-			return nil, errors.Wrapf(err, "can't update field (key: %s)", fieldToDecode)
+			return nil, fmt.Errorf("can't update field (key: %s): %s", fieldToDecode, err)
 		}
 	}
 	return object, nil

--- a/internal/export/transform_standardize.go
+++ b/internal/export/transform_standardize.go
@@ -5,10 +5,9 @@
 package export
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/common"
 )
@@ -20,23 +19,23 @@ func standardizeObjectID(ctx *transformationContext, object common.MapStr) (comm
 	id, _ := object.GetValue("id")
 	_, err := object.Put("id", adjustObjectID(ctx, id.(string)))
 	if err != nil {
-		return nil, errors.Wrapf(err, "can't update object ID")
+		return nil, fmt.Errorf("can't update object ID: %s", err)
 	}
 
 	// Adjust references
 	references, err := object.GetValue("references")
 	if err != nil && err != common.ErrKeyNotFound {
-		return nil, errors.Wrap(err, "retrieving object references failed")
+		return nil, fmt.Errorf("retrieving object references failed: %s", err)
 	}
 
 	newReferences, err := adjustObjectReferences(ctx, references.([]interface{}))
 	if err != nil {
-		return nil, errors.Wrapf(err, "can't adjust object references (ID: %s)", id)
+		return nil, fmt.Errorf("can't adjust object references (ID: %s): %s", id, err)
 	}
 
 	_, err = object.Put("references", newReferences)
 	if err != nil {
-		return nil, errors.Wrapf(err, "can't update references")
+		return nil, fmt.Errorf("can't update references: %s", err)
 	}
 	return object, nil
 }
@@ -62,7 +61,7 @@ func standardizeObjectProperties(ctx *transformationContext, object common.MapSt
 		if key == "title" {
 			_, err := object.Put(key, adjustTitleProperty(value.(string)))
 			if err != nil {
-				return nil, errors.Wrapf(err, "can't update field (key: %s)", key)
+				return nil, fmt.Errorf("can't update field (key: %s): %s", key, err)
 			}
 			continue
 		}
@@ -70,7 +69,7 @@ func standardizeObjectProperties(ctx *transformationContext, object common.MapSt
 		if key == "markdown" {
 			_, err := object.Put(key, adjustMarkdownProperty(ctx, value.(string)))
 			if err != nil {
-				return nil, errors.Wrapf(err, "can't update field (key: %s)", key)
+				return nil, fmt.Errorf("can't update field (key: %s): %s", key, err)
 			}
 			continue
 		}
@@ -83,7 +82,7 @@ func standardizeObjectProperties(ctx *transformationContext, object common.MapSt
 		case map[string]interface{}:
 			target, err = standardizeObjectProperties(ctx, value)
 			if err != nil {
-				return nil, errors.Wrapf(err, "can't standardize object (key: %s)", key)
+				return nil, fmt.Errorf("can't standardize object (key: %s): %s", key, err)
 			}
 			updated = true
 		case []map[string]interface{}:
@@ -91,7 +90,7 @@ func standardizeObjectProperties(ctx *transformationContext, object common.MapSt
 			for i, obj := range arr {
 				newValue, err := standardizeObjectProperties(ctx, obj)
 				if err != nil {
-					return nil, errors.Wrapf(err, "can't standardize object (array index: %d)", i)
+					return nil, fmt.Errorf("can't standardize object (array index: %d): %s", i, err)
 				}
 				arr[i] = newValue
 			}
@@ -105,7 +104,7 @@ func standardizeObjectProperties(ctx *transformationContext, object common.MapSt
 
 		_, err = object.Put(key, target)
 		if err != nil {
-			return nil, errors.Wrapf(err, "can't update field (key: %s)", key)
+			return nil, fmt.Errorf("can't update field (key: %s): %s", key, err)
 		}
 	}
 	return object, nil

--- a/internal/export/transform_strip.go
+++ b/internal/export/transform_strip.go
@@ -5,7 +5,7 @@
 package export
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/elastic/elastic-package/internal/common"
 )
@@ -13,17 +13,17 @@ import (
 func stripObjectProperties(ctx *transformationContext, object common.MapStr) (common.MapStr, error) {
 	err := object.Delete("namespaces")
 	if err != nil && err != common.ErrKeyNotFound {
-		return nil, errors.Wrapf(err, "removing field \"namespaces\" failed")
+		return nil, fmt.Errorf("removing field \"namespaces\" failed: %s", err)
 	}
 
 	err = object.Delete("updated_at")
 	if err != nil && err != common.ErrKeyNotFound {
-		return nil, errors.Wrapf(err, "removing field \"updated_at\" failed")
+		return nil, fmt.Errorf("removing field \"updated_at\" failed: %s", err)
 	}
 
 	err = object.Delete("version")
 	if err != nil && err != common.ErrKeyNotFound {
-		return nil, errors.Wrapf(err, "removing field \"version\" failed")
+		return nil, fmt.Errorf("removing field \"version\" failed: %s", err)
 	}
 	return object, nil
 }

--- a/internal/fields/dependency_manager.go
+++ b/internal/fields/dependency_manager.go
@@ -5,6 +5,7 @@
 package fields
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,7 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/elastic-package/internal/common"
@@ -38,7 +38,7 @@ type DependencyManager struct {
 func CreateFieldDependencyManager(deps buildmanifest.Dependencies) (*DependencyManager, error) {
 	schema, err := buildFieldsSchema(deps)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't build fields schema")
+		return nil, fmt.Errorf("can't build fields schema: %s", err)
 	}
 	return &DependencyManager{
 		schema: schema,
@@ -49,7 +49,7 @@ func buildFieldsSchema(deps buildmanifest.Dependencies) (map[string][]FieldDefin
 	schema := map[string][]FieldDefinition{}
 	ecsSchema, err := loadECSFieldsSchema(deps.ECS)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't load fields")
+		return nil, fmt.Errorf("can't load fields: %s", err)
 	}
 	schema[ecsSchemaName] = ecsSchema
 	return schema, nil
@@ -63,7 +63,7 @@ func loadECSFieldsSchema(dep buildmanifest.ECSDependency) ([]FieldDefinition, er
 
 	content, err := readECSFieldsSchemaFile(dep)
 	if err != nil {
-		return nil, errors.Wrap(err, "error reading ECS fields schema file")
+		return nil, fmt.Errorf("error reading ECS fields schema file: %s", err)
 	}
 
 	return parseECSFieldsSchema(content)
@@ -72,12 +72,12 @@ func loadECSFieldsSchema(dep buildmanifest.ECSDependency) ([]FieldDefinition, er
 func readECSFieldsSchemaFile(dep buildmanifest.ECSDependency) ([]byte, error) {
 	gitReference, err := asGitReference(dep.Reference)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't process the value as Git reference")
+		return nil, fmt.Errorf("can't process the value as Git reference: %s", err)
 	}
 
 	loc, err := locations.NewLocationManager()
 	if err != nil {
-		return nil, errors.Wrap(err, "error fetching profile path")
+		return nil, fmt.Errorf("error fetching profile path: %s", err)
 	}
 	cachedSchemaPath := filepath.Join(loc.FieldsCacheDir(), ecsSchemaName, gitReference, ecsSchemaFile)
 	content, err := os.ReadFile(cachedSchemaPath)
@@ -88,7 +88,7 @@ func readECSFieldsSchemaFile(dep buildmanifest.ECSDependency) ([]byte, error) {
 		logger.Debugf("Schema URL: %s", url)
 		resp, err := http.Get(url)
 		if err != nil {
-			return nil, errors.Wrapf(err, "can't download the online schema (URL: %s)", url)
+			return nil, fmt.Errorf("can't download the online schema (URL: %s): %s", url, err)
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode == http.StatusNotFound {
@@ -99,23 +99,23 @@ func readECSFieldsSchemaFile(dep buildmanifest.ECSDependency) ([]byte, error) {
 
 		content, err = io.ReadAll(resp.Body)
 		if err != nil {
-			return nil, errors.Wrapf(err, "can't read schema content (URL: %s)", url)
+			return nil, fmt.Errorf("can't read schema content (URL: %s): %s", url, err)
 		}
 		logger.Debugf("Downloaded %d bytes", len(content))
 
 		cachedSchemaDir := filepath.Dir(cachedSchemaPath)
 		err = os.MkdirAll(cachedSchemaDir, 0755)
 		if err != nil {
-			return nil, errors.Wrapf(err, "can't create cache directories for schema (path: %s)", cachedSchemaDir)
+			return nil, fmt.Errorf("can't create cache directories for schema (path: %s): %s", cachedSchemaDir, err)
 		}
 
 		logger.Debugf("Cache downloaded schema: %s", cachedSchemaPath)
 		err = os.WriteFile(cachedSchemaPath, content, 0644)
 		if err != nil {
-			return nil, errors.Wrapf(err, "can't write cached schema (path: %s)", cachedSchemaPath)
+			return nil, fmt.Errorf("can't write cached schema (path: %s): %s", cachedSchemaPath, err)
 		}
 	} else if err != nil {
-		return nil, errors.Wrapf(err, "can't read cached schema (path: %s)", cachedSchemaPath)
+		return nil, fmt.Errorf("can't read cached schema (path: %s): %s", cachedSchemaPath, err)
 	}
 
 	return content, nil
@@ -125,7 +125,7 @@ func parseECSFieldsSchema(content []byte) ([]FieldDefinition, error) {
 	var fields FieldDefinitions
 	err := yaml.Unmarshal(content, &fields)
 	if err != nil {
-		return nil, errors.Wrap(err, "unmarshalling field body failed")
+		return nil, fmt.Errorf("unmarshalling field body failed: %s", err)
 	}
 
 	return fields, nil
@@ -133,7 +133,7 @@ func parseECSFieldsSchema(content []byte) ([]FieldDefinition, error) {
 
 func asGitReference(reference string) (string, error) {
 	if !strings.HasPrefix(reference, gitReferencePrefix) {
-		return "", errors.New(`invalid Git reference ("git@" prefix expected)`)
+		return "", fmt.Errorf(`invalid Git reference ("git@" prefix expected)`)
 	}
 	return reference[len(gitReferencePrefix):], nil
 }
@@ -153,7 +153,7 @@ func (dm *DependencyManager) injectFieldsWithRoot(root string, defs []common.Map
 		if external != nil {
 			imported, err := dm.ImportField(external.(string), fieldPath)
 			if err != nil {
-				return nil, false, errors.Wrap(err, "can't import field")
+				return nil, false, fmt.Errorf("can't import field: %s", err)
 			}
 
 			transformed := transformImportedField(imported)
@@ -175,7 +175,7 @@ func (dm *DependencyManager) injectFieldsWithRoot(root string, defs []common.Map
 			if fields != nil {
 				fieldsMs, err := common.ToMapStrSlice(fields)
 				if err != nil {
-					return nil, false, errors.Wrap(err, "can't convert fields")
+					return nil, false, fmt.Errorf("can't convert fields: %s", err)
 				}
 				updatedFields, fieldsChanged, err := dm.injectFieldsWithRoot(fieldPath, fieldsMs)
 				if err != nil {

--- a/internal/fields/dependency_manager_test.go
+++ b/internal/fields/dependency_manager_test.go
@@ -367,7 +367,7 @@ func TestDependencyManagerInjectExternalFields(t *testing.T) {
 	}
 
 	indexFalse := false
-	schema := map[string][]FieldDefinition{"test": []FieldDefinition{
+	schema := map[string][]FieldDefinition{"test": {
 		{
 			Name:        "container.id",
 			Description: "Container identifier.",

--- a/internal/files/clear.go
+++ b/internal/files/clear.go
@@ -5,9 +5,8 @@
 package files
 
 import (
+	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 // ClearDir method removes all items from the destination directory.
@@ -15,12 +14,12 @@ import (
 func ClearDir(destinationPath string) error {
 	err := os.RemoveAll(destinationPath)
 	if err != nil {
-		return errors.Wrapf(err, "removing directory failed (path: %s)", destinationPath)
+		return fmt.Errorf("removing directory failed (path: %s): %s", destinationPath, err)
 	}
 
 	err = os.MkdirAll(destinationPath, 0755)
 	if err != nil {
-		return errors.Wrapf(err, "creating directory failed (path: %s)", destinationPath)
+		return fmt.Errorf("creating directory failed (path: %s): %s", destinationPath, err)
 	}
 	return nil
 }

--- a/internal/files/compress.go
+++ b/internal/files/compress.go
@@ -6,6 +6,7 @@ package files
 
 import (
 	"compress/flate"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,7 +14,6 @@ import (
 	"github.com/elastic/elastic-package/internal/logger"
 
 	"github.com/mholt/archiver/v3"
-	"github.com/pkg/errors"
 )
 
 // Zip function creates the .zip archive from the source path (built package content).
@@ -32,24 +32,24 @@ func Zip(sourcePath, destinationFile string) error {
 	// Create a temporary work directory to properly name the root directory in the archive, e.g. aws-1.0.1
 	tempDir, err := os.MkdirTemp("", "elastic-package-")
 	if err != nil {
-		return errors.Wrap(err, "can't prepare a temporary directory")
+		return fmt.Errorf("can't prepare a temporary directory: %s", err)
 	}
 	defer os.RemoveAll(tempDir)
 	workDir := filepath.Join(tempDir, folderNameFromFileName(destinationFile))
 	err = os.MkdirAll(workDir, 0755)
 	if err != nil {
-		return errors.Wrapf(err, "can't prepare work directory: %s", workDir)
+		return fmt.Errorf("can't prepare work directory: %s: %s", workDir, err)
 	}
 
 	logger.Debugf("Create work directory for archiving: %s", workDir)
 	err = CopyAll(sourcePath, workDir)
 	if err != nil {
-		return errors.Wrapf(err, "can't create a work directory (path: %s)", workDir)
+		return fmt.Errorf("can't create a work directory (path: %s): %s", workDir, err)
 	}
 
 	err = z.Archive([]string{workDir}, destinationFile)
 	if err != nil {
-		return errors.Wrapf(err, "can't archive source directory (source path: %s)", sourcePath)
+		return fmt.Errorf("can't archive source directory (source path: %s): %s", sourcePath, err)
 	}
 	return nil
 }

--- a/internal/files/remove.go
+++ b/internal/files/remove.go
@@ -5,24 +5,23 @@
 package files
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
 // RemoveContent method wipes out the directory content.
 func RemoveContent(dir string) error {
 	fis, err := os.ReadDir(dir)
 	if err != nil {
-		return errors.Wrapf(err, "readdir failed (path: %s)", dir)
+		return fmt.Errorf("readdir failed (path: %s): %s", dir, err)
 	}
 
 	for _, fi := range fis {
 		p := filepath.Join(dir, fi.Name())
 		err = os.RemoveAll(p)
 		if err != nil {
-			return errors.Wrapf(err, "removing resource failed (path: %s)", p)
+			return fmt.Errorf("removing resource failed (path: %s): %s", p, err)
 		}
 	}
 	return nil

--- a/internal/files/repository.go
+++ b/internal/files/repository.go
@@ -5,16 +5,15 @@
 package files
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
 func FindRepositoryRootDirectory() (string, error) {
 	workDir, err := os.Getwd()
 	if err != nil {
-		return "", errors.Wrap(err, "locating working directory failed")
+		return "", fmt.Errorf("locating working directory failed: %s", err)
 	}
 
 	dir := workDir

--- a/internal/files/sign.go
+++ b/internal/files/sign.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ProtonMail/gopenpgp/v2/armor"
 	"github.com/ProtonMail/gopenpgp/v2/constants"
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/environment"
 	"github.com/elastic/elastic-package/internal/logger"
@@ -38,7 +37,7 @@ func VerifySignerConfiguration() error {
 
 	_, err := os.Stat(signerPrivateKeyfile)
 	if err != nil {
-		return errors.Wrap(err, "can't access the signer private keyfile")
+		return fmt.Errorf("can't access the signer private keyfile: %s", err)
 	}
 
 	signerPassphrase := os.Getenv(signerPassphraseEnv)
@@ -55,7 +54,7 @@ func Sign(targetFile string, options SignOptions) error {
 	logger.Debugf("Read signer private keyfile: %s", signerPrivateKeyfile)
 	signerPrivateKey, err := os.ReadFile(signerPrivateKeyfile)
 	if err != nil {
-		return errors.Wrapf(err, "can't read the signer private keyfile (path: %s)", signerPrivateKeyfile)
+		return fmt.Errorf("can't read the signer private keyfile (path: %s): %s", signerPrivateKeyfile, err)
 	}
 
 	signerPassphrase := []byte(os.Getenv(signerPassphraseEnv))
@@ -63,42 +62,42 @@ func Sign(targetFile string, options SignOptions) error {
 	logger.Debug("Start the signing routine")
 	signingKey, err := crypto.NewKeyFromArmored(string(signerPrivateKey))
 	if err != nil {
-		return errors.Wrap(err, "crypto.NewKeyFromArmored failed")
+		return fmt.Errorf("crypto.NewKeyFromArmored failed: %s", err)
 	}
 
 	unlockedKey, err := signingKey.Unlock(signerPassphrase)
 	if err != nil {
-		return errors.Wrap(err, "signingKey.Unlock failed")
+		return fmt.Errorf("signingKey.Unlock failed: %s", err)
 	}
 	defer unlockedKey.ClearPrivateParams()
 
 	keyRing, err := crypto.NewKeyRing(unlockedKey)
 	if err != nil {
-		return errors.Wrap(err, "crypto.NewKeyRing failed")
+		return fmt.Errorf("crypto.NewKeyRing failed: %s", err)
 	}
 
 	messageReader, err := os.Open(targetFile)
 	if err != nil {
-		return errors.Wrapf(err, "os.Open failed (targetFile: %s)", targetFile)
+		return fmt.Errorf("os.Open failed (targetFile: %s): %s", targetFile, err)
 	}
 	defer messageReader.Close()
 
 	signature, err := keyRing.SignDetachedStream(messageReader)
 	if err != nil {
-		return errors.Wrap(err, "keyRing.SignDetached failed")
+		return fmt.Errorf("keyRing.SignDetached failed: %s", err)
 	}
 
 	armoredSignature, err := armor.ArmorWithTypeAndCustomHeaders(signature.Data, constants.PGPSignatureHeader,
 		fmt.Sprintf("%s-%s", options.PackageName, options.PackageVersion), signatureComment)
 	if err != nil {
-		return errors.Wrap(err, "signature.GetArmored failed")
+		return fmt.Errorf("signature.GetArmored failed: %s", err)
 	}
 
 	logger.Debug("Signature generated for the target file, writing the .sig file")
 	targetSigFile := targetFile + ".sig"
 	err = os.WriteFile(targetSigFile, []byte(armoredSignature), 0644)
 	if err != nil {
-		return errors.Wrap(err, "can't write the signature file")
+		return fmt.Errorf("can't write the signature file: %s", err)
 	}
 
 	logger.Infof("Signature file written: %s", targetSigFile)

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
 type formatter func(content []byte) ([]byte, bool, error)
@@ -35,13 +33,13 @@ func Format(packageRoot string, failFast bool) error {
 		}
 		err = formatFile(path, failFast)
 		if err != nil {
-			return errors.Wrapf(err, "formatting file failed (path: %s)", path)
+			return fmt.Errorf("formatting file failed (path: %s): %s", path, err)
 		}
 
 		return nil
 	})
 	if err != nil {
-		return errors.Wrap(err, "walking through the integration files failed")
+		return fmt.Errorf("walking through the integration files failed: %s", err)
 	}
 	return nil
 }
@@ -52,7 +50,7 @@ func formatFile(path string, failFast bool) error {
 
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return errors.Wrap(err, "reading file content failed")
+		return fmt.Errorf("reading file content failed: %s", err)
 	}
 
 	format, defined := formatters[ext]
@@ -62,7 +60,7 @@ func formatFile(path string, failFast bool) error {
 
 	newContent, alreadyFormatted, err := format(content)
 	if err != nil {
-		return errors.Wrap(err, "formatting file content failed")
+		return fmt.Errorf("formatting file content failed: %s", err)
 	}
 
 	if alreadyFormatted {
@@ -75,7 +73,7 @@ func formatFile(path string, failFast bool) error {
 
 	err = os.WriteFile(path, newContent, 0755)
 	if err != nil {
-		return errors.Wrapf(err, "rewriting file failed (path: %s)", path)
+		return fmt.Errorf("rewriting file failed (path: %s): %s", path, err)
 	}
 	return nil
 }

--- a/internal/formatter/json_formatter.go
+++ b/internal/formatter/json_formatter.go
@@ -6,8 +6,7 @@ package formatter
 
 import (
 	"encoding/json"
-
-	"github.com/pkg/errors"
+	"fmt"
 )
 
 // JSONFormatter function is responsible for formatting the given JSON input.
@@ -16,12 +15,12 @@ func JSONFormatter(content []byte) ([]byte, bool, error) {
 	var rawMessage json.RawMessage
 	err := json.Unmarshal(content, &rawMessage)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "unmarshalling JSON file failed")
+		return nil, false, fmt.Errorf("unmarshalling JSON file failed: %s", err)
 	}
 
 	formatted, err := json.MarshalIndent(&rawMessage, "", "    ")
 	if err != nil {
-		return nil, false, errors.Wrap(err, "marshalling JSON raw message failed")
+		return nil, false, fmt.Errorf("marshalling JSON raw message failed: %s", err)
 	}
 	return formatted, string(content) == string(formatted), nil
 }

--- a/internal/formatter/yaml_formatter.go
+++ b/internal/formatter/yaml_formatter.go
@@ -6,10 +6,9 @@ package formatter
 
 import (
 	"bytes"
+	"fmt"
 
 	"gopkg.in/yaml.v3"
-
-	"github.com/pkg/errors"
 )
 
 // YAMLFormatter function is responsible for formatting the given YAML input.
@@ -20,7 +19,7 @@ func YAMLFormatter(content []byte) ([]byte, bool, error) {
 	var node yaml.Node
 	err := yaml.Unmarshal(content, &node)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "unmarshalling YAML file failed")
+		return nil, false, fmt.Errorf("unmarshalling YAML file failed: %s", err)
 	}
 
 	var b bytes.Buffer
@@ -28,7 +27,7 @@ func YAMLFormatter(content []byte) ([]byte, bool, error) {
 	encoder.SetIndent(2)
 	err = encoder.Encode(&node)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "marshalling YAML node failed")
+		return nil, false, fmt.Errorf("marshalling YAML node failed: %s", err)
 	}
 	formatted := b.Bytes()
 	return formatted, string(content) == string(formatted), nil

--- a/internal/github/auth.go
+++ b/internal/github/auth.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -22,8 +20,9 @@ const (
 func EnsureAuthConfigured() error {
 	_, err := AuthToken()
 	if err != nil {
-		return errors.Wrapf(err, "GitHub authorization token is missing. Please use either environment variable %s or ~/%s",
-			envAuth, authTokenFile)
+		return fmt.Errorf("GitHub authorization token is missing. Please use either environment variable %s or ~/%s: %s",
+			envAuth, authTokenFile, err)
+
 	}
 	return nil
 }
@@ -38,13 +37,13 @@ func AuthToken() (string, error) {
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return "", errors.Wrap(err, "reading user home directory failed")
+		return "", fmt.Errorf("reading user home directory failed: %s", err)
 	}
 
 	githubTokenPath := filepath.Join(homeDir, ".elastic/github.token")
 	token, err := os.ReadFile(githubTokenPath)
 	if err != nil {
-		return "", errors.Wrapf(err, "reading Github token file failed (path: %s)", githubTokenPath)
+		return "", fmt.Errorf("reading Github token file failed (path: %s): %s", githubTokenPath, err)
 	}
 	return strings.TrimSpace(string(token)), nil
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -6,9 +6,8 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 
 	"github.com/google/go-github/v32/github"
 	"golang.org/x/oauth2"
@@ -18,7 +17,7 @@ import (
 func Client() (*github.Client, error) {
 	authToken, err := AuthToken()
 	if err != nil {
-		return nil, errors.Wrap(err, "reading auth token failed")
+		return nil, fmt.Errorf("reading auth token failed: %s", err)
 	}
 	return github.NewClient(oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: authToken},
@@ -34,7 +33,7 @@ func UnauthorizedClient() *github.Client {
 func User(client *github.Client) (string, error) {
 	user, _, err := client.Users.Get(context.Background(), "")
 	if err != nil {
-		return "", errors.Wrap(err, "fetching authenticated user failed")
+		return "", fmt.Errorf("fetching authenticated user failed: %s", err)
 	}
 	return *user.Login, nil
 }

--- a/internal/install/application_configuration.go
+++ b/internal/install/application_configuration.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/elastic-package/internal/configuration/locations"
@@ -104,18 +103,18 @@ func selectElasticAgentImageName(version string) string {
 func Configuration() (*ApplicationConfiguration, error) {
 	configPath, err := locations.NewLocationManager()
 	if err != nil {
-		return nil, errors.Wrap(err, "can't read configuration directory")
+		return nil, fmt.Errorf("can't read configuration directory: %s", err)
 	}
 
 	cfg, err := os.ReadFile(filepath.Join(configPath.RootDir(), applicationConfigurationYmlFile))
 	if err != nil {
-		return nil, errors.Wrap(err, "can't read configuration file")
+		return nil, fmt.Errorf("can't read configuration file: %s", err)
 	}
 
 	var c configFile
 	err = yaml.Unmarshal(cfg, &c)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't unmarshal configuration file")
+		return nil, fmt.Errorf("can't unmarshal configuration file: %s", err)
 	}
 
 	return &ApplicationConfiguration{

--- a/internal/install/version_file.go
+++ b/internal/install/version_file.go
@@ -10,8 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/configuration/locations"
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/version"
@@ -24,7 +22,7 @@ func checkIfLatestVersionInstalled(elasticPackagePath *locations.LocationManager
 		return false, nil // old version, no version file
 	}
 	if err != nil {
-		return false, errors.Wrap(err, "reading version file failed")
+		return false, fmt.Errorf("reading version file failed: %s", err)
 	}
 	v := string(versionFile)
 	if version.CommitHash == "undefined" && strings.Contains(v, "undefined") {
@@ -39,7 +37,7 @@ func writeVersionFile(elasticPackagePath *locations.LocationManager) error {
 		filepath.Join(elasticPackagePath.RootDir(), versionFilename),
 		buildVersionFile(version.CommitHash, version.BuildTime))
 	if err != nil {
-		return errors.Wrap(err, "writing static resource failed")
+		return fmt.Errorf("writing static resource failed: %s", err)
 	}
 	return nil
 }

--- a/internal/kibana/agents.go
+++ b/internal/kibana/agents.go
@@ -10,8 +10,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/signal"
 )
@@ -43,7 +41,7 @@ func (a *Agent) String() string {
 func (c *Client) ListAgents() ([]Agent, error) {
 	statusCode, respBody, err := c.get(fmt.Sprintf("%s/agents", FleetAPI))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not list agents")
+		return nil, fmt.Errorf("could not list agents: %s", err)
 	}
 
 	if statusCode != http.StatusOK {
@@ -55,7 +53,7 @@ func (c *Client) ListAgents() ([]Agent, error) {
 	}
 
 	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, errors.Wrap(err, "could not convert list agents (response) to JSON")
+		return nil, fmt.Errorf("could not convert list agents (response) to JSON: %s", err)
 	}
 
 	return resp.List, nil
@@ -68,7 +66,7 @@ func (c *Client) AssignPolicyToAgent(a Agent, p Policy) error {
 	path := fmt.Sprintf("%s/agents/%s/reassign", FleetAPI, a.ID)
 	statusCode, respBody, err := c.put(path, []byte(reqBody))
 	if err != nil {
-		return errors.Wrap(err, "could not assign policy to agent")
+		return fmt.Errorf("could not assign policy to agent: %s", err)
 	}
 
 	if statusCode != http.StatusOK {
@@ -77,7 +75,7 @@ func (c *Client) AssignPolicyToAgent(a Agent, p Policy) error {
 
 	err = c.waitUntilPolicyAssigned(a, p)
 	if err != nil {
-		return errors.Wrap(err, "error occurred while waiting for the policy to be assigned to all agents")
+		return fmt.Errorf("error occurred while waiting for the policy to be assigned to all agents: %s", err)
 	}
 	return nil
 }
@@ -86,16 +84,16 @@ func (c *Client) waitUntilPolicyAssigned(a Agent, p Policy) error {
 	timeout := time.Now().Add(waitForPolicyAssignedTimeout)
 	for {
 		if time.Now().After(timeout) {
-			return errors.New("timeout: policy hasn't been assigned in time")
+			return fmt.Errorf("timeout: policy hasn't been assigned in time")
 		}
 
 		if signal.SIGINT() {
-			return errors.New("SIGINT: cancel waiting for policy assigned")
+			return fmt.Errorf("SIGINT: cancel waiting for policy assigned")
 		}
 
 		agent, err := c.getAgent(a.ID)
 		if err != nil {
-			return errors.Wrap(err, "can't get the agent")
+			return fmt.Errorf("can't get the agent: %s", err)
 		}
 		logger.Debugf("Agent data: %s", agent.String())
 
@@ -113,7 +111,7 @@ func (c *Client) waitUntilPolicyAssigned(a Agent, p Policy) error {
 func (c *Client) getAgent(agentID string) (*Agent, error) {
 	statusCode, respBody, err := c.get(fmt.Sprintf("%s/agents/%s", FleetAPI, agentID))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not list agents")
+		return nil, fmt.Errorf("could not list agents: %s", err)
 	}
 
 	if statusCode != http.StatusOK {
@@ -124,7 +122,7 @@ func (c *Client) getAgent(agentID string) (*Agent, error) {
 		Item Agent `json:"item"`
 	}
 	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, errors.Wrap(err, "could not convert list agents (response) to JSON")
+		return nil, fmt.Errorf("could not convert list agents (response) to JSON: %s", err)
 	}
 	return &resp.Item, nil
 }

--- a/internal/kibana/client.go
+++ b/internal/kibana/client.go
@@ -13,8 +13,6 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/certs"
 	"github.com/elastic/elastic-package/internal/install"
 	"github.com/elastic/elastic-package/internal/logger"
@@ -100,12 +98,12 @@ func (c *Client) sendRequest(method, resourcePath string, body []byte) (int, []b
 	reqBody := bytes.NewReader(body)
 	base, err := url.Parse(c.host)
 	if err != nil {
-		return 0, nil, errors.Wrapf(err, "could not create base URL from host: %v", c.host)
+		return 0, nil, fmt.Errorf("could not create base URL from host: %v: %s", c.host, err)
 	}
 
 	rel, err := url.Parse(resourcePath)
 	if err != nil {
-		return 0, nil, errors.Wrapf(err, "could not create relative URL from resource path: %v", resourcePath)
+		return 0, nil, fmt.Errorf("could not create relative URL from resource path: %v: %s", resourcePath, err)
 	}
 
 	u := base.JoinPath(rel.EscapedPath())
@@ -115,7 +113,7 @@ func (c *Client) sendRequest(method, resourcePath string, body []byte) (int, []b
 
 	req, err := http.NewRequest(method, u.String(), reqBody)
 	if err != nil {
-		return 0, nil, errors.Wrapf(err, "could not create %v request to Kibana API resource: %s", method, resourcePath)
+		return 0, nil, fmt.Errorf("could not create %v request to Kibana API resource: %s: %s", method, resourcePath, err)
 	}
 
 	req.SetBasicAuth(c.username, c.password)
@@ -139,13 +137,13 @@ func (c *Client) sendRequest(method, resourcePath string, body []byte) (int, []b
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return 0, nil, errors.Wrap(err, "could not send request to Kibana API")
+		return 0, nil, fmt.Errorf("could not send request to Kibana API: %s", err)
 	}
 
 	defer resp.Body.Close()
 	body, err = io.ReadAll(resp.Body)
 	if err != nil {
-		return resp.StatusCode, nil, errors.Wrap(err, "could not read response body")
+		return resp.StatusCode, nil, fmt.Errorf("could not read response body: %s", err)
 	}
 
 	return resp.StatusCode, body, nil

--- a/internal/kibana/dashboards.go
+++ b/internal/kibana/dashboards.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/common"
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/multierror"
@@ -35,20 +33,20 @@ func (c *Client) Export(dashboardIDs []string) ([]common.MapStr, error) {
 	path := fmt.Sprintf("%s/dashboards/export%s", CoreAPI, query.String())
 	statusCode, respBody, err := c.get(path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not export dashboards; API status code = %d; response body = %s", statusCode, respBody)
+		return nil, fmt.Errorf("could not export dashboards; API status code = %d; response body = %s: %s", statusCode, respBody, err)
 	}
 
 	var exported exportedType
 	err = json.Unmarshal(respBody, &exported)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unmarshalling response failed (body: \n%s)", respBody)
+		return nil, fmt.Errorf("unmarshalling response failed (body: \n%s): %s", respBody, err)
 	}
 
 	var multiErr multierror.Error
 	for _, obj := range exported.Objects {
 		errMsg, err := obj.GetValue("error.message")
 		if errMsg != nil {
-			multiErr = append(multiErr, errors.New(errMsg.(string)))
+			multiErr = append(multiErr, fmt.Errorf(errMsg.(string)))
 			continue
 		}
 		if err != nil && err != common.ErrKeyNotFound {
@@ -57,7 +55,7 @@ func (c *Client) Export(dashboardIDs []string) ([]common.MapStr, error) {
 	}
 
 	if len(multiErr) > 0 {
-		return nil, errors.Wrap(multiErr, "at least Kibana object returned an error")
+		return nil, fmt.Errorf("at least Kibana object returned an error: %s", multiErr)
 	}
 	return exported.Objects, nil
 }

--- a/internal/kibana/packages.go
+++ b/internal/kibana/packages.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/packages"
 )
 
@@ -21,7 +19,7 @@ func (c *Client) InstallPackage(pkg packages.PackageManifest) ([]packages.Asset,
 
 	statusCode, respBody, err := c.post(path, reqBody)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not install package")
+		return nil, fmt.Errorf("could not install package: %s", err)
 	}
 
 	return processResults("install", statusCode, respBody)
@@ -32,7 +30,7 @@ func (c *Client) RemovePackage(pkg packages.PackageManifest) ([]packages.Asset, 
 	path := fmt.Sprintf("%s/epm/packages/%s-%s", FleetAPI, pkg.Name, pkg.Version)
 	statusCode, respBody, err := c.delete(path)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not delete package")
+		return nil, fmt.Errorf("could not delete package: %s", err)
 	}
 
 	return processResults("remove", statusCode, respBody)
@@ -48,7 +46,7 @@ func processResults(action string, statusCode int, respBody []byte) ([]packages.
 	}
 
 	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, errors.Wrapf(err, "could not convert %s package (response) to JSON", action)
+		return nil, fmt.Errorf("could not convert %s package (response) to JSON: %s", action, err)
 	}
 
 	return resp.Assets, nil

--- a/internal/kibana/policies.go
+++ b/internal/kibana/policies.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/packages"
 )
 
@@ -27,12 +25,12 @@ type Policy struct {
 func (c *Client) CreatePolicy(p Policy) (*Policy, error) {
 	reqBody, err := json.Marshal(p)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not convert policy (request) to JSON")
+		return nil, fmt.Errorf("could not convert policy (request) to JSON: %s", err)
 	}
 
 	statusCode, respBody, err := c.post(fmt.Sprintf("%s/agent_policies", FleetAPI), reqBody)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create policy")
+		return nil, fmt.Errorf("could not create policy: %s", err)
 	}
 
 	if statusCode != http.StatusOK {
@@ -44,7 +42,7 @@ func (c *Client) CreatePolicy(p Policy) (*Policy, error) {
 	}
 
 	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, errors.Wrap(err, "could not convert policy (response) to JSON")
+		return nil, fmt.Errorf("could not convert policy (response) to JSON: %s", err)
 	}
 
 	return &resp.Item, nil
@@ -54,7 +52,7 @@ func (c *Client) CreatePolicy(p Policy) (*Policy, error) {
 func (c *Client) GetPolicy(policyID string) (*Policy, error) {
 	statusCode, respBody, err := c.get(fmt.Sprintf("%s/agent_policies/%s", FleetAPI, policyID))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get policy")
+		return nil, fmt.Errorf("could not get policy: %s", err)
 	}
 
 	if statusCode != http.StatusOK {
@@ -66,7 +64,7 @@ func (c *Client) GetPolicy(policyID string) (*Policy, error) {
 	}
 
 	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, errors.Wrap(err, "could not convert policy (response) to JSON")
+		return nil, fmt.Errorf("could not convert policy (response) to JSON: %s", err)
 	}
 
 	return &resp.Item, nil
@@ -76,7 +74,7 @@ func (c *Client) GetPolicy(policyID string) (*Policy, error) {
 func (c *Client) GetRawPolicy(policyID string) (json.RawMessage, error) {
 	statusCode, respBody, err := c.get(fmt.Sprintf("%s/agent_policies/%s", FleetAPI, policyID))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get policy")
+		return nil, fmt.Errorf("could not get policy: %s", err)
 	}
 
 	if statusCode != http.StatusOK {
@@ -88,7 +86,7 @@ func (c *Client) GetRawPolicy(policyID string) (json.RawMessage, error) {
 	}
 
 	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, errors.Wrap(err, "could not convert policy (response) to JSON")
+		return nil, fmt.Errorf("could not convert policy (response) to JSON: %s", err)
 	}
 
 	return resp.Item, nil
@@ -109,7 +107,7 @@ func (c *Client) ListRawPolicies() ([]json.RawMessage, error) {
 	for finished := false; !finished; finished = itemsRetrieved == resp.Total {
 		statusCode, respBody, err := c.get(fmt.Sprintf("%s/agent_policies?full=true&page=%d", FleetAPI, currentPage))
 		if err != nil {
-			return nil, errors.Wrap(err, "could not get policies")
+			return nil, fmt.Errorf("could not get policies: %s", err)
 		}
 
 		if statusCode != http.StatusOK {
@@ -117,7 +115,7 @@ func (c *Client) ListRawPolicies() ([]json.RawMessage, error) {
 		}
 
 		if err := json.Unmarshal(respBody, &resp); err != nil {
-			return nil, errors.Wrap(err, "could not convert policies (response) to JSON")
+			return nil, fmt.Errorf("could not convert policies (response) to JSON: %s", err)
 		}
 
 		itemsRetrieved += len(resp.Items)
@@ -134,7 +132,7 @@ func (c *Client) DeletePolicy(p Policy) error {
 
 	statusCode, respBody, err := c.post(fmt.Sprintf("%s/agent_policies/delete", FleetAPI), []byte(reqBody))
 	if err != nil {
-		return errors.Wrap(err, "could not delete policy")
+		return fmt.Errorf("could not delete policy: %s", err)
 	}
 
 	if statusCode != http.StatusOK {
@@ -200,12 +198,12 @@ type PackageDataStream struct {
 func (c *Client) AddPackageDataStreamToPolicy(r PackageDataStream) error {
 	reqBody, err := json.Marshal(r)
 	if err != nil {
-		return errors.Wrap(err, "could not convert policy-package (request) to JSON")
+		return fmt.Errorf("could not convert policy-package (request) to JSON: %s", err)
 	}
 
 	statusCode, respBody, err := c.post(fmt.Sprintf("%s/package_policies", FleetAPI), reqBody)
 	if err != nil {
-		return errors.Wrap(err, "could not add package to policy")
+		return fmt.Errorf("could not add package to policy: %s", err)
 	}
 
 	if statusCode != http.StatusOK {

--- a/internal/kibana/saved_objects.go
+++ b/internal/kibana/saved_objects.go
@@ -10,8 +10,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/logger"
 )
 
@@ -65,7 +63,7 @@ func (c *Client) FindDashboards() (DashboardSavedObjects, error) {
 	for {
 		r, err := c.findDashboardsNextPage(page)
 		if err != nil {
-			return nil, errors.Wrap(err, "can't fetch page with results")
+			return nil, fmt.Errorf("can't fetch page with results: %s", err)
 		}
 		if r.Error != "" {
 			return nil, fmt.Errorf("%s: %s", r.Error, r.Message)
@@ -94,13 +92,13 @@ func (c *Client) findDashboardsNextPage(page int) (*savedObjectsResponse, error)
 	path := fmt.Sprintf("%s/_find?type=dashboard&fields=title&per_page=%d&page=%d", SavedObjectsAPI, findDashboardsPerPage, page)
 	statusCode, respBody, err := c.get(path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not find dashboards; API status code = %d; response body = %s", statusCode, respBody)
+		return nil, fmt.Errorf("could not find dashboards; API status code = %d; response body = %s: %s", statusCode, respBody, err)
 	}
 
 	var r savedObjectsResponse
 	err = json.Unmarshal(respBody, &r)
 	if err != nil {
-		return nil, errors.Wrap(err, "unmarshalling response failed")
+		return nil, fmt.Errorf("unmarshalling response failed: %s", err)
 	}
 	return &r, nil
 }

--- a/internal/kibana/status.go
+++ b/internal/kibana/status.go
@@ -8,8 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 const SNAPSHOT_SUFFIX = "-SNAPSHOT"
@@ -39,7 +37,7 @@ func (c *Client) Version() (VersionInfo, error) {
 	var version VersionInfo
 	statusCode, respBody, err := c.get(StatusAPI)
 	if err != nil {
-		return version, errors.Wrapf(err, "could not reach status endpoint")
+		return version, fmt.Errorf("could not reach status endpoint: %s", err)
 	}
 
 	if statusCode != http.StatusOK {
@@ -49,7 +47,7 @@ func (c *Client) Version() (VersionInfo, error) {
 	var status statusType
 	err = json.Unmarshal(respBody, &status)
 	if err != nil {
-		return version, errors.Wrapf(err, "unmarshalling response failed (body: \n%s)", respBody)
+		return version, fmt.Errorf("unmarshalling response failed (body: \n%s): %s", respBody, err)
 	}
 
 	return status.Version, nil

--- a/internal/kind/kind.go
+++ b/internal/kind/kind.go
@@ -7,8 +7,6 @@ package kind
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/docker"
 	"github.com/elastic/elastic-package/internal/kubectl"
 	"github.com/elastic/elastic-package/internal/logger"
@@ -26,7 +24,7 @@ func VerifyContext() error {
 
 	currentContext, err := kubectl.CurrentContext()
 	if err != nil {
-		return errors.Wrap(err, "can't read current Kubernetes context")
+		return fmt.Errorf("can't read current Kubernetes context: %s", err)
 	}
 	if currentContext != kindContext {
 		return fmt.Errorf("unexpected Kubernetes context selected (actual: %s, expected: %s)", currentContext, kindContext)
@@ -38,7 +36,7 @@ func VerifyContext() error {
 func ConnectToElasticStackNetwork() error {
 	containerID, err := controlPlaneContainerID()
 	if err != nil {
-		return errors.Wrap(err, "can't find kind-control plane node")
+		return fmt.Errorf("can't find kind-control plane node: %s", err)
 	}
 
 	stackNetwork := stack.Network()
@@ -46,7 +44,7 @@ func ConnectToElasticStackNetwork() error {
 
 	networkDescriptions, err := docker.InspectNetwork(stackNetwork)
 	if err != nil {
-		return errors.Wrap(err, "can't inspect network")
+		return fmt.Errorf("can't inspect network: %s", err)
 	}
 	if len(networkDescriptions) != 1 {
 		return fmt.Errorf("expected single network description, got %d entries", len(networkDescriptions))
@@ -62,7 +60,7 @@ func ConnectToElasticStackNetwork() error {
 	logger.Debugf("attach %s container (ID: %s) to stack network %s", ControlPlaneContainerName, containerID, stackNetwork)
 	err = docker.ConnectToNetwork(containerID, stackNetwork)
 	if err != nil {
-		return errors.Wrap(err, "can't connect to the Elastic stack network")
+		return fmt.Errorf("can't connect to the Elastic stack network: %s", err)
 	}
 	return nil
 }
@@ -72,7 +70,7 @@ func controlPlaneContainerID() (string, error) {
 
 	containerID, err := docker.ContainerID(ControlPlaneContainerName)
 	if err != nil {
-		return "", errors.Wrap(err, "can't find container ID, make sure you have run \"kind create cluster\"")
+		return "", fmt.Errorf("can't find container ID, make sure you have run \"kind create cluster\": %s", err)
 	}
 	return containerID, nil
 }

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -6,9 +6,8 @@ package kubectl
 
 import (
 	"bytes"
+	"fmt"
 	"os/exec"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/logger"
 )
@@ -22,7 +21,7 @@ func CurrentContext() (string, error) {
 	logger.Debugf("output command: %s", cmd)
 	output, err := cmd.Output()
 	if err != nil {
-		return "", errors.Wrapf(err, "kubectl command failed (stderr=%q)", errOutput.String())
+		return "", fmt.Errorf("kubectl command failed (stderr=%q): %s", errOutput.String(), err)
 	}
 	return string(bytes.TrimSpace(output)), nil
 }
@@ -45,7 +44,7 @@ func modifyKubernetesResources(action string, definitionPaths ...string) ([]byte
 	logger.Debugf("run command: %s", cmd)
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, errors.Wrapf(err, "kubectl apply failed (stderr=%q)", errOutput.String())
+		return nil, fmt.Errorf("kubectl apply failed (stderr=%q): %s", errOutput.String(), err)
 	}
 	return output, nil
 }
@@ -63,7 +62,7 @@ func applyKubernetesResourcesStdin(input []byte) ([]byte, error) {
 	logger.Debugf("run command: %s", kubectlCmd)
 	output, err := kubectlCmd.Output()
 	if err != nil {
-		return nil, errors.Wrapf(err, "kubectl apply failed (stderr=%q)", errOutput.String())
+		return nil, fmt.Errorf("kubectl apply failed (stderr=%q): %s", errOutput.String(), err)
 	}
 	return output, nil
 }

--- a/internal/kubectl/kubectl_apply.go
+++ b/internal/kubectl/kubectl_apply.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 	"helm.sh/helm/v3/pkg/kube"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -74,13 +73,13 @@ func Apply(definitionPaths ...string) error {
 	logger.Debugf("Apply Kubernetes definitions")
 	out, err := modifyKubernetesResources("apply", definitionPaths...)
 	if err != nil {
-		return errors.Wrap(err, "can't modify Kubernetes resources (apply)")
+		return fmt.Errorf("can't modify Kubernetes resources (apply): %s", err)
 	}
 
 	logger.Debugf("Handle \"apply\" command output")
 	err = handleApplyCommandOutput(out)
 	if err != nil {
-		return errors.Wrap(err, "can't handle command output")
+		return fmt.Errorf("can't handle command output: %s", err)
 	}
 	return nil
 }
@@ -90,13 +89,13 @@ func ApplyStdin(input []byte) error {
 	logger.Debugf("Apply Kubernetes stdin")
 	out, err := applyKubernetesResourcesStdin(input)
 	if err != nil {
-		return errors.Wrap(err, "can't modify Kubernetes resources (apply stdin)")
+		return fmt.Errorf("can't modify Kubernetes resources (apply stdin): %s", err)
 	}
 
 	logger.Debugf("Handle \"apply\" command output")
 	err = handleApplyCommandOutput(out)
 	if err != nil {
-		return errors.Wrap(err, "can't handle command output")
+		return fmt.Errorf("can't handle command output: %s", err)
 	}
 	return nil
 }
@@ -105,13 +104,13 @@ func handleApplyCommandOutput(out []byte) error {
 	logger.Debugf("Extract resources from command output")
 	resources, err := extractResources(out)
 	if err != nil {
-		return errors.Wrap(err, "can't extract resources")
+		return fmt.Errorf("can't extract resources: %s", err)
 	}
 
 	logger.Debugf("Wait for ready resources")
 	err = waitForReadyResources(resources)
 	if err != nil {
-		return errors.Wrap(err, "resources are not ready")
+		return fmt.Errorf("resources are not ready: %s", err)
 	}
 	return nil
 }
@@ -121,7 +120,7 @@ func waitForReadyResources(resources []resource) error {
 	for _, r := range resources {
 		resInfo, err := createResourceInfo(r)
 		if err != nil {
-			return errors.Wrap(err, "can't fetch resource info")
+			return fmt.Errorf("can't fetch resource info: %s", err)
 		}
 		resList = append(resList, resInfo)
 	}
@@ -137,7 +136,7 @@ func waitForReadyResources(resources []resource) error {
 	// Can be solved with multi-node clusters.
 	err := kubeClient.Wait(resList, readinessTimeout)
 	if err != nil {
-		return errors.Wrap(err, "waiter failed")
+		return fmt.Errorf("waiter failed: %s", err)
 	}
 	return nil
 }
@@ -158,7 +157,7 @@ func extractResource(output []byte) (*resource, error) {
 	var r resource
 	err := yaml.Unmarshal(output, &r)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't unmarshal command output")
+		return nil, fmt.Errorf("can't unmarshal command output: %s", err)
 	}
 	return &r, nil
 }
@@ -171,7 +170,7 @@ func createResourceInfo(r resource) (*kresource.Info, error) {
 
 	restClient, err := createRESTClientForResource(r)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't create REST client for resource")
+		return nil, fmt.Errorf("can't create REST client for resource: %s", err)
 	}
 
 	var group string
@@ -206,7 +205,7 @@ func createResourceInfo(r resource) (*kresource.Info, error) {
 	logger.Debugf("Sync resource info: %s (kind: %s, namespace: %s)", r.Metadata.Name, r.Kind, r.Metadata.Namespace)
 	err = resInfo.Get()
 	if err != nil {
-		return nil, errors.Wrap(err, "can't sync resource info")
+		return nil, fmt.Errorf("can't sync resource info: %s", err)
 	}
 	return resInfo, nil
 }
@@ -215,7 +214,7 @@ func createRESTClientForResource(r resource) (*rest.RESTClient, error) {
 	restClientGetter := genericclioptions.NewConfigFlags(true)
 	restConfig, err := restClientGetter.ToRESTConfig()
 	if err != nil {
-		return nil, errors.Wrap(err, "can't convert to REST config")
+		return nil, fmt.Errorf("can't convert to REST config: %s", err)
 	}
 	restConfig.NegotiatedSerializer = kresource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer
 
@@ -227,7 +226,7 @@ func createRESTClientForResource(r resource) (*rest.RESTClient, error) {
 
 	restClient, err := rest.UnversionedRESTClientFor(restConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't create unversioned REST client")
+		return nil, fmt.Errorf("can't create unversioned REST client: %s", err)
 	}
 	return restClient, nil
 }

--- a/internal/multierror/error_test.go
+++ b/internal/multierror/error_test.go
@@ -5,7 +5,7 @@
 package multierror
 
 import (
-	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,11 +13,11 @@ import (
 
 func TestUnique(t *testing.T) {
 	errs := Error{
-		errors.New("2"),
-		errors.New("1"),
-		errors.New("2"),
-		errors.New("1"),
-		errors.New("3"),
+		fmt.Errorf("2"),
+		fmt.Errorf("1"),
+		fmt.Errorf("2"),
+		fmt.Errorf("1"),
+		fmt.Errorf("3"),
 	}
 
 	unique := errs.Unique()

--- a/internal/packages/archetype/archetype.go
+++ b/internal/packages/archetype/archetype.go
@@ -7,11 +7,10 @@ package archetype
 import (
 	"bytes"
 	"encoding/base64"
+	"fmt"
 	"os"
 	"path/filepath"
 	"text/template"
-
-	"github.com/pkg/errors"
 )
 
 func renderResourceFile(templateBody string, data interface{}, targetPath string) error {
@@ -19,18 +18,18 @@ func renderResourceFile(templateBody string, data interface{}, targetPath string
 	var rendered bytes.Buffer
 	err := t.Execute(&rendered, data)
 	if err != nil {
-		return errors.Wrap(err, "can't render package resource")
+		return fmt.Errorf("can't render package resource: %s", err)
 	}
 
 	err = os.MkdirAll(filepath.Dir(targetPath), 0755)
 	if err != nil {
-		return errors.Wrap(err, "can't create base directory")
+		return fmt.Errorf("can't create base directory: %s", err)
 	}
 
 	packageManifestPath := targetPath
 	err = os.WriteFile(packageManifestPath, rendered.Bytes(), 0644)
 	if err != nil {
-		return errors.Wrapf(err, "can't write resource file (path: %s)", packageManifestPath)
+		return fmt.Errorf("can't write resource file (path: %s): %s", packageManifestPath, err)
 	}
 	return nil
 }
@@ -38,7 +37,7 @@ func renderResourceFile(templateBody string, data interface{}, targetPath string
 func decodeBase64Resource(encoded string) ([]byte, error) {
 	decoded, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't decode encoded resource")
+		return nil, fmt.Errorf("can't decode encoded resource: %s", err)
 	}
 	return decoded, nil
 }
@@ -46,13 +45,13 @@ func decodeBase64Resource(encoded string) ([]byte, error) {
 func writeRawResourceFile(content []byte, targetPath string) error {
 	err := os.MkdirAll(filepath.Dir(targetPath), 0755)
 	if err != nil {
-		return errors.Wrap(err, "can't create base directory")
+		return fmt.Errorf("can't create base directory: %s", err)
 	}
 
 	packageManifestPath := targetPath
 	err = os.WriteFile(packageManifestPath, content, 0644)
 	if err != nil {
-		return errors.Wrapf(err, "can't write resource file (path: %s)", packageManifestPath)
+		return fmt.Errorf("can't write resource file (path: %s): %s", packageManifestPath, err)
 	}
 	return nil
 }

--- a/internal/packages/archetype/data_stream.go
+++ b/internal/packages/archetype/data_stream.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/formatter"
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/packages"
@@ -33,33 +31,33 @@ func CreateDataStream(dataStreamDescriptor DataStreamDescriptor) error {
 	logger.Debugf("Write data stream manifest")
 	err = renderResourceFile(dataStreamManifestTemplate, &dataStreamDescriptor, filepath.Join(dataStreamDir, "manifest.yml"))
 	if err != nil {
-		return errors.Wrap(err, "can't render data stream manifest")
+		return fmt.Errorf("can't render data stream manifest: %s", err)
 	}
 
 	logger.Debugf("Write base fields")
 	err = renderResourceFile(dataStreamFieldsBaseTemplate, &dataStreamDescriptor, filepath.Join(dataStreamDir, "fields", "base-fields.yml"))
 	if err != nil {
-		return errors.Wrap(err, "can't render base fields")
+		return fmt.Errorf("can't render base fields: %s", err)
 	}
 
 	logger.Debugf("Write agent stream")
 	err = renderResourceFile(dataStreamAgentStreamTemplate, &dataStreamDescriptor, filepath.Join(dataStreamDir, "agent", "stream", "stream.yml.hbs"))
 	if err != nil {
-		return errors.Wrap(err, "can't render base fields")
+		return fmt.Errorf("can't render base fields: %s", err)
 	}
 
 	if dataStreamDescriptor.Manifest.Type == "logs" {
 		logger.Debugf("Write ingest pipeline")
 		err = renderResourceFile(dataStreamElasticsearchIngestPipelineTemplate, &dataStreamDescriptor, filepath.Join(dataStreamDir, "elasticsearch", "ingest_pipeline", "default.yml"))
 		if err != nil {
-			return errors.Wrap(err, "can't render ingest pipeline")
+			return fmt.Errorf("can't render ingest pipeline: %s", err)
 		}
 	}
 
 	logger.Debugf("Format the entire package")
 	err = formatter.Format(dataStreamDescriptor.PackageRoot, false)
 	if err != nil {
-		return errors.Wrap(err, "can't format the new package")
+		return fmt.Errorf("can't format the new package: %s", err)
 	}
 
 	fmt.Printf("New data stream has been created: %s\n", dataStreamDescriptor.Manifest.Name)

--- a/internal/packages/archetype/package.go
+++ b/internal/packages/archetype/package.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/formatter"
 	"github.com/elastic/elastic-package/internal/licenses"
 	"github.com/elastic/elastic-package/internal/logger"
@@ -33,49 +31,49 @@ func CreatePackage(packageDescriptor PackageDescriptor) error {
 	logger.Debugf("Write package manifest")
 	err = renderResourceFile(packageManifestTemplate, &packageDescriptor, filepath.Join(baseDir, "manifest.yml"))
 	if err != nil {
-		return errors.Wrap(err, "can't render package manifest")
+		return fmt.Errorf("can't render package manifest: %s", err)
 	}
 
 	logger.Debugf("Write package changelog")
 	err = renderResourceFile(packageChangelogTemplate, &packageDescriptor, filepath.Join(baseDir, "changelog.yml"))
 	if err != nil {
-		return errors.Wrap(err, "can't render package changelog")
+		return fmt.Errorf("can't render package changelog: %s", err)
 	}
 
 	logger.Debugf("Write docs readme")
 	err = renderResourceFile(packageDocsReadme, &packageDescriptor, filepath.Join(baseDir, "docs", "README.md"))
 	if err != nil {
-		return errors.Wrap(err, "can't render package README")
+		return fmt.Errorf("can't render package README: %s", err)
 	}
 
 	if license := packageDescriptor.Manifest.Source.License; license != "" {
 		logger.Debugf("Write license file")
 		err = licenses.WriteTextToFile(license, filepath.Join(baseDir, "LICENSE.txt"))
 		if err != nil {
-			return errors.Wrap(err, "can't write license file")
+			return fmt.Errorf("can't write license file: %s", err)
 		}
 	}
 
 	logger.Debugf("Write sample icon")
 	err = writeRawResourceFile(packageImgSampleIcon, filepath.Join(baseDir, "img", "sample-logo.svg"))
 	if err != nil {
-		return errors.Wrap(err, "can't render sample icon")
+		return fmt.Errorf("can't render sample icon: %s", err)
 	}
 
 	logger.Debugf("Write sample screenshot")
 	decodedSampleScreenshot, err := decodeBase64Resource(packageImgSampleScreenshot)
 	if err != nil {
-		return errors.Wrap(err, "can't decode sample screenshot")
+		return fmt.Errorf("can't decode sample screenshot: %s", err)
 	}
 	err = writeRawResourceFile(decodedSampleScreenshot, filepath.Join(baseDir, "img", "sample-screenshot.png"))
 	if err != nil {
-		return errors.Wrap(err, "can't render sample screenshot")
+		return fmt.Errorf("can't render sample screenshot: %s", err)
 	}
 
 	logger.Debugf("Format the entire package")
 	err = formatter.Format(baseDir, false)
 	if err != nil {
-		return errors.Wrap(err, "can't format the new package")
+		return fmt.Errorf("can't format the new package: %s", err)
 	}
 
 	fmt.Printf("New package has been created: %s\n", baseDir)

--- a/internal/packages/archetype/package_test.go
+++ b/internal/packages/archetype/package_test.go
@@ -5,12 +5,12 @@
 package archetype
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/elastic/package-spec/v2/code/go/pkg/validator"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-package/internal/packages"
@@ -80,7 +80,7 @@ func createPackageDescriptorForTest() PackageDescriptor {
 func checkPackage(packageName string) error {
 	wd, err := os.Getwd()
 	if err != nil {
-		return errors.Wrap(err, "can't get working directory")
+		return fmt.Errorf("can't get working directory: %s", err)
 	}
 	packageRoot := filepath.Join(wd, packageName)
 
@@ -89,7 +89,7 @@ func checkPackage(packageName string) error {
 
 	err = validator.ValidateFromPath(packageRoot)
 	if err != nil {
-		return errors.Wrap(err, "linting package failed")
+		return fmt.Errorf("linting package failed: %s", err)
 	}
 	return nil
 }

--- a/internal/packages/assets.go
+++ b/internal/packages/assets.go
@@ -6,11 +6,10 @@ package packages
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/multierror"
 )
@@ -46,12 +45,12 @@ func (asset Asset) String() string {
 func LoadPackageAssets(pkgRootPath string) ([]Asset, error) {
 	assets, err := loadKibanaAssets(pkgRootPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not load kibana assets")
+		return nil, fmt.Errorf("could not load kibana assets: %s", err)
 	}
 
 	a, err := loadElasticsearchAssets(pkgRootPath)
 	if err != nil {
-		return a, errors.Wrap(err, "could not load elasticsearch assets")
+		return a, fmt.Errorf("could not load elasticsearch assets: %s", err)
 	}
 	assets = append(assets, a...)
 
@@ -78,7 +77,7 @@ func loadKibanaAssets(pkgRootPath string) ([]Asset, error) {
 	for _, assetType := range assetTypes {
 		a, err := loadFileBasedAssets(kibanaAssetsFolderPath, assetType)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "could not load kibana %s assets", assetType))
+			errs = append(errs, fmt.Errorf("could not load kibana %s assets: %s", assetType, err))
 			continue
 		}
 
@@ -96,19 +95,19 @@ func loadElasticsearchAssets(pkgRootPath string) ([]Asset, error) {
 	packageManifestPath := filepath.Join(pkgRootPath, PackageManifestFile)
 	pkgManifest, err := ReadPackageManifest(packageManifestPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "reading package manifest file failed")
+		return nil, fmt.Errorf("reading package manifest file failed: %s", err)
 	}
 
 	dataStreamManifestPaths, err := filepath.Glob(filepath.Join(pkgRootPath, "data_stream", "*", DataStreamManifestFile))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not read data stream manifest file paths")
+		return nil, fmt.Errorf("could not read data stream manifest file paths: %s", err)
 	}
 
 	var assets []Asset
 	for _, dsManifestPath := range dataStreamManifestPaths {
 		dsManifest, err := ReadDataStreamManifest(dsManifestPath)
 		if err != nil {
-			return nil, errors.Wrap(err, "reading data stream manifest failed")
+			return nil, fmt.Errorf("reading data stream manifest failed: %s", err)
 		}
 
 		indexTemplateName := dsManifest.IndexTemplateName(pkgManifest.Name)
@@ -127,7 +126,7 @@ func loadElasticsearchAssets(pkgRootPath string) ([]Asset, error) {
 			for _, pattern := range []string{"*.json", "*.yml"} {
 				files, err := filepath.Glob(filepath.Join(elasticsearchDirPath, pattern))
 				if err != nil {
-					return nil, errors.Wrapf(err, "listing '%s' in '%s'", pattern, elasticsearchDirPath)
+					return nil, fmt.Errorf("listing '%s' in '%s': %s", pattern, elasticsearchDirPath, err)
 				}
 				pipelineFiles = append(pipelineFiles, files...)
 			}
@@ -160,19 +159,19 @@ func loadFileBasedAssets(kibanaAssetsFolderPath string, assetType AssetType) ([]
 		return nil, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error finding kibana %s assets folder", assetType)
+		return nil, fmt.Errorf("error finding kibana %s assets folder: %s", assetType, err)
 	}
 
 	paths, err := filepath.Glob(filepath.Join(assetsFolderPath, "*.json"))
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not read %s files", assetType)
+		return nil, fmt.Errorf("could not read %s files: %s", assetType, err)
 	}
 
 	var assets []Asset
 	for _, assetPath := range paths {
 		assetID, err := readAssetID(assetPath)
 		if err != nil {
-			return nil, errors.Wrapf(err, "can't read asset ID (path: %s)", assetPath)
+			return nil, fmt.Errorf("can't read asset ID (path: %s): %s", assetPath, err)
 		}
 
 		asset := Asset{
@@ -188,7 +187,7 @@ func loadFileBasedAssets(kibanaAssetsFolderPath string, assetType AssetType) ([]
 func readAssetID(assetPath string) (string, error) {
 	content, err := os.ReadFile(assetPath)
 	if err != nil {
-		return "", errors.Wrap(err, "can't read file body")
+		return "", fmt.Errorf("can't read file body: %s", err)
 	}
 
 	assetBody := struct {
@@ -197,11 +196,11 @@ func readAssetID(assetPath string) (string, error) {
 
 	err = json.Unmarshal(content, &assetBody)
 	if err != nil {
-		return "", errors.Wrap(err, "can't unmarshal asset")
+		return "", fmt.Errorf("can't unmarshal asset: %s", err)
 	}
 
 	if assetBody.ID == "" {
-		return "", errors.New("empty asset ID")
+		return "", fmt.Errorf("empty asset ID")
 	}
 	return assetBody.ID, nil
 }

--- a/internal/packages/buildmanifest/build_manifest.go
+++ b/internal/packages/buildmanifest/build_manifest.go
@@ -5,10 +5,10 @@
 package buildmanifest
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/go-ucfg"
 	"github.com/elastic/go-ucfg/yaml"
@@ -48,13 +48,13 @@ func ReadBuildManifest(packageRoot string) (*BuildManifest, bool, error) {
 		return nil, false, nil // ignore not found errors
 	}
 	if err != nil {
-		return nil, false, errors.Wrapf(err, "reading file failed (path: %s)", path)
+		return nil, false, fmt.Errorf("reading file failed (path: %s): %s", path, err)
 	}
 
 	var bm BuildManifest
 	err = cfg.Unpack(&bm)
 	if err != nil {
-		return nil, true, errors.Wrapf(err, "unpacking build manifest failed (path: %s)", path)
+		return nil, true, fmt.Errorf("unpacking build manifest failed (path: %s): %s", path, err)
 	}
 	return &bm, true, nil
 }

--- a/internal/packages/changelog/changelog.go
+++ b/internal/packages/changelog/changelog.go
@@ -5,11 +5,11 @@
 package changelog
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/elastic/go-ucfg"
 	"github.com/elastic/go-ucfg/yaml"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -39,13 +39,13 @@ func ReadChangelogFromPackageRoot(packageRoot string) ([]Revision, error) {
 func ReadChangelog(path string) ([]Revision, error) {
 	cfg, err := yaml.NewConfigWithFile(path, ucfg.PathSep("."))
 	if err != nil {
-		return nil, errors.Wrapf(err, "reading file failed (path: %s)", path)
+		return nil, fmt.Errorf("reading file failed (path: %s): %s", path, err)
 	}
 
 	var c []Revision
 	err = cfg.Unpack(&c)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unpacking package changelog failed (path: %s)", path)
+		return nil, fmt.Errorf("unpacking package changelog failed (path: %s): %s", path, err)
 	}
 	return c, nil
 }

--- a/internal/packages/conditions.go
+++ b/internal/packages/conditions.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/multierror"
@@ -28,19 +27,19 @@ type packageRequirements struct {
 func CheckConditions(manifest PackageManifest, keyValuePairs []string) error {
 	requirements, err := parsePackageRequirements(keyValuePairs)
 	if err != nil {
-		return errors.Wrap(err, "can't parse given keyValue pairs as package conditions")
+		return fmt.Errorf("can't parse given keyValue pairs as package conditions: %s", err)
 	}
 
 	// So far, Kibana is the only supported constraint
 	if len(manifest.Conditions.Kibana.Version) > 0 && requirements.kibana.version != nil {
 		kibanaConstraint, err := semver.NewConstraint(manifest.Conditions.Kibana.Version)
 		if err != nil {
-			return errors.Wrap(err, "invalid constraint for Kibana")
+			return fmt.Errorf("invalid constraint for Kibana: %s", err)
 		}
 
 		logger.Debugf("Verify Kibana version (constraint: %s, requirement: %s)", manifest.Conditions.Kibana.Version, requirements.kibana.version)
 		if ok, errs := kibanaConstraint.Validate(requirements.kibana.version); !ok {
-			return errors.Wrap(multierror.Error(errs), "Kibana constraint unsatisfied")
+			return fmt.Errorf("kibana constraint unsatisfied: %v", multierror.Error(errs))
 		}
 		logger.Debugf("Constraint %s = %s is satisfied", kibanaVersionRequirement, manifest.Conditions.Kibana.Version)
 	}
@@ -60,7 +59,7 @@ func parsePackageRequirements(keyValuePairs []string) (*packageRequirements, err
 		case kibanaVersionRequirement:
 			ver, err := semver.NewVersion(s[1])
 			if err != nil {
-				return nil, errors.Wrap(err, "can't parse kibana.version as valid semver")
+				return nil, fmt.Errorf("can't parse kibana.version as valid semver: %s", err)
 			}
 
 			// Constraint validation doesn't handle prerelease tags. It fails with error:
@@ -69,7 +68,7 @@ func parsePackageRequirements(keyValuePairs []string) (*packageRequirements, err
 			// Source code reference: https://github.com/Masterminds/semver/blob/7e314bd12e4aa8ea9742b1e4765f3fe65de38c2d/constraints.go#L89
 			withoutPrerelease, err := ver.SetPrerelease("") // clean prerelease tag
 			if err != nil {
-				return nil, errors.Wrap(err, "can't clean prerelease tag from semver")
+				return nil, fmt.Errorf("can't clean prerelease tag from semver: %s", err)
 			}
 			pr.kibana.version = &withoutPrerelease
 		default:

--- a/internal/packages/installer/installer.go
+++ b/internal/packages/installer/installer.go
@@ -5,7 +5,7 @@
 package installer
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/packages"
@@ -28,7 +28,7 @@ type InstalledPackage struct {
 func CreateForManifest(manifest packages.PackageManifest) (*Installer, error) {
 	kibanaClient, err := kibana.NewClient()
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create kibana client")
+		return nil, fmt.Errorf("could not create kibana client: %s", err)
 	}
 
 	return &Installer{
@@ -41,7 +41,7 @@ func CreateForManifest(manifest packages.PackageManifest) (*Installer, error) {
 func (i *Installer) Install() (*InstalledPackage, error) {
 	assets, err := i.kibanaClient.InstallPackage(i.manifest)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't install the package")
+		return nil, fmt.Errorf("can't install the package: %s", err)
 	}
 
 	return &InstalledPackage{
@@ -54,7 +54,7 @@ func (i *Installer) Install() (*InstalledPackage, error) {
 func (i *Installer) Uninstall() error {
 	_, err := i.kibanaClient.RemovePackage(i.manifest)
 	if err != nil {
-		return errors.Wrap(err, "can't remove the package")
+		return fmt.Errorf("can't remove the package: %s", err)
 	}
 	return nil
 }

--- a/internal/packages/status/status.go
+++ b/internal/packages/status/status.go
@@ -5,8 +5,9 @@
 package status
 
 import (
+	"fmt"
+
 	"github.com/Masterminds/semver/v3"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/packages/changelog"
@@ -26,11 +27,11 @@ type PackageStatus struct {
 func LocalPackage(packageRootPath string, options registry.SearchOptions) (*PackageStatus, error) {
 	manifest, err := packages.ReadPackageManifestFromPackageRoot(packageRootPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "reading package manifest failed")
+		return nil, fmt.Errorf("reading package manifest failed: %s", err)
 	}
 	changelog, err := changelog.ReadChangelogFromPackageRoot(packageRootPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "reading package changelog failed")
+		return nil, fmt.Errorf("reading package changelog failed: %s", err)
 	}
 	status, err := RemotePackage(manifest.Name, options)
 	if err != nil {
@@ -45,11 +46,11 @@ func LocalPackage(packageRootPath string, options registry.SearchOptions) (*Pack
 	lastChangelogEntry := changelog[0]
 	pendingVersion, err := semver.NewVersion(lastChangelogEntry.Version)
 	if err != nil {
-		return nil, errors.Wrap(err, "reading changelog semver failed")
+		return nil, fmt.Errorf("reading changelog semver failed: %s", err)
 	}
 	currentVersion, err := semver.NewVersion(manifest.Version)
 	if err != nil {
-		return nil, errors.Wrap(err, "reading manifest semver failed")
+		return nil, fmt.Errorf("reading manifest semver failed: %s", err)
 	}
 	if currentVersion.LessThan(pendingVersion) {
 		status.PendingChanges = &lastChangelogEntry
@@ -61,7 +62,7 @@ func LocalPackage(packageRootPath string, options registry.SearchOptions) (*Pack
 func RemotePackage(packageName string, options registry.SearchOptions) (*PackageStatus, error) {
 	productionManifests, err := registry.Production.Revisions(packageName, options)
 	if err != nil {
-		return nil, errors.Wrap(err, "retrieving production deployment failed")
+		return nil, fmt.Errorf("retrieving production deployment failed: %s", err)
 	}
 	return &PackageStatus{
 		Name:       packageName,

--- a/internal/profile/files.go
+++ b/internal/profile/files.go
@@ -5,10 +5,10 @@
 package profile
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
 // NewConfig is a generic function type to return a new Managed config
@@ -31,7 +31,7 @@ func (cfg simpleFile) configFilesDiffer() (bool, error) {
 		return false, nil
 	}
 	if err != nil {
-		return false, errors.Wrapf(err, "error reading %s", cfg.path)
+		return false, fmt.Errorf("error reading %s: %s", cfg.path, err)
 	}
 	if string(changes) == cfg.body {
 		return false, nil
@@ -43,11 +43,11 @@ func (cfg simpleFile) configFilesDiffer() (bool, error) {
 func (cfg simpleFile) writeConfig() error {
 	err := os.MkdirAll(filepath.Dir(cfg.path), 0755)
 	if err != nil {
-		return errors.Wrapf(err, "creating parent directories for file failed (path: %s)", cfg.path)
+		return fmt.Errorf("creating parent directories for file failed (path: %s): %s", cfg.path, err)
 	}
 	err = os.WriteFile(cfg.path, []byte(cfg.body), 0644)
 	if err != nil {
-		return errors.Wrapf(err, "writing file failed (path: %s)", cfg.path)
+		return fmt.Errorf("writing file failed (path: %s): %s", cfg.path, err)
 	}
 	return nil
 }
@@ -56,7 +56,7 @@ func (cfg simpleFile) writeConfig() error {
 func (cfg *simpleFile) readConfig() error {
 	body, err := os.ReadFile(cfg.path)
 	if err != nil {
-		return errors.Wrapf(err, "reading file failed (path: %s)", cfg.path)
+		return fmt.Errorf("reading file failed (path: %s): %s", cfg.path, err)
 	}
 	cfg.body = string(body)
 	return nil

--- a/internal/profile/profile_json.go
+++ b/internal/profile/profile_json.go
@@ -6,11 +6,10 @@ package profile
 
 import (
 	"encoding/json"
+	"fmt"
 	"os/user"
 	"path/filepath"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/version"
 )
@@ -31,7 +30,7 @@ const PackageProfileMetaFile configFile = "profile.json"
 func createProfileMetadata(profileName string, profilePath string) (*simpleFile, error) {
 	currentUser, err := user.Current()
 	if err != nil {
-		return nil, errors.Wrap(err, "error fetching current user")
+		return nil, fmt.Errorf("error fetching current user: %s", err)
 	}
 
 	profileData := Metadata{
@@ -44,7 +43,7 @@ func createProfileMetadata(profileName string, profilePath string) (*simpleFile,
 
 	jsonRaw, err := json.MarshalIndent(profileData, "", "  ")
 	if err != nil {
-		return nil, errors.Wrap(err, "error marshalling json")
+		return nil, fmt.Errorf("error marshalling json: %s", err)
 	}
 
 	return &simpleFile{

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -5,11 +5,10 @@
 package registry
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -36,12 +35,12 @@ func NewClient(baseURL string) *Client {
 func (c *Client) get(resourcePath string) (int, []byte, error) {
 	base, err := url.Parse(c.baseURL)
 	if err != nil {
-		return 0, nil, errors.Wrapf(err, "could not parse base URL: %v", c.baseURL)
+		return 0, nil, fmt.Errorf("could not parse base URL: %v: %s", c.baseURL, err)
 	}
 
 	rel, err := url.Parse(resourcePath)
 	if err != nil {
-		return 0, nil, errors.Wrapf(err, "could not create relative URL from resource path: %v", resourcePath)
+		return 0, nil, fmt.Errorf("could not create relative URL from resource path: %v: %s", resourcePath, err)
 	}
 
 	u := base.JoinPath(rel.EscapedPath())
@@ -49,19 +48,19 @@ func (c *Client) get(resourcePath string) (int, []byte, error) {
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
-		return 0, nil, errors.Wrapf(err, "could not create request to Package Registry API resource: %s", resourcePath)
+		return 0, nil, fmt.Errorf("could not create request to Package Registry API resource: %s: %s", resourcePath, err)
 	}
 
 	client := http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return 0, nil, errors.Wrap(err, "could not send request to Package Registry API")
+		return 0, nil, fmt.Errorf("could not send request to Package Registry API: %s", err)
 	}
 
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return resp.StatusCode, nil, errors.Wrap(err, "could not read response body")
+		return resp.StatusCode, nil, fmt.Errorf("could not read response body: %s", err)
 	}
 
 	return resp.StatusCode, body, nil

--- a/internal/registry/revisions.go
+++ b/internal/registry/revisions.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-querystring/query"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/packages"
 )
@@ -40,13 +39,13 @@ func (c *Client) Revisions(packageName string, options SearchOptions) ([]package
 		Package:       packageName,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "could not encode options as query parameters")
+		return nil, fmt.Errorf("could not encode options as query parameters: %s", err)
 	}
 	path := searchAPI + "?" + parameters.Encode()
 
 	statusCode, respBody, err := c.get(path)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not retrieve package")
+		return nil, fmt.Errorf("could not retrieve package: %s", err)
 	}
 	if statusCode != http.StatusOK {
 		return nil, fmt.Errorf("could not retrieve package; API status code = %d; response body = %s", statusCode, respBody)
@@ -54,7 +53,7 @@ func (c *Client) Revisions(packageName string, options SearchOptions) ([]package
 
 	var packageManifests []packages.PackageManifest
 	if err := json.Unmarshal(respBody, &packageManifests); err != nil {
-		return nil, errors.Wrap(err, "could not convert package manifests from JSON")
+		return nil, fmt.Errorf("could not convert package manifests from JSON: %s", err)
 	}
 	sort.Slice(packageManifests, func(i, j int) bool {
 		firstVersion, err := semver.NewVersion(packageManifests[i].Version)

--- a/internal/service/boot.go
+++ b/internal/service/boot.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/elastic/elastic-package/internal/logger"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/configuration/locations"
 	"github.com/elastic/elastic-package/internal/testrunner/runners/system"
 	"github.com/elastic/elastic-package/internal/testrunner/runners/system/servicedeployer"
@@ -37,14 +35,14 @@ func BootUp(options Options) error {
 		Variant:            options.Variant,
 	})
 	if err != nil {
-		return errors.Wrap(err, "can't create the service deployer instance")
+		return fmt.Errorf("can't create the service deployer instance: %s", err)
 	}
 
 	// Boot up the service
 	logger.Debugf("Boot up the service instance")
 	locationManager, err := locations.NewLocationManager()
 	if err != nil {
-		return errors.Wrap(err, "reading service logs directory failed")
+		return fmt.Errorf("reading service logs directory failed: %s", err)
 	}
 
 	var serviceCtxt servicedeployer.ServiceContext
@@ -53,7 +51,7 @@ func BootUp(options Options) error {
 	serviceCtxt.Logs.Folder.Local = locationManager.ServiceLogDir()
 	deployed, err := serviceDeployer.SetUp(serviceCtxt)
 	if err != nil {
-		return errors.Wrap(err, "can't set up the service deployer")
+		return fmt.Errorf("can't set up the service deployer: %s", err)
 	}
 
 	fmt.Println("Service is up, please use ctrl+c to take it down")
@@ -65,7 +63,7 @@ func BootUp(options Options) error {
 	fmt.Println("Take down the service")
 	err = deployed.TearDown()
 	if err != nil {
-		return errors.Wrap(err, "can't tear down the service")
+		return fmt.Errorf("can't tear down the service: %s", err)
 	}
 	return nil
 }

--- a/internal/stack/boot.go
+++ b/internal/stack/boot.go
@@ -10,8 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/builder"
 	"github.com/elastic/elastic-package/internal/configuration/locations"
 	"github.com/elastic/elastic-package/internal/files"
@@ -25,24 +23,24 @@ const DockerComposeProjectName = "elastic-package-stack"
 func BootUp(options Options) error {
 	buildPackagesPath, found, err := builder.FindBuildPackagesDirectory()
 	if err != nil {
-		return errors.Wrap(err, "finding build packages directory failed")
+		return fmt.Errorf("finding build packages directory failed: %s", err)
 	}
 
 	stackPackagesDir, err := locations.NewLocationManager()
 	if err != nil {
-		return errors.Wrap(err, "locating stack packages directory failed")
+		return fmt.Errorf("locating stack packages directory failed: %s", err)
 	}
 
 	err = files.ClearDir(stackPackagesDir.PackagesDir())
 	if err != nil {
-		return errors.Wrap(err, "clearing package contents failed")
+		return fmt.Errorf("clearing package contents failed: %s", err)
 	}
 
 	if found {
 		fmt.Printf("Custom build packages directory found: %s\n", buildPackagesPath)
 		err = copyUniquePackages(buildPackagesPath, stackPackagesDir.PackagesDir())
 		if err != nil {
-			return errors.Wrap(err, "copying package contents failed")
+			return fmt.Errorf("copying package contents failed: %s", err)
 		}
 	}
 
@@ -55,12 +53,12 @@ func BootUp(options Options) error {
 
 	err = dockerComposeBuild(options)
 	if err != nil {
-		return errors.Wrap(err, "building docker images failed")
+		return fmt.Errorf("building docker images failed: %s", err)
 	}
 
 	err = dockerComposeUp(options)
 	if err != nil {
-		return errors.Wrap(err, "running docker-compose failed")
+		return fmt.Errorf("running docker-compose failed: %s", err)
 	}
 
 	return nil
@@ -70,7 +68,7 @@ func BootUp(options Options) error {
 func TearDown(options Options) error {
 	err := dockerComposeDown(options)
 	if err != nil {
-		return errors.Wrap(err, "stopping docker containers failed")
+		return fmt.Errorf("stopping docker containers failed: %s", err)
 	}
 	return nil
 }
@@ -80,7 +78,7 @@ func copyUniquePackages(sourcePath, destinationPath string) error {
 
 	dirEntries, err := os.ReadDir(sourcePath)
 	if err != nil {
-		return errors.Wrapf(err, "can't read source dir (sourcePath: %s)", sourcePath)
+		return fmt.Errorf("can't read source dir (sourcePath: %s): %s", sourcePath, err)
 	}
 	for _, entry := range dirEntries {
 		if entry.IsDir() {

--- a/internal/stack/compose.go
+++ b/internal/stack/compose.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/compose"
 	"github.com/elastic/elastic-package/internal/docker"
 	"github.com/elastic/elastic-package/internal/install"
@@ -57,12 +55,12 @@ func (eb *envBuilder) build() []string {
 func dockerComposeBuild(options Options) error {
 	c, err := compose.NewProject(DockerComposeProjectName, options.Profile.FetchPath(profile.SnapshotFile))
 	if err != nil {
-		return errors.Wrap(err, "could not create docker compose project")
+		return fmt.Errorf("could not create docker compose project: %s", err)
 	}
 
 	appConfig, err := install.Configuration()
 	if err != nil {
-		return errors.Wrap(err, "can't read application configuration")
+		return fmt.Errorf("can't read application configuration: %s", err)
 	}
 
 	opts := compose.CommandOptions{
@@ -75,7 +73,7 @@ func dockerComposeBuild(options Options) error {
 	}
 
 	if err := c.Build(opts); err != nil {
-		return errors.Wrap(err, "running command failed")
+		return fmt.Errorf("running command failed: %s", err)
 	}
 	return nil
 }
@@ -83,12 +81,12 @@ func dockerComposeBuild(options Options) error {
 func dockerComposePull(options Options) error {
 	c, err := compose.NewProject(DockerComposeProjectName, options.Profile.FetchPath(profile.SnapshotFile))
 	if err != nil {
-		return errors.Wrap(err, "could not create docker compose project")
+		return fmt.Errorf("could not create docker compose project: %s", err)
 	}
 
 	appConfig, err := install.Configuration()
 	if err != nil {
-		return errors.Wrap(err, "can't read application configuration")
+		return fmt.Errorf("can't read application configuration: %s", err)
 	}
 
 	opts := compose.CommandOptions{
@@ -101,7 +99,7 @@ func dockerComposePull(options Options) error {
 	}
 
 	if err := c.Pull(opts); err != nil {
-		return errors.Wrap(err, "running command failed")
+		return fmt.Errorf("running command failed: %s", err)
 	}
 	return nil
 }
@@ -109,7 +107,7 @@ func dockerComposePull(options Options) error {
 func dockerComposeUp(options Options) error {
 	c, err := compose.NewProject(DockerComposeProjectName, options.Profile.FetchPath(profile.SnapshotFile))
 	if err != nil {
-		return errors.Wrap(err, "could not create docker compose project")
+		return fmt.Errorf("could not create docker compose project: %s", err)
 	}
 
 	var args []string
@@ -119,7 +117,7 @@ func dockerComposeUp(options Options) error {
 
 	appConfig, err := install.Configuration()
 	if err != nil {
-		return errors.Wrap(err, "can't read application configuration")
+		return fmt.Errorf("can't read application configuration: %s", err)
 	}
 
 	opts := compose.CommandOptions{
@@ -133,7 +131,7 @@ func dockerComposeUp(options Options) error {
 	}
 
 	if err := c.Up(opts); err != nil {
-		return errors.Wrap(err, "running command failed")
+		return fmt.Errorf("running command failed: %s", err)
 	}
 	return nil
 }
@@ -141,12 +139,12 @@ func dockerComposeUp(options Options) error {
 func dockerComposeDown(options Options) error {
 	c, err := compose.NewProject(DockerComposeProjectName, options.Profile.FetchPath(profile.SnapshotFile))
 	if err != nil {
-		return errors.Wrap(err, "could not create docker compose project")
+		return fmt.Errorf("could not create docker compose project: %s", err)
 	}
 
 	appConfig, err := install.Configuration()
 	if err != nil {
-		return errors.Wrap(err, "can't read application configuration")
+		return fmt.Errorf("can't read application configuration: %s", err)
 	}
 
 	downOptions := compose.CommandOptions{
@@ -159,7 +157,7 @@ func dockerComposeDown(options Options) error {
 		ExtraArgs: []string{"--volumes", "--remove-orphans"},
 	}
 	if err := c.Down(downOptions); err != nil {
-		return errors.Wrap(err, "running command failed")
+		return fmt.Errorf("running command failed: %s", err)
 	}
 	return nil
 }

--- a/internal/stack/dump.go
+++ b/internal/stack/dump.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/profile"
 )
@@ -34,7 +32,7 @@ func Dump(options DumpOptions) (string, error) {
 
 	err := dumpStackLogs(options)
 	if err != nil {
-		return "", errors.Wrap(err, "can't dump Elastic stack logs")
+		return "", fmt.Errorf("can't dump Elastic stack logs: %s", err)
 	}
 	return options.Output, nil
 }
@@ -43,13 +41,13 @@ func dumpStackLogs(options DumpOptions) error {
 	logger.Debugf("Dump stack logs (location: %s)", options.Output)
 	err := os.RemoveAll(options.Output)
 	if err != nil {
-		return errors.Wrap(err, "can't remove output location")
+		return fmt.Errorf("can't remove output location: %s", err)
 	}
 
 	logsPath := filepath.Join(options.Output, "logs")
 	err = os.MkdirAll(logsPath, 0755)
 	if err != nil {
-		return errors.Wrapf(err, "can't create output location (path: %s)", logsPath)
+		return fmt.Errorf("can't create output location (path: %s): %s", logsPath, err)
 	}
 
 	snapshotPath := options.Profile.FetchPath(profile.SnapshotFile)

--- a/internal/stack/initconfig.go
+++ b/internal/stack/initconfig.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/elastic-package/internal/compose"
@@ -29,7 +28,7 @@ func StackInitConfig(elasticStackProfile *profile.Profile) (*InitConfig, error) 
 	// FIXME read credentials from correct Kibana config file, not default
 	body, err := os.ReadFile(elasticStackProfile.FetchPath(profile.KibanaConfigDefaultFile))
 	if err != nil {
-		return nil, errors.Wrap(err, "error reading Kibana config file")
+		return nil, fmt.Errorf("error reading Kibana config file: %s", err)
 	}
 
 	var kibanaCfg struct {
@@ -38,18 +37,18 @@ func StackInitConfig(elasticStackProfile *profile.Profile) (*InitConfig, error) 
 	}
 	err = yaml.Unmarshal(body, &kibanaCfg)
 	if err != nil {
-		return nil, errors.Wrap(err, "unmarshalling Kibana configuration failed")
+		return nil, fmt.Errorf("unmarshalling Kibana configuration failed: %s", err)
 	}
 
 	// Read Elasticsearch and Kibana hostnames from Elastic Stack Docker Compose configuration file.
 	p, err := compose.NewProject(DockerComposeProjectName, elasticStackProfile.FetchPath(profile.SnapshotFile))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create docker compose project")
+		return nil, fmt.Errorf("could not create docker compose project: %s", err)
 	}
 
 	appConfig, err := install.Configuration()
 	if err != nil {
-		return nil, errors.Wrap(err, "can't read application configuration")
+		return nil, fmt.Errorf("can't read application configuration: %s", err)
 	}
 
 	serviceComposeConfig, err := p.Config(compose.CommandOptions{
@@ -60,7 +59,7 @@ func StackInitConfig(elasticStackProfile *profile.Profile) (*InitConfig, error) 
 			build(),
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get Docker Compose configuration for service")
+		return nil, fmt.Errorf("could not get Docker Compose configuration for service: %s", err)
 	}
 
 	kib := serviceComposeConfig.Services["kibana"]

--- a/internal/stack/logs.go
+++ b/internal/stack/logs.go
@@ -5,9 +5,8 @@
 package stack
 
 import (
+	"fmt"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/compose"
 	"github.com/elastic/elastic-package/internal/docker"
@@ -17,7 +16,7 @@ import (
 func dockerComposeLogs(serviceName string, snapshotFile string) ([]byte, error) {
 	p, err := compose.NewProject(DockerComposeProjectName, snapshotFile)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create docker compose project")
+		return nil, fmt.Errorf("could not create docker compose project: %s", err)
 	}
 
 	opts := compose.CommandOptions{
@@ -29,7 +28,7 @@ func dockerComposeLogs(serviceName string, snapshotFile string) ([]byte, error) 
 
 	out, err := p.Logs(opts)
 	if err != nil {
-		return nil, errors.Wrap(err, "running command failed")
+		return nil, fmt.Errorf("running command failed: %s", err)
 	}
 	return out, nil
 }
@@ -43,14 +42,14 @@ func copyDockerInternalLogs(serviceName, outputPath string) error {
 
 	p, err := compose.NewProject(DockerComposeProjectName)
 	if err != nil {
-		return errors.Wrap(err, "could not create docker compose project")
+		return fmt.Errorf("could not create docker compose project: %s", err)
 	}
 
 	outputPath = filepath.Join(outputPath, serviceName+"-internal")
 	serviceContainer := p.ContainerName(serviceName)
 	err = docker.Copy(serviceContainer, "/usr/share/elastic-agent/state/data/logs/default", outputPath)
 	if err != nil {
-		return errors.Wrap(err, "docker copy failed")
+		return fmt.Errorf("docker copy failed: %s", err)
 	}
 	return nil
 }

--- a/internal/stack/network.go
+++ b/internal/stack/network.go
@@ -7,15 +7,15 @@ package stack
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/docker"
 )
 
 // EnsureStackNetworkUp function verifies if stack network is up and running.
 func EnsureStackNetworkUp() error {
-	_, err := docker.InspectNetwork(Network())
-	return errors.Wrap(err, "network not available")
+	if _, err := docker.InspectNetwork(Network()); err != nil {
+		return fmt.Errorf("network not available: %s", err)
+	}
+	return nil
 }
 
 // Network function returns the stack network name.

--- a/internal/stack/shellinit.go
+++ b/internal/stack/shellinit.go
@@ -5,7 +5,6 @@
 package stack
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -94,7 +93,7 @@ func initTemplate(s string) (string, error) {
 	case "pwsh", "powershell":
 		return powershellTemplate, nil
 	default:
-		return "", errors.New("shell type is unknown, should be one of " + strings.Join(availableShellTypes, ", "))
+		return "", fmt.Errorf("shell type is unknown, should be one of " + strings.Join(availableShellTypes, ", "))
 	}
 }
 

--- a/internal/stack/update.go
+++ b/internal/stack/update.go
@@ -5,7 +5,7 @@
 package stack
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/elastic/elastic-package/internal/docker"
 	"github.com/elastic/elastic-package/internal/profile"
@@ -15,12 +15,12 @@ import (
 func Update(options Options) error {
 	err := docker.Pull(profile.PackageRegistryBaseImage)
 	if err != nil {
-		return errors.Wrap(err, "pulling package-registry docker image failed")
+		return fmt.Errorf("pulling package-registry docker image failed: %s", err)
 	}
 
 	err = dockerComposePull(options)
 	if err != nil {
-		return errors.Wrap(err, "updating docker images failed")
+		return fmt.Errorf("updating docker images failed: %s", err)
 	}
 	return nil
 }

--- a/internal/surveyext/validators.go
+++ b/internal/surveyext/validators.go
@@ -11,7 +11,6 @@ import (
 	"regexp"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -22,7 +21,7 @@ var (
 func PackageDoesNotExistValidator(val interface{}) error {
 	baseDir, ok := val.(string)
 	if !ok {
-		return errors.New("string type expected")
+		return fmt.Errorf("string type expected")
 	}
 	_, err := os.Stat(baseDir)
 	if err == nil {
@@ -35,7 +34,7 @@ func PackageDoesNotExistValidator(val interface{}) error {
 func DataStreamDoesNotExistValidator(val interface{}) error {
 	name, ok := val.(string)
 	if !ok {
-		return errors.New("string type expected")
+		return fmt.Errorf("string type expected")
 	}
 
 	dataStreamDir := filepath.Join("data_stream", name)
@@ -50,11 +49,11 @@ func DataStreamDoesNotExistValidator(val interface{}) error {
 func SemverValidator(val interface{}) error {
 	ver, ok := val.(string)
 	if !ok {
-		return errors.New("string type expected")
+		return fmt.Errorf("string type expected")
 	}
 	_, err := semver.NewVersion(ver)
 	if err != nil {
-		return errors.Wrap(err, "can't parse value as proper semver")
+		return fmt.Errorf("can't parse value as proper semver: %s", err)
 	}
 	return nil
 }
@@ -63,11 +62,11 @@ func SemverValidator(val interface{}) error {
 func ConstraintValidator(val interface{}) error {
 	c, ok := val.(string)
 	if !ok {
-		return errors.New("string type expected")
+		return fmt.Errorf("string type expected")
 	}
 	_, err := semver.NewConstraint(c)
 	if err != nil {
-		return errors.Wrap(err, "can't parse value as proper constraint")
+		return fmt.Errorf("can't parse value as proper constraint: %s", err)
 	}
 	return nil
 }
@@ -76,7 +75,7 @@ func ConstraintValidator(val interface{}) error {
 func GithubOwnerValidator(val interface{}) error {
 	githubOwner, ok := val.(string)
 	if !ok {
-		return errors.New("string type expected")
+		return fmt.Errorf("string type expected")
 	}
 
 	if !githubOwnerRegexp.MatchString(githubOwner) {

--- a/internal/testrunner/reporters/formats/xunit.go
+++ b/internal/testrunner/reporters/formats/xunit.go
@@ -8,8 +8,6 @@ import (
 	"encoding/xml"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/testrunner"
 )
 
@@ -138,7 +136,7 @@ func reportXUnitFormat(results []testrunner.TestResult) (string, error) {
 
 	out, err := xml.MarshalIndent(&ts, "", "  ")
 	if err != nil {
-		return "", errors.Wrap(err, "unable to format test results as xUnit")
+		return "", fmt.Errorf("unable to format test results as xUnit: %s", err)
 	}
 
 	return xml.Header + string(out), nil

--- a/internal/testrunner/reporters/outputs/file.go
+++ b/internal/testrunner/reporters/outputs/file.go
@@ -5,12 +5,11 @@
 package outputs
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/builder"
 	"github.com/elastic/elastic-package/internal/testrunner"
@@ -29,13 +28,13 @@ const (
 func reportToFile(pkg, report string, format testrunner.TestReportFormat) error {
 	dest, err := testReportsDir()
 	if err != nil {
-		return errors.Wrap(err, "could not determine test reports folder")
+		return fmt.Errorf("could not determine test reports folder: %s", err)
 	}
 	// Create test reports folder if it doesn't exist
 	_, err = os.Stat(dest)
 	if err != nil && errors.Is(err, os.ErrNotExist) {
 		if err := os.MkdirAll(dest, 0755); err != nil {
-			return errors.Wrap(err, "could not create test reports folder")
+			return fmt.Errorf("could not create test reports folder: %s", err)
 		}
 	}
 
@@ -48,7 +47,7 @@ func reportToFile(pkg, report string, format testrunner.TestReportFormat) error 
 	filePath := filepath.Join(dest, fileName)
 
 	if err := os.WriteFile(filePath, []byte(report+"\n"), 0644); err != nil {
-		return errors.Wrap(err, "could not write report file")
+		return fmt.Errorf("could not write report file: %s", err)
 	}
 
 	return nil
@@ -58,7 +57,7 @@ func reportToFile(pkg, report string, format testrunner.TestReportFormat) error 
 func testReportsDir() (string, error) {
 	buildDir, err := builder.BuildDirectory()
 	if err != nil {
-		return "", errors.Wrap(err, "locating build directory failed")
+		return "", fmt.Errorf("locating build directory failed: %s", err)
 	}
 	return filepath.Join(buildDir, "test-results"), nil
 }

--- a/internal/testrunner/runners/asset/runner.go
+++ b/internal/testrunner/runners/asset/runner.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/packages/installer"
@@ -65,7 +63,7 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 
 	testConfig, err := newConfig(r.testFolder.Path)
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "unable to load asset loading test config file"))
+		return result.WithError(fmt.Errorf("unable to load asset loading test config file: %s", err))
 
 	}
 
@@ -79,29 +77,29 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 	logger.Debug("installing package...")
 	manifest, err := packages.ReadPackageManifestFromPackageRoot(r.packageRootPath)
 	if err != nil {
-		return result.WithError(errors.Wrapf(err, "reading package manifest failed (path: %s)", r.packageRootPath))
+		return result.WithError(fmt.Errorf("reading package manifest failed (path: %s): %s", r.packageRootPath, err))
 	}
 
 	packageInstaller, err := installer.CreateForManifest(*manifest)
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "can't create the package installer"))
+		return result.WithError(fmt.Errorf("can't create the package installer: %s", err))
 	}
 	installedPackage, err := packageInstaller.Install()
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "can't install the package"))
+		return result.WithError(fmt.Errorf("can't install the package: %s", err))
 	}
 
 	r.removePackageHandler = func() error {
 		logger.Debug("removing package...")
 		if err := packageInstaller.Uninstall(); err != nil {
-			return errors.Wrap(err, "error cleaning up package")
+			return fmt.Errorf("error cleaning up package: %s", err)
 		}
 		return nil
 	}
 
 	expectedAssets, err := packages.LoadPackageAssets(r.packageRootPath)
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "could not load expected package assets"))
+		return result.WithError(fmt.Errorf("could not load expected package assets: %s", err))
 	}
 
 	results := make([]testrunner.TestResult, 0, len(expectedAssets))

--- a/internal/testrunner/runners/asset/test_config.go
+++ b/internal/testrunner/runners/asset/test_config.go
@@ -5,12 +5,13 @@
 package asset
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/elastic/go-ucfg"
 	"github.com/elastic/go-ucfg/yaml"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/testrunner"
 )
@@ -30,16 +31,16 @@ func newConfig(assetTestFolderPath string) (*testConfig, error) {
 
 	data, err := os.ReadFile(configFilePath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not load asset loading test configuration file: %s", configFilePath)
+		return nil, fmt.Errorf("could not load asset loading test configuration file: %s: %s", configFilePath, err)
 	}
 
 	var c testConfig
 	cfg, err := yaml.NewConfig(data, ucfg.PathSep("."))
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to load asset loading test configuration file: %s", configFilePath)
+		return nil, fmt.Errorf("unable to load asset loading test configuration file: %s: %s", configFilePath, err)
 	}
 	if err := cfg.Unpack(&c); err != nil {
-		return nil, errors.Wrapf(err, "unable to unpack asset loading test configuration file: %s", configFilePath)
+		return nil, fmt.Errorf("unable to unpack asset loading test configuration file: %s: %s", configFilePath, err)
 	}
 
 	return &c, nil

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/internal/common"
 	"github.com/elastic/elastic-package/internal/elasticsearch/ingest"
 	"github.com/elastic/elastic-package/internal/fields"
@@ -63,7 +61,7 @@ func (r *runner) TearDown() error {
 	}
 
 	if err := ingest.UninstallPipelines(r.options.API, r.pipelines); err != nil {
-		return errors.Wrap(err, "uninstalling ingest pipelines failed")
+		return fmt.Errorf("uninstalling ingest pipelines failed: %s", err)
 	}
 	return nil
 }
@@ -77,31 +75,31 @@ func (r *runner) CanRunPerDataStream() bool {
 func (r *runner) run() ([]testrunner.TestResult, error) {
 	testCaseFiles, err := r.listTestCaseFiles()
 	if err != nil {
-		return nil, errors.Wrap(err, "listing test case definitions failed")
+		return nil, fmt.Errorf("listing test case definitions failed: %s", err)
 	}
 
 	dataStreamPath, found, err := packages.FindDataStreamRootForPath(r.options.TestFolder.Path)
 	if err != nil {
-		return nil, errors.Wrap(err, "locating data_stream root failed")
+		return nil, fmt.Errorf("locating data_stream root failed: %s", err)
 	}
 	if !found {
-		return nil, errors.New("data stream root not found")
+		return nil, fmt.Errorf("data stream root not found")
 	}
 
 	var entryPipeline string
 	entryPipeline, r.pipelines, err = ingest.InstallDataStreamPipelines(r.options.API, dataStreamPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "installing ingest pipelines failed")
+		return nil, fmt.Errorf("installing ingest pipelines failed: %s", err)
 	}
 
 	pkgManifest, err := packages.ReadPackageManifestFromPackageRoot(r.options.PackageRootPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to read manifest")
+		return nil, fmt.Errorf("failed to read manifest: %s", err)
 	}
 
 	dsManifest, err := packages.ReadDataStreamManifestFromPackageRoot(r.options.PackageRootPath, r.options.TestFolder.DataStream)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to read data stream manifest")
+		return nil, fmt.Errorf("failed to read data stream manifest: %s", err)
 	}
 
 	expectedDataset := dsManifest.Dataset
@@ -122,7 +120,7 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 		// See https://github.com/elastic/elastic-package/pull/717.
 		tc, err := r.loadTestCaseFile(testCaseFile)
 		if err != nil {
-			err := errors.Wrap(err, "loading test case failed")
+			err := fmt.Errorf("loading test case failed: %s", err)
 			tr.ErrorMsg = err.Error()
 			results = append(results, tr)
 			continue
@@ -141,7 +139,7 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 
 		processedEvents, err := ingest.SimulatePipeline(r.options.API, entryPipeline, tc.events)
 		if err != nil {
-			err := errors.Wrap(err, "simulating pipeline processing failed")
+			err := fmt.Errorf("simulating pipeline processing failed: %s", err)
 			tr.ErrorMsg = err.Error()
 			results = append(results, tr)
 			continue
@@ -160,7 +158,7 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 			fields.WithEnabledImportAllECSSChema(true),
 		)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating fields validator for data stream failed (path: %s, test case file: %s)", dataStreamPath, testCaseFile)
+			return nil, fmt.Errorf("creating fields validator for data stream failed (path: %s, test case file: %s): %s", dataStreamPath, testCaseFile, err)
 		}
 
 		// TODO: Add tests to cover regressive use of json.Unmarshal in verifyResults.
@@ -174,7 +172,7 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 			continue
 		}
 		if err != nil {
-			err := errors.Wrap(err, "verifying test result failed")
+			err := fmt.Errorf("verifying test result failed: %s", err)
 			tr.ErrorMsg = err.Error()
 			results = append(results, tr)
 			continue
@@ -183,7 +181,7 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 		if r.options.WithCoverage {
 			tr.Coverage, err = GetPipelineCoverage(r.options, r.pipelines)
 			if err != nil {
-				return nil, errors.Wrap(err, "error calculating pipeline coverage")
+				return nil, fmt.Errorf("error calculating pipeline coverage: %s", err)
 			}
 		}
 		results = append(results, tr)
@@ -195,7 +193,7 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 func (r *runner) listTestCaseFiles() ([]string, error) {
 	fis, err := os.ReadDir(r.options.TestFolder.Path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "reading pipeline tests failed (path: %s)", r.options.TestFolder.Path)
+		return nil, fmt.Errorf("reading pipeline tests failed (path: %s): %s", r.options.TestFolder.Path, err)
 	}
 
 	var files []string
@@ -213,12 +211,12 @@ func (r *runner) loadTestCaseFile(testCaseFile string) (*testCase, error) {
 	testCasePath := filepath.Join(r.options.TestFolder.Path, testCaseFile)
 	testCaseData, err := os.ReadFile(testCasePath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "reading input file failed (testCasePath: %s)", testCasePath)
+		return nil, fmt.Errorf("reading input file failed (testCasePath: %s): %s", testCasePath, err)
 	}
 
 	config, err := readConfigForTestCase(testCasePath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "reading config for test case failed (testCasePath: %s)", testCasePath)
+		return nil, fmt.Errorf("reading config for test case failed (testCasePath: %s): %s", testCasePath, err)
 	}
 
 	if config.Skip != nil {
@@ -235,12 +233,12 @@ func (r *runner) loadTestCaseFile(testCaseFile string) (*testCase, error) {
 	case ".json":
 		entries, err = readTestCaseEntriesForEvents(testCaseData)
 		if err != nil {
-			return nil, errors.Wrapf(err, "reading test case entries for events failed (testCasePath: %s)", testCasePath)
+			return nil, fmt.Errorf("reading test case entries for events failed (testCasePath: %s): %s", testCasePath, err)
 		}
 	case ".log":
 		entries, err = readTestCaseEntriesForRawInput(testCaseData, config)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating test case entries for raw input failed (testCasePath: %s)", testCasePath)
+			return nil, fmt.Errorf("creating test case entries for raw input failed (testCasePath: %s): %s", testCasePath, err)
 		}
 	default:
 		return nil, fmt.Errorf("unsupported extension for test case file (ext: %s)", ext)
@@ -248,7 +246,7 @@ func (r *runner) loadTestCaseFile(testCaseFile string) (*testCase, error) {
 
 	tc, err := createTestCase(testCaseFile, entries, config)
 	if err != nil {
-		return nil, errors.Wrapf(err, "can't create test case (testCasePath: %s)", testCasePath)
+		return nil, fmt.Errorf("can't create test case (testCasePath: %s): %s", testCasePath, err)
 	}
 	return tc, nil
 }
@@ -261,7 +259,7 @@ func (r *runner) verifyResults(testCaseFile string, config *testConfig, result *
 		// See https://github.com/elastic/elastic-package/pull/717.
 		err := writeTestResult(testCasePath, result)
 		if err != nil {
-			return errors.Wrap(err, "writing test result failed")
+			return fmt.Errorf("writing test result failed: %s", err)
 		}
 	}
 
@@ -270,7 +268,7 @@ func (r *runner) verifyResults(testCaseFile string, config *testConfig, result *
 		return err
 	}
 	if err != nil {
-		return errors.Wrap(err, "comparing test results failed")
+		return fmt.Errorf("comparing test results failed: %s", err)
 	}
 
 	result = stripEmptyTestResults(result)
@@ -310,13 +308,13 @@ func verifyDynamicFields(result *testResult, config *testConfig) error {
 		var m common.MapStr
 		err := jsonUnmarshalUsingNumber(event, &m)
 		if err != nil {
-			return errors.Wrap(err, "can't unmarshal event")
+			return fmt.Errorf("can't unmarshal event: %s", err)
 		}
 
 		for key, pattern := range config.DynamicFields {
 			val, err := m.GetValue(key)
 			if err != nil && err != common.ErrKeyNotFound {
-				return errors.Wrap(err, "can't remove dynamic field")
+				return fmt.Errorf("can't remove dynamic field: %s", err)
 			}
 
 			valStr, ok := val.(string)
@@ -326,7 +324,7 @@ func verifyDynamicFields(result *testResult, config *testConfig) error {
 
 			matched, err := regexp.MatchString(pattern, valStr)
 			if err != nil {
-				return errors.Wrap(err, "pattern matching for dynamic field failed")
+				return fmt.Errorf("pattern matching for dynamic field failed: %s", err)
 			}
 
 			if !matched {
@@ -377,7 +375,7 @@ func checkErrorMessage(event json.RawMessage) error {
 	}
 	err := jsonUnmarshalUsingNumber(event, &pipelineError)
 	if err != nil {
-		return errors.Wrapf(err, "can't unmarshal event to check pipeline error: %#q", event)
+		return fmt.Errorf("can't unmarshal event to check pipeline error: %#q: %s", event, err)
 	}
 
 	switch m := pipelineError.Error.Message.(type) {

--- a/internal/testrunner/runners/pipeline/test_case.go
+++ b/internal/testrunner/runners/pipeline/test_case.go
@@ -8,12 +8,11 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/elastic/elastic-package/internal/common"
-
-	"github.com/pkg/errors"
 )
 
 type testCase struct {
@@ -30,7 +29,7 @@ func readTestCaseEntriesForEvents(inputData []byte) ([]json.RawMessage, error) {
 	var tcd testCaseDefinition
 	err := jsonUnmarshalUsingNumber(inputData, &tcd)
 	if err != nil {
-		return nil, errors.Wrap(err, "unmarshalling input data failed")
+		return nil, fmt.Errorf("unmarshalling input data failed: %s", err)
 	}
 	return tcd.Events, nil
 }
@@ -38,7 +37,7 @@ func readTestCaseEntriesForEvents(inputData []byte) ([]json.RawMessage, error) {
 func readTestCaseEntriesForRawInput(inputData []byte, config *testConfig) ([]json.RawMessage, error) {
 	entries, err := readRawInputEntries(inputData, config)
 	if err != nil {
-		return nil, errors.Wrap(err, "reading raw input entries failed")
+		return nil, fmt.Errorf("reading raw input entries failed: %s", err)
 	}
 
 	var events []json.RawMessage
@@ -48,7 +47,7 @@ func readTestCaseEntriesForRawInput(inputData []byte, config *testConfig) ([]jso
 
 		m, err := json.Marshal(&event)
 		if err != nil {
-			return nil, errors.Wrap(err, "marshalling mocked event failed")
+			return nil, fmt.Errorf("marshalling mocked event failed: %s", err)
 		}
 		events = append(events, m)
 	}
@@ -61,19 +60,19 @@ func createTestCase(filename string, entries []json.RawMessage, config *testConf
 		var m common.MapStr
 		err := jsonUnmarshalUsingNumber(entry, &m)
 		if err != nil {
-			return nil, errors.Wrap(err, "can't unmarshal test case entry")
+			return nil, fmt.Errorf("can't unmarshal test case entry: %s", err)
 		}
 
 		for k, v := range config.Fields {
 			_, err = m.Put(k, v)
 			if err != nil {
-				return nil, errors.Wrap(err, "can't set custom field")
+				return nil, fmt.Errorf("can't set custom field: %s", err)
 			}
 		}
 
 		event, err := json.Marshal(&m)
 		if err != nil {
-			return nil, errors.Wrap(err, "marshalling event failed")
+			return nil, fmt.Errorf("marshalling event failed: %s", err)
 		}
 		events = append(events, event)
 	}
@@ -96,7 +95,7 @@ func readRawInputEntries(inputData []byte, c *testConfig) ([]string, error) {
 		if c.Multiline != nil && c.Multiline.FirstLinePattern != "" {
 			matched, err := regexp.MatchString(c.Multiline.FirstLinePattern, line)
 			if err != nil {
-				return nil, errors.Wrapf(err, "regexp matching failed (pattern: %s)", c.Multiline.FirstLinePattern)
+				return nil, fmt.Errorf("regexp matching failed (pattern: %s): %s", c.Multiline.FirstLinePattern, err)
 			}
 
 			if matched {
@@ -118,7 +117,7 @@ func readRawInputEntries(inputData []byte, c *testConfig) ([]string, error) {
 	}
 	err := scanner.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "reading raw input test file failed")
+		return nil, fmt.Errorf("reading raw input test file failed: %s", err)
 	}
 
 	lastEntry := builder.String()

--- a/internal/testrunner/runners/pipeline/test_config.go
+++ b/internal/testrunner/runners/pipeline/test_config.go
@@ -5,12 +5,12 @@
 package pipeline
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/elastic/go-ucfg/yaml"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/testrunner"
 )
@@ -44,24 +44,24 @@ func readConfigForTestCase(testCasePath string) (*testConfig, error) {
 	var c testConfig
 	cfg, err := yaml.NewConfigWithFile(commonConfigPath)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, errors.Wrapf(err, "can't load common configuration: %s", commonConfigPath)
+		return nil, fmt.Errorf("can't load common configuration: %s: %s", commonConfigPath, err)
 	}
 
 	if err == nil {
 		if err := cfg.Unpack(&c); err != nil {
-			return nil, errors.Wrapf(err, "can't unpack test configuration: %s", commonConfigPath)
+			return nil, fmt.Errorf("can't unpack test configuration: %s: %s", commonConfigPath, err)
 		}
 	}
 
 	configPath := filepath.Join(testCaseDir, expectedTestConfigFile(testCaseFile, configTestSuffixYAML))
 	cfg, err = yaml.NewConfigWithFile(configPath)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, errors.Wrapf(err, "can't load test configuration: %s", configPath)
+		return nil, fmt.Errorf("can't load test configuration: %s: %s", configPath, err)
 	}
 
 	if err == nil {
 		if err := cfg.Unpack(&c); err != nil {
-			return nil, errors.Wrapf(err, "can't unpack test configuration: %s", configPath)
+			return nil, fmt.Errorf("can't unpack test configuration: %s: %s", configPath, err)
 		}
 	}
 	return &c, nil

--- a/internal/testrunner/runners/static/runner.go
+++ b/internal/testrunner/runners/static/runner.go
@@ -5,10 +5,10 @@
 package static
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/fields"
 	"github.com/elastic/elastic-package/internal/logger"
@@ -55,7 +55,7 @@ func (r runner) run() ([]testrunner.TestResult, error) {
 
 	testConfig, err := newConfig(r.options.TestFolder.Path)
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "unable to load asset loading test config file"))
+		return result.WithError(fmt.Errorf("unable to load asset loading test config file: %s", err))
 	}
 
 	if testConfig != nil && testConfig.Skip != nil {
@@ -67,7 +67,7 @@ func (r runner) run() ([]testrunner.TestResult, error) {
 
 	pkgManifest, err := packages.ReadPackageManifestFromPackageRoot(r.options.PackageRootPath)
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "failed to read manifest"))
+		return result.WithError(fmt.Errorf("failed to read manifest: %s", err))
 	}
 
 	return r.verifySampleEvent(pkgManifest), nil
@@ -103,13 +103,13 @@ func (r runner) verifySampleEvent(pkgManifest *packages.PackageManifest) []testr
 		fields.WithEnabledImportAllECSSChema(true),
 	)
 	if err != nil {
-		results, _ := resultComposer.WithError(errors.Wrap(err, "creating fields validator for data stream failed"))
+		results, _ := resultComposer.WithError(fmt.Errorf("creating fields validator for data stream failed: %s", err))
 		return results
 	}
 
 	content, err := os.ReadFile(sampleEventPath)
 	if err != nil {
-		results, _ := resultComposer.WithError(errors.Wrap(err, "can't read file"))
+		results, _ := resultComposer.WithError(fmt.Errorf("can't read file: %s", err))
 		return results
 	}
 
@@ -142,7 +142,7 @@ func (r runner) getSampleEventPath() (string, bool, error) {
 		return "", false, nil
 	}
 	if err != nil {
-		return "", false, errors.Wrap(err, "stat file failed")
+		return "", false, fmt.Errorf("stat file failed: %s", err)
 	}
 	return sampleEventPath, true, nil
 }
@@ -158,7 +158,7 @@ func (r runner) getExpectedDataset(pkgManifest *packages.PackageManifest) (strin
 
 	dataStreamManifest, err := packages.ReadDataStreamManifestFromPackageRoot(r.options.PackageRootPath, dsName)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to read data stream manifest")
+		return "", fmt.Errorf("failed to read data stream manifest: %s", err)
 	}
 	if ds := dataStreamManifest.Dataset; ds != "" {
 		return ds, nil

--- a/internal/testrunner/runners/static/test_config.go
+++ b/internal/testrunner/runners/static/test_config.go
@@ -5,12 +5,13 @@
 package static
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/elastic/go-ucfg"
 	"github.com/elastic/go-ucfg/yaml"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/testrunner"
 )
@@ -30,17 +31,17 @@ func newConfig(staticTestFolderPath string) (*testConfig, error) {
 
 	data, err := os.ReadFile(configFilePath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not load static test configuration file: %s", configFilePath)
+		return nil, fmt.Errorf("could not load static test configuration file: %s: %s", configFilePath, err)
 	}
 
 	cfg, err := yaml.NewConfig(data, ucfg.PathSep("."))
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to load static test configuration file: %s", configFilePath)
+		return nil, fmt.Errorf("unable to load static test configuration file: %s: %s", configFilePath, err)
 	}
 
 	var c testConfig
 	if err := cfg.Unpack(&c); err != nil {
-		return nil, errors.Wrapf(err, "unable to unpack static test configuration file: %s", configFilePath)
+		return nil, fmt.Errorf("unable to unpack static test configuration file: %s: %s", configFilePath, err)
 	}
 
 	return &c, nil

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -6,14 +6,13 @@ package system
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/common"
 	"github.com/elastic/elastic-package/internal/configuration/locations"
@@ -142,12 +141,12 @@ func (r *runner) run() (results []testrunner.TestResult, err error) {
 	result := r.newResult("(init)")
 	locationManager, err := locations.NewLocationManager()
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "reading service logs directory failed"))
+		return result.WithError(fmt.Errorf("reading service logs directory failed: %s", err))
 	}
 
 	dataStreamPath, found, err := packages.FindDataStreamRootForPath(r.options.TestFolder.Path)
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "locating data stream root failed"))
+		return result.WithError(fmt.Errorf("locating data stream root failed: %s", err))
 	}
 	if found {
 		logger.Debug("Running system tests for data stream")
@@ -160,17 +159,17 @@ func (r *runner) run() (results []testrunner.TestResult, err error) {
 		DataStreamRootPath: dataStreamPath,
 	})
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "_dev/deploy directory not found"))
+		return result.WithError(fmt.Errorf("_dev/deploy directory not found: %s", err))
 	}
 
 	cfgFiles, err := listConfigFiles(r.options.TestFolder.Path)
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "failed listing test case config cfgFiles"))
+		return result.WithError(fmt.Errorf("failed listing test case config cfgFiles: %s", err))
 	}
 
 	variantsFile, err := servicedeployer.ReadVariantsFile(devDeployPath)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return result.WithError(errors.Wrap(err, "can't read service variant"))
+		return result.WithError(fmt.Errorf("can't read service variant: %s", err))
 	}
 
 	for _, cfgFile := range cfgFiles {
@@ -199,7 +198,7 @@ func (r *runner) runTestPerVariant(result *testrunner.ResultComposer, locationMa
 	ctxt.Test.RunID = createTestRunID()
 	testConfig, err := newConfig(filepath.Join(r.options.TestFolder.Path, cfgFile), ctxt, variantName)
 	if err != nil {
-		return result.WithError(errors.Wrapf(err, "unable to load system test case file '%s'", cfgFile))
+		return result.WithError(fmt.Errorf("unable to load system test case file '%s': %s", cfgFile, err))
 	}
 
 	var partial []testrunner.TestResult
@@ -219,7 +218,7 @@ func (r *runner) runTestPerVariant(result *testrunner.ResultComposer, locationMa
 		return partial, err
 	}
 	if tdErr != nil {
-		return partial, errors.Wrap(tdErr, "failed to tear down runner")
+		return partial, fmt.Errorf("failed to tear down runner: %s", tdErr)
 	}
 	return partial, nil
 }
@@ -235,7 +234,7 @@ func (r *runner) getDocs(dataStream string) ([]common.MapStr, error) {
 		r.options.API.Search.WithSize(elasticsearchQuerySize),
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not search data stream")
+		return nil, fmt.Errorf("could not search data stream: %s", err)
 	}
 	defer resp.Body.Close()
 
@@ -256,7 +255,7 @@ func (r *runner) getDocs(dataStream string) ([]common.MapStr, error) {
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
-		return nil, errors.Wrap(err, "could not decode search results response")
+		return nil, fmt.Errorf("could not decode search results response: %s", err)
 	}
 
 	numHits := results.Hits.Total.Value
@@ -280,32 +279,32 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 
 	pkgManifest, err := packages.ReadPackageManifestFromPackageRoot(r.options.PackageRootPath)
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "reading package manifest failed"))
+		return result.WithError(fmt.Errorf("reading package manifest failed: %s", err))
 	}
 
 	dataStreamManifest, err := packages.ReadDataStreamManifest(filepath.Join(serviceOptions.DataStreamRootPath, packages.DataStreamManifestFile))
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "reading data stream manifest failed"))
+		return result.WithError(fmt.Errorf("reading data stream manifest failed: %s", err))
 	}
 
 	policyTemplateName := config.PolicyTemplate
 	if policyTemplateName == "" {
 		policyTemplateName, err = findPolicyTemplateForInput(*pkgManifest, *dataStreamManifest, config.Input)
 		if err != nil {
-			return result.WithError(errors.Wrap(err, "failed to determine the associated policy_template"))
+			return result.WithError(fmt.Errorf("failed to determine the associated policy_template: %s", err))
 		}
 	}
 
 	policyTemplate, err := selectPolicyTemplateByName(pkgManifest.PolicyTemplates, policyTemplateName)
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "failed to find the selected policy_template"))
+		return result.WithError(fmt.Errorf("failed to find the selected policy_template: %s", err))
 	}
 
 	// Setup service.
 	logger.Debug("setting up service...")
 	serviceDeployer, err := servicedeployer.Factory(serviceOptions)
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "could not create service runner"))
+		return result.WithError(fmt.Errorf("could not create service runner: %s", err))
 	}
 
 	if config.Service != "" {
@@ -313,13 +312,13 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 	}
 	service, err := serviceDeployer.SetUp(ctxt)
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "could not setup service"))
+		return result.WithError(fmt.Errorf("could not setup service: %s", err))
 	}
 	ctxt = service.Context()
 	r.shutdownServiceHandler = func() error {
 		logger.Debug("tearing down service...")
 		if err := service.TearDown(); err != nil {
-			return errors.Wrap(err, "error tearing down service")
+			return fmt.Errorf("error tearing down service: %s", err)
 		}
 
 		return nil
@@ -328,12 +327,12 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 	// Reload test config with ctx variable substitution.
 	config, err = newConfig(config.Path, ctxt, serviceOptions.Variant)
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "unable to reload system test case configuration"))
+		return result.WithError(fmt.Errorf("unable to reload system test case configuration: %s", err))
 	}
 
 	kib, err := kibana.NewClient()
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "can't create Kibana client"))
+		return result.WithError(fmt.Errorf("can't create Kibana client: %s", err))
 	}
 
 	// Configure package (single data stream) via Ingest Manager APIs.
@@ -346,12 +345,12 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 	}
 	policy, err := kib.CreatePolicy(p)
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "could not create test policy"))
+		return result.WithError(fmt.Errorf("could not create test policy: %s", err))
 	}
 	r.deleteTestPolicyHandler = func() error {
 		logger.Debug("deleting test policy...")
 		if err := kib.DeletePolicy(*policy); err != nil {
-			return errors.Wrap(err, "error cleaning up test policy")
+			return fmt.Errorf("error cleaning up test policy: %s", err)
 		}
 		return nil
 	}
@@ -359,7 +358,7 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 	logger.Debug("adding package data stream to test policy...")
 	ds := createPackageDatastream(*policy, *pkgManifest, policyTemplate, *dataStreamManifest, *config)
 	if err := kib.AddPackageDataStreamToPolicy(ds); err != nil {
-		return result.WithError(errors.Wrap(err, "could not add data stream config to policy"))
+		return result.WithError(fmt.Errorf("could not add data stream config to policy: %s", err))
 	}
 
 	// Delete old data
@@ -374,18 +373,18 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 	r.wipeDataStreamHandler = func() error {
 		logger.Debugf("deleting data in data stream...")
 		if err := deleteDataStreamDocs(r.options.API, dataStream); err != nil {
-			return errors.Wrap(err, "error deleting data in data stream")
+			return fmt.Errorf("error deleting data in data stream: %s", err)
 		}
 		return nil
 	}
 
 	if err := deleteDataStreamDocs(r.options.API, dataStream); err != nil {
-		return result.WithError(errors.Wrapf(err, "error deleting old data in data stream: %s", dataStream))
+		return result.WithError(fmt.Errorf("error deleting old data in data stream: %s: %s", dataStream, err))
 	}
 
 	cleared, err := waitUntilTrue(func() (bool, error) {
 		if signal.SIGINT() {
-			return true, errors.New("SIGINT: cancel clearing data")
+			return true, fmt.Errorf("SIGINT: cancel clearing data")
 		}
 
 		docs, err := r.getDocs(dataStream)
@@ -393,14 +392,14 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 	}, 2*time.Minute)
 	if err != nil || !cleared {
 		if err == nil {
-			err = errors.New("unable to clear previous data")
+			err = fmt.Errorf("unable to clear previous data")
 		}
 		return result.WithError(err)
 	}
 
 	agents, err := checkEnrolledAgents(kib, ctxt)
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "can't check enrolled agents"))
+		return result.WithError(fmt.Errorf("can't check enrolled agents: %s", err))
 	}
 	agent := agents[0]
 	origPolicy := kibana.Policy{
@@ -412,25 +411,25 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 	r.resetAgentPolicyHandler = func() error {
 		logger.Debug("reassigning original policy back to agent...")
 		if err := kib.AssignPolicyToAgent(agent, origPolicy); err != nil {
-			return errors.Wrap(err, "error reassigning original policy to agent")
+			return fmt.Errorf("error reassigning original policy to agent: %s", err)
 		}
 		return nil
 	}
 
 	policyWithDataStream, err := kib.GetPolicy(policy.ID)
 	if err != nil {
-		return result.WithError(errors.Wrap(err, "could not read the policy with data stream"))
+		return result.WithError(fmt.Errorf("could not read the policy with data stream: %s", err))
 	}
 
 	logger.Debug("assigning package data stream to agent...")
 	if err := kib.AssignPolicyToAgent(agent, *policyWithDataStream); err != nil {
-		return result.WithError(errors.Wrap(err, "could not assign policy to agent"))
+		return result.WithError(fmt.Errorf("could not assign policy to agent: %s", err))
 	}
 
 	// Signal to the service that the agent is ready (policy is assigned).
 	if config.ServiceNotifySignal != "" {
 		if err = service.Signal(config.ServiceNotifySignal); err != nil {
-			return result.WithError(errors.Wrap(err, "failed to notify test service"))
+			return result.WithError(fmt.Errorf("failed to notify test service: %s", err))
 		}
 	}
 
@@ -445,7 +444,7 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 	var docs []common.MapStr
 	passed, err := waitUntilTrue(func() (bool, error) {
 		if signal.SIGINT() {
-			return true, errors.New("SIGINT: cancel waiting for policy assigned")
+			return true, fmt.Errorf("SIGINT: cancel waiting for policy assigned")
 		}
 
 		var err error
@@ -475,7 +474,7 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 		fields.WithEnabledImportAllECSSChema(true),
 	)
 	if err != nil {
-		return result.WithError(errors.Wrapf(err, "creating fields validator for data stream failed (path: %s)", serviceOptions.DataStreamRootPath))
+		return result.WithError(fmt.Errorf("creating fields validator for data stream failed (path: %s): %s", serviceOptions.DataStreamRootPath, err))
 	}
 	if err := validateFields(docs, fieldsValidator, dataStream); err != nil {
 		return result.WithError(err)
@@ -493,12 +492,12 @@ func checkEnrolledAgents(client *kibana.Client, ctxt servicedeployer.ServiceCont
 	var agents []kibana.Agent
 	enrolled, err := waitUntilTrue(func() (bool, error) {
 		if signal.SIGINT() {
-			return false, errors.New("SIGINT: cancel checking enrolled agents")
+			return false, fmt.Errorf("SIGINT: cancel checking enrolled agents")
 		}
 
 		allAgents, err := client.ListAgents()
 		if err != nil {
-			return false, errors.Wrap(err, "could not list agents")
+			return false, fmt.Errorf("could not list agents: %s", err)
 		}
 
 		agents = filterAgents(allAgents, ctxt)
@@ -509,10 +508,10 @@ func checkEnrolledAgents(client *kibana.Client, ctxt servicedeployer.ServiceCont
 		return true, nil
 	}, 5*time.Minute)
 	if err != nil {
-		return nil, errors.Wrap(err, "agent enrollment failed")
+		return nil, fmt.Errorf("agent enrollment failed: %s", err)
 	}
 	if !enrolled {
-		return nil, errors.New("no agent enrolled in time")
+		return nil, fmt.Errorf("no agent enrolled in time")
 	}
 	return agents, nil
 }
@@ -690,7 +689,7 @@ func findPolicyTemplateForInput(pkg packages.PackageManifest, ds packages.DataSt
 func findPolicyTemplateForDataStream(pkg packages.PackageManifest, ds packages.DataStreamManifest, inputName string) (string, error) {
 	if inputName == "" {
 		if len(ds.Streams) == 0 {
-			return "", errors.New("no streams declared in data stream manifest")
+			return "", fmt.Errorf("no streams declared in data stream manifest")
 		}
 		inputName = ds.Streams[getDataStreamIndex(inputName, ds)].Input
 	}
@@ -728,7 +727,7 @@ func findPolicyTemplateForDataStream(pkg packages.PackageManifest, ds packages.D
 func findPolicyTemplateForInputPackage(pkg packages.PackageManifest, inputName string) (string, error) {
 	if inputName == "" {
 		if len(pkg.PolicyTemplates) == 0 {
-			return "", errors.New("no policy templates specified for input package")
+			return "", fmt.Errorf("no policy templates specified for input package")
 		}
 		inputName = pkg.PolicyTemplates[0].Input
 	}
@@ -823,12 +822,12 @@ func filterAgents(allAgents []kibana.Agent, ctx servicedeployer.ServiceContext) 
 func writeSampleEvent(path string, doc common.MapStr) error {
 	body, err := json.MarshalIndent(doc, "", "    ")
 	if err != nil {
-		return errors.Wrap(err, "marshalling sample event failed")
+		return fmt.Errorf("marshalling sample event failed: %s", err)
 	}
 
 	err = os.WriteFile(filepath.Join(path, "sample_event.json"), body, 0644)
 	if err != nil {
-		return errors.Wrap(err, "writing sample event failed")
+		return fmt.Errorf("writing sample event failed: %s", err)
 	}
 
 	return nil
@@ -886,7 +885,7 @@ func (r *runner) generateTestResult(docs []common.MapStr) error {
 	}
 
 	if err := writeSampleEvent(rootPath, docs[0]); err != nil {
-		return errors.Wrap(err, "failed to write sample event file")
+		return fmt.Errorf("failed to write sample event file: %s", err)
 	}
 
 	return nil

--- a/internal/testrunner/runners/system/servicedeployer/factory.go
+++ b/internal/testrunner/runners/system/servicedeployer/factory.go
@@ -5,11 +5,10 @@
 package servicedeployer
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
 const devDeployDir = "_dev/deploy"
@@ -27,12 +26,12 @@ type FactoryOptions struct {
 func Factory(options FactoryOptions) (ServiceDeployer, error) {
 	devDeployPath, err := FindDevDeployPath(options)
 	if err != nil {
-		return nil, errors.Wrapf(err, "can't find \"%s\" directory", devDeployDir)
+		return nil, fmt.Errorf("can't find \"%s\" directory: %s", devDeployDir, err)
 	}
 
 	serviceDeployerName, err := findServiceDeployer(devDeployPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't find any valid service deployer")
+		return nil, fmt.Errorf("can't find any valid service deployer: %s", err)
 	}
 
 	serviceDeployerPath := filepath.Join(devDeployPath, serviceDeployerName)
@@ -47,14 +46,14 @@ func Factory(options FactoryOptions) (ServiceDeployer, error) {
 		if _, err := os.Stat(dockerComposeYMLPath); err == nil {
 			sv, err := useServiceVariant(devDeployPath, options.Variant)
 			if err != nil {
-				return nil, errors.Wrap(err, "can't use service variant")
+				return nil, fmt.Errorf("can't use service variant: %s", err)
 			}
 			return NewDockerComposeServiceDeployer([]string{dockerComposeYMLPath}, sv)
 		}
 	case "agent":
 		customAgentCfgYMLPath := filepath.Join(serviceDeployerPath, "custom-agent.yml")
 		if _, err := os.Stat(customAgentCfgYMLPath); err != nil {
-			return nil, errors.Wrap(err, "can't find expected file custom-agent.yml")
+			return nil, fmt.Errorf("can't find expected file custom-agent.yml: %s", err)
 		}
 		return NewCustomAgentDeployer(customAgentCfgYMLPath)
 
@@ -73,7 +72,7 @@ func FindDevDeployPath(options FactoryOptions) (string, error) {
 	if err == nil {
 		return dataStreamDevDeployPath, nil
 	} else if !errors.Is(err, os.ErrNotExist) {
-		return "", errors.Wrapf(err, "stat failed for data stream (path: %s)", dataStreamDevDeployPath)
+		return "", fmt.Errorf("stat failed for data stream (path: %s): %s", dataStreamDevDeployPath, err)
 	}
 
 	packageDevDeployPath := filepath.Join(options.PackageRootPath, devDeployDir)
@@ -81,7 +80,7 @@ func FindDevDeployPath(options FactoryOptions) (string, error) {
 	if err == nil {
 		return packageDevDeployPath, nil
 	} else if !errors.Is(err, os.ErrNotExist) {
-		return "", errors.Wrapf(err, "stat failed for package (path: %s)", packageDevDeployPath)
+		return "", fmt.Errorf("stat failed for package (path: %s): %s", packageDevDeployPath, err)
 	}
 	return "", fmt.Errorf("\"%s\" directory doesn't exist", devDeployDir)
 }
@@ -89,7 +88,7 @@ func FindDevDeployPath(options FactoryOptions) (string, error) {
 func findServiceDeployer(devDeployPath string) (string, error) {
 	fis, err := os.ReadDir(devDeployPath)
 	if err != nil {
-		return "", errors.Wrapf(err, "can't read directory (path: %s)", devDeployDir)
+		return "", fmt.Errorf("can't read directory (path: %s): %s", devDeployDir, err)
 	}
 
 	var folders []os.DirEntry

--- a/internal/testrunner/runners/system/servicedeployer/terraform_env.go
+++ b/internal/testrunner/runners/system/servicedeployer/terraform_env.go
@@ -5,7 +5,6 @@
 package servicedeployer
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -35,7 +34,7 @@ func (tsd TerraformServiceDeployer) buildTerraformExecutorEnvironment(ctxt Servi
 func buildTerraformAliases(serviceComposeConfig *compose.Config) (map[string]interface{}, error) {
 	terraformService, found := serviceComposeConfig.Services["terraform"]
 	if !found {
-		return nil, errors.New("missing config section for terraform service")
+		return nil, fmt.Errorf("missing config section for terraform service")
 	}
 
 	m := map[string]interface{}{}

--- a/internal/testrunner/runners/system/servicedeployer/variants.go
+++ b/internal/testrunner/runners/system/servicedeployer/variants.go
@@ -5,12 +5,12 @@
 package servicedeployer
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
 
@@ -46,18 +46,18 @@ func ReadVariantsFile(devDeployPath string) (*VariantsFile, error) {
 		return nil, os.ErrNotExist
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "can't stat variants file")
+		return nil, fmt.Errorf("can't stat variants file: %s", err)
 	}
 
 	content, err := os.ReadFile(variantsYmlPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't read variants file")
+		return nil, fmt.Errorf("can't read variants file: %s", err)
 	}
 
 	var f VariantsFile
 	err = yaml.Unmarshal(content, &f)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't unmarshal variants file")
+		return nil, fmt.Errorf("can't unmarshal variants file: %s", err)
 	}
 	return &f, nil
 }
@@ -75,7 +75,7 @@ func useServiceVariant(devDeployPath, selected string) (ServiceVariant, error) {
 	}
 
 	if f.Default == "" {
-		return ServiceVariant{}, errors.New("default variant is undefined")
+		return ServiceVariant{}, fmt.Errorf("default variant is undefined")
 	}
 
 	env, ok := f.Variants[selected]

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -5,14 +5,13 @@
 package testrunner
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/elasticsearch"
 )
@@ -159,7 +158,7 @@ func AssumeTestFolders(packageRootPath string, dataStreams []string, testType Te
 			return []TestFolder{}, nil // data streams defined
 		}
 		if err != nil {
-			return nil, errors.Wrapf(err, "can't read directory (path: %s)", dataStreamsPath)
+			return nil, fmt.Errorf("can't read directory (path: %s): %s", dataStreamsPath, err)
 		}
 
 		for _, fi := range fileInfos {
@@ -268,10 +267,10 @@ func Run(testType TestType, options TestOptions) ([]TestResult, error) {
 	results, err := runner.Run(options)
 	tdErr := runner.TearDown()
 	if err != nil {
-		return nil, errors.Wrap(err, "could not complete test run")
+		return nil, fmt.Errorf("could not complete test run: %s", err)
 	}
 	if tdErr != nil {
-		return results, errors.Wrap(err, "could not teardown test runner")
+		return results, fmt.Errorf("could not teardown test runner: %s", err)
 	}
 	return results, nil
 }
@@ -287,7 +286,7 @@ func findDataStreamTestFolderPaths(packageRootPath, dataStreamGlob, testTypeGlob
 	testFoldersGlob := filepath.Join(packageRootPath, "data_stream", dataStreamGlob, "_dev", "test", testTypeGlob)
 	paths, err := filepath.Glob(testFoldersGlob)
 	if err != nil {
-		return nil, errors.Wrap(err, "error finding test folders")
+		return nil, fmt.Errorf("error finding test folders: %s", err)
 	}
 	return paths, err
 }
@@ -297,7 +296,7 @@ func findPackageTestFolderPaths(packageRootPath, testTypeGlob string) ([]string,
 	testFoldersGlob := filepath.Join(packageRootPath, "_dev", "test", testTypeGlob)
 	paths, err := filepath.Glob(testFoldersGlob)
 	if err != nil {
-		return nil, errors.Wrap(err, "error finding test folders")
+		return nil, fmt.Errorf("error finding test folders: %s", err)
 	}
 	return paths, err
 }

--- a/main.go
+++ b/main.go
@@ -5,12 +5,11 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"math/rand"
 	"os"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/cmd"
 	"github.com/elastic/elastic-package/internal/install"
@@ -23,7 +22,7 @@ func main() {
 
 	err := install.EnsureInstalled()
 	if err != nil {
-		log.Fatal(errors.Wrap(err, "validating installation failed"))
+		log.Fatal(fmt.Errorf("validating installation failed: %s", err))
 	}
 
 	err = rootCmd.Execute()

--- a/tools/readme/main.go
+++ b/tools/readme/main.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/elastic-package/cmd"
 )
 
@@ -35,7 +33,7 @@ type readmeVars struct {
 func loadCommandTemplate() *template.Template {
 	cmdTmpl, err := template.ParseFiles("./cmd.md.tmpl")
 	if err != nil {
-		log.Fatal(errors.Wrap(err, "loading command template failed"))
+		log.Fatal(fmt.Errorf("loading command template failed: %s", err))
 	}
 	return cmdTmpl
 }
@@ -45,7 +43,7 @@ func generateCommandsDoc(cmdTmpl *template.Template) strings.Builder {
 	for _, cmd := range cmd.Commands() {
 		log.Printf("generating command doc for %s...\n", cmd.Name())
 		if err := cmdTmpl.Execute(&cmdsDoc, cmd); err != nil {
-			log.Fatal(errors.Wrapf(err, "writing documentation for command '%s' failed", cmd.Name()))
+			log.Fatal(fmt.Errorf("writing documentation for command '%s' failed: %s", cmd.Name(), err))
 		}
 	}
 	return cmdsDoc
@@ -54,7 +52,7 @@ func generateCommandsDoc(cmdTmpl *template.Template) strings.Builder {
 func loadReadmeTemplate() *template.Template {
 	readmeTmpl, err := template.ParseFiles("./readme.md.tmpl")
 	if err != nil {
-		log.Fatal(errors.Wrap(err, "loading README template failed"))
+		log.Fatal(fmt.Errorf("loading README template failed: %s", err))
 	}
 	return readmeTmpl
 }
@@ -62,17 +60,17 @@ func loadReadmeTemplate() *template.Template {
 func generateReadme(readmeTmpl *template.Template, cmdsDoc string) {
 	readmePath, err := filepath.Abs("../../README.md")
 	if err != nil {
-		log.Fatal(errors.Wrap(err, "creating README absolute file path failed"))
+		log.Fatal(fmt.Errorf("creating README absolute file path failed: %s", err))
 	}
 
 	readme, err := os.OpenFile(readmePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
-		log.Fatal(errors.Wrapf(err, "opening README file %s failed", readmePath))
+		log.Fatal(fmt.Errorf("opening README file %s failed: %s", readmePath, err))
 	}
 	defer readme.Close()
 
 	r := readmeVars{cmdsDoc}
 	if err := readmeTmpl.Execute(readme, r); err != nil {
-		log.Fatal(errors.Wrapf(err, "writing README file %s failed", readmePath))
+		log.Fatal(fmt.Errorf("writing README file %s failed: %sn", readmePath, err))
 	}
 }


### PR DESCRIPTION
Signed-off-by: Florian Lehner <florian.lehner@elastic.co>

This PR replaces the no longer maintained dependency `github.com/pkg/errors` with its standard library equivalent. 

The standard library package `errors` was introduced with Go 1.13. 