### PR TITLE
Update Elastic stack versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,11 @@ test-stack-command-oldest:
 	./scripts/test-stack-command.sh 7.14.2
 
 test-stack-command-7x:
-	./scripts/test-stack-command.sh 7.17.8
+	./scripts/test-stack-command.sh 7.17.9
 
 # Keeping a test for 8.6 because it has an specific configuration file.
 test-stack-command-86:
-	./scripts/test-stack-command.sh 8.6.1
+	./scripts/test-stack-command.sh 8.6.2
 
 test-stack-command-8x:
 	./scripts/test-stack-command.sh 8.7.0-SNAPSHOT

--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "8.6.1"
+	DefaultStackVersion = "8.6.2"
 )


### PR DESCRIPTION
This PR updates the Elastic stack versions used in test (stack command targets) and the default Elastic stack used by the elastic-package.

Updated to the latest versions of 7.17 (7.17.9) and 8.6 (8.6.2) released.