### PR TITLE
[Fleet] Update version constraint for experimentalDataStreamSettings

### DIFF
--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -28,7 +28,7 @@ xpack.fleet.registryUrl: "https://package-registry:8080"
 xpack.fleet.agents.enabled: true
 xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server:8220"]
 
-{{ if not (semverLessThan $version "8.7.0") }}
+{{ if and (not (semverLessThan $version "8.7.0")) (semverLessThan $version "8.10.0") }}
 xpack.fleet.enableExperimental: ["experimentalDataStreamSettings"] # Enable experimental toggles in Fleet UI
 {{ end }}
 


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/155516

https://github.com/elastic/kibana/pull/160642 removes the `experimentalDataStreamSettings` feature flag in Kibana v8.10.0. This PR updates the version condition in `kibana.yml.tmpl` accordingly.

I have used [this working example](https://go.dev/play/p/gv8t8n_tR90) to validate the syntax.