### PR TITLE
Add new pipeline to test elastic-package with integrations repository

### DIFF
--- a/.buildkite/pipeline.test-with-integrations-repo.yml
+++ b/.buildkite/pipeline.test-with-integrations-repo.yml
@@ -1,0 +1,12 @@
+env:
+  GOLANG_VERSION: "1.20.3"
+
+steps:
+  - label: ":go: Run check-static"
+    key: check-static
+    command: "make check-static"
+    agents:
+      image: "golang:${GOLANG_VERSION}"
+      cpu: "8"
+      memory: "4G"
+

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -38,7 +38,7 @@
         "allow_org_users": true,
         "allowed_repo_permissions": ["admin", "write"],
         "allowed_list": [ ],
-        "set_commit_status": true,
+        "set_commit_status": false,
         "build_on_commit": false,
         "build_on_comment": true,
         "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:test)\\W+(?:integrations))$",

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -31,6 +31,22 @@
         "skip_target_branches": [ ],
         "skip_ci_on_only_changed": [ ],
         "always_require_ci_on_changed": [ ]
+     },
+     {
+        "enabled": true,
+        "pipelineSlug": "elastic-package-test-with-integrations",
+        "allow_org_users": true,
+        "allowed_repo_permissions": ["admin", "write"],
+        "allowed_list": [ ],
+        "set_commit_status": true,
+        "build_on_commit": false,
+        "build_on_comment": true,
+        "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:test)\\W+(?:integrations))$",
+        "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:test)\\W+(?:integrations))$",
+        "skip_ci_labels": [ ],
+        "skip_target_branches": [ ],
+        "skip_ci_on_only_changed": [ ],
+        "always_require_ci_on_changed": [ ]
      }
    ]
 }

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -69,7 +69,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
   name: buildkite-pipeline-elastic-package-package-storage-publish
-  description: 'Minimal Jenkins pipeline to exercise publishing a package to Package Storage (for testing only)'
+  description: 'Minimal pipeline to exercise publishing a package to Package Storage (for testing only)'
   links:
     - title: Pipeline
       url: https://buildkite.com/elastic/elastic-package-package-storage-publish
@@ -83,7 +83,7 @@ spec:
     kind: Pipeline
     metadata:
       name: elastic-package-package-storage-publish
-      description: 'Minimal Jenkins pipeline to exercise publishing a package to Package Storage (for testing only)'
+      description: 'Minimal pipeline to exercise publishing a package to Package Storage (for testing only)'
     spec:
       branch_configuration: main
       pipeline_file: ".buildkite/pipeline.package-storage-publish.yml"
@@ -91,6 +91,52 @@ spec:
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
         build_tags: true
+        filter_enabled: true
+        filter_condition: |
+          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
+      repository: elastic/elastic-package
+      cancel_intermediate_builds: true
+      cancel_intermediate_builds_branch_filter: '!main'
+      skip_intermediate_builds: true
+      skip_intermediate_builds_branch_filter: '!main'
+      teams:
+        ecosystem:
+          access_level: MANAGE_BUILD_AND_READ
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elastic-package-test-with-integrations
+  description: 'Buildkite pipeline to run specific elastic-package version with all packages in integrations repository'
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/elastic-package-test-with-integrations
+
+spec:
+  type: buildkite-pipeline
+  owner: group:ingest-fp
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: elastic-package-test-with-integrations
+      description: 'Buildkite pipeline to run specific elastic-package version with all packages in integrations repository'
+    spec:
+      branch_configuration: main
+      pipeline_file: ".buildkite/pipeline.test-with-integrations-repo.yml"
+      provider_settings:
+        build_tags: false # just run on demand
+        build_branches: false # just run on demand
+        publish_commit_status: false # do not update status of commits for this pipeline
+        build_pull_request_forks: false
+        build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
         filter_enabled: true
         filter_condition: |
           build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)


### PR DESCRIPTION
This PR adds a new pipeline `elastic-package-test-with-integrations` for Buildkite. This pipeline is intended to check a specific version of elastic-package with all the defined packages in the [integrations repository](https://github.com/elastic/integrations)

This PR includes:
- Add the new pipeline and its settings into `catalog-info.yaml`
- Add a new configuration entry for the bot: just allowing running on comments
    - Examples of valid comments:
        - `buildkite test integrations`
        - `test integrations`
- Add a minimal pipeline with just one step as a placeholder (`.buildkite/test-with-integrations-repo.yml`)