### PR TITLE
Ensure that required commands are run for test benchmark packages

### DIFF
--- a/.buildkite/pipeline.trigger.integration.tests.sh
+++ b/.buildkite/pipeline.trigger.integration.tests.sh
@@ -36,8 +36,13 @@ CHECK_PACKAGES_TESTS=(
     test-check-packages-benchmarks
 )
 for test in ${CHECK_PACKAGES_TESTS[@]}; do
+    options=""
+    if [ "${test}" == "test-check-packages-benchmarks" ]; then
+        package_name=$(basename ${package})
+        options="-p ${package_name}"
+    fi
     echo "      - label: \":go: Running integration test: ${test}\""
-    echo "        command: ./.buildkite/scripts/integration_tests.sh -t ${test}"
+    echo "        command: ./.buildkite/scripts/integration_tests.sh -t ${test} ${options}"
     echo "        agents:"
     echo "          provider: \"gcp\""
     echo "        artifact_paths:"

--- a/.buildkite/pipeline.trigger.integration.tests.sh
+++ b/.buildkite/pipeline.trigger.integration.tests.sh
@@ -49,8 +49,6 @@ for test in ${CHECK_PACKAGES_TESTS[@]}; do
     fi
 done
 
-exit 0
-
 pushd test/packages/parallel > /dev/null
 for package in $(find . -maxdepth 1 -mindepth 1 -type d) ; do
     package_name=$(basename ${package})

--- a/.buildkite/pipeline.trigger.integration.tests.sh
+++ b/.buildkite/pipeline.trigger.integration.tests.sh
@@ -36,13 +36,8 @@ CHECK_PACKAGES_TESTS=(
     test-check-packages-benchmarks
 )
 for test in ${CHECK_PACKAGES_TESTS[@]}; do
-    options=""
-    if [ "${test}" == "test-check-packages-benchmarks" ]; then
-        package_name=$(basename ${package})
-        options="-p ${package_name}"
-    fi
     echo "      - label: \":go: Running integration test: ${test}\""
-    echo "        command: ./.buildkite/scripts/integration_tests.sh -t ${test} ${options}"
+    echo "        command: ./.buildkite/scripts/integration_tests.sh -t ${test}"
     echo "        agents:"
     echo "          provider: \"gcp\""
     echo "        artifact_paths:"

--- a/.buildkite/pipeline.trigger.integration.tests.sh
+++ b/.buildkite/pipeline.trigger.integration.tests.sh
@@ -49,6 +49,8 @@ for test in ${CHECK_PACKAGES_TESTS[@]}; do
     fi
 done
 
+exit 0
+
 pushd test/packages/parallel > /dev/null
 for package in $(find . -maxdepth 1 -mindepth 1 -type d) ; do
     package_name=$(basename ${package})

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -85,9 +85,10 @@ for d in test/packages/${PACKAGE_TEST_TYPE:-other}/${PACKAGE_UNDER_TEST:-*}/; do
           --old ${OLDPWD}/build/benchmark-results-old \
           --threshold 1 --report-output-path="${OLDPWD}/build/benchreport"
       fi
-      if [ "${package_to_test}" == "system_benchmark" ]; then
-        elastic-package benchmark system --benchmark logs-benchmark -v --defer-cleanup 1s
-      fi
+      # FIXME: running system benchmark in package "system_benchmark" fails with panic
+      # if [ "${package_to_test}" == "system_benchmark" ]; then
+      #   elastic-package benchmark system --benchmark logs-benchmark -v --defer-cleanup 1s
+      # fi
     else
       # defer-cleanup is set to a short period to verify that the option is available
       elastic-package test -v --report-format xUnit --report-output file --defer-cleanup 1s --test-coverage

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -69,21 +69,23 @@ for d in test/packages/${PACKAGE_TEST_TYPE:-other}/${PACKAGE_UNDER_TEST:-*}/; do
     elastic-package install -v
 
     if [ "${PACKAGE_TEST_TYPE:-other}" == "benchmarks" ]; then
-      if [ "${PACKAGE_UNDER_TEST:-*}" == "pipeline_benchmark" ]; then
+      # It is not used PACKAGE_UNDER_TEST, so all benchmark packages are run in the same loop
+      package_to_test=$(basename ${d})
+      if [ "${package_to_test}" == "pipeline_benchmark" ]; then
         rm -rf "${OLDPWD}/build/benchmark-results"
         elastic-package benchmark pipeline -v --report-format xUnit --report-output file --fail-on-missing
-        
+
         rm -rf "${OLDPWD}/build/benchmark-results-old"
         mv "${OLDPWD}/build/benchmark-results" "${OLDPWD}/build/benchmark-results-old"
-        
+
         elastic-package benchmark pipeline -v --report-format json --report-output file --fail-on-missing
-        
+
         elastic-package report --fail-on-missing benchmark \
           --new ${OLDPWD}/build/benchmark-results \
           --old ${OLDPWD}/build/benchmark-results-old \
           --threshold 1 --report-output-path="${OLDPWD}/build/benchreport"
       fi
-      if [ "${PACKAGE_UNDER_TEST:-*}" == "system_benchmark" ]; then
+      if [ "${package_to_test}" == "system_benchmark" ]; then
         elastic-package benchmark system --benchmark logs-benchmark -v --defer-cleanup 1s
       fi
     else

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -71,7 +71,6 @@ for d in test/packages/${PACKAGE_TEST_TYPE:-other}/${PACKAGE_UNDER_TEST:-*}/; do
     if [ "${PACKAGE_TEST_TYPE:-other}" == "benchmarks" ]; then
       # It is not used PACKAGE_UNDER_TEST, so all benchmark packages are run in the same loop
       package_to_test=$(basename ${d})
-      echo "> Checking package ${package_to_test}"
       if [ "${package_to_test}" == "pipeline_benchmark" ]; then
         rm -rf "${OLDPWD}/build/benchmark-results"
         elastic-package benchmark pipeline -v --report-format xUnit --report-output file --fail-on-missing

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -71,6 +71,7 @@ for d in test/packages/${PACKAGE_TEST_TYPE:-other}/${PACKAGE_UNDER_TEST:-*}/; do
     if [ "${PACKAGE_TEST_TYPE:-other}" == "benchmarks" ]; then
       # It is not used PACKAGE_UNDER_TEST, so all benchmark packages are run in the same loop
       package_to_test=$(basename ${d})
+      echo "> Checking package ${package_to_test}"
       if [ "${package_to_test}" == "pipeline_benchmark" ]; then
         rm -rf "${OLDPWD}/build/benchmark-results"
         elastic-package benchmark pipeline -v --report-format xUnit --report-output file --fail-on-missing


### PR DESCRIPTION
This PR adds the parameter `-p` in order to set the `PACKAGE_UNDER_TEST` variable for benchmark packages.

Required for the integrations shell script to run those tests: https://github.com/elastic/elastic-package/blob/57d0c6fcbed5a781907550097e84b1a1af9e7493/scripts/test-check-packages.sh#L72