### PR TITLE
Fix package-level variables in system tests

### DIFF
--- a/internal/kibana/policies.go
+++ b/internal/kibana/policies.go
@@ -189,7 +189,7 @@ type PackageDataStream struct {
 	Enabled     bool    `json:"enabled"`
 	OutputID    string  `json:"output_id"`
 	Inputs      []Input `json:"inputs"`
-	Vars        Vars    `json:"vars"`
+	Vars        Vars    `json:"vars,omitempty"`
 	Package     struct {
 		Name    string `json:"name"`
 		Title   string `json:"title"`

--- a/internal/kibana/policies.go
+++ b/internal/kibana/policies.go
@@ -189,6 +189,7 @@ type PackageDataStream struct {
 	Enabled     bool    `json:"enabled"`
 	OutputID    string  `json:"output_id"`
 	Inputs      []Input `json:"inputs"`
+	Vars        Vars    `json:"vars"`
 	Package     struct {
 		Name    string `json:"name"`
 		Title   string `json:"title"`

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -582,17 +582,14 @@ func createIntegrationPackageDatastream(
 	streams[0].Vars = setKibanaVariables(stream.Vars, config.DataStream.Vars)
 	r.Inputs[0].Streams = streams
 
-	// Add package-level vars
-	var inputVars []packages.Variable
+	// Add input-level vars
 	input := policyTemplate.FindInputByType(streamInput)
 	if input != nil {
-		// copy package-level vars into each input
-		inputVars = append(inputVars, input.Vars...)
-		inputVars = append(inputVars, pkg.Vars...)
+		r.Inputs[0].Vars = setKibanaVariables(input.Vars, config.Vars)
 	}
 
-	r.Inputs[0].Vars = setKibanaVariables(inputVars, config.Vars)
-	r.Vars = r.Inputs[0].Vars
+	// Add package-level vars
+	r.Vars = setKibanaVariables(pkg.Vars, config.Vars)
 
 	return r
 }

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -592,6 +592,7 @@ func createIntegrationPackageDatastream(
 	}
 
 	r.Inputs[0].Vars = setKibanaVariables(inputVars, config.Vars)
+	r.Vars = r.Inputs[0].Vars
 
 	return r
 }

--- a/test/packages/parallel/gcp/data_stream/compute/_dev/test/system/test-default-config.yml
+++ b/test/packages/parallel/gcp/data_stream/compute/_dev/test/system/test-default-config.yml
@@ -1,7 +1,8 @@
 # wait_for_data_timeout: 10m
 vars:
   project_id: "{{GCP_PROJECT_ID}}"
-  zone: "{{GCP_ZONE}}"
   credentials_json: '{{{GOOGLE_CREDENTIALS}}}'
-data_streams:
-  vars: ~
+data_stream:
+  vars:
+    zone: "{{GCP_ZONE}}"
+    region: "{{GCP_REGION}}"

--- a/test/packages/parallel/gcp/manifest.yml
+++ b/test/packages/parallel/gcp/manifest.yml
@@ -32,7 +32,6 @@ vars:
     multi: false
     required: true
     show_user: true
-    default: SET_PROJECT_NAME
   - name: credentials_file
     type: text
     title: Credentials File


### PR DESCRIPTION
There can be variables at the data stream, input and package levels. We were mixing variables at the input and package level. This was probably hiding issues, for example the GCP test package had a default in the project ID, and this was hiding that the project ID wasn't actually being set. Removing this default reproduced the issue.