### PR TITLE
remove mapping to trigger field

### DIFF
--- a/internal/builder/_static/ecs_mappings.yaml
+++ b/internal/builder/_static/ecs_mappings.yaml
@@ -447,7 +447,3 @@ mappings:
             mapping:
                 type: nested
             path_match: '*.macho.sections'
-        - trigger_to_nested:
-            mapping:
-                type: nested
-            match: trigger

--- a/internal/builder/testdata/existing.yml
+++ b/internal/builder/testdata/existing.yml
@@ -6,3 +6,10 @@ elasticsearch:
       properties:
         example:
           type: short
+      dynamic_templates:
+        - forwarded_ip_to_ip:
+            mapping:
+                type: ip
+            match: forwarded_ip
+            match_mapping_type: string
+

--- a/internal/builder/testdata/existing.yml
+++ b/internal/builder/testdata/existing.yml
@@ -6,8 +6,3 @@ elasticsearch:
       properties:
         example:
           type: short
-      dynamic_templates:
-        - to_nested:
-            path: trigger
-            mapping:
-              type: nested

--- a/internal/builder/testdata/existing.yml
+++ b/internal/builder/testdata/existing.yml
@@ -9,7 +9,7 @@ elasticsearch:
       dynamic_templates:
         - forwarded_ip_to_ip:
             mapping:
-                type: ip
+              type: ip
             match: forwarded_ip
             match_mapping_type: string
 

--- a/internal/builder/testdata/expected.existing.mappings.yml
+++ b/internal/builder/testdata/expected.existing.mappings.yml
@@ -6,6 +6,11 @@ elasticsearch:
         example:
           type: short
       dynamic_templates:
+        - forwarded_ip_to_ip:
+            mapping:
+                type: ip
+            match: forwarded_ip
+            match_mapping_type: string
         - _embedded_ecs-example_template:
             mapping:
               type: short

--- a/internal/builder/testdata/expected.existing.mappings.yml
+++ b/internal/builder/testdata/expected.existing.mappings.yml
@@ -6,10 +6,6 @@ elasticsearch:
         example:
           type: short
       dynamic_templates:
-        - to_nested:
-            path: trigger
-            mapping:
-              type: nested
         - _embedded_ecs-example_template:
             mapping:
               type: short

--- a/internal/builder/testdata/expected.existing.mappings.yml
+++ b/internal/builder/testdata/expected.existing.mappings.yml
@@ -8,7 +8,7 @@ elasticsearch:
       dynamic_templates:
         - forwarded_ip_to_ip:
             mapping:
-                type: ip
+              type: ip
             match: forwarded_ip
             match_mapping_type: string
         - _embedded_ecs-example_template:


### PR DESCRIPTION
Since we removed the field `faas.trigger` with type nested from ECS definition with this issue https://github.com/elastic/ecs/issues/2192, we also want to remove the dynamic mapping definition.