### PR TITLE
Add skeleton for elastic-package-package-storage-publish pipeline

### DIFF
--- a/.buildkite/pipeline.package-storage-publish.yml
+++ b/.buildkite/pipeline.package-storage-publish.yml
@@ -1,0 +1,3 @@
+steps:
+  - label: "Example Test"
+    command: echo "Hello!"


### PR DESCRIPTION
Add skeleton for the elastic-package-package-storage-publish for Buildkite before creating the buildkite pipeline resource.
This goal of this pipeline is to replace this Jenkins pipeline:
- https://github.com/elastic/elastic-package/blob/main/.ci/package-storage-publish.groovy