### PR TITLE
Add parameter --zip into install command

### DIFF
--- a/.buildkite/pipeline.trigger.integration.tests.sh
+++ b/.buildkite/pipeline.trigger.integration.tests.sh
@@ -44,6 +44,7 @@ for test in ${CHECK_PACKAGES_TESTS[@]}; do
     echo "          - build/test-results/*.xml"
     echo "          - build/elastic-stack-dump/stack/check-*/logs/*.log"
     echo "          - build/elastic-stack-dump/stack/check-*/logs/fleet-server-internal/*.log"
+    echo "          - build/elastic-stack-status/*/*"
     if [[ $test =~ with-kind$ ]]; then
         echo "          - build/kubectl-dump.txt"
     fi
@@ -70,7 +71,7 @@ echo "        command: ./.buildkite/scripts/integration_tests.sh -t test-build-z
 echo "        agents:"
 echo "          provider: \"gcp\""
 echo "        artifact_paths:"
-echo "          - build/elastic-stack-dump/stack/*/logs/*.log"
+echo "          - build/elastic-stack-dump/build-zip/logs/*.log"
 echo "          - build/packages/*.sig"
 
 echo "      - label: \":go: Running integration test: test-install-zip\""
@@ -78,7 +79,7 @@ echo "        command: ./.buildkite/scripts/integration_tests.sh -t test-install
 echo "        agents:"
 echo "          provider: \"gcp\""
 echo "        artifact_paths:"
-echo "          - build/elastic-stack-dump/stack/*/logs/*.log"
+echo "          - build/elastic-stack-dump/install-zip/logs/*.log"
 
 echo "      - label: \":go: Running integration test: test-profiles-command\""
 echo "        command: ./.buildkite/scripts/integration_tests.sh -t test-profiles-command"

--- a/.buildkite/pipeline.trigger.integration.tests.sh
+++ b/.buildkite/pipeline.trigger.integration.tests.sh
@@ -73,7 +73,7 @@ echo "        artifact_paths:"
 echo "          - build/elastic-stack-dump/stack/*/logs/*.log"
 echo "          - build/packages/*.sig"
 
-echo "      - label: \":go: Running integration test: test-instgall-zip\""
+echo "      - label: \":go: Running integration test: test-install-zip\""
 echo "        command: ./.buildkite/scripts/integration_tests.sh -t test-install-zip"
 echo "        agents:"
 echo "          provider: \"gcp\""

--- a/.buildkite/pipeline.trigger.integration.tests.sh
+++ b/.buildkite/pipeline.trigger.integration.tests.sh
@@ -73,6 +73,13 @@ echo "        artifact_paths:"
 echo "          - build/elastic-stack-dump/stack/*/logs/*.log"
 echo "          - build/packages/*.sig"
 
+echo "      - label: \":go: Running integration test: test-instgall-zip\""
+echo "        command: ./.buildkite/scripts/integration_tests.sh -t test-install-zip"
+echo "        agents:"
+echo "          provider: \"gcp\""
+echo "        artifact_paths:"
+echo "          - build/elastic-stack-dump/stack/*/logs/*.log"
+
 echo "      - label: \":go: Running integration test: test-profiles-command\""
 echo "        command: ./.buildkite/scripts/integration_tests.sh -t test-profiles-command"
 echo "        agents:"

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,10 @@ test-check-packages-with-custom-agent:
 test-build-zip:
 	./scripts/test-build-zip.sh
 
+# TODO remove version once default one is 8.7.0 or higher
+test-install-zip:
+	./scripts/test-install-zip.sh 8.7.0-SNAPSHOT
+
 test-profiles-command:
 	./scripts/test-profiles-command.sh
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ _Context: package_
 
 Use this command to install the package in Kibana.
 
-The command uses Kibana API to install the package in Kibana. The package must be exposed via the Package Registry.
+The command uses Kibana API to install the package in Kibana. The package must be exposed via the Package Registry or built locally in zip format so they can be installed using --zip parameter. Zip packages can be installed directly in Kibana >= 8.7.0.
 
 ### `elastic-package lint`
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -85,15 +85,7 @@ func installLocalPackage(cmd *cobra.Command, m *packages.PackageManifest) error 
 		return errors.Wrap(err, "can't create the package installer")
 	}
 
-	cmd.Println("Install the package")
-	installedPackage, err := packageInstaller.Install()
-	if err != nil {
-		return errors.Wrap(err, "can't install the package")
-	}
-
-	showAssets(cmd, installedPackage)
-	cmd.Println("Done")
-	return nil
+	return installPackage(cmd, packageInstaller)
 }
 
 func installZipPackage(cmd *cobra.Command, zipPath string) error {
@@ -104,20 +96,20 @@ func installZipPackage(cmd *cobra.Command, zipPath string) error {
 		return errors.Wrap(err, "can't create the package installer")
 	}
 
+	return installPackage(cmd, packageInstaller)
+}
+
+func installPackage(cmd *cobra.Command, packageInstaller installer.Installer) error {
 	cmd.Println("Install the package")
 	installedPackage, err := packageInstaller.Install()
 	if err != nil {
 		return errors.Wrap(err, "can't install the package")
 	}
 
-	showAssets(cmd, installedPackage)
-	cmd.Println("Done")
-	return nil
-}
-
-func showAssets(cmd *cobra.Command, installedPackage *installer.InstalledPackage) {
 	cmd.Println("Installed assets:")
 	for _, asset := range installedPackage.Assets {
 		cmd.Printf("- %s (type: %s)\n", asset.ID, asset.Type)
 	}
+	cmd.Println("Done")
+	return nil
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -92,10 +92,7 @@ func installLocalPackage(cmd *cobra.Command, m *packages.PackageManifest) error 
 		return errors.Wrap(err, "can't install the package")
 	}
 
-	cmd.Println("Installed assets:")
-	for _, asset := range installedPackage.Assets {
-		cmd.Printf("- %s (type: %s)\n", asset.ID, asset.Type)
-	}
+	showAssets(cmd, installedPackage)
 	cmd.Println("Done")
 	return nil
 }
@@ -103,6 +100,24 @@ func installLocalPackage(cmd *cobra.Command, m *packages.PackageManifest) error 
 func installZipPackage(cmd *cobra.Command, zipPath string) error {
 	cmd.Printf("Install zip package: %s\n", zipPath)
 
+	packageInstaller, err := installer.CreateForZip(zipPath)
+	if err != nil {
+		return errors.Wrap(err, "can't create the package installer")
+	}
+
+	installedPackage, err := packageInstaller.Install()
+	if err != nil {
+		return errors.Wrap(err, "can't install the package")
+	}
+
+	showAssets(cmd, installedPackage)
 	cmd.Println("Done")
 	return nil
+}
+
+func showAssets(cmd *cobra.Command, installedPackage *installer.InstalledPackage) {
+	cmd.Println("Installed assets:")
+	for _, asset := range installedPackage.Assets {
+		cmd.Printf("- %s (type: %s)\n", asset.ID, asset.Type)
+	}
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -74,12 +74,12 @@ func installCommandAction(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	return aInstaller.install(cmd, manifest)
+	return aInstaller.install(cmd, manifest.Name, manifest.Version)
 }
 
 type packageInstaller interface {
 	manifest() (*packages.PackageManifest, error)
-	install(cmd *cobra.Command, manifest *packages.PackageManifest) error
+	install(cmd *cobra.Command, name, version string) error
 }
 
 func newInstaller(zipPath, packageRootPath string) packageInstaller {
@@ -102,8 +102,8 @@ func (l localPackage) manifest() (*packages.PackageManifest, error) {
 	return manifest, nil
 }
 
-func (l localPackage) install(cmd *cobra.Command, manifest *packages.PackageManifest) error {
-	aInstaller, err := installer.CreateForManifest(*manifest)
+func (l localPackage) install(cmd *cobra.Command, name, version string) error {
+	aInstaller, err := installer.CreateForManifest(name, version)
 	if err != nil {
 		return errors.Wrap(err, "can't create the package installer")
 	}
@@ -125,8 +125,8 @@ func (z zipPackage) manifest() (*packages.PackageManifest, error) {
 	return manifest, nil
 }
 
-func (z zipPackage) install(cmd *cobra.Command, manifest *packages.PackageManifest) error {
-	aInstaller, err := installer.CreateForZip(z.zipPath, *manifest)
+func (z zipPackage) install(cmd *cobra.Command, name, version string) error {
+	aInstaller, err := installer.CreateForZip(z.zipPath, name, version)
 	if err != nil {
 		return errors.Wrap(err, "can't create the package installer")
 	}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -16,7 +16,7 @@ import (
 
 const installLongDescription = `Use this command to install the package in Kibana.
 
-The command uses Kibana API to install the package in Kibana. The package must be exposed via the Package Registry.`
+The command uses Kibana API to install the package in Kibana. The package must be exposed via the Package Registry or built locally in zip format so they can be installed using --zip parameter. Zip packages can be installed directly in Kibana >= 8.7.0.`
 
 func setupInstallCommand() *cobraext.Command {
 	cmd := &cobra.Command{

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -64,7 +64,6 @@ func installCommandAction(cmd *cobra.Command, _ []string) error {
 		if err != nil {
 			return errors.Wrapf(err, "reading package manifest failed (path: %s)", packageRootPath)
 		}
-
 	}
 
 	// Check conditions

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -95,22 +95,22 @@ func installLocalPackage(cmd *cobra.Command, m *packages.PackageManifest) error 
 		return errors.Wrap(err, "can't create the package installer")
 	}
 
+	cmd.Println("Install the package")
 	return installPackage(cmd, packageInstaller)
 }
 
 func installZipPackage(cmd *cobra.Command, zipPath string, m *packages.PackageManifest) error {
-	cmd.Printf("Install zip package: %s\n", zipPath)
 
 	packageInstaller, err := installer.CreateForZip(zipPath, *m)
 	if err != nil {
 		return errors.Wrap(err, "can't create the package installer")
 	}
 
+	cmd.Printf("Install zip package: %s\n", zipPath)
 	return installPackage(cmd, packageInstaller)
 }
 
 func installPackage(cmd *cobra.Command, packageInstaller installer.Installer) error {
-	cmd.Println("Install the package")
 	installedPackage, err := packageInstaller.Install()
 	if err != nil {
 		return errors.Wrap(err, "can't install the package")

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -85,7 +85,6 @@ func installLocalPackage(cmd *cobra.Command, m *packages.PackageManifest) error 
 		return errors.Wrap(err, "can't create the package installer")
 	}
 
-	// Install the package
 	cmd.Println("Install the package")
 	installedPackage, err := packageInstaller.Install()
 	if err != nil {
@@ -105,6 +104,7 @@ func installZipPackage(cmd *cobra.Command, zipPath string) error {
 		return errors.Wrap(err, "can't create the package installer")
 	}
 
+	cmd.Println("Install the package")
 	installedPackage, err := packageInstaller.Install()
 	if err != nil {
 		return errors.Wrap(err, "can't install the package")

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -42,12 +42,12 @@ func installCommandAction(cmd *cobra.Command, _ []string) error {
 		return cobraext.FlagParsingError(err, cobraext.PackageRootFlagName)
 	}
 
-	aInstaller, err := newInstaller(zipPathFile, packageRootPath)
+	installer, err := newInstaller(zipPathFile, packageRootPath)
 	if err != nil {
 		return err
 	}
 
-	manifest, err := aInstaller.manifest()
+	manifest, err := installer.manifest()
 	if err != nil {
 		return err
 	}
@@ -68,7 +68,7 @@ func installCommandAction(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	return aInstaller.install(cmd, manifest.Name, manifest.Version)
+	return installer.install(cmd, manifest.Name, manifest.Version)
 }
 
 type packageInstaller interface {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -26,15 +26,15 @@ func setupInstallCommand() *cobraext.Command {
 	}
 	cmd.Flags().StringSliceP(cobraext.CheckConditionFlagName, "c", nil, cobraext.CheckConditionFlagDescription)
 	cmd.Flags().StringP(cobraext.PackageRootFlagName, cobraext.PackageRootFlagShorthand, "", cobraext.PackageRootFlagDescription)
-	cmd.Flags().StringP(cobraext.InstallZipPackageFlagName, "", "", cobraext.InstallZipPackageFlagDescription)
+	cmd.Flags().StringP(cobraext.ZipPackageFilePathFlagName, cobraext.ZipPackageFilePathFlagShorthand, "", cobraext.ZipPackageFilePathFlagDescription)
 
 	return cobraext.NewCommand(cmd, cobraext.ContextPackage)
 }
 
 func installCommandAction(cmd *cobra.Command, _ []string) error {
-	zipPathFile, err := cmd.Flags().GetString(cobraext.InstallZipPackageFlagName)
+	zipPathFile, err := cmd.Flags().GetString(cobraext.ZipPackageFilePathFlagName)
 	if err != nil {
-		return cobraext.FlagParsingError(err, cobraext.InstallZipPackageFlagName)
+		return cobraext.FlagParsingError(err, cobraext.ZipPackageFilePathFlagName)
 	}
 	if zipPathFile != "" {
 		return installZipPackage(cmd, zipPathFile)

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -42,7 +42,7 @@ func uninstallCommandAction(cmd *cobra.Command, args []string) error {
 		return errors.Wrapf(err, "reading package manifest failed (path: %s)", packageRootPath)
 	}
 
-	packageInstaller, err := installer.CreateForManifest(*m)
+	packageInstaller, err := installer.CreateForManifest(m.Name, m.Version)
 	if err != nil {
 		return errors.Wrap(err, "can't create the package installer")
 	}

--- a/internal/cobraext/flags.go
+++ b/internal/cobraext/flags.go
@@ -95,6 +95,9 @@ const (
 	GenerateTestResultFlagName        = "generate"
 	GenerateTestResultFlagDescription = "generate test result file"
 
+	InstallZipPackageFlagName        = "zip"
+	InstallZipPackageFlagDescription = "install package from zip file path"
+
 	ProfileFlagName        = "profile"
 	ProfileFlagDescription = "select a profile to use for the stack configuration. Can also be set with %s"
 

--- a/internal/cobraext/flags.go
+++ b/internal/cobraext/flags.go
@@ -95,9 +95,6 @@ const (
 	GenerateTestResultFlagName        = "generate"
 	GenerateTestResultFlagDescription = "generate test result file"
 
-	InstallZipPackageFlagName        = "zip"
-	InstallZipPackageFlagDescription = "install package from zip file path"
-
 	ProfileFlagName        = "profile"
 	ProfileFlagDescription = "select a profile to use for the stack configuration. Can also be set with %s"
 
@@ -149,6 +146,10 @@ const (
 
 	VariantFlagName        = "variant"
 	VariantFlagDescription = "service variant"
+
+	ZipPackageFilePathFlagName        = "zip"
+	ZipPackageFilePathFlagShorthand   = "z"
+	ZipPackageFilePathFlagDescription = "path to the zip package file (*.zip)"
 
 	// To be removed promote commands flags
 	DirectionFlagName        = "direction"

--- a/internal/kibana/client.go
+++ b/internal/kibana/client.go
@@ -150,8 +150,6 @@ func (c *Client) doRequest(request *http.Request) (int, []byte, error) {
 		}
 	}
 
-	logger.Debugf("Headers: %s", request.Header)
-
 	resp, err := client.Do(request)
 	if err != nil {
 		return 0, nil, errors.Wrap(err, "could not send request to Kibana API")

--- a/internal/kibana/client.go
+++ b/internal/kibana/client.go
@@ -21,8 +21,6 @@ import (
 	"github.com/elastic/elastic-package/internal/stack"
 )
 
-const defaultContentType = "application/json"
-
 // Client is responsible for exporting dashboards from Kibana.
 type Client struct {
 	host     string

--- a/internal/kibana/client.go
+++ b/internal/kibana/client.go
@@ -21,7 +21,7 @@ import (
 	"github.com/elastic/elastic-package/internal/stack"
 )
 
-const DefaultContentType = "application/json"
+const defaultContentType = "application/json"
 
 // Client is responsible for exporting dashboards from Kibana.
 type Client struct {
@@ -83,11 +83,11 @@ func CertificateAuthority(certificateAuthority string) ClientOption {
 }
 
 func (c *Client) get(resourcePath string) (int, []byte, error) {
-	return c.sendRequest(http.MethodGet, resourcePath, nil, map[string]string{"content-type": DefaultContentType})
+	return c.sendRequest(http.MethodGet, resourcePath, nil, map[string]string{"content-type": defaultContentType})
 }
 
 func (c *Client) post(resourcePath string, body []byte) (int, []byte, error) {
-	return c.sendRequest(http.MethodPost, resourcePath, body, map[string]string{"content-type": DefaultContentType})
+	return c.sendRequest(http.MethodPost, resourcePath, body, map[string]string{"content-type": defaultContentType})
 }
 
 func (c *Client) postFile(resourcePath, contentTypeHeader string, body []byte) (int, []byte, error) {
@@ -95,11 +95,11 @@ func (c *Client) postFile(resourcePath, contentTypeHeader string, body []byte) (
 }
 
 func (c *Client) put(resourcePath string, body []byte) (int, []byte, error) {
-	return c.sendRequest(http.MethodPut, resourcePath, body, map[string]string{"content-type": DefaultContentType})
+	return c.sendRequest(http.MethodPut, resourcePath, body, map[string]string{"content-type": defaultContentType})
 }
 
 func (c *Client) delete(resourcePath string) (int, []byte, error) {
-	return c.sendRequest(http.MethodDelete, resourcePath, nil, map[string]string{"content-type": DefaultContentType})
+	return c.sendRequest(http.MethodDelete, resourcePath, nil, map[string]string{"content-type": defaultContentType})
 }
 
 func (c *Client) sendRequest(method, resourcePath string, body []byte, extraHeaders map[string]string) (int, []byte, error) {
@@ -118,7 +118,6 @@ func (c *Client) sendRequest(method, resourcePath string, body []byte, extraHead
 	u.RawQuery = rel.RawQuery
 
 	logger.Debugf("%s %s", method, u)
-	logger.Debugf("Request %s", u.String())
 
 	req, err := http.NewRequest(method, u.String(), reqBody)
 	if err != nil {
@@ -131,9 +130,6 @@ func (c *Client) sendRequest(method, resourcePath string, body []byte, extraHead
 	for k, v := range extraHeaders {
 		req.Header.Add(k, v)
 	}
-
-	logger.Debugf("Headers %s", req.Header)
-	logger.Debugf("ContentLength %s", req.ContentLength)
 
 	client := http.Client{}
 	if c.tlSkipVerify {

--- a/internal/kibana/client.go
+++ b/internal/kibana/client.go
@@ -87,10 +87,10 @@ func (c *Client) get(resourcePath string) (int, []byte, error) {
 }
 
 func (c *Client) post(resourcePath string, body []byte) (int, []byte, error) {
-	return c.sendRequest(http.MethodPost, resourcePath, body, map[string]string{"content-type": defaultContentType})
+	return c.postWithContentType(resourcePath, defaultContentType, body)
 }
 
-func (c *Client) postFile(resourcePath, contentTypeHeader string, body []byte) (int, []byte, error) {
+func (c *Client) postWithContentType(resourcePath, contentTypeHeader string, body []byte) (int, []byte, error) {
 	return c.sendRequest(http.MethodPost, resourcePath, body, map[string]string{"content-type": contentTypeHeader})
 }
 

--- a/internal/kibana/client.go
+++ b/internal/kibana/client.go
@@ -97,7 +97,7 @@ func (c *Client) delete(resourcePath string) (int, []byte, error) {
 }
 
 func (c *Client) sendRequest(method, resourcePath string, body []byte) (int, []byte, error) {
-	request, err := c.newRequest(method, resourcePath, body)
+	request, err := c.newRequest(method, resourcePath, bytes.NewReader(body))
 	if err != nil {
 		return 0, nil, err
 	}
@@ -105,8 +105,7 @@ func (c *Client) sendRequest(method, resourcePath string, body []byte) (int, []b
 	return c.doRequest(request)
 }
 
-func (c *Client) newRequest(method, resourcePath string, body []byte) (*http.Request, error) {
-	reqBody := bytes.NewReader(body)
+func (c *Client) newRequest(method, resourcePath string, reqBody io.Reader) (*http.Request, error) {
 	base, err := url.Parse(c.host)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not create base URL from host: %v", c.host)

--- a/internal/kibana/packages.go
+++ b/internal/kibana/packages.go
@@ -31,7 +31,7 @@ func (c *Client) InstallPackage(pkg packages.PackageManifest) ([]packages.Asset,
 
 // InstallZipPackage installs the local zip package in Fleet.
 func (c *Client) InstallZipPackage(zipFile string) ([]packages.Asset, error) {
-	path := fmt.Sprintf("%s/epm/packages/", FleetAPI)
+	path := fmt.Sprintf("%s/epm/packages", FleetAPI)
 
 	fileContents, err := os.ReadFile(zipFile)
 	if err != nil {

--- a/internal/kibana/packages.go
+++ b/internal/kibana/packages.go
@@ -43,7 +43,7 @@ func (c *Client) InstallZipPackage(zipFile string) ([]packages.Asset, error) {
 	case strings.HasSuffix(zipFile, ".zip"):
 		contentTypeHeader = "application/zip"
 	default:
-		return nil, errors.Wrap(err, "compress file not supported")
+		return nil, errors.Errorf("archive type not supported")
 	}
 
 	statusCode, respBody, err := c.postFile(path, contentTypeHeader, fileContents)

--- a/internal/kibana/packages.go
+++ b/internal/kibana/packages.go
@@ -16,8 +16,8 @@ import (
 )
 
 // InstallPackage installs the given package in Fleet.
-func (c *Client) InstallPackage(pkg packages.PackageManifest) ([]packages.Asset, error) {
-	path := fmt.Sprintf("%s/epm/packages/%s-%s", FleetAPI, pkg.Name, pkg.Version)
+func (c *Client) InstallPackage(name, version string) ([]packages.Asset, error) {
+	path := fmt.Sprintf("%s/epm/packages/%s-%s", FleetAPI, name, version)
 	reqBody := []byte(`{"force":true}`) // allows installing older versions of the package being tested
 
 	statusCode, respBody, err := c.post(path, reqBody)
@@ -52,8 +52,8 @@ func (c *Client) InstallZipPackage(zipFile string) ([]packages.Asset, error) {
 }
 
 // RemovePackage removes the given package from Fleet.
-func (c *Client) RemovePackage(pkg packages.PackageManifest) ([]packages.Asset, error) {
-	path := fmt.Sprintf("%s/epm/packages/%s-%s", FleetAPI, pkg.Name, pkg.Version)
+func (c *Client) RemovePackage(name, version string) ([]packages.Asset, error) {
+	path := fmt.Sprintf("%s/epm/packages/%s-%s", FleetAPI, name, version)
 	statusCode, respBody, err := c.delete(path)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not delete package")

--- a/internal/kibana/packages.go
+++ b/internal/kibana/packages.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/pkg/errors"
 
@@ -38,15 +37,13 @@ func (c *Client) InstallZipPackage(zipFile string) ([]packages.Asset, error) {
 		return nil, errors.Wrap(err, "failed to read zip file")
 	}
 
-	contentTypeHeader := ""
-	switch {
-	case strings.HasSuffix(zipFile, ".zip"):
-		contentTypeHeader = "application/zip"
-	default:
-		return nil, errors.Errorf("archive type not supported")
+	req, err := c.newRequest(http.MethodPost, path, fileContents)
+	if err != nil {
+		return nil, err
 	}
+	req.Header.Set("Content-Type", "application/zip")
 
-	statusCode, respBody, err := c.postWithContentType(path, contentTypeHeader, fileContents)
+	statusCode, respBody, err := c.doRequest(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not install zip package")
 	}

--- a/internal/kibana/packages.go
+++ b/internal/kibana/packages.go
@@ -32,12 +32,12 @@ func (c *Client) InstallPackage(name, version string) ([]packages.Asset, error) 
 func (c *Client) InstallZipPackage(zipFile string) ([]packages.Asset, error) {
 	path := fmt.Sprintf("%s/epm/packages", FleetAPI)
 
-	fileContents, err := os.ReadFile(zipFile)
+	body, err := os.Open(zipFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read zip file")
 	}
 
-	req, err := c.newRequest(http.MethodPost, path, fileContents)
+	req, err := c.newRequest(http.MethodPost, path, body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/kibana/packages.go
+++ b/internal/kibana/packages.go
@@ -46,7 +46,7 @@ func (c *Client) InstallZipPackage(zipFile string) ([]packages.Asset, error) {
 		return nil, errors.Errorf("archive type not supported")
 	}
 
-	statusCode, respBody, err := c.postFile(path, contentTypeHeader, fileContents)
+	statusCode, respBody, err := c.postWithContentType(path, contentTypeHeader, fileContents)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not install package")
 	}

--- a/internal/kibana/packages.go
+++ b/internal/kibana/packages.go
@@ -48,7 +48,7 @@ func (c *Client) InstallZipPackage(zipFile string) ([]packages.Asset, error) {
 
 	statusCode, respBody, err := c.postWithContentType(path, contentTypeHeader, fileContents)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not install package")
+		return nil, errors.Wrap(err, "could not install zip package")
 	}
 
 	return processResults("zip-install", statusCode, respBody)

--- a/internal/kibana/packages.go
+++ b/internal/kibana/packages.go
@@ -36,6 +36,7 @@ func (c *Client) InstallZipPackage(zipFile string) ([]packages.Asset, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read zip file")
 	}
+	defer body.Close()
 
 	req, err := c.newRequest(http.MethodPost, path, body)
 	if err != nil {

--- a/internal/packages/installer/installer.go
+++ b/internal/packages/installer/installer.go
@@ -30,7 +30,7 @@ type InstalledPackage struct {
 }
 
 // CreateForManifest function creates a new instance of the installer.
-func CreateForManifest(manifest packages.PackageManifest) (Installer, error) {
+func CreateForManifest(manifest packages.PackageManifest) (*manifestInstaller, error) {
 	kibanaClient, err := kibana.NewClient()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create kibana client")

--- a/internal/packages/installer/installer.go
+++ b/internal/packages/installer/installer.go
@@ -18,46 +18,50 @@ type Installer interface {
 }
 
 type manifestInstaller struct {
-	manifest packages.PackageManifest
+	name    string
+	version string
 
 	kibanaClient *kibana.Client
 }
 
 // InstalledPackage represents the installed package (including assets).
 type InstalledPackage struct {
-	Assets   []packages.Asset
-	Manifest packages.PackageManifest
+	Assets  []packages.Asset
+	Name    string
+	Version string
 }
 
 // CreateForManifest function creates a new instance of the installer.
-func CreateForManifest(manifest packages.PackageManifest) (*manifestInstaller, error) {
+func CreateForManifest(name, version string) (*manifestInstaller, error) {
 	kibanaClient, err := kibana.NewClient()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create kibana client")
 	}
 
 	return &manifestInstaller{
-		manifest:     manifest,
+		name:         name,
+		version:      version,
 		kibanaClient: kibanaClient,
 	}, nil
 }
 
 // Install method installs the package using Kibana API.
 func (i *manifestInstaller) Install() (*InstalledPackage, error) {
-	assets, err := i.kibanaClient.InstallPackage(i.manifest)
+	assets, err := i.kibanaClient.InstallPackage(i.name, i.version)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't install the package")
 	}
 
 	return &InstalledPackage{
-		Manifest: i.manifest,
-		Assets:   assets,
+		Name:    i.name,
+		Version: i.version,
+		Assets:  assets,
 	}, nil
 }
 
 // Uninstall method uninstalls the package using Kibana API.
 func (i *manifestInstaller) Uninstall() error {
-	_, err := i.kibanaClient.RemovePackage(i.manifest)
+	_, err := i.kibanaClient.RemovePackage(i.name, i.version)
 	if err != nil {
 		return errors.Wrap(err, "can't remove the package")
 	}

--- a/internal/packages/installer/zip_installer.go
+++ b/internal/packages/installer/zip_installer.go
@@ -23,7 +23,7 @@ type zipInstaller struct {
 	kibanaClient *kibana.Client
 }
 
-// CreateForManifest function creates a new instance of the installer.
+// CreateForZip function creates a new instance of the installer.
 func CreateForZip(zipPath string) (Installer, error) {
 	kibanaClient, err := kibana.NewClient()
 	if err != nil {
@@ -47,7 +47,11 @@ func CreateForZip(zipPath string) (Installer, error) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	uncompressManifestZipPackage(zipPath, tempDir)
+	err = uncompressManifestZipPackage(zipPath, tempDir)
+	if err != nil {
+		return nil, errors.Wrap(err, "extracting manifest from zip failed")
+	}
+
 	m, err := packages.ReadPackageManifestFromPackageRoot(tempDir)
 	if err != nil {
 		return nil, errors.Wrapf(err, "reading package manifest from zip failed (path: %s)", zipPath)
@@ -97,7 +101,7 @@ func uncompressManifestZipPackage(zipPath, target string) error {
 }
 
 // Install method installs the package using Kibana API.
-func (i zipInstaller) Install() (*InstalledPackage, error) {
+func (i *zipInstaller) Install() (*InstalledPackage, error) {
 	assets, err := i.kibanaClient.InstallZipPackage(i.zipPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't install the package")
@@ -110,6 +114,6 @@ func (i zipInstaller) Install() (*InstalledPackage, error) {
 }
 
 // Uninstall method uninstalls the package using Kibana API.
-func (i zipInstaller) Uninstall() error {
+func (i *zipInstaller) Uninstall() error {
 	return errors.Errorf("not implemented")
 }

--- a/internal/packages/installer/zip_installer.go
+++ b/internal/packages/installer/zip_installer.go
@@ -24,7 +24,7 @@ type zipInstaller struct {
 }
 
 // CreateForZip function creates a new instance of the installer.
-func CreateForZip(zipPath string) (Installer, error) {
+func CreateForZip(zipPath string, m packages.PackageManifest) (Installer, error) {
 	kibanaClient, err := kibana.NewClient()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create kibana client")
@@ -41,15 +41,10 @@ func CreateForZip(zipPath string) (Installer, error) {
 		return nil, fmt.Errorf("not supported uploading zip packages in Kibana %s", kibanaVersion.Number)
 	}
 
-	manifest, err := packages.ReadPackageManifestFromZipPackage(zipPath)
-	if err != nil {
-		return nil, err
-	}
-
 	return &zipInstaller{
 		zipPath:      zipPath,
 		kibanaClient: kibanaClient,
-		manifest:     *manifest,
+		manifest:     m,
 	}, nil
 }
 

--- a/internal/packages/installer/zip_installer.go
+++ b/internal/packages/installer/zip_installer.go
@@ -1,0 +1,106 @@
+package installer
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/elastic-package/internal/kibana"
+	"github.com/elastic/elastic-package/internal/packages"
+)
+
+type zipInstaller struct {
+	zipPath  string
+	manifest packages.PackageManifest
+
+	kibanaClient *kibana.Client
+}
+
+// CreateForManifest function creates a new instance of the installer.
+func CreateForZip(zipPath string) (Installer, error) {
+	kibanaClient, err := kibana.NewClient()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create kibana client")
+	}
+	kibanaVersion, err := kibanaClient.Version()
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("Kibana Version %s\n", kibanaVersion.Number)
+
+	tempDir, err := os.MkdirTemp("", "elastic-package-")
+	if err != nil {
+		return nil, errors.Wrap(err, "can't prepare a temporary directory")
+	}
+	defer os.RemoveAll(tempDir)
+
+	uncompressManifestZipPackage(zipPath, tempDir)
+	m, err := packages.ReadPackageManifestFromPackageRoot(tempDir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "reading package manifest from zip failed (path: %s)", zipPath)
+	}
+
+	return &zipInstaller{
+		zipPath:      zipPath,
+		kibanaClient: kibanaClient,
+		manifest:     *m,
+	}, nil
+}
+
+func uncompressManifestZipPackage(zipPath, target string) error {
+	zipReader, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return err
+	}
+	defer zipReader.Close()
+	targetPath := filepath.Join(target, packages.PackageManifestFile)
+	outputFile, err := os.OpenFile(
+		targetPath,
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+		0644,
+	)
+	if err != nil {
+		return err
+	}
+	defer outputFile.Close()
+
+	for _, f := range zipReader.File {
+		if f.Name != packages.PackageManifestFile {
+			continue
+		}
+		zippedFile, err := f.Open()
+		if err != nil {
+			return err
+		}
+		defer zippedFile.Close()
+
+		_, err = io.Copy(outputFile, zippedFile)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	return errors.Errorf("not found package %s in %s", packages.PackageManifestFile, zipPath)
+}
+
+// Install method installs the package using Kibana API.
+func (i zipInstaller) Install() (*InstalledPackage, error) {
+	assets, err := i.kibanaClient.InstallZipPackage(i.zipPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't install the package")
+	}
+
+	return &InstalledPackage{
+		Manifest: i.manifest,
+		Assets:   assets,
+	}, nil
+}
+
+// Uninstall method uninstalls the package using Kibana API.
+func (i zipInstaller) Uninstall() error {
+	return errors.Errorf("not implemented")
+}

--- a/internal/packages/installer/zip_installer.go
+++ b/internal/packages/installer/zip_installer.go
@@ -7,11 +7,14 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/packages"
 )
+
+var semver8_7_0 = semver.MustParse("8.7.0")
 
 type zipInstaller struct {
 	zipPath  string
@@ -30,7 +33,13 @@ func CreateForZip(zipPath string) (Installer, error) {
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("Kibana Version %s\n", kibanaVersion.Number)
+	v, err := semver.NewVersion(kibanaVersion.Number)
+	if err != nil {
+		return nil, fmt.Errorf("invalid kibana version")
+	}
+	if v.LessThan(semver8_7_0) {
+		return nil, fmt.Errorf("not supported uploading zip packages in %s", kibanaVersion.Number)
+	}
 
 	tempDir, err := os.MkdirTemp("", "elastic-package-")
 	if err != nil {

--- a/internal/packages/installer/zip_installer.go
+++ b/internal/packages/installer/zip_installer.go
@@ -11,20 +11,20 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/kibana"
-	"github.com/elastic/elastic-package/internal/packages"
 )
 
 var semver8_7_0 = semver.MustParse("8.7.0")
 
 type zipInstaller struct {
-	zipPath  string
-	manifest packages.PackageManifest
+	zipPath string
+	name    string
+	version string
 
 	kibanaClient *kibana.Client
 }
 
 // CreateForZip function creates a new instance of the installer.
-func CreateForZip(zipPath string, m packages.PackageManifest) (*zipInstaller, error) {
+func CreateForZip(zipPath, name, version string) (*zipInstaller, error) {
 	kibanaClient, err := kibana.NewClient()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create kibana client")
@@ -44,7 +44,8 @@ func CreateForZip(zipPath string, m packages.PackageManifest) (*zipInstaller, er
 	return &zipInstaller{
 		zipPath:      zipPath,
 		kibanaClient: kibanaClient,
-		manifest:     m,
+		name:         name,
+		version:      version,
 	}, nil
 }
 
@@ -56,14 +57,15 @@ func (i *zipInstaller) Install() (*InstalledPackage, error) {
 	}
 
 	return &InstalledPackage{
-		Manifest: i.manifest,
-		Assets:   assets,
+		Name:    i.name,
+		Version: i.version,
+		Assets:  assets,
 	}, nil
 }
 
 // Uninstall method uninstalls the package using Kibana API.
 func (i *zipInstaller) Uninstall() error {
-	_, err := i.kibanaClient.RemovePackage(i.manifest)
+	_, err := i.kibanaClient.RemovePackage(i.name, i.version)
 	if err != nil {
 		return errors.Wrap(err, "can't remove the package")
 	}

--- a/internal/packages/installer/zip_installer.go
+++ b/internal/packages/installer/zip_installer.go
@@ -24,7 +24,7 @@ type zipInstaller struct {
 }
 
 // CreateForZip function creates a new instance of the installer.
-func CreateForZip(zipPath string, m packages.PackageManifest) (Installer, error) {
+func CreateForZip(zipPath string, m packages.PackageManifest) (*zipInstaller, error) {
 	kibanaClient, err := kibana.NewClient()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create kibana client")

--- a/internal/packages/installer/zip_installer.go
+++ b/internal/packages/installer/zip_installer.go
@@ -63,5 +63,9 @@ func (i *zipInstaller) Install() (*InstalledPackage, error) {
 
 // Uninstall method uninstalls the package using Kibana API.
 func (i *zipInstaller) Uninstall() error {
-	return errors.Errorf("not implemented")
+	_, err := i.kibanaClient.RemovePackage(i.manifest)
+	if err != nil {
+		return errors.Wrap(err, "can't remove the package")
+	}
+	return nil
 }

--- a/internal/packages/installer/zip_installer.go
+++ b/internal/packages/installer/zip_installer.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package installer
 
 import (

--- a/internal/testrunner/runners/asset/runner.go
+++ b/internal/testrunner/runners/asset/runner.go
@@ -82,7 +82,7 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 		return result.WithError(errors.Wrapf(err, "reading package manifest failed (path: %s)", r.packageRootPath))
 	}
 
-	packageInstaller, err := installer.CreateForManifest(*manifest)
+	packageInstaller, err := installer.CreateForManifest(manifest.Name, manifest.Version)
 	if err != nil {
 		return result.WithError(errors.Wrap(err, "can't create the package installer"))
 	}
@@ -108,7 +108,7 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 	for _, e := range expectedAssets {
 		rc := testrunner.NewResultComposer(testrunner.TestResult{
 			Name:       fmt.Sprintf("%s %s is loaded", e.Type, e.ID),
-			Package:    installedPackage.Manifest.Name,
+			Package:    installedPackage.Name,
 			DataStream: e.DataStream,
 			TestType:   TestType,
 		})

--- a/scripts/test-install-zip.sh
+++ b/scripts/test-install-zip.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+STACK_VERSION=${1:-default}
+
+cleanup() {
+  r=$?
+
+  # Dump stack logs
+  elastic-package stack dump -v --output build/elastic-stack-dump/install-zip
+
+  # Take down the stack
+  elastic-package stack down -v
+
+  for d in test/packages/*/*/; do
+    (
+      cd $d
+      elastic-package clean -v
+    )
+  done
+
+  exit $r
+}
+
+trap cleanup EXIT
+
+ARG_VERSION=""
+if [ "${STACK_VERSION}" != "default" ]; then
+  ARG_VERSION="--version ${STACK_VERSION}"
+fi
+
+# Update the stack
+elastic-package stack update -v ${ARG_VERSION}
+
+# Boot up the stack
+elastic-package stack up -d -v ${ARG_VERSION}
+
+# Verify it's accessible
+eval "$(elastic-package stack shellinit)"
+
+export ELASTIC_PACKAGE_LINKS_FILE_PATH="$(pwd)/scripts/links_table.yml"
+OLDPWD=$PWD
+
+# Build packages
+for d in test/packages/*/*/; do
+  (
+    cd $d
+    elastic-package build
+  )
+done
+cd $OLDPWD
+
+# Remove unzipped built packages, leave .zip files
+rm -r build/packages/*/
+
+# Install packages and verify
+for zipFile in build/packages/*.zip; do
+  PACKAGE_NAME_VERSION=$(basename ${zipFile} .zip)
+
+  # check that the package is installed
+  elastic-package install -v --zip ${zipFile}
+
+  curl -s \
+    -u ${ELASTIC_PACKAGE_ELASTICSEARCH_USERNAME}:${ELASTIC_PACKAGE_ELASTICSEARCH_PASSWORD} \
+    --cacert ${ELASTIC_PACKAGE_CA_CERT} \
+    -H 'content-type: application/json' \
+    -H 'kbn-xsrf: true' \
+    -f ${ELASTIC_PACKAGE_KIBANA_HOST}/api/fleet/epm/packages/${PACKAGE_NAME_VERSION} | grep -q '"status":"installed"'
+done

--- a/scripts/test-install-zip.sh
+++ b/scripts/test-install-zip.sh
@@ -58,9 +58,9 @@ rm -r build/packages/*/
 for zipFile in build/packages/*.zip; do
   PACKAGE_NAME_VERSION=$(basename ${zipFile} .zip)
 
-  # check that the package is installed
   elastic-package install -v --zip ${zipFile}
 
+  # check that the package is installed
   curl -s \
     -u ${ELASTIC_PACKAGE_ELASTICSEARCH_USERNAME}:${ELASTIC_PACKAGE_ELASTICSEARCH_PASSWORD} \
     --cacert ${ELASTIC_PACKAGE_CA_CERT} \


### PR DESCRIPTION
Relates https://github.com/elastic/elastic-package/issues/1084

This PR adds a new parameter under install command `--zip`. This parameter requires a path to a zip file (this package must be built using `elastic-package build` command):
```
 $ elastic-package install -h
Use this command to install the package in Kibana.

The command uses Kibana API to install the package in Kibana. The package must be exposed via the Package Registry or built locally in zip format so they can be installed using --zip parameter. Zip packages can be installed directly in Kibana >= 8.7.0.

Context: package

Usage:
  elastic-package install [flags]

Flags:
  -c, --check-condition strings   check if the condition is met for the package, but don't install the package (e.g. kibana.version=7.10.0)
  -h, --help                      help for install
  -R, --root string               root directory of the package
  -z, --zip string                path to the zip package file (*.zip)

Global Flags:
  -v, --verbose   verbose mode
```

This parameter will just be available if the Elastic stack running (kibana) version is >= 8.7.

Example of usage:
- Using Elastic stack 8.7.0-SNAPSHOT
```
 $ elastic-package install --zip /home/mariorodriguez/Coding/work/integrations/build/packages/elastic_package_registry-0.0.6.zip -v
2023/02/23 18:44:59 DEBUG Enable verbose logging
2023/02/23 18:44:59 DEBUG Distribution built without a version tag, can't determine release chronology. Please consider using official releases at https://github.com/elastic/elastic-package/releases
Install zip package: /home/mariorodriguez/Coding/work/integrations/build/packages/elastic_package_registry-0.0.6.zip
2023/02/23 18:44:59 DEBUG GET https://127.0.0.1:5601/api/status
Install the package
2023/02/23 18:44:59 DEBUG POST https://127.0.0.1:5601/api/fleet/epm/packages
Installed assets:
- elastic_package_registry-313c2700-099b-11ed-91b6-3b1f9c2b2771 (type: dashboard)
- metrics-elastic_package_registry.metrics-0.0.6 (type: ingest_pipeline)
- metrics-elastic_package_registry.metrics (type: index_template)
- metrics-elastic_package_registry.metrics@package (type: component_template)
- metrics-elastic_package_registry.metrics@custom (type: component_template)
Done
```
- Using Elastic stack 8.6.0
```
 $ elastic-package install --zip /home/mariorodriguez/Coding/work/integrations/build/packages/elastic_package_registry-0.0.6.zip -v
2023/02/24 10:35:10 DEBUG Enable verbose logging
2023/02/24 10:35:10 DEBUG Distribution built without a version tag, can't determine release chronology. Please consider using official releases at https://github.com/elastic/elastic-package/releases
Install zip package: /home/mariorodriguez/Coding/work/integrations/build/packages/elastic_package_registry-0.0.6.zip
2023/02/24 10:35:10 DEBUG GET https://127.0.0.1:5601/api/status
Error: can't create the package installer: not supported uploading zip packages in Kibana 8.6.0
```
- Set `check-condition` parameter with zip file:
```
 $ elastic-package install --zip build/packages/package_storage_candidate-0.0.1.zip -v --check-condition kibana.version=7.10.0
2023/02/27 17:08:33 DEBUG Enable verbose logging
2023/02/27 17:08:33 DEBUG Distribution built without a version tag, can't determine release chronology. Please consider using official releases at https://github.com/elastic/elastic-package/releases
2023/02/27 17:08:33 DEBUG Reading package manifest from build/packages/package_storage_candidate-0.0.1.zip
Check conditions for package
2023/02/27 17:08:33 DEBUG Verify Kibana version (constraint: ^8.0.0, requirement: 7.10.0)
Error: checking conditions failed: Kibana constraint unsatisfied: [0] 7.10.0 is less than 8.0.0
```