### PR TITLE
Add timeout for sign and publish step

### DIFF
--- a/.buildkite/pipeline.package-storage-publish.yml
+++ b/.buildkite/pipeline.package-storage-publish.yml
@@ -19,6 +19,7 @@ steps:
     command: ".buildkite/scripts/signAndPublishPackage.sh"
     depends_on:
       - build-package
+    timeout_in_minutes: 30
     agents:
       provider: "gcp"
       image: family/core-ubuntu-2004


### PR DESCRIPTION
This PR adds a timeout step for the sign and publish step:
- https://buildkite.com/docs/pipelines/command-step#timeout_in_minutes

There is some condition or scenario where the Jenkins build is not triggered and the script waits for that job forever.
In order to reduce the waiting time, a timeout of 30 minutes is set for that step. Usually that step is completed in 10 minutes or so.

The output in those builds are:
```
2023/03/22 10:18:22 Triggering job: elastic+unified-release+master+sign-artifacts-with-gpg
2023/03/22 10:18:22 job.go:428: elastic+unified-release+master+sign-artifacts-with-gpg is already running
```

Relates https://github.com/elastic/elastic-package/issues/1200