### PR TITLE
Reduce expiration time of certificates

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -152,7 +152,9 @@ func New(isCA bool, issuer *Issuer, opts ...Option) (*Certificate, error) {
 		return nil, fmt.Errorf("failed to get a unique serial number: %w", err)
 	}
 
-	const longTime = 100 * 24 * 365 * time.Hour
+	// Don't use a expiration time longer than 825 days.
+	// See https://rahulkj.github.io/openssl,/certificates/2022/09/09/self-signed-certificates.html.
+	const longTime = 800 * 24 * time.Hour
 	template := x509.Certificate{
 		NotBefore: time.Now(),
 		NotAfter:  time.Now().Add(longTime),


### PR DESCRIPTION
Clients that rely on OSX APIs for certificate validation may find an error with the message "certificate is not standards compliant" with certificates that don't comply with Apple rules for certificate validation. When this error happens, the actual reason for each certificate is not exposed, and it seems to happen with certificates that should be valid in the context of the validation. More discussion about this can be found in https://github.com/golang/go/issues/51991.

This happens with certificates generated by elastic-package, clients sometimes report this error with configurations that otherwise should accept these certificates.

According to this post, one of the rules is that certificates cannot be valid for more than 825 days.
https://rahulkj.github.io/openssl,/certificates/2022/09/09/self-signed-certificates.html

Reduce the expiration time to try to reduce the chances of triggering this error.