### PR TITLE
Add catalog information to define pipelines as a Backstage Resource

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -21,6 +21,7 @@ spec:
       description: ':go: Build and test the elastic-package project'
     spec:
       branch_configuration: "main v0.* v1.*"
+      pipeline_file: ".buildkite/pipeline.yml"
       provider_settings:
         build_pull_request_forks: false
         build_tags: true

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,78 @@
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elastic-package
+  description: ':go: Build and test the elastic-package project'
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/elastic-package
+
+spec:
+  type: buildkite-pipeline
+  owner: group:ingest-fp
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: elastic-package
+      description: ':go: Build and test the elastic-package project'
+    spec:
+      branch_configuration: "main v0.* v1.*"
+      provider_settings:
+        build_pull_request_forks: false
+        build_tags: true
+      repository: elastic/elastic-package
+      cancel_intermediate_builds: true
+      cancel_intermediate_builds_branch_filter: '!main'
+      skip_intermediate_builds: true
+      skip_intermediate_builds_branch_filter: '!main'
+      env:
+        ELASTIC_PR_COMMENTS_ENABLED: 'true'
+      teams:
+        ecosystem: {}
+        ingest-fp:
+          access_level: BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elastic-package-package-storage-publish
+  description: 'Minimal Jenkins pipeline to exercise publishing a package to Package Storage (for testing only)'
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/elastic-package-package-storage-publish
+
+spec:
+  type: buildkite-pipeline
+  owner: group:ingest-fp
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: elastic-package-package-stroage-publish
+      description: 'Minimal Jenkins pipeline to exercise publishing a package to Package Storage (for testing only)'
+    spec:
+      branch_configuration: main
+      pipeline_file: ".buildkite/pipeline.package-storage-publish.yml"
+      provider_settings:
+        build_pull_request_forks: false
+        build_tags: true
+      repository: elastic/elastic-package
+      cancel_intermediate_builds: true
+      cancel_intermediate_builds_branch_filter: '!main'
+      skip_intermediate_builds: true
+      skip_intermediate_builds_branch_filter: '!main'
+      teams:
+        ecosystem: {}
+        ingest-fp:
+          access_level: BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY


### PR DESCRIPTION
This PR creates the catalog information for the BackStage internal system locally in this repository.
This catalog information includes the same pipelines definitions that were already defined previously for Buildkite. Specifically these two pipelines:
- .buildkite/pipeline.yml
- .buildkite/pipeline.package-storage-publish.yml