### PR TITLE
Add synthetic mode as default when creating a datastream

### DIFF
--- a/internal/packages/archetype/data_stream_manifest.go
+++ b/internal/packages/archetype/data_stream_manifest.go
@@ -27,4 +27,6 @@ streams:{{if eq .Manifest.Type "logs" }}
         title: Period
         default: 10s
 {{- end}}
+elasticsearch:
+  source_mode: synthetic
 `


### PR DESCRIPTION
Relates #1026 

This PR adds into the template the needed fields to enable synthetic mode when creating a new datastream.

Example:
```
 $ elastic-package create data-stream
Create a new data stream
? Data stream name: foo
? Data stream title: Foo
? Type: logs
New data stream has been created: foo
Done
```

Manifest file generated:
```yaml
title: "Foo"
type: logs
streams:
  - input: logfile
    title: Sample logs
    description: Collect sample logs
    vars:
      - name: paths
        type: text
        title: Paths
        multi: true
        default:
          - /var/log/*.log
elasticsearch:
  source_mode: synthetic
```