### PR TITLE
[Fleet] Fix version constraint for experimentalDataStreamSettings

### DIFF
--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -28,7 +28,7 @@ xpack.fleet.registryUrl: "https://package-registry:8080"
 xpack.fleet.agents.enabled: true
 xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server:8220"]
 
-{{ if and (not (semverLessThan $version "8.7.0")) (semverLessThan $version "8.10.0") }}
+{{ if and (not (semverLessThan $version "8.7.0")) (semverLessThan $version "8.10.0-SNAPSHOT") }}
 xpack.fleet.enableExperimental: ["experimentalDataStreamSettings"] # Enable experimental toggles in Fleet UI
 {{ end }}
 

--- a/internal/stack/resources_test.go
+++ b/internal/stack/resources_test.go
@@ -69,3 +69,13 @@ func TestApplyResourcesWithCustomGeoipDir(t *testing.T) {
 	expectedVolume := fmt.Sprintf("%s:/usr/share/elasticsearch/config/ingest-geoip", expectedGeoipPath)
 	assert.Contains(t, volumes, expectedVolume)
 }
+
+func TestSemverLessThan(t *testing.T) {
+	b, err := semverLessThan("8.9.0", "8.10.0-SNAPSHOT")
+	require.NoError(t, err)
+	assert.True(t, b)
+
+	b, err = semverLessThan("8.10.0-SNAPSHOT", "8.10.0")
+	require.NoError(t, err)
+	assert.True(t, b)
+}


### PR DESCRIPTION
Fixes https://github.com/elastic/elastic-package/issues/1348

The Kibana version constraint of the `experimentalDataStreamSettings` was amended in https://github.com/elastic/elastic-package/pull/1328 to version > 8.7.0 and < 8.10.0. However, this fails for version 8.10.0-SNAPSHOT which is lower than 8.10.0.

This PR fixes the constraint and adds a unit test to the `TestSemverLessThan` function.