### PR TITLE
docker-compose config - bind mount /run/service_logs/ in Agent container

### DIFF
--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -137,6 +137,9 @@ services:
     - type: bind
       source: ../../../tmp/service_logs/
       target: /tmp/service_logs/
+    - type: bind
+      source: ../../../tmp/service_logs/
+      target: /run/service_logs/
 
   elastic-agent_is_ready:
     image: tianon/true

--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -137,6 +137,7 @@ services:
     - type: bind
       source: ../../../tmp/service_logs/
       target: /tmp/service_logs/
+    # Mount service_logs under /run too as a testing workaround for the journald input (see elastic-package#1235).
     - type: bind
       source: ../../../tmp/service_logs/
       target: /run/service_logs/


### PR DESCRIPTION
This mounts the service_logs directory at `/run/service_logs` for the purpose of testing the Filebeat `journald` input. It is a workaround for an upstream ubuntu 20.04->systemd bug (see linked issue).

Closes #1235
Unblocks https://github.com/elastic/integrations/pull/5984