### PR TITLE
Remove notification of the build result in Jenkins

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -67,11 +67,6 @@ pipeline {
       }
     }
   }
-  post {
-    cleanup {
-      notifyBuildResult(prComment: true)
-    }
-  }
 }
 
 def cleanup(){


### PR DESCRIPTION
As this pipeline has been migrated to Buildkite, the notification related to build result should be removed.