### PR TITLE
[Buildkite] Avoid paging issues for git log messages

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -47,7 +47,7 @@ MERGE_BRANCH="pr_merge_${PR_ID}"
 checkout_merge "${TARGET_BRANCH}" "${PR_COMMIT}" "${MERGE_BRANCH}"
 
 echo "Commit information"
-git log --format=%B -n 1
+git --no-pager log --format=%B -n 1
 
 # Ensure buildkite groups are rendered
 echo ""


### PR DESCRIPTION
This PR adds the parameter `--no-pager` to the git log command used in the buildkite post-checkout hook.
This avoids that the Buildkite build gets stuck waiting for a press key.