### PR TITLE
Update package-registry image to v1.20.0 tag

### DIFF
--- a/internal/stack/resources.go
+++ b/internal/stack/resources.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+
 	"github.com/elastic/go-resource"
 
 	"github.com/elastic/elastic-package/internal/profile"
@@ -38,7 +39,7 @@ const (
 	PackageRegistryConfigFile = "package-registry.yml"
 
 	// PackageRegistryBaseImage is the base Docker image of the Elastic Package Registry.
-	PackageRegistryBaseImage = "docker.elastic.co/package-registry/package-registry:v1.19.0"
+	PackageRegistryBaseImage = "docker.elastic.co/package-registry/package-registry:v1.20.0"
 
 	// ElasticAgentEnvFile is the elastic agent environment variables file.
 	ElasticAgentEnvFile = "elastic-agent.env"


### PR DESCRIPTION
This PR updates package-registry to boot up the latest release in package-registry:
https://github.com/elastic/package-registry/releases/tag/v1.20.0