### PR TITLE
Update format_version set when creating new packages

### DIFF
--- a/internal/packages/archetype/package_manifest.go
+++ b/internal/packages/archetype/package_manifest.go
@@ -4,7 +4,7 @@
 
 package archetype
 
-const packageManifestTemplate = `format_version: 2.5.1
+const packageManifestTemplate = `format_version: 2.8.0
 name: {{.Manifest.Name}}
 title: "{{.Manifest.Title}}"
 version: {{.Manifest.Version}}


### PR DESCRIPTION
This PR updates the default version used when creating new packages to the latest package-spec version. At the moment of creating this PR, this version is 2.8.0.

