### PR TITLE
internal/testrunner/runners/pipeline: clarify warning of error.message type

### DIFF
--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -385,6 +385,16 @@ func checkErrorMessage(event json.RawMessage) error {
 		return nil
 	case string, []string:
 		return fmt.Errorf("unexpected pipeline error: %s", m)
+	case []interface{}:
+		for i, v := range m {
+			switch v.(type) {
+			case string:
+				break
+			default:
+				return fmt.Errorf("unexpected pipeline error (unexpected error.message type %T at position %d): %v", v, i, m)
+			}
+		}
+		return fmt.Errorf("unexpected pipeline error: %s", m)
 	default:
 		return fmt.Errorf("unexpected pipeline error (unexpected error.message type %T): %[1]v", m)
 	}


### PR DESCRIPTION
The current warning is unclear and confusing when a []any containing only strings is held in error.message. encoding/json will store an array of string as []any, so when we see that check each element for stringness.

Relates to https://github.com/elastic/integrations/pull/6258#issuecomment-1569066252.

Please take a look.