### PR TITLE
Initialize default reports directory only when needed

### DIFF
--- a/internal/cobraext/flags.go
+++ b/internal/cobraext/flags.go
@@ -130,7 +130,7 @@ const (
 	ReportOutputFlagDescription = "output type for test report, eg: stdout, file"
 
 	ReportOutputPathFlagName        = "report-output-path"
-	ReportOutputPathFlagDescription = "output path for test report"
+	ReportOutputPathFlagDescription = "output path for test report (defaults to %q in build directory)"
 
 	ShowAllFlagName        = "all"
 	ShowAllFlagDescription = "show all deployed package revisions"


### PR DESCRIPTION
`report` subcommand had some code to initialize its defaults for the output directory. This code was executed during the initialization of the subcommand, that is allways executed.

When running any command out of a package directory, this initialization fails, as it depends on the package directory, and it produces an error message.

Move this initialization to the code that gets the parameter in the `report` subcommand, so it is only executed there, and only if the user has not provided a value for the flag.

This was reported in https://github.com/elastic/elastic-package/issues/1282#issuecomment-1573067350.