### PR TITLE
Use latest docker-compose v2 version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 env:
   SETUP_GVM_VERSION: 'v0.5.0' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
-  DOCKER_COMPOSE_VERSION: "1.25.5" # "v2.15.1"
+  DOCKER_COMPOSE_VERSION: "v2.17.2"
   ELASTIC_PACKAGE_COMPOSE_DISABLE_ANSI: "true"
   KIND_VERSION: 'v0.17.0'
   K8S_VERSION: 'v1.26.0'

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -111,7 +111,12 @@ fi
 echo "--- Run integration test ${TARGET}"
 if [[ "${TARGET}" == "${PARALLEL_TARGET}" ]]; then
     make install
+
+    # allow to fail this command, to be able to upload safe logs
+    set +e
     make PACKAGE_UNDER_TEST=${PACKAGE} ${TARGET}
+    testReturnCode=$?
+    set -e
 
     if [[ "${UPLOAD_SAFE_LOGS}" -eq 1 ]] ; then
         upload_safe_logs \
@@ -124,6 +129,12 @@ if [[ "${TARGET}" == "${PARALLEL_TARGET}" ]]; then
             "build/container-logs/*.log" \
             "insecure-logs/${PACKAGE}/container-logs/"
     fi
+
+    if [ $testReturnCode != 0 ]; then
+        echo "make PACKAGE_UDER_TEST=${PACKAGE} ${TARGET} failed with ${testReturnCode}"
+        exit ${testReturnCode}
+    fi
+
     make check-git-clean
     exit 0
 fi

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -179,10 +179,13 @@ func NewProject(name string, paths ...string) (*Project, error) {
 		c.dockerComposeV1 = true
 		return &c, nil
 	}
+
+	versionMessage := fmt.Sprintf("Determined Docker Compose version: %v", ver)
 	if ver.Major() == 1 {
-		logger.Debugf("Determined Docker Compose version: %v, the tool will use Compose V1", ver)
+		versionMessage = fmt.Sprintf("%s, the tool will use Compose V1", versionMessage)
 		c.dockerComposeV1 = true
 	}
+	logger.Debug(versionMessage)
 
 	v, ok := os.LookupEnv(DisableANSIComposeEnv)
 	if !c.dockerComposeV1 && ok && strings.ToLower(v) != "false" {


### PR DESCRIPTION
This PR enables docker-compose v2 in CI.
Setting the latest version available at the time of creating this PR (2.17.2)
https://docs.docker.com/compose/release-notes/


Relates https://github.com/elastic/elastic-package/issues/1116