### PR TITLE
Validate JSON output file before unmarshall

### DIFF
--- a/internal/testrunner/runners/system/servicedeployer/terraform.go
+++ b/internal/testrunner/runners/system/servicedeployer/terraform.go
@@ -64,8 +64,14 @@ func addTerraformOutputs(outCtxt ServiceContext) error {
 	// Unmarshall the data into `terraformOutputs`
 	logger.Debug("Unmarshalling terraform output json")
 	var terraformOutputs map[string]OutputMeta
-	if err = json.Unmarshal(content, &terraformOutputs); err != nil {
-		return fmt.Errorf("error during json Unmarshal %w", err)
+
+	if json.Valid(content) {
+		if err = json.Unmarshal(content, &terraformOutputs); err != nil {
+			return fmt.Errorf("error during json Unmarshal %w", err)
+		}
+	} else {
+		logger.Error("Invalid Json Content")
+		return nil
 	}
 
 	if len(terraformOutputs) == 0 {

--- a/internal/testrunner/runners/system/servicedeployer/terraform.go
+++ b/internal/testrunner/runners/system/servicedeployer/terraform.go
@@ -65,13 +65,13 @@ func addTerraformOutputs(outCtxt ServiceContext) error {
 	logger.Debug("Unmarshalling terraform output json")
 	var terraformOutputs map[string]OutputMeta
 
-	if json.Valid(content) {
-		if err = json.Unmarshal(content, &terraformOutputs); err != nil {
-			return fmt.Errorf("error during json Unmarshal %w", err)
-		}
-	} else {
-		logger.Error("Invalid Json Content")
+	if !json.Valid(content) {
+		logger.Debug("Invalid Json content in the terraform output file, skipped creating outputs")
 		return nil
+	}
+
+	if err = json.Unmarshal(content, &terraformOutputs); err != nil {
+		return fmt.Errorf("error during json Unmarshal %w", err)
 	}
 
 	if len(terraformOutputs) == 0 {

--- a/internal/testrunner/runners/system/servicedeployer/terraform_test.go
+++ b/internal/testrunner/runners/system/servicedeployer/terraform_test.go
@@ -21,6 +21,28 @@ func TestAddTerraformOutputs(t *testing.T) {
 		expectedProps map[string]interface{}
 	}{
 		{
+			testName: "invalid_json_output",
+			runId:    "987987",
+			ctxt: ServiceContext{
+				Test: struct{ RunID string }{"987987"},
+			},
+			content: []byte(
+				``,
+			),
+			expectedProps: map[string]interface{}{},
+		},
+		{
+			testName: "empty_json_output",
+			runId:    "v",
+			ctxt: ServiceContext{
+				Test: struct{ RunID string }{"9887"},
+			},
+			content: []byte(
+				`{}`,
+			),
+			expectedProps: map[string]interface{}{},
+		},
+		{
 			testName: "single_value_output",
 			runId:    "99999",
 			ctxt: ServiceContext{
@@ -121,7 +143,8 @@ func TestAddTerraformOutputs(t *testing.T) {
 			}
 
 			// Test that the terraform output values are generated correctly
-			addTerraformOutputs(tc.ctxt)
+			err := addTerraformOutputs(tc.ctxt)
+			assert.Equal(t, err, nil)
 			assert.Equal(t, tc.expectedProps, tc.ctxt.CustomProperties)
 		})
 	}

--- a/internal/testrunner/runners/system/servicedeployer/terraform_test.go
+++ b/internal/testrunner/runners/system/servicedeployer/terraform_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddTerraformOutputs(t *testing.T) {
@@ -144,7 +145,7 @@ func TestAddTerraformOutputs(t *testing.T) {
 
 			// Test that the terraform output values are generated correctly
 			err := addTerraformOutputs(tc.ctxt)
-			assert.Equal(t, err, nil)
+			require.NoError(t, err)
 			assert.Equal(t, tc.expectedProps, tc.ctxt.CustomProperties)
 		})
 	}

--- a/test/packages/parallel/aws/data_stream/ec2_metrics/_dev/deploy/tf/main.tf
+++ b/test/packages/parallel/aws/data_stream/ec2_metrics/_dev/deploy/tf/main.tf
@@ -31,3 +31,7 @@ data "aws_ami" "latest-amzn" {
     values = ["amzn2-ami-minimal-hvm-*-ebs"]
   }
 }
+
+output "instance_id" {
+  value = aws_instance.i.id
+}

--- a/test/packages/parallel/aws/data_stream/ec2_metrics/_dev/deploy/tf/main.tf
+++ b/test/packages/parallel/aws/data_stream/ec2_metrics/_dev/deploy/tf/main.tf
@@ -31,7 +31,3 @@ data "aws_ami" "latest-amzn" {
     values = ["amzn2-ami-minimal-hvm-*-ebs"]
   }
 }
-
-output "instance_id" {
-  value = aws_instance.i.id
-}


### PR DESCRIPTION
The terraform output file sometimes is empty and json [unmarshall](https://github.com/elastic/elastic-package/blob/main/internal/testrunner/runners/system/servicedeployer/terraform.go#L67) throws an error.

The fix is to validate the json file before unmarshalling it.

- Fixes #1299