### PR TITLE
Add serverless flag to stack up

### DIFF
--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -73,6 +73,11 @@ func setupStackCommand() *cobraext.Command {
 				return cobraext.FlagParsingError(err, cobraext.StackVersionFlagName)
 			}
 
+			/*serverless, err := cmd.Flags().GetString(cobraext.ServerlessFlagName)
+			if err != nil {
+				return cobraext.FlagParsingError(err, cobraext.ServerlessFlagName)
+			}*/
+
 			profile, err := getProfileFlag(cmd)
 			if err != nil {
 				return err

--- a/internal/cobraext/flags.go
+++ b/internal/cobraext/flags.go
@@ -170,6 +170,9 @@ const (
 	ZipPackageFilePathFlagShorthand   = "z"
 	ZipPackageFilePathFlagDescription = "path to the zip package file (*.zip)"
 
+	ServerlessFlagName        = "serverless"
+	ServerlessFlagDescription = "serverless flag (true or false)"
+
 	// To be removed promote commands flags
 	DirectionFlagName        = "direction"
 	DirectionFlagDescription = "promotion direction"

--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -1,5 +1,6 @@
 {{ $username := fact "username" }}
 {{ $password := fact "password" }}
+{{ $serverless := fact "serverless" }}
 version: '2.3'
 services:
   elasticsearch:
@@ -9,7 +10,7 @@ services:
       start_period: 300s
       interval: 5s
     environment:
-      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g -Des.serverless={{ $serverless }}"
       - "ELASTIC_PASSWORD={{ $password }}"
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml"

--- a/internal/stack/resources.go
+++ b/internal/stack/resources.go
@@ -47,6 +47,8 @@ const (
 
 	elasticsearchUsername = "elastic"
 	elasticsearchPassword = "changeme"
+
+	serverless = "false"
 )
 
 var (
@@ -117,6 +119,8 @@ func applyResources(profile *profile.Profile, stackVersion string) error {
 
 		"username": elasticsearchUsername,
 		"password": elasticsearchPassword,
+
+		"serverless": serverless,
 
 		"geoip_dir": profile.Config("stack.geoip_dir", "./ingest-geoip"),
 	})


### PR DESCRIPTION
The idea behind this pull request is to be able to run a `serverless` stack of Elasticsearch with the following command:

```
elastic-package stack up --version=8.8.0-SNAPSHOT -v --serverless
```

I'm opening this PR as draft as I have a few questions on how to implement it best.