### PR TITLE
Update mergify rules to use Buildkite pipelines

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 queue_rules:
   - name: default
     conditions:
-      - check-success=elastic-package/pr-merge
+      - check-success=buildkite/elastic-package
 
 pull_request_rules:
   - name: automatic approval for Dependabot pull requests
@@ -13,7 +13,7 @@ pull_request_rules:
         message: Automatically approving dependabot
   - name: automatic merge of bot 🤖
     conditions:
-      - check-success=elastic-package/pr-merge
+      - check-success=buildkite/elastic-package
       - check-success=CLA
       - base=main
       - author~=^dependabot(|-preview)\[bot\]$


### PR DESCRIPTION
After being removed Jenkins pipeline in #1347, this PR updates Mergify rules to use buildkite pipeline.

