### PR TITLE
Some UI improvements around current profile

### DIFF
--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -63,9 +63,9 @@ User profiles can be configured with a "config.yml" file in the profile director
 			}
 
 			if fromName == "" {
-				fmt.Printf("Created profile %s.\n", newProfileName)
+				fmt.Printf("Created profile %q.\n", newProfileName)
 			} else {
-				fmt.Printf("Created profile %s from %s.\n", newProfileName, fromName)
+				fmt.Printf("Created profile %q from %q.\n", newProfileName, fromName)
 			}
 
 			return nil
@@ -82,12 +82,32 @@ User profiles can be configured with a "config.yml" file in the profile director
 			}
 			profileName := args[0]
 
-			err := profile.DeleteProfile(profileName)
+			config, err := install.Configuration()
+			if err != nil {
+				return fmt.Errorf("failed to load current configuration: %w", err)
+			}
+
+			err = profile.DeleteProfile(profileName)
 			if err != nil {
 				return errors.Wrap(err, "error deleting profile")
 			}
 
-			fmt.Printf("Deleted profile %s\n", profileName)
+			if currentProfile := config.CurrentProfile(); currentProfile == profileName {
+				config.SetCurrentProfile(profile.DefaultProfile)
+
+				location, err := locations.NewLocationManager()
+				if err != nil {
+					return fmt.Errorf("error fetching profile: %w", err)
+				}
+				err = install.WriteConfigFile(location, config)
+				if err != nil {
+					return fmt.Errorf("failed to store configuration: %w", err)
+				}
+
+				cmd.Printf("%q was the current profile. Default profile will be used now.\n", profileName)
+			}
+
+			fmt.Printf("Deleted profile %q.\n", profileName)
 
 			return nil
 		},
@@ -117,7 +137,11 @@ User profiles can be configured with a "config.yml" file in the profile director
 
 			switch format {
 			case tableFormat:
-				return formatTable(profileList)
+				config, err := install.Configuration()
+				if err != nil {
+					return fmt.Errorf("failed to load current configuration: %w", err)
+				}
+				return formatTable(profileList, config.CurrentProfile())
 			case jsonFormat:
 				return formatJSON(profileList)
 			default:
@@ -156,6 +180,8 @@ User profiles can be configured with a "config.yml" file in the profile director
 			if err != nil {
 				return fmt.Errorf("failed to store configuration: %w", err)
 			}
+
+			cmd.Printf("Current profile set to %q.\n", profileName)
 			return nil
 		},
 	}
@@ -181,9 +207,9 @@ func formatJSON(profileList []profile.Metadata) error {
 	return nil
 }
 
-func formatTable(profileList []profile.Metadata) error {
+func formatTable(profileList []profile.Metadata, currentProfile string) error {
 	table := tablewriter.NewWriter(os.Stdout)
-	var profilesTable = profileToList(profileList)
+	var profilesTable = profileToList(profileList, currentProfile)
 
 	table.SetHeader([]string{"Name", "Date Created", "User", "Version", "Path"})
 	table.SetHeaderColor(
@@ -209,10 +235,14 @@ func formatTable(profileList []profile.Metadata) error {
 	return nil
 }
 
-func profileToList(profiles []profile.Metadata) [][]string {
+func profileToList(profiles []profile.Metadata, currentProfile string) [][]string {
 	var profileList [][]string
 	for _, profile := range profiles {
-		profileList = append(profileList, []string{profile.Name, profile.DateCreated.Format(time.RFC3339), profile.User, profile.Version, profile.Path})
+		name := profile.Name
+		if name == currentProfile {
+			name = name + " (current)"
+		}
+		profileList = append(profileList, []string{name, profile.DateCreated.Format(time.RFC3339), profile.User, profile.Version, profile.Path})
 	}
 
 	return profileList


### PR DESCRIPTION
`elastic-package profiles use` can be used to select the profile that will be used by default. This change includes some UI improvements around it.

* Current profile is shown now in `elastic-package profiles list`.
* If current profile is deleted, current profile is replaced by the default profile, that cannot be removed.
* A confirmation message is shown now after changing the current profile.

How to test
---
* Create a new profile (`elastic-package profiles create test`).
* List profiles, and check that you can see what is the current profile (`elastic-package profiles list`).
* Select the created profile as the current one (`elastic-package profiles use test`).
* List profiles, and check that you can see that your profile is the current profile (`elastic-package profiles list`).
* Delete the current profile (`elastic-package profiles delete test`). 
* List profiles, and check that the default profile is the current profile (`elastic-package profiles list`).