### PR TITLE
Add skip validation flag in elastic-package install command

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -124,7 +124,7 @@ func newInstaller(zipPath, packageRootPath string, kibanaVersion *semver.Version
 		PackageRoot:    packageRootPath,
 		CreateZip:      true,
 		SignPackage:    false,
-		SkipValidation: false,
+		SkipValidation: true,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "building package failed")


### PR DESCRIPTION
Follow-up https://github.com/elastic/elastic-package/pull/1163

This PR adds the `--skip-validation` flag to the `elastic-package install` command.

By default, elastic-package install will validate the zip files before installing in the Kibana instance. Setting this new flag, this validation is skipped.

**NOTE**: This validation is just performed from Kibana>=8.7.0 where zip files are used. Previously, it is kept the same behavior.

This applies for both install directly a local zip file or running `elastic-package install`. 

Some examples using `elastic-package install --zip`:
- Running validation
```
 $ elastic-package install --zip ./elastic_package_registry-0.0.6.zip -v 
2023/03/08 18:15:02 DEBUG Enable verbose logging
2023/03/08 18:15:02 DEBUG Distribution built without a version tag, can't determine release chronology. Please consider using official releases at https://github.com/elastic/elastic-package/releases
2023/03/08 18:15:02 DEBUG GET https://127.0.0.1:5601/api/status
2023/03/08 18:15:02 DEBUG Validating built .zip package (path: ./elastic_package_registry-0.0.6.zip)
2023/03/08 18:15:02 DEBUG Skip validation of the built .zip package
2023/03/08 18:15:02 DEBUG Reading package manifest from ./elastic_package_registry-0.0.6.zip
Install zip package: ./elastic_package_registry-0.0.6.zip
2023/03/08 18:15:02 DEBUG POST https://127.0.0.1:5601/api/fleet/epm/packages
Installed assets:
- elastic_package_registry-313c2700-099b-11ed-91b6-3b1f9c2b2771 (type: dashboard)
- metrics-elastic_package_registry.metrics-0.0.6 (type: ingest_pipeline)
- metrics-elastic_package_registry.metrics (type: index_template)
- metrics-elastic_package_registry.metrics@package (type: component_template)
- metrics-elastic_package_registry.metrics@custom (type: component_template)
Done
```
- Running without validation
```
 $ elastic-package install --zip ./elastic_package_registry-0.0.6.zip -v --skip-validation
2023/03/08 18:14:56 DEBUG Enable verbose logging
2023/03/08 18:14:56 DEBUG Distribution built without a version tag, can't determine release chronology. Please consider using official releases at https://github.com/elastic/elastic-package/releases
2023/03/08 18:14:56 DEBUG GET https://127.0.0.1:5601/api/status
2023/03/08 18:14:56 DEBUG Skip validation of the built .zip package
2023/03/08 18:14:56 DEBUG Reading package manifest from ./elastic_package_registry-0.0.6.zip
Install zip package: ./elastic_package_registry-0.0.6.zip
2023/03/08 18:14:56 DEBUG POST https://127.0.0.1:5601/api/fleet/epm/packages
Installed assets:
- elastic_package_registry-313c2700-099b-11ed-91b6-3b1f9c2b2771 (type: dashboard)
- metrics-elastic_package_registry.metrics-0.0.6 (type: ingest_pipeline)
- metrics-elastic_package_registry.metrics (type: index_template)
- metrics-elastic_package_registry.metrics@package (type: component_template)
- metrics-elastic_package_registry.metrics@custom (type: component_template)
Done
```