### PR TITLE
Increase wait_for_data_timeout for GCP test package

### DIFF
--- a/docs/howto/static_testing.md
+++ b/docs/howto/static_testing.md
@@ -26,4 +26,3 @@ If you want to run pipeline tests for **specific data streams** in a package, na
 ```
 elastic-package test static --data-streams <data stream 1>[,<data stream 2>,...]
 ```
-

--- a/docs/howto/static_testing.md
+++ b/docs/howto/static_testing.md
@@ -26,3 +26,4 @@ If you want to run pipeline tests for **specific data streams** in a package, na
 ```
 elastic-package test static --data-streams <data stream 1>[,<data stream 2>,...]
 ```
+

--- a/test/packages/parallel/gcp/data_stream/compute/_dev/test/system/test-default-config.yml
+++ b/test/packages/parallel/gcp/data_stream/compute/_dev/test/system/test-default-config.yml
@@ -1,4 +1,4 @@
-wait_for_data_timeout: 20m
+wait_for_data_timeout: 30m
 vars:
   project_id: "{{GCP_PROJECT_ID}}"
   credentials_json: '{{{GOOGLE_CREDENTIALS}}}'

--- a/test/packages/parallel/gcp/data_stream/compute/_dev/test/system/test-default-config.yml
+++ b/test/packages/parallel/gcp/data_stream/compute/_dev/test/system/test-default-config.yml
@@ -1,4 +1,4 @@
-wait_for_data_timeout: 35m
+wait_for_data_timeout: 40m
 vars:
   project_id: "{{GCP_PROJECT_ID}}"
   credentials_json: '{{{GOOGLE_CREDENTIALS}}}'

--- a/test/packages/parallel/gcp/data_stream/compute/_dev/test/system/test-default-config.yml
+++ b/test/packages/parallel/gcp/data_stream/compute/_dev/test/system/test-default-config.yml
@@ -1,4 +1,4 @@
-wait_for_data_timeout: 30m
+wait_for_data_timeout: 35m
 vars:
   project_id: "{{GCP_PROJECT_ID}}"
   credentials_json: '{{{GOOGLE_CREDENTIALS}}}'


### PR DESCRIPTION
 This PR updates the `wait_for_data_timeout` for the `gcp` test package.

Latest builds were failing due to ([example](https://buildkite.com/elastic/elastic-package/builds/1202#0189870a-c593-43c0-8f2a-a922e1c715f3)):
> Error: error running package system tests: could not complete test run: could not find hits in metrics-gcp.compute-ep data stream

Tested with 30 minutes and the build finished successfully:

https://buildkite.com/elastic/elastic-package/builds/1206

Attemps:
1. 29 minutes (30 min timeout).
    - starting to check for hits at **16:09:35**: https://buildkite.com/elastic/elastic-package/builds/1206#018988a2-035d-4b8f-8b96-aeb22ec38094/100-668
    - found hits at **16:38:48**: https://buildkite.com/elastic/elastic-package/builds/1206#018988a2-035d-4b8f-8b96-aeb22ec38094/100-2422
2. 32 mins (35 min timeout):
    - starting to check for hits at **08:40:12**: https://buildkite.com/elastic/elastic-package/builds/1209#01898c2d-28cb-4dd8-8ed9-727d520f01d7/101-670
    - found hits at **09:12:17**: https://buildkite.com/elastic/elastic-package/builds/1209#01898c2d-28cb-4dd8-8ed9-727d520f01d7/101-2595
3. 35 min (hit threshold 35 min and failed)
    - https://buildkite.com/elastic/elastic-package/builds/1211#01898c67-6adc-41fa-a0d3-2326a54453b2 
4. 32 min (35 min threshold)
    - https://buildkite.com/elastic/elastic-package/builds/1215#01898c9b-3380-4fae-959f-e35a102a6d7b  
6. 31 min (40 min threshold)
    - https://buildkite.com/elastic/elastic-package/builds/1216#01898cce-c902-45e9-b921-585954616289
7. 29 min (40 min threshold)
    - https://buildkite.com/elastic/elastic-package/builds/1217#01898d0d-96f5-4780-9138-6388b238f0a0
8. 23 min (40 min threshold)
    - https://buildkite.com/elastic/elastic-package/builds/1218#01898d49-09ae-406e-98a6-aaab2e690437
9. 37 mins (40 min threshold)
    - https://buildkite.com/elastic/elastic-package/builds/1219#01898d8e-e1ff-4151-becd-7396a0d3499e