### PR TITLE
Disable monitoring on system tests

### DIFF
--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -511,10 +511,9 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 	logger.Debug("creating test policy...")
 	testTime := time.Now().Format("20060102T15:04:05Z")
 	p := kibana.Policy{
-		Name:              fmt.Sprintf("ep-test-system-%s-%s-%s", r.options.TestFolder.Package, r.options.TestFolder.DataStream, testTime),
-		Description:       fmt.Sprintf("test policy created by elastic-package test system for data stream %s/%s", r.options.TestFolder.Package, r.options.TestFolder.DataStream),
-		Namespace:         "ep",
-		MonitoringEnabled: []string{"logs", "metrics"},
+		Name:        fmt.Sprintf("ep-test-system-%s-%s-%s", r.options.TestFolder.Package, r.options.TestFolder.DataStream, testTime),
+		Description: fmt.Sprintf("test policy created by elastic-package test system for data stream %s/%s", r.options.TestFolder.Package, r.options.TestFolder.DataStream),
+		Namespace:   "ep",
 	}
 	policy, err := kib.CreatePolicy(p)
 	if err != nil {


### PR DESCRIPTION
Revert this change included as part of #1232, that might be causing the issues seen in https://github.com/elastic/integrations/pull/6679.