### PR TITLE
Unit test corpusgenerator

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -269,7 +269,8 @@ func generateDataStreamCorpusCommandAction(cmd *cobra.Command, _ []string) error
 		return cobraext.FlagParsingError(err, cobraext.GenerateCorpusRallyTrackOutputDirFlagName)
 	}
 
-	generator, err := corpusgenerator.NewGenerator(packageName, dataSetName, commit, totSizeInBytes)
+	genLibClient := corpusgenerator.NewClient(commit)
+	generator, err := corpusgenerator.NewGenerator(genLibClient, packageName, dataSetName, totSizeInBytes)
 	if err != nil {
 		return errors.Wrap(err, "can't generate benchmarks data corpus for data stream")
 	}

--- a/internal/corpusgenerator/client.go
+++ b/internal/corpusgenerator/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/elastic/elastic-integration-corpus-generator-tool/pkg/genlib"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-package/internal/logger"
@@ -27,8 +28,15 @@ type Client struct {
 	commit string
 }
 
+// GenLibClient is an interface for the genlib client
+type GenLibClient interface {
+	GetGoTextTemplate(packageName, dataStreamName string) ([]byte, error)
+	GetConf(packageName, dataStreamName string) (genlib.Config, error)
+	GetFields(packageName, dataStreamName string) (genlib.Fields, error)
+}
+
 // NewClient creates a new instance of the client.
-func NewClient(commit string) *Client {
+func NewClient(commit string) GenLibClient {
 	return &Client{commit: commit}
 }
 

--- a/internal/corpusgenerator/utils.go
+++ b/internal/corpusgenerator/utils.go
@@ -73,9 +73,7 @@ func RunGenerator(generator genlib.Generator, dataStream, rallyTrackOutputDir st
 	return generator.Close()
 }
 
-func NewGenerator(packageName, dataStreamName, commit string, totSizeInBytes uint64) (genlib.Generator, error) {
-
-	genLibClient := NewClient(commit)
+func NewGenerator(genLibClient GenLibClient, packageName, dataStreamName string, totSizeInBytes uint64) (genlib.Generator, error) {
 
 	config, err := genLibClient.GetConf(packageName, dataStreamName)
 	if err != nil {

--- a/internal/corpusgenerator/utils_test.go
+++ b/internal/corpusgenerator/utils_test.go
@@ -1,0 +1,42 @@
+package corpusgenerator
+
+import (
+	"bytes"
+	"github.com/elastic/elastic-integration-corpus-generator-tool/pkg/genlib"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"testing"
+)
+
+type mockClient struct {
+}
+
+func (c mockClient) GetGoTextTemplate(packageName, dataStreamName string) ([]byte, error) {
+	return []byte("7 bytes"), nil
+}
+func (c mockClient) GetConf(packageName, dataStreamName string) (genlib.Config, error) {
+	return genlib.Config{}, nil
+}
+func (c mockClient) GetFields(packageName, dataStreamName string) (genlib.Fields, error) {
+	return genlib.Fields{}, nil
+}
+
+func TestGeneratorEmitTotEvents(t *testing.T) {
+	generator, err := NewGenerator(mockClient{}, "packageName", "dataSetName", 7)
+	assert.NoError(t, err)
+
+	state := genlib.NewGenState()
+
+	totEvents := 0
+	buf := bytes.NewBufferString("")
+	for {
+		err := generator.Emit(state, buf)
+		if err == io.EOF {
+			break
+		}
+
+		totEvents += 1
+	}
+
+	assert.Equal(t, 1, totEvents, "expected 1 totEvents, got %d", totEvents)
+}


### PR DESCRIPTION
We'll soon release a new version of the corpus generator tool

the the signature of the function used from the dependency didn't change:
new
```
func NewGeneratorWithTextTemplate(tpl []byte, cfg Config, fields Fields, totEvents uint64) (*GeneratorWithTextTemplate, error) {
```
v0.5.0
```
func NewGeneratorWithTextTemplate(tpl []byte, cfg Config, fields Fields, totSize uint64) (*GeneratorWithTextTemplate, error) {
```

just the last `uint64` has a different meaning, so nothing will break: just the number of events generated will be different

here we add a unit test to check the expected number of events so when dependabot will create the PR for the bump will fail

