### PR TITLE
Update catalog filter condition

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,7 +7,7 @@ metadata:
   name: elastic-package
   description: elastic-package - Command line tool for developing Elastic Integrations
   links:
-    - title: Developer Documentation 
+    - title: Developer Documentation
       icon: file-doc
       url: https://www.elastic.co/guide/en/integrations-developer/current/elastic-package.html
 
@@ -43,8 +43,11 @@ spec:
       pipeline_file: ".buildkite/pipeline.yml"
       provider_settings:
         build_pull_request_forks: false
-        build_pull_requests: true # TODO: PR builds are managed by buildkite-pr-bot
+        build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
         build_tags: true
+        filter_enabled: true
+        filter_condition: |
+          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
       repository: elastic/elastic-package
       cancel_intermediate_builds: true
       cancel_intermediate_builds_branch_filter: '!main'
@@ -86,8 +89,11 @@ spec:
       pipeline_file: ".buildkite/pipeline.package-storage-publish.yml"
       provider_settings:
         build_pull_request_forks: false
-        build_pull_requests: true # TODO: PR builds are managed by buildkite-pr-bot
+        build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
         build_tags: true
+        filter_enabled: true
+        filter_condition: |
+          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
       repository: elastic/elastic-package
       cancel_intermediate_builds: true
       cancel_intermediate_builds_branch_filter: '!main'


### PR DESCRIPTION
This PR adds `filter_enabled` and `filter_condition` settings to filter the builds triggered in Buildkite. In case of Pull Requests, just the ones triggered by buildkite-pr-bot will be the ones to be run.