### PR TITLE
Move to a GCP agent the release step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -58,8 +58,8 @@ steps:
   - label: ":github: Release"
     key: "release"
     # build.tag != null && build.branch == "main"
-    if: |
-      build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
+    #if: |
+    #  build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
     command: ".buildkite/scripts/release.sh"
     agents:
       provider: "gcp"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -62,6 +62,4 @@ steps:
       build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
     command: ".buildkite/scripts/release.sh"
     agents:
-      image: "golang:1.19.5"
-      cpu: "4"
-      memory: "16G"
+      provider: "gcp"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,25 +25,25 @@ steps:
       cpu: "8"
       memory: "4G"
 
-  # - label: ":go: :windows: Run unit tests"
-  #   key: unit-tests-windows
-  #   command: ".buildkite/scripts/unit_tests_windows.ps1"
-  #   agents:
-  #     provider: "gcp"
-  #     image: "family/ci-windows-2022"
+  - label: ":go: :windows: Run unit tests"
+    key: unit-tests-windows
+    command: ".buildkite/scripts/unit_tests_windows.ps1"
+    agents:
+      provider: "gcp"
+      image: "family/ci-windows-2022"
 
   - wait: ~
     continue_on_failure: true
 
-  # - label: ":pipeline: Trigger Integration tests"
-  #   command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
-  #   depends_on:
-  #     - step: check-static
-  #       allow_failure: false
-  #     - step: unit-tests-linux
-  #       allow_failure: false
-  #     - step: unit-tests-windows
-  #       allow_failure: false
+  - label: ":pipeline: Trigger Integration tests"
+    command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
+    depends_on:
+      - step: check-static
+        allow_failure: false
+      - step: unit-tests-linux
+        allow_failure: false
+      - step: unit-tests-windows
+        allow_failure: false
 
   - wait: ~
     continue_on_failure: true
@@ -57,9 +57,8 @@ steps:
 
   - label: ":github: Release"
     key: "release"
-    # build.tag != null && build.branch == "main"
-    #if: |
-    #  build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
+    if: |
+      build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
     command: ".buildkite/scripts/release.sh"
     agents:
       provider: "gcp"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,15 +35,15 @@ steps:
   - wait: ~
     continue_on_failure: true
 
-  - label: ":pipeline: Trigger Integration tests"
-    command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
-    depends_on:
-      - step: check-static
-        allow_failure: false
-      - step: unit-tests-linux
-        allow_failure: false
-      - step: unit-tests-windows
-        allow_failure: false
+  # - label: ":pipeline: Trigger Integration tests"
+  #   command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
+  #   depends_on:
+  #     - step: check-static
+  #       allow_failure: false
+  #     - step: unit-tests-linux
+  #       allow_failure: false
+  #     - step: unit-tests-windows
+  #       allow_failure: false
 
   - wait: ~
     continue_on_failure: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,12 +25,12 @@ steps:
       cpu: "8"
       memory: "4G"
 
-  - label: ":go: :windows: Run unit tests"
-    key: unit-tests-windows
-    command: ".buildkite/scripts/unit_tests_windows.ps1"
-    agents:
-      provider: "gcp"
-      image: "family/ci-windows-2022"
+  # - label: ":go: :windows: Run unit tests"
+  #   key: unit-tests-windows
+  #   command: ".buildkite/scripts/unit_tests_windows.ps1"
+  #   agents:
+  #     provider: "gcp"
+  #     image: "family/ci-windows-2022"
 
   - wait: ~
     continue_on_failure: true

--- a/.buildkite/scripts/install_deps.sh
+++ b/.buildkite/scripts/install_deps.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 source .buildkite/scripts/tooling.sh
 
 add_bin_path(){
+    mkdir -p ${WORKSPACE}/bin
     export PATH="${WORKSPACE}/bin:${PATH}"
 }
 

--- a/.buildkite/scripts/release.sh
+++ b/.buildkite/scripts/release.sh
@@ -23,38 +23,4 @@ git fetch origin --tags
 
 echo "--- running goreleaser"
 # Run latest version of goreleaser
-# curl -sL https://git.io/goreleaser | bash
-
-TAR_FILE="/tmp/goreleaser.tar.gz"
-RELEASES_URL="https://github.com/goreleaser/goreleaser/releases"
-# test -z "$TMPDIR" && TMPDIR="$(mktemp -d)"
-TARGET_DIR="${WORKSPACE}/bin"
-
-last_version() {
-  curl -sL -o /dev/null -w %{url_effective} "$RELEASES_URL/latest" |
-    rev |
-    cut -f1 -d'/'|
-    rev
-}
-
-download() {
-  test -z "$VERSION" && VERSION="$(last_version)"
-  test -z "$VERSION" && {
-    echo "Unable to get goreleaser version." >&2
-    exit 1
-  }
-  rm -f "$TAR_FILE"
-  curl -s -L -o "$TAR_FILE" \
-    "$RELEASES_URL/download/$VERSION/goreleaser_$(uname -s)_$(uname -m).tar.gz"
-}
-
-download
-tar -xf "$TAR_FILE" -C "${TARGET_DIR}"
-
-rm ${TAR_FILE}
-chmod u+x ${TARGET_DIR}/goreleaser
-
-git status
-
-# release skip
-goreleaser release --skip-publish --snapshot
+curl -sL https://git.io/goreleaser | bash

--- a/.buildkite/scripts/release.sh
+++ b/.buildkite/scripts/release.sh
@@ -2,7 +2,13 @@
 
 set -euo pipefail
 
-WORKSPACE="$(pwd)"
+cleanup() {
+    rm -rf ${WORKSPACE}
+}
+trap cleanup exit
+
+WORKSPACE="/tmp/bin-buildkite/"
+
 VERSION=""
 source .buildkite/scripts/install_deps.sh
 source .buildkite/scripts/tooling.sh
@@ -48,8 +54,7 @@ tar -xf "$TAR_FILE" -C "${TARGET_DIR}"
 rm ${TAR_FILE}
 chmod u+x ${TARGET_DIR}/goreleaser
 
-# build
-goreleaser build
+git status
 
 # release skip
-goreleaser release --skip-publish
+goreleaser release --skip-publish --snapshot

--- a/.buildkite/scripts/release.sh
+++ b/.buildkite/scripts/release.sh
@@ -45,7 +45,7 @@ download() {
 download
 tar -xf "$TAR_FILE" -C "${TARGET_DIR}"
 
-rm ${TARGET_FILE}
+rm ${TAR_FILE}
 chmod u+x ${TARGET_DIR}/goreleaser
 
 # build

--- a/.buildkite/scripts/release.sh
+++ b/.buildkite/scripts/release.sh
@@ -2,6 +2,13 @@
 
 set -euo pipefail
 
+WORKSPACE="$(pwd)"
+source .buildkite/scripts/install_deps.sh
+source .buildkite/scripts/tooling.sh
+
+add_bin_path
+with_go
+
 echo "--- fetching tags"
 # Ensure that tags are present so goreleaser can build the changelog from the last release.
 git rev-parse --is-shallow-repository

--- a/.buildkite/scripts/release.sh
+++ b/.buildkite/scripts/release.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 WORKSPACE="$(pwd)"
+VERSION=""
 source .buildkite/scripts/install_deps.sh
 source .buildkite/scripts/tooling.sh
 

--- a/.buildkite/scripts/release.sh
+++ b/.buildkite/scripts/release.sh
@@ -16,5 +16,39 @@ git fetch origin --tags
 
 echo "--- running goreleaser"
 # Run latest version of goreleaser
-curl -sL https://git.io/goreleaser | bash
+# curl -sL https://git.io/goreleaser | bash
 
+TAR_FILE="/tmp/goreleaser.tar.gz"
+RELEASES_URL="https://github.com/goreleaser/goreleaser/releases"
+# test -z "$TMPDIR" && TMPDIR="$(mktemp -d)"
+TARGET_DIR="${WORKSPACE}/bin"
+
+last_version() {
+  curl -sL -o /dev/null -w %{url_effective} "$RELEASES_URL/latest" |
+    rev |
+    cut -f1 -d'/'|
+    rev
+}
+
+download() {
+  test -z "$VERSION" && VERSION="$(last_version)"
+  test -z "$VERSION" && {
+    echo "Unable to get goreleaser version." >&2
+    exit 1
+  }
+  rm -f "$TAR_FILE"
+  curl -s -L -o "$TAR_FILE" \
+    "$RELEASES_URL/download/$VERSION/goreleaser_$(uname -s)_$(uname -m).tar.gz"
+}
+
+download
+tar -xf "$TAR_FILE" -C "${TARGET_DIR}"
+
+rm ${TARGET_FILE}
+chmod u+x ${TARGET_DIR}/goreleaser
+
+# build
+goreleaser build
+
+# release skip
+goreleaser release --skip-publish


### PR DESCRIPTION
This PR moves the goreleaser step to be run in a GCP agent.

Increasing memory was not successful: https://buildkite.com/elastic/elastic-package/builds/473#018704b5-4263-4d7e-9f30-b171bd8eb5b3

Successful build https://buildkite.com/elastic/elastic-package/builds/478
Triggering directly this command: `goreleaser releaser --skip-publish --snapshot`