### PR TITLE
Exclude failures on auto_create when checking logs

### DIFF
--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -73,8 +73,10 @@ var (
 				logsRegexp{
 					includes: regexp.MustCompile("^Cannot index event publisher.Event"),
 					excludes: []*regexp.Regexp{
-						// this regex is excluded to ensure that logs coming from the `system` package installed by default are not taken into account
+						// This regex is excluded to ensure that logs coming from the `system` package installed by default are not taken into account
 						regexp.MustCompile(`action \[indices:data\/write\/bulk\[s\]\] is unauthorized for API key id \[.*\] of user \[.*\] on indices \[.*\], this action is granted by the index privileges \[.*\]`),
+						// Some packages fail with this error, seen when upgrading to 0.83 in https://github.com/elastic/integrations/pull/6679
+						regexp.MustCompile(`action \[indices:admin\/auto_create\] is unauthorized for API key id \[.*\] of user \[.*\] on indices \[.*\], this action is granted by the index privileges \[.*\]`),
 					},
 				},
 				logsRegexp{


### PR DESCRIPTION
Attempt to fix issues appearing when upgrading to 0.83 (https://github.com/elastic/integrations/pull/6679), like these ones:
```
test case failed: one or more errors found while examining elastic-agent.log: [0] found error "Cannot index event publisher.Event{Content:beat.Event{Timestamp:time.Date(2023, time.June, 23, 18, 52, 30, 292868966, time.Local), Meta:{\"input_id\":\"metrics-monitoring-agent\",\"raw_index\":\"metrics-elastic_agent.filebeat_input-default\",\"stream_id\":\"metrics-monitoring-filebeat-1\"}, Fields:{\"agent\":{\"ephemeral_id\":\"e286b019-8818-4643-8fb1-e7484335c031\",\"id\":\"441247d6-867a-42dc-88b9-46a00005bf9e\",\"name\":\"docker-fleet-agent\",\"type\":\"metricbeat\",\"version\":\"8.8.0\"},\"cloud\":{\"account\":{\"id\":\"elastic-ci-prod\"},\"availability_zone\":\"us-central1-a\",\"instance\":{\"id\":\"643591845883436719\",\"name\":\"fleet-ci-immutable-ubuntu-2004-1687543784926570620\"},\"machine\":{\"type\":\"n1-highmem-8\"},\"project\":{\"id\":\"elastic-ci-prod\"},\"provider\":\"gcp\",\"region\":\"us-central1\",\"service\":{\"name\":\"GCE\"}},\"data_stream\":{\"dataset\":\"elastic_agent.filebeat_input\",\"namespace\":\"default\",\"type\":\"metrics\"},\"ecs\":{\"version\":\"8.0.0\"},\"elastic_agent\":{\"id\":\"441247d6-867a-42dc-88b9-46a00005bf9e\",\"process\":\"filebeat\",\"snapshot\":false,\"version\":\"8.8.0\"},\"error\":{\"message\":\"error making http request: Get \\\"http://unix/inputs\\\": dial unix /usr/share/elastic-agent/state/data/tmp/log-default.sock: connect: no such file or directory\"},\"event\":{\"dataset\":\"elastic_agent.filebeat_input\",\"duration\":316301,\"module\":\"http\"},\"host\":{\"architecture\":\"x86_64\",\"containerized\":true,\"hostname\":\"docker-fleet-agent\",\"id\":\"e8978f2086c14e13b7a0af9ed0011d19\",\"ip\":[\"172.18.0.7\"],\"mac\":[\"02-42-AC-12-00-07\"],\"name\":\"docker-fleet-agent\",\"os\":{\"codename\":\"focal\",\"family\":\"debian\",\"kernel\":\"5.15.0-1036-gcp\",\"name\":\"Ubuntu\",\"platform\":\"ubuntu\",\"type\":\"linux\",\"version\":\"20.04.6 LTS (Focal Fossa)\"}},\"metricset\":{\"name\":\"json\",\"period\":10000},\"service\":{\"address\":\"http://unix/inputs\",\"type\":\"http\"}}, Private:interface {}(nil), TimeSeries:true}, Flags:0x0, Cache:publisher.EventCache{m:mapstr.M(nil)}} (status=403): {\"type\":\"security_exception\",\"reason\":\"action [indices:admin/auto_create] is unauthorized for API key id [rgGZ6YgB_Y3KnevBSxrC] of user [elastic/fleet-server] on indices [metrics-elastic_agent.filebeat_input-default], this action is granted by the index privileges [auto_configure,create_index,manage,all]\"}, dropping event!"
```