### PR TITLE
Skipped malformed docker-compose log lines

### DIFF
--- a/internal/stack/parselogs.go
+++ b/internal/stack/parselogs.go
@@ -56,6 +56,8 @@ func ParseLogs(options ParseLogsOptions, process func(log LogLine) error) error 
 		}
 
 		// There could be valid messages with just plain text without timestamp
+		// and therefore not processed, cannot be ensured in which timestamp they
+		// were generated
 		if !startProcessing && log.Timestamp.Before(options.StartTime) {
 			continue
 		}

--- a/internal/stack/parselogs.go
+++ b/internal/stack/parselogs.go
@@ -7,10 +7,11 @@ package stack
 import (
 	"bufio"
 	"encoding/json"
-	"fmt"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/elastic/elastic-package/internal/logger"
 )
 
 type ParseLogsOptions struct {
@@ -41,7 +42,8 @@ func ParseLogs(options ParseLogsOptions, process func(log LogLine) error) error 
 		messageSlice := strings.SplitN(line, "|", 2)
 
 		if len(messageSlice) != 2 {
-			return fmt.Errorf("malformed docker-compose log line")
+			logger.Debugf("skipped malformed docker-compose log line: %s", line)
+			continue
 		}
 
 		messageLog := messageSlice[1]


### PR DESCRIPTION
Closes #1296 

When running `elastic-package` along with docker-compose v1.* , the first line of the `docker-compose logs` command is always like: `Attaching to <container>`. For instance:
```
Attaching to elastic-package-stack_elastic-agent_1
```


This message is not actual log and `elastic-package test system` was failing due to that. Expected messages should be like:
```
elastic-package-stack-elastic-agent-1  | {"log.level":"info","@timestamp":"2023-06-07T13:27:48.548Z","message":"Non-zero metrics in the last 30s","component":{"binary":"metricbeat","dataset":"elastic_agent.metricbeat","id":"beat/metrics-monitoring","type":"beat/metrics"},"log":{"source":"beat/metrics-monitoring"},"log.logger":"monitoring","log.origin":{"file.line":187,"file.name":"log/log.go"},"service.name":"metricbeat",...,"ecs.version":"1.6.0"}
```

This PR changes this behaviour to avoid raising an error and instead it logs a debug message. Those log lines that are not log-like messages are skipped.