### PR TITLE
Disable build pull requests from webhook

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -39,6 +39,7 @@ spec:
       pipeline_file: ".buildkite/pipeline.yml"
       provider_settings:
         build_pull_request_forks: false
+        build_pull_requests: false # PR builds are managed by buildkite-pr-bot
         build_tags: true
       repository: elastic/elastic-package
       cancel_intermediate_builds: true
@@ -48,9 +49,10 @@ spec:
       env:
         ELASTIC_PR_COMMENTS_ENABLED: 'true'
       teams:
-        ecosystem: {}
+        ecosystem:
+          access_level: MANAGE_BUILD_AND_READ
         ingest-fp:
-          access_level: BUILD_AND_READ
+          access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
 
@@ -80,6 +82,7 @@ spec:
       pipeline_file: ".buildkite/pipeline.package-storage-publish.yml"
       provider_settings:
         build_pull_request_forks: false
+        build_pull_requests: false # PR builds are managed by buildkite-pr-bot
         build_tags: true
       repository: elastic/elastic-package
       cancel_intermediate_builds: true
@@ -87,8 +90,9 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: '!main'
       teams:
-        ecosystem: {}
+        ecosystem:
+          access_level: MANAGE_BUILD_AND_READ
         ingest-fp:
-          access_level: BUILD_AND_READ
+          access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY


### PR DESCRIPTION
This PR disables the builds from pull requests from the webhook.

It also adds the access_level MANAGE_BUILD_AND_READ to the ingest-fp team.