### PR TITLE
Change folder ordering in PATH

### DIFF
--- a/.buildkite/scripts/install_deps.sh
+++ b/.buildkite/scripts/install_deps.sh
@@ -6,7 +6,7 @@ source .buildkite/scripts/tooling.sh
 
 add_bin_path(){
     mkdir -p ${WORKSPACE}/bin
-    export PATH="${PATH}:${WORKSPACE}/bin"
+    export PATH="${WORKSPACE}/bin:${PATH}"
 }
 
 with_kubernetes() {


### PR DESCRIPTION
This PR reverts partially #1290 
- Just reverted `add_bin_path` method
  ```
  PATH="${WORKSPACE}/bin:${PATH}"
  ```
- Order in PATH for go binaries is not changed. Should this be changed too? @alexsapran
  ```
  PATH="${PATH}:$(go env GOPATH)/bin"
  ```

In order to be able to use the docker-compose version set in the pipeline https://github.com/elastic/elastic-package/blob/main/.buildkite/pipeline.yml#L3 , `${WORKSPACE}/bin` should have preference over the paths in PATH.

- Currently, it is used the version installed in the agent image v2.18.1: [Example output in main](https://buildkite.com/elastic/elastic-package/builds/939#01889bdf-af07-41ee-9ec7-19d789df281e/56-61)
- In this PR, docker-compose version used is the one defined in the pipeline v2.17.2: [Example from this PR](https://buildkite.com/elastic/elastic-package/builds/971#0188b422-d07b-4ce9-b62f-effc4e4f5e5a/86-91)