### PR TITLE
servicedeployer/compose.go - pass env vars when signalling

### DIFF
--- a/internal/testrunner/runners/system/servicedeployer/compose.go
+++ b/internal/testrunner/runners/system/servicedeployer/compose.go
@@ -135,7 +135,12 @@ func (s *dockerComposeDeployedService) Signal(signal string) error {
 		return errors.Wrap(err, "could not create Docker Compose project for service")
 	}
 
-	opts := compose.CommandOptions{ExtraArgs: []string{"-s", signal}}
+	opts := compose.CommandOptions{
+		Env: append(
+			[]string{fmt.Sprintf("%s=%s", serviceLogsDirEnv, s.ctxt.Logs.Folder.Local)},
+			s.sv.Env...),
+		ExtraArgs: []string{"-s", signal},
+	}
 	if s.ctxt.Name != "" {
 		opts.Services = append(opts.Services, s.ctxt.Name)
 	}


### PR DESCRIPTION
Pass environment variables when invoking docker-compose to send a signal to a service.

Fixes #1114