### PR TITLE
Fix search of repository root in Windows

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -41,6 +41,8 @@ steps:
         allow_failure: false
       - step: unit-tests-linux
         allow_failure: false
+      - step: unit-tests-windows
+        allow_failure: false
 
   - wait: ~
     continue_on_failure: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,12 +26,10 @@ steps:
 
   - label: ":go: :windows: Run unit tests"
     key: unit-tests-windows
-    command: "go test ./..."
+    command: ".buildkite/scripts/unit_tests_windows.ps1"
     agents:
-      windows: true
-      image: "golang:1.19.5-windowsservercore-ltsc2022"
-      cpu: "8"
-      memory: "4G"
+      provider: "gcp"
+      image: "family/ci-windows-2022"
 
   - wait: ~
     continue_on_failure: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,6 +24,15 @@ steps:
       cpu: "8"
       memory: "4G"
 
+  - label: ":go: :windows: Run unit tests"
+    key: unit-tests-windows
+    command: "go test ./..."
+    agents:
+      windows: true
+      image: "golang:1.19.5-windowsservercore-ltsc2022"
+      cpu: "8"
+      memory: "4G"
+
   - wait: ~
     continue_on_failure: true
 

--- a/.buildkite/scripts/unit_tests_windows.ps1
+++ b/.buildkite/scripts/unit_tests_windows.ps1
@@ -1,0 +1,24 @@
+echo "--- Fixing CRLF in git checkout"
+# Forcing to checkout again all the files with a correct autocrlf.
+# Doing this here because we cannot set git clone options before.
+git config core.autocrlf input
+git rm --quiet --cached -r .
+git reset --quiet --hard
+
+echo "--- Installing golang"
+choco install -y golang --version 1.19.5
+
+echo "--- Updating session environment"
+# refreshenv requires to have chocolatey profile installed
+$env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
+Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+
+refreshenv
+
+echo "--- Downloading Go modules"
+go version
+go mod download -x
+
+echo "--- Running unit tests"
+go version
+go test ./...

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -5,7 +5,7 @@
 package cmd
 
 import (
-	"strings"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -76,8 +76,8 @@ func buildCommandAction(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, target := range targets {
-		splitTarget := strings.Split(target, "/")
-		cmd.Printf("%s file rendered: %s\n", splitTarget[len(splitTarget)-1], target)
+		fileName := filepath.Base(target)
+		cmd.Printf("%s file rendered: %s\n", fileName, target)
 	}
 
 	target, err := builder.BuildPackage(builder.BuildOptions{

--- a/internal/certs/certs_test.go
+++ b/internal/certs/certs_test.go
@@ -142,6 +142,8 @@ func testCurl(t *testing.T, root *Certificate, commonName, address string) {
 		"--cacert", caCert,
 		// Send requests to the listener address.
 		"--resolve", reqAddress + ":" + serverHost,
+		// Ignore check for revocation status when not available.
+		"--ssl-revoke-best-effort",
 		"https://" + reqAddress,
 	}
 

--- a/internal/files/repository.go
+++ b/internal/files/repository.go
@@ -5,17 +5,20 @@
 package files
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
 func FindRepositoryRootDirectory() (string, error) {
 	workDir, err := os.Getwd()
 	if err != nil {
-		return "", errors.Wrap(err, "locating working directory failed")
+		return "", fmt.Errorf("locating working directory failed: %w", err)
 	}
+
+	// VolumeName() will return something like "C:" in Windows, and "" in other OSs
+	// rootDir will be something like "C:\" in Windows, and "/" everywhere else.
+	rootDir := filepath.VolumeName(workDir) + string(filepath.Separator)
 
 	dir := workDir
 	for dir != "." {
@@ -25,7 +28,7 @@ func FindRepositoryRootDirectory() (string, error) {
 			return dir, nil
 		}
 
-		if dir == "/" {
+		if dir == rootDir {
 			break
 		}
 		dir = filepath.Dir(dir)

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -173,6 +173,10 @@ func FindPackageRoot() (string, bool, error) {
 		return "", false, errors.Wrap(err, "locating working directory failed")
 	}
 
+	// VolumeName() will return something like "C:" in Windows, and "" in other OSs
+	// rootDir will be something like "C:\" in Windows, and "/" everywhere else.
+	rootDir := filepath.VolumeName(workDir) + string(filepath.Separator)
+
 	dir := workDir
 	for dir != "." {
 		path := filepath.Join(dir, PackageManifestFile)
@@ -187,7 +191,7 @@ func FindPackageRoot() (string, bool, error) {
 			}
 		}
 
-		if dir == "/" {
+		if dir == rootDir {
 			break
 		}
 		dir = filepath.Dir(dir)

--- a/internal/testrunner/coverageoutput.go
+++ b/internal/testrunner/coverageoutput.go
@@ -9,6 +9,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"time"
 
@@ -346,7 +347,7 @@ func transformToCoberturaReport(details *testCoverageDetails) *CoberturaCoverage
 
 		aClass := &CoberturaClass{
 			Name:     string(details.testType),
-			Filename: details.packageName + "/" + dataStream,
+			Filename: path.Join(details.packageName, dataStream),
 			Methods:  methods,
 		}
 		classes = append(classes, aClass)


### PR DESCRIPTION
When looking for the repository root in Windows, if the command hasn't been called inside a git repository, the search will loop forever, hanging the process. Same thing happens when looking for package root.

Finalization condition is based on checking all parent directories till root, but root was checked with "/", that will never be the case in Windows.

Changed to take into account the volume name and the OS-specific path separator.

Add step to buildkite pipeline to run unit tests on Windows.

Fixes https://github.com/elastic/elastic-package/issues/1100.