### PR TITLE
Update conditional for release step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -49,7 +49,7 @@ steps:
     key: "release"
     # build.tag != null && build.branch == "main"
     if: |
-      build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/ && build.branch == "main"
+      build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
     command: ".buildkite/scripts/release.sh"
     agents:
       image: "golang:1.19.5"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -43,10 +43,10 @@ pipeline {
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
           }
         }
-        /**
-        Check the source code.
-        */
-        stage('Check it contains Buildkite pipeline') {
+        stage('Check if the PR contains Buildkite pipeline') {
+          when {
+            changeRequest()
+          }
           steps {
             cleanup()
             dir("${BASE_DIR}"){


### PR DESCRIPTION
This PR updates the filtering in the release step since in the latest attempt to push a tag, that step was not executed.
It looks like build.branch is set to the same value as the tag. At least this is what the environment variables show:
```
BUILDKITE_BRANCH="v0.75.0"
BUILDKITE_TAG="v0.75.0"
```

The condition now is just the value of the `build.tag`.