### PR TITLE
Update agent settings for goreleaser step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,5 +63,5 @@ steps:
     command: ".buildkite/scripts/release.sh"
     agents:
       image: "golang:1.19.5"
-      cpu: "8"
-      memory: "4G"
+      cpu: "4"
+      memory: "16G"


### PR DESCRIPTION
Update agent settings for the `goreleaser` step.
Previous build failed with signal killed: https://buildkite.com/elastic/elastic-package/builds/453#0186ffa2-7a87-497f-8a92-c3b948646372

In this PR, it is reduced the number of CPUs since that number is used for setting the parallelism by default:
> -p, --parallelism int    Amount tasks to run concurrently (default: number of CPUs)

And at the same time, it has been increased the RAM for the agent to try to be able to cope with the process.