### PR TITLE
Fix retrieve logs in elastic-package stack dump

### DIFF
--- a/.buildkite/pipeline.trigger.integration.tests.sh
+++ b/.buildkite/pipeline.trigger.integration.tests.sh
@@ -25,7 +25,7 @@ for test in ${STACK_COMMAND_TESTS[@]}; do
     echo "          provider: \"gcp\""
     echo "        artifact_paths:"
     echo "          - build/elastic-stack-dump/stack/*/logs/*.log"
-    echo "          - build/elastic-stack-dump/stack/*/logs/fleet-server-internal/*.log"
+    echo "          - build/elastic-stack-dump/stack/*/logs/fleet-server-internal/**/*"
     echo "          - build/elastic-stack-status/*/*"
 done
 
@@ -43,7 +43,7 @@ for test in ${CHECK_PACKAGES_TESTS[@]}; do
     echo "        artifact_paths:"
     echo "          - build/test-results/*.xml"
     echo "          - build/elastic-stack-dump/stack/check-*/logs/*.log"
-    echo "          - build/elastic-stack-dump/stack/check-*/logs/fleet-server-internal/*.log"
+    echo "          - build/elastic-stack-dump/stack/check-*/logs/fleet-server-internal/**/*"
     echo "          - build/elastic-stack-status/*/*"
     if [[ $test =~ with-kind$ ]]; then
         echo "          - build/kubectl-dump.txt"
@@ -63,7 +63,7 @@ for package in $(find . -maxdepth 1 -mindepth 1 -type d) ; do
     echo "        artifact_paths:"
     echo "          - build/test-results/*.xml"
     echo "          - build/elastic-stack-dump/stack/check-*/logs/*.log"
-    echo "          - build/elastic-stack-dump/stack/check-*/logs/fleet-server-internal/*.log"
+    echo "          - build/elastic-stack-dump/stack/check-*/logs/fleet-server-internal/**/*"
 done
 
 popd > /dev/null

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -122,13 +122,13 @@ if [[ "${TARGET}" == "${PARALLEL_TARGET}" ]]; then
         upload_safe_logs \
             "${JOB_GCS_BUCKET_INTERNAL}" \
             "build/elastic-stack-dump/check-${PACKAGE}/logs/elastic-agent-internal/*.*" \
-            "insecure-logs/${PACKAGE}/"
+            "insecure-logs/${PACKAGE}/elastic-agent-logs/"
 
         # required for <8.6.0
         upload_safe_logs \
             "${JOB_GCS_BUCKET_INTERNAL}" \
             "build/elastic-stack-dump/check-${PACKAGE}/logs/elastic-agent-internal/default/*" \
-            "insecure-logs/${PACKAGE}/default/"
+            "insecure-logs/${PACKAGE}/elastic-agent-logs/default/"
 
         upload_safe_logs \
             "${JOB_GCS_BUCKET_INTERNAL}" \

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -121,8 +121,14 @@ if [[ "${TARGET}" == "${PARALLEL_TARGET}" ]]; then
     if [[ "${UPLOAD_SAFE_LOGS}" -eq 1 ]] ; then
         upload_safe_logs \
             "${JOB_GCS_BUCKET_INTERNAL}" \
-            "build/elastic-stack-dump/check-${PACKAGE}/logs/elastic-agent-internal/*" \
+            "build/elastic-stack-dump/check-${PACKAGE}/logs/elastic-agent-internal/*.*" \
             "insecure-logs/${PACKAGE}/"
+
+        # required for <8.6.0
+        upload_safe_logs \
+            "${JOB_GCS_BUCKET_INTERNAL}" \
+            "build/elastic-stack-dump/check-${PACKAGE}/logs/elastic-agent-internal/default/*" \
+            "insecure-logs/${PACKAGE}/default/"
 
         upload_safe_logs \
             "${JOB_GCS_BUCKET_INTERNAL}" \

--- a/internal/stack/dump.go
+++ b/internal/stack/dump.go
@@ -57,7 +57,7 @@ func dumpStackLogs(options DumpOptions) error {
 	for _, serviceName := range observedServices {
 		logger.Debugf("Dump stack logs for %s", serviceName)
 
-		content, err := dockerComposeLogs(serviceName, snapshotPath)
+		content, err := dockerComposeLogs(serviceName, snapshotPath, options.Profile)
 		if err != nil {
 			logger.Errorf("can't fetch service logs (service: %s): %v", serviceName, err)
 		} else {

--- a/internal/stack/dump.go
+++ b/internal/stack/dump.go
@@ -52,12 +52,10 @@ func dumpStackLogs(options DumpOptions) error {
 		return errors.Wrapf(err, "can't create output location (path: %s)", logsPath)
 	}
 
-	snapshotPath := options.Profile.Path(profileStackPath, SnapshotFile)
-
 	for _, serviceName := range observedServices {
 		logger.Debugf("Dump stack logs for %s", serviceName)
 
-		content, err := dockerComposeLogs(serviceName, snapshotPath, options.Profile)
+		content, err := dockerComposeLogs(serviceName, options.Profile)
 		if err != nil {
 			logger.Errorf("can't fetch service logs (service: %s): %v", serviceName, err)
 		} else {

--- a/internal/stack/logs.go
+++ b/internal/stack/logs.go
@@ -54,7 +54,7 @@ func copyDockerInternalLogs(serviceName, outputPath string) error {
 
 	outputPath = filepath.Join(outputPath, serviceName+"-internal")
 	serviceContainer := p.ContainerName(serviceName)
-	err = docker.Copy(serviceContainer, "/usr/share/elastic-agent/state/data/logs/default", outputPath)
+	err = docker.Copy(serviceContainer, "/usr/share/elastic-agent/state/data/logs/", outputPath)
 	if err != nil {
 		return errors.Wrap(err, "docker copy failed")
 	}

--- a/internal/stack/logs.go
+++ b/internal/stack/logs.go
@@ -15,6 +15,11 @@ import (
 )
 
 func dockerComposeLogs(serviceName string, snapshotFile string) ([]byte, error) {
+	appConfig, err := install.Configuration()
+	if err != nil {
+		return nil, errors.Wrap(err, "can't read application configuration")
+	}
+
 	p, err := compose.NewProject(DockerComposeProjectName, snapshotFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create docker compose project")
@@ -22,6 +27,7 @@ func dockerComposeLogs(serviceName string, snapshotFile string) ([]byte, error) 
 
 	opts := compose.CommandOptions{
 		Env: newEnvBuilder().
+			withEnvs(appConfig.StackImageRefs(install.DefaultStackVersion).AsEnv()).
 			withEnv(stackVariantAsEnv(install.DefaultStackVersion)).
 			build(),
 		Services: []string{serviceName},

--- a/internal/stack/logs.go
+++ b/internal/stack/logs.go
@@ -21,7 +21,7 @@ func dockerComposeLogs(serviceName string, profile *profile.Profile) ([]byte, er
 		return nil, errors.Wrap(err, "can't read application configuration")
 	}
 
-	snapshotFile := options.Profile.Path(profileStackPath, SnapshotFile)
+	snapshotFile := profile.Path(profileStackPath, SnapshotFile)
 
 	p, err := compose.NewProject(DockerComposeProjectName, snapshotFile)
 	if err != nil {

--- a/internal/stack/logs.go
+++ b/internal/stack/logs.go
@@ -26,12 +26,16 @@ func dockerComposeLogs(serviceName string, snapshotFile string, profile *profile
 		return nil, errors.Wrap(err, "could not create docker compose project")
 	}
 
+	envBuilder := newEnvBuilder().
+		withEnvs(appConfig.StackImageRefs(install.DefaultStackVersion).AsEnv()).
+		withEnv(stackVariantAsEnv(install.DefaultStackVersion))
+
+	if profile != nil {
+		envBuilder = envBuilder.withEnvs(profile.ComposeEnvVars())
+	}
+
 	opts := compose.CommandOptions{
-		Env: newEnvBuilder().
-			withEnvs(appConfig.StackImageRefs(install.DefaultStackVersion).AsEnv()).
-			withEnv(stackVariantAsEnv(install.DefaultStackVersion)).
-			withEnvs(profile.ComposeEnvVars()).
-			build(),
+		Env:      envBuilder.build(),
 		Services: []string{serviceName},
 	}
 

--- a/internal/stack/logs.go
+++ b/internal/stack/logs.go
@@ -12,9 +12,10 @@ import (
 	"github.com/elastic/elastic-package/internal/compose"
 	"github.com/elastic/elastic-package/internal/docker"
 	"github.com/elastic/elastic-package/internal/install"
+	"github.com/elastic/elastic-package/internal/profile"
 )
 
-func dockerComposeLogs(serviceName string, snapshotFile string) ([]byte, error) {
+func dockerComposeLogs(serviceName string, snapshotFile string, profile *profile.Profile) ([]byte, error) {
 	appConfig, err := install.Configuration()
 	if err != nil {
 		return nil, errors.Wrap(err, "can't read application configuration")
@@ -29,6 +30,7 @@ func dockerComposeLogs(serviceName string, snapshotFile string) ([]byte, error) 
 		Env: newEnvBuilder().
 			withEnvs(appConfig.StackImageRefs(install.DefaultStackVersion).AsEnv()).
 			withEnv(stackVariantAsEnv(install.DefaultStackVersion)).
+			withEnvs(profile.ComposeEnvVars()).
 			build(),
 		Services: []string{serviceName},
 	}


### PR DESCRIPTION
Closes #1251 

This PR solves two issues related to logs retrieved by `elastic-package stack dump` command:
- using docker-compose v2 some environment variables are missing
- starting with 8.6.0, paths where logs can be found for elastic-agent and fleet-server has changed to be one unified log file:
    - Prior to that version those internal logs follow this pattern:
        - `/usr/share/elastic-agent/state/data/logs/default/*` (elastic-package copy these ones)
        - `/usr/share/elastic-agent/state/data/logs/*`
    - Since 8.6.0, there is no `default` folder
        - `/usr/share/elastic-agent/state/data/logs/`


Example of current failures against 8.8.0-SNAPSHOT:
- using docker-compose v1:
    - some files cannot be copied due to the missing `default` folder
```
 $ docker-compose version --short
1.25.5

 $ elastic-package stack up -v -d --version 8.8.0-SNAPSHOT
 $ elastic-package stack dump
2023/05/05 17:49:25 ERROR can't copy internal logs (service: elastic-agent): docker copy failed: could not copy files from the container (stderr="Error response from daemon: Could not find the file /usr/share/elastic-agent/state/data/logs/default in container elastic-package-stack_elastic-agent_1\n"): exit status 1
2023/05/05 17:49:27 ERROR can't copy internal logs (service: fleet-server): docker copy failed: could not copy files from the container (stderr="Error response from daemon: Could not find the file /usr/share/elastic-agent/state/data/logs/default in container elastic-package-stack_fleet-server_1\n"): exit status 1
Path to stack dump: elastic-stack-dump
Done

 $ tree elastic-stack-dump/logs
elastic-stack-dump/logs
├── elastic-agent.log
├── elasticsearch.log
├── fleet-server.log
├── kibana.log
└── package-registry.log

0 directories, 5 files
``` 
- using docker-compose v2
```
 $ docker-compose version --short
2.17.2

 $ elastic-package stack up -v -d --version 8.8.0-SNAPSHOT
 $ elastic-package stack dump
2023/05/05 17:51:57 ERROR can't fetch service logs (service: elasticsearch): running command failed: exit status 15
2023/05/05 17:51:57 ERROR can't fetch service logs (service: elastic-agent): running command failed: exit status 15
2023/05/05 17:51:57 ERROR can't copy internal logs (service: elastic-agent): docker copy failed: could not copy files from the container (stderr="Error response from daemon: Could not find the file /usr/share/elastic-agent/state/data/logs/default in container elastic-package-stack-elastic-agent-1\n"): exit status 1
2023/05/05 17:51:57 ERROR can't fetch service logs (service: fleet-server): running command failed: exit status 15
2023/05/05 17:51:57 ERROR can't copy internal logs (service: fleet-server): docker copy failed: could not copy files from the container (stderr="Error response from daemon: Could not find the file /usr/share/elastic-agent/state/data/logs/default in container elastic-package-stack-fleet-server-1\n"): exit status 1
2023/05/05 17:51:57 ERROR can't fetch service logs (service: kibana): running command failed: exit status 15
2023/05/05 17:51:57 ERROR can't fetch service logs (service: package-registry): running command failed: exit status 15
Path to stack dump: elastic-stack-dump
Done

 $ tree elastic-stack-dump/logs
elastic-stack-dump/logs/

0 directories, 0 files

 $ elastic-package stack down
```

Example of files present in different Elastic stack versions for elastic-agent-internal:
- 7.17.10
```
 $ tree -l elastic-stack-dump-7.17.10/logs/elastic-agent-internal/
elastic-stack-dump-7.17.10/logs/elastic-agent-internal/
├── default
│   ├── filebeat-json.log
│   ├── filebeat-json.log-2023-05-05-15-1
│   ├── metricbeat-json.log
│   └── metricbeat-json.log-2023-05-05-15-1
└── elastic-agent-json.log-20230505150712

1 directory, 5 files
```
- 8.0.0
```
 $ tree elastic-stack-dump-8.0.0/logs/elastic-agent-internal/
elastic-stack-dump-8.0.0/logs/elastic-agent-internal/
├── default
│   ├── filebeat-20230505-1.ndjson
│   ├── filebeat-20230505-2.ndjson
│   ├── filebeat-20230505-3.ndjson
│   ├── filebeat-20230505.ndjson
│   ├── metricbeat-20230505-1.ndjson
│   ├── metricbeat-20230505-2.ndjson
│   ├── metricbeat-20230505-3.ndjson
│   ├── metricbeat-20230505-4.ndjson
│   ├── metricbeat-20230505-5.ndjson
│   └── metricbeat-20230505.ndjson
└── elastic-agent-20230505.ndjson

1 directory, 11 files
```
- 8.5.0
```
 $ tree elastic-stack-dump-8.5.0/logs/elastic-agent-internal/
elastic-stack-dump-8.5.0/logs/elastic-agent-internal/
├── default
│   ├── filebeat-20230505-1.ndjson
│   ├── filebeat-20230505-2.ndjson
│   ├── filebeat-20230505-3.ndjson
│   ├── filebeat-20230505.ndjson
│   ├── metricbeat-20230505-1.ndjson
│   └── metricbeat-20230505.ndjson
└── elastic-agent-20230505.ndjson

1 directory, 7 files
```
- 8.8.0-SNAPSHOT
```
 $ tree elastic-stack-dump-8.8.0-SNAPSHOT/logs/elastic-agent-internal/
elastic-stack-dump-8.8.0-SNAPSHOT/logs/elastic-agent-internal/
└── elastic-agent-20230505.ndjson

0 directories, 1 file
```

## Checklist
- [x] Tested using docker-compose v1
- [x] Tested using docker-compose v2
- [x] Tested with different Elastic stack versions (7.17.10, 8.0.0, 8.5.0, 8.6.0 and 8.8.0-SNAPSHOT)

## How to test this change

- Check docker-compose version installed in your system:
```
 $ docker-compose version --short
2.17.2
```
- Start a Elastic stack using elastic-package with the desired version (e.g. 8.8.0-SNAPSHOT)
```
 $ elastic-package stack up -v -d --version 8.8.0-SNAPSHOT
```
- Dump information from the stack command and check logs
```
 $ elastic-package stack dump
Path to stack dump: elastic-stack-dump
Done
 $ tree elastic-stack-dump/logs/
elastic-stack-dump/logs/
├── elastic-agent-internal
│   └── elastic-agent-20230505.ndjson
├── elastic-agent.log
├── elasticsearch.log
├── fleet-server-internal
│   ├── elastic-agent-20230505-1.ndjson
│   └── elastic-agent-20230505.ndjson
├── fleet-server.log
├── kibana.log
└── package-registry.log
```