### PR TITLE
Increase format version to 2.5.1 for new packages

### DIFF
--- a/internal/packages/archetype/package_manifest.go
+++ b/internal/packages/archetype/package_manifest.go
@@ -4,7 +4,7 @@
 
 package archetype
 
-const packageManifestTemplate = `format_version: 2.3.0
+const packageManifestTemplate = `format_version: 2.5.1
 name: {{.Manifest.Name}}
 title: "{{.Manifest.Title}}"
 version: {{.Manifest.Version}}

--- a/internal/packages/archetype/package_manifest.go
+++ b/internal/packages/archetype/package_manifest.go
@@ -4,7 +4,7 @@
 
 package archetype
 
-const packageManifestTemplate = `format_version: 2.0.0
+const packageManifestTemplate = `format_version: 2.3.0
 name: {{.Manifest.Name}}
 title: "{{.Manifest.Title}}"
 version: {{.Manifest.Version}}


### PR DESCRIPTION
New packages that were generated, used 2.0.0 by default instead of the most recent format_version of 2.5.1. To make sure new packages have by default access to the most recent features, the format_version should be the latest one.