### PR TITLE
Add more skipped directories when copying package files

### DIFF
--- a/internal/files/copy.go
+++ b/internal/files/copy.go
@@ -18,7 +18,7 @@ func CopyAll(sourcePath, destinationPath string) error {
 
 // CopyWithoutDev method copies files from the source to the destination, but skips _dev directories and empty folders.
 func CopyWithoutDev(sourcePath, destinationPath string) error {
-	return CopyWithSkipped(sourcePath, destinationPath, []string{"_dev"})
+	return CopyWithSkipped(sourcePath, destinationPath, []string{"_dev", "build", ".git"})
 }
 
 // CopyWithSkipped method copies files from the source to the destination, but skips selected directories and empty folders.


### PR DESCRIPTION
Fixes https://github.com/elastic/elastic-package/issues/1154

This PR adds the following folders to be considered skipped when building the package:
- `.git`
- `build`

This is needed when the package files are directly located in the root of the repository.

As it is now, `elastic-package build` command copies all the folders/files except `_dev`. As the `build` folder is created in the root of the repository (same as other package files) it is also copied to the `build` folder again. `.git` folder would be also copied along with the others.