### PR TITLE
Add profile flag to commands to allow running profiles at the same time

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dustin/go-humanize"
 
 	"github.com/elastic/elastic-package/internal/corpusgenerator"
+	"github.com/elastic/elastic-package/internal/install"
 	"github.com/elastic/elastic-package/internal/kibana"
 
 	"github.com/spf13/cobra"
@@ -56,6 +57,8 @@ func setupBenchmarkCommand() *cobraext.Command {
 		Short: "Run benchmarks for the package",
 		Long:  benchLongDescription,
 	}
+
+	cmd.PersistentFlags().StringP(cobraext.ProfileFlagDescription, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
 
 	pipelineCmd := getPipelineCommand()
 	cmd.AddCommand(pipelineCmd)
@@ -248,6 +251,11 @@ func systemCommandAction(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("locating package root failed: %w", err)
 	}
 
+	profile, err := cobraext.GetProfileFlag(cmd)
+	if err != nil {
+		return nil
+	}
+
 	signal.Enable()
 
 	esClient, err := elasticsearch.NewClient()
@@ -272,6 +280,7 @@ func systemCommandAction(cmd *cobra.Command, args []string) error {
 		system.WithPackageRootPath(packageRootPath),
 		system.WithESAPI(esClient.API),
 		system.WithKibanaClient(kc),
+		system.WithProfile(profile),
 	)
 	runner := system.NewSystemBenchmark(opts)
 

--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -58,7 +58,7 @@ func setupBenchmarkCommand() *cobraext.Command {
 		Long:  benchLongDescription,
 	}
 
-	cmd.PersistentFlags().StringP(cobraext.ProfileFlagDescription, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
+	cmd.PersistentFlags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
 
 	pipelineCmd := getPipelineCommand()
 	cmd.AddCommand(pipelineCmd)

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cobraext"
+	"github.com/elastic/elastic-package/internal/install"
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/service"
 )
@@ -35,6 +36,7 @@ func setupServiceCommand() *cobraext.Command {
 		Long:  serviceLongDescription,
 	}
 	cmd.AddCommand(upCommand)
+	cmd.PersistentFlags().StringP(cobraext.ProfileFlagDescription, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
 
 	return cobraext.NewCommand(cmd, cobraext.ContextPackage)
 }
@@ -58,8 +60,14 @@ func upCommandAction(cmd *cobra.Command, args []string) error {
 
 	variantFlag, _ := cmd.Flags().GetString(cobraext.VariantFlagName)
 
+	profile, err := cobraext.GetProfileFlag(cmd)
+	if err != nil {
+		return nil
+	}
+
 	_, serviceName := filepath.Split(packageRoot)
 	err = service.BootUp(service.Options{
+		Profile:            profile,
 		ServiceName:        serviceName,
 		PackageRootPath:    packageRoot,
 		DataStreamRootPath: dataStreamPath,

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -36,7 +36,7 @@ func setupServiceCommand() *cobraext.Command {
 		Long:  serviceLongDescription,
 	}
 	cmd.AddCommand(upCommand)
-	cmd.PersistentFlags().StringP(cobraext.ProfileFlagDescription, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
+	cmd.PersistentFlags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
 
 	return cobraext.NewCommand(cmd, cobraext.ContextPackage)
 }

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -226,6 +226,7 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 		var results []testrunner.TestResult
 		for _, folder := range testFolders {
 			r, err := testrunner.Run(testType, testrunner.TestOptions{
+				Profile:            profile,
 				TestFolder:         folder,
 				PackageRootPath:    packageRootPath,
 				GenerateTestResult: generateTestResult,
@@ -233,7 +234,6 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 				DeferCleanup:       deferCleanup,
 				ServiceVariant:     variantFlag,
 				WithCoverage:       testCoverage,
-				Profile:            profile,
 			})
 
 			results = append(results, r...)

--- a/internal/benchrunner/runners/system/options.go
+++ b/internal/benchrunner/runners/system/options.go
@@ -9,10 +9,12 @@ import (
 
 	"github.com/elastic/elastic-package/internal/elasticsearch"
 	"github.com/elastic/elastic-package/internal/kibana"
+	"github.com/elastic/elastic-package/internal/profile"
 )
 
 // Options contains benchmark runner options.
 type Options struct {
+	Profile          *profile.Profile
 	ESAPI            *elasticsearch.API
 	KibanaClient     *kibana.Client
 	DeferCleanup     time.Duration
@@ -70,5 +72,11 @@ func WithMetricsInterval(d time.Duration) OptionFunc {
 func WithDataReindexing(b bool) OptionFunc {
 	return func(opts *Options) {
 		opts.ReindexData = b
+	}
+}
+
+func WithProfile(p *profile.Profile) OptionFunc {
+	return func(opts *Options) {
+		opts.Profile = p
 	}
 }

--- a/internal/benchrunner/runners/system/runner.go
+++ b/internal/benchrunner/runners/system/runner.go
@@ -230,6 +230,7 @@ func (r *runner) run() (report reporters.Reportable, err error) {
 		// Setup service.
 		logger.Debug("setting up service...")
 		serviceDeployer, err := servicedeployer.Factory(servicedeployer.FactoryOptions{
+			Profile:  r.options.Profile,
 			RootPath: r.options.PackageRootPath,
 		})
 

--- a/internal/benchrunner/runners/system/servicedeployer/compose.go
+++ b/internal/benchrunner/runners/system/servicedeployer/compose.go
@@ -15,12 +15,14 @@ import (
 	"github.com/elastic/elastic-package/internal/docker"
 	"github.com/elastic/elastic-package/internal/files"
 	"github.com/elastic/elastic-package/internal/logger"
+	"github.com/elastic/elastic-package/internal/profile"
 	"github.com/elastic/elastic-package/internal/stack"
 )
 
 // DockerComposeServiceDeployer knows how to deploy a service defined via
 // a Docker Compose file.
 type DockerComposeServiceDeployer struct {
+	profile  *profile.Profile
 	ymlPaths []string
 }
 
@@ -32,8 +34,9 @@ type dockerComposeDeployedService struct {
 }
 
 // NewDockerComposeServiceDeployer returns a new instance of a DockerComposeServiceDeployer.
-func NewDockerComposeServiceDeployer(ymlPaths []string) (*DockerComposeServiceDeployer, error) {
+func NewDockerComposeServiceDeployer(profile *profile.Profile, ymlPaths []string) (*DockerComposeServiceDeployer, error) {
 	return &DockerComposeServiceDeployer{
+		profile:  profile,
 		ymlPaths: ymlPaths,
 	}, nil
 }
@@ -53,7 +56,7 @@ func (d *DockerComposeServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedSer
 	}
 
 	// Verify the Elastic stack network
-	err = stack.EnsureStackNetworkUp()
+	err = stack.EnsureStackNetworkUp(d.profile)
 	if err != nil {
 		return nil, fmt.Errorf("elastic stack network is not ready: %w", err)
 	}
@@ -85,7 +88,7 @@ func (d *DockerComposeServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedSer
 	outCtxt.Hostname = p.ContainerName(serviceName)
 
 	// Connect service network with stack network (for the purpose of metrics collection)
-	err = docker.ConnectToNetwork(p.ContainerName(serviceName), stack.Network())
+	err = docker.ConnectToNetwork(p.ContainerName(serviceName), stack.Network(d.profile))
 	if err != nil {
 		return nil, fmt.Errorf("can't attach service container to the stack network: %w", err)
 	}

--- a/internal/benchrunner/runners/system/servicedeployer/factory.go
+++ b/internal/benchrunner/runners/system/servicedeployer/factory.go
@@ -9,12 +9,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/elastic/elastic-package/internal/profile"
 )
 
 const devDeployDir = "_dev/benchmark/system/deploy"
 
 // FactoryOptions defines options used to create an instance of a service deployer.
 type FactoryOptions struct {
+	Profile *profile.Profile
+
 	RootPath string
 }
 
@@ -37,7 +41,7 @@ func Factory(options FactoryOptions) (ServiceDeployer, error) {
 	case "docker":
 		dockerComposeYMLPath := filepath.Join(serviceDeployerPath, "docker-compose.yml")
 		if _, err := os.Stat(dockerComposeYMLPath); err == nil {
-			return NewDockerComposeServiceDeployer([]string{dockerComposeYMLPath})
+			return NewDockerComposeServiceDeployer(options.Profile, []string{dockerComposeYMLPath})
 		}
 	}
 	return nil, fmt.Errorf("unsupported service deployer (name: %s)", serviceDeployerName)

--- a/internal/kind/kind.go
+++ b/internal/kind/kind.go
@@ -10,6 +10,7 @@ import (
 	"github.com/elastic/elastic-package/internal/docker"
 	"github.com/elastic/elastic-package/internal/kubectl"
 	"github.com/elastic/elastic-package/internal/logger"
+	"github.com/elastic/elastic-package/internal/profile"
 	"github.com/elastic/elastic-package/internal/stack"
 )
 
@@ -33,13 +34,13 @@ func VerifyContext() error {
 }
 
 // ConnectToElasticStackNetwork function ensures that the control plane node is connected to the Elastic stack network.
-func ConnectToElasticStackNetwork() error {
+func ConnectToElasticStackNetwork(profile *profile.Profile) error {
 	containerID, err := controlPlaneContainerID()
 	if err != nil {
 		return fmt.Errorf("can't find kind-control plane node: %w", err)
 	}
 
-	stackNetwork := stack.Network()
+	stackNetwork := stack.Network(profile)
 	logger.Debugf("check network connectivity between service container %s (ID: %s) and the stack network %s", ControlPlaneContainerName, containerID, stackNetwork)
 
 	networkDescriptions, err := docker.InspectNetwork(stackNetwork)

--- a/internal/service/boot.go
+++ b/internal/service/boot.go
@@ -20,7 +20,8 @@ import (
 
 // Options define the details of the service which should be booted up.
 type Options struct {
-	Profile            *profile.Profile
+	Profile *profile.Profile
+
 	ServiceName        string
 	PackageRootPath    string
 	DataStreamRootPath string

--- a/internal/service/boot.go
+++ b/internal/service/boot.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	"github.com/elastic/elastic-package/internal/logger"
+	"github.com/elastic/elastic-package/internal/profile"
 
 	"github.com/elastic/elastic-package/internal/configuration/locations"
 	"github.com/elastic/elastic-package/internal/testrunner/runners/system"
@@ -19,6 +20,7 @@ import (
 
 // Options define the details of the service which should be booted up.
 type Options struct {
+	Profile            *profile.Profile
 	ServiceName        string
 	PackageRootPath    string
 	DataStreamRootPath string
@@ -30,6 +32,7 @@ type Options struct {
 func BootUp(options Options) error {
 	logger.Debugf("Create new instance of the service deployer")
 	serviceDeployer, err := servicedeployer.Factory(servicedeployer.FactoryOptions{
+		Profile:            options.Profile,
 		PackageRootPath:    options.DataStreamRootPath,
 		DataStreamRootPath: options.DataStreamRootPath,
 		Variant:            options.Variant,

--- a/internal/stack/compose.go
+++ b/internal/stack/compose.go
@@ -52,7 +52,7 @@ func (eb *envBuilder) build() []string {
 }
 
 func dockerComposeBuild(options Options) error {
-	c, err := compose.NewProject(DockerComposeProjectName, options.Profile.Path(profileStackPath, SnapshotFile))
+	c, err := compose.NewProject(DockerComposeProjectName(options.Profile), options.Profile.Path(profileStackPath, SnapshotFile))
 	if err != nil {
 		return fmt.Errorf("could not create docker compose project: %w", err)
 	}
@@ -78,7 +78,7 @@ func dockerComposeBuild(options Options) error {
 }
 
 func dockerComposePull(options Options) error {
-	c, err := compose.NewProject(DockerComposeProjectName, options.Profile.Path(profileStackPath, SnapshotFile))
+	c, err := compose.NewProject(DockerComposeProjectName(options.Profile), options.Profile.Path(profileStackPath, SnapshotFile))
 	if err != nil {
 		return fmt.Errorf("could not create docker compose project: %w", err)
 	}
@@ -104,7 +104,7 @@ func dockerComposePull(options Options) error {
 }
 
 func dockerComposeUp(options Options) error {
-	c, err := compose.NewProject(DockerComposeProjectName, options.Profile.Path(profileStackPath, SnapshotFile))
+	c, err := compose.NewProject(DockerComposeProjectName(options.Profile), options.Profile.Path(profileStackPath, SnapshotFile))
 	if err != nil {
 		return fmt.Errorf("could not create docker compose project: %w", err)
 	}
@@ -136,7 +136,7 @@ func dockerComposeUp(options Options) error {
 }
 
 func dockerComposeDown(options Options) error {
-	c, err := compose.NewProject(DockerComposeProjectName, options.Profile.Path(profileStackPath, SnapshotFile))
+	c, err := compose.NewProject(DockerComposeProjectName(options.Profile), options.Profile.Path(profileStackPath, SnapshotFile))
 	if err != nil {
 		return fmt.Errorf("could not create docker compose project: %w", err)
 	}
@@ -182,10 +182,10 @@ func withIsReadyServices(services []string) []string {
 	return allServices
 }
 
-func dockerComposeStatus() ([]ServiceStatus, error) {
+func dockerComposeStatus(options Options) ([]ServiceStatus, error) {
 	var services []ServiceStatus
 	// query directly to docker to avoid load environment variables (e.g. STACK_VERSION_VARIANT) and profiles
-	containerIDs, err := docker.ContainerIDsWithLabel(projectLabelDockerCompose, DockerComposeProjectName)
+	containerIDs, err := docker.ContainerIDsWithLabel(projectLabelDockerCompose, DockerComposeProjectName(options.Profile))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/stack/dump.go
+++ b/internal/stack/dump.go
@@ -60,7 +60,7 @@ func dumpStackLogs(options DumpOptions) error {
 			writeLogFiles(logsPath, serviceName, content)
 		}
 
-		err = copyDockerInternalLogs(serviceName, logsPath)
+		err = copyDockerInternalLogs(serviceName, logsPath, options.Profile)
 		if err != nil {
 			logger.Errorf("can't copy internal logs (service: %s): %v", serviceName, err)
 		}

--- a/internal/stack/logs.go
+++ b/internal/stack/logs.go
@@ -22,7 +22,7 @@ func dockerComposeLogs(serviceName string, profile *profile.Profile) ([]byte, er
 
 	snapshotFile := profile.Path(profileStackPath, SnapshotFile)
 
-	p, err := compose.NewProject(DockerComposeProjectName, snapshotFile)
+	p, err := compose.NewProject(DockerComposeProjectName(profile), snapshotFile)
 	if err != nil {
 		return nil, fmt.Errorf("could not create docker compose project: %w", err)
 	}
@@ -43,14 +43,14 @@ func dockerComposeLogs(serviceName string, profile *profile.Profile) ([]byte, er
 	return out, nil
 }
 
-func copyDockerInternalLogs(serviceName, outputPath string) error {
+func copyDockerInternalLogs(serviceName, outputPath string, profile *profile.Profile) error {
 	switch serviceName {
 	case elasticAgentService, fleetServerService:
 	default:
 		return nil // we need to pull internal logs only from Elastic-Agent and Fleets Server container
 	}
 
-	p, err := compose.NewProject(DockerComposeProjectName)
+	p, err := compose.NewProject(DockerComposeProjectName(profile))
 	if err != nil {
 		return fmt.Errorf("could not create docker compose project: %w", err)
 	}

--- a/internal/stack/network.go
+++ b/internal/stack/network.go
@@ -8,11 +8,12 @@ import (
 	"fmt"
 
 	"github.com/elastic/elastic-package/internal/docker"
+	"github.com/elastic/elastic-package/internal/profile"
 )
 
 // EnsureStackNetworkUp function verifies if stack network is up and running.
-func EnsureStackNetworkUp() error {
-	_, err := docker.InspectNetwork(Network())
+func EnsureStackNetworkUp(profile *profile.Profile) error {
+	_, err := docker.InspectNetwork(Network(profile))
 	if err != nil {
 		return fmt.Errorf("network not available: %w", err)
 	}
@@ -20,6 +21,6 @@ func EnsureStackNetworkUp() error {
 }
 
 // Network function returns the stack network name.
-func Network() string {
-	return fmt.Sprintf("%s_default", DockerComposeProjectName)
+func Network(profile *profile.Profile) string {
+	return fmt.Sprintf("%s_default", DockerComposeProjectName(profile))
 }

--- a/internal/stack/providers.go
+++ b/internal/stack/providers.go
@@ -75,5 +75,5 @@ func (*composeProvider) Dump(options DumpOptions) (string, error) {
 }
 
 func (*composeProvider) Status(options Options) ([]ServiceStatus, error) {
-	return Status()
+	return Status(options)
 }

--- a/internal/stack/status.go
+++ b/internal/stack/status.go
@@ -12,8 +12,8 @@ import (
 )
 
 // Status shows the status for each service
-func Status() ([]ServiceStatus, error) {
-	servicesStatus, err := dockerComposeStatus()
+func Status(options Options) ([]ServiceStatus, error) {
+	servicesStatus, err := dockerComposeStatus(options)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -198,6 +198,7 @@ func (r *runner) run() (results []testrunner.TestResult, err error) {
 	}
 
 	devDeployPath, err := servicedeployer.FindDevDeployPath(servicedeployer.FactoryOptions{
+		Profile:            r.options.Profile,
 		PackageRootPath:    r.options.PackageRootPath,
 		DataStreamRootPath: dataStreamPath,
 	})
@@ -249,6 +250,7 @@ func (r *runner) run() (results []testrunner.TestResult, err error) {
 
 func (r *runner) runTestPerVariant(result *testrunner.ResultComposer, locationManager *locations.LocationManager, cfgFile, dataStreamPath, variantName string) ([]testrunner.TestResult, error) {
 	serviceOptions := servicedeployer.FactoryOptions{
+		Profile:            r.options.Profile,
 		PackageRootPath:    r.options.PackageRootPath,
 		DataStreamRootPath: dataStreamPath,
 		Variant:            variantName,

--- a/internal/testrunner/runners/system/servicedeployer/custom_agent.go
+++ b/internal/testrunner/runners/system/servicedeployer/custom_agent.go
@@ -17,6 +17,7 @@ import (
 	"github.com/elastic/elastic-package/internal/install"
 	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/logger"
+	"github.com/elastic/elastic-package/internal/profile"
 	"github.com/elastic/elastic-package/internal/stack"
 )
 
@@ -32,12 +33,14 @@ var dockerCustomAgentDockerfileContent []byte
 // CustomAgentDeployer knows how to deploy a custom elastic-agent defined via
 // a Docker Compose file.
 type CustomAgentDeployer struct {
+	profile           *profile.Profile
 	dockerComposeFile string
 }
 
 // NewCustomAgentDeployer returns a new instance of a deployedCustomAgent.
-func NewCustomAgentDeployer(dockerComposeFile string) (*CustomAgentDeployer, error) {
+func NewCustomAgentDeployer(profile *profile.Profile, dockerComposeFile string) (*CustomAgentDeployer, error) {
 	return &CustomAgentDeployer{
+		profile:           profile,
 		dockerComposeFile: dockerComposeFile,
 	}, nil
 }
@@ -99,7 +102,7 @@ func (d *CustomAgentDeployer) SetUp(inCtxt ServiceContext) (DeployedService, err
 	}
 
 	// Verify the Elastic stack network
-	err = stack.EnsureStackNetworkUp()
+	err = stack.EnsureStackNetworkUp(d.profile)
 	if err != nil {
 		return nil, fmt.Errorf("stack network is not ready: %w", err)
 	}
@@ -122,7 +125,7 @@ func (d *CustomAgentDeployer) SetUp(inCtxt ServiceContext) (DeployedService, err
 	}
 
 	// Connect service network with stack network (for the purpose of metrics collection)
-	err = docker.ConnectToNetwork(p.ContainerName(serviceName), stack.Network())
+	err = docker.ConnectToNetwork(p.ContainerName(serviceName), stack.Network(d.profile))
 	if err != nil {
 		return nil, fmt.Errorf("can't attach service container to the stack network: %w", err)
 	}

--- a/internal/testrunner/runners/system/servicedeployer/factory.go
+++ b/internal/testrunner/runners/system/servicedeployer/factory.go
@@ -43,7 +43,7 @@ func Factory(options FactoryOptions) (ServiceDeployer, error) {
 	switch serviceDeployerName {
 	case "k8s":
 		if _, err := os.Stat(serviceDeployerPath); err == nil {
-			return NewKubernetesServiceDeployer(serviceDeployerPath)
+			return NewKubernetesServiceDeployer(options.Profile, serviceDeployerPath)
 		}
 	case "docker":
 		dockerComposeYMLPath := filepath.Join(serviceDeployerPath, "docker-compose.yml")

--- a/internal/testrunner/runners/system/servicedeployer/factory.go
+++ b/internal/testrunner/runners/system/servicedeployer/factory.go
@@ -9,12 +9,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/elastic/elastic-package/internal/profile"
 )
 
 const devDeployDir = "_dev/deploy"
 
 // FactoryOptions defines options used to create an instance of a service deployer.
 type FactoryOptions struct {
+	Profile *profile.Profile
+
 	PackageRootPath    string
 	DataStreamRootPath string
 
@@ -48,14 +52,14 @@ func Factory(options FactoryOptions) (ServiceDeployer, error) {
 			if err != nil {
 				return nil, fmt.Errorf("can't use service variant: %w", err)
 			}
-			return NewDockerComposeServiceDeployer([]string{dockerComposeYMLPath}, sv)
+			return NewDockerComposeServiceDeployer(options.Profile, []string{dockerComposeYMLPath}, sv)
 		}
 	case "agent":
 		customAgentCfgYMLPath := filepath.Join(serviceDeployerPath, "custom-agent.yml")
 		if _, err := os.Stat(customAgentCfgYMLPath); err != nil {
 			return nil, fmt.Errorf("can't find expected file custom-agent.yml: %w", err)
 		}
-		return NewCustomAgentDeployer(customAgentCfgYMLPath)
+		return NewCustomAgentDeployer(options.Profile, customAgentCfgYMLPath)
 
 	case "tf":
 		if _, err := os.Stat(serviceDeployerPath); err == nil {

--- a/internal/testrunner/runners/system/servicedeployer/kubernetes.go
+++ b/internal/testrunner/runners/system/servicedeployer/kubernetes.go
@@ -20,11 +20,13 @@ import (
 	"github.com/elastic/elastic-package/internal/kind"
 	"github.com/elastic/elastic-package/internal/kubectl"
 	"github.com/elastic/elastic-package/internal/logger"
+	"github.com/elastic/elastic-package/internal/profile"
 	"github.com/elastic/elastic-package/internal/stack"
 )
 
 // KubernetesServiceDeployer is responsible for deploying resources in the Kubernetes cluster.
 type KubernetesServiceDeployer struct {
+	profile        *profile.Profile
 	definitionsDir string
 }
 
@@ -84,7 +86,7 @@ func (ksd KubernetesServiceDeployer) SetUp(ctxt ServiceContext) (DeployedService
 		return nil, fmt.Errorf("kind context verification failed: %w", err)
 	}
 
-	err = kind.ConnectToElasticStackNetwork()
+	err = kind.ConnectToElasticStackNetwork(ksd.profile)
 	if err != nil {
 		return nil, fmt.Errorf("can't connect control plane to Elastic stack network: %w", err)
 	}

--- a/internal/testrunner/runners/system/servicedeployer/kubernetes.go
+++ b/internal/testrunner/runners/system/servicedeployer/kubernetes.go
@@ -72,8 +72,9 @@ func (s *kubernetesDeployedService) SetContext(sc ServiceContext) error {
 var _ DeployedService = new(kubernetesDeployedService)
 
 // NewKubernetesServiceDeployer function creates a new instance of KubernetesServiceDeployer.
-func NewKubernetesServiceDeployer(definitionsPath string) (*KubernetesServiceDeployer, error) {
+func NewKubernetesServiceDeployer(profile *profile.Profile, definitionsPath string) (*KubernetesServiceDeployer, error) {
 	return &KubernetesServiceDeployer{
+		profile:        profile,
 		definitionsDir: definitionsPath,
 	}, nil
 }

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -22,6 +22,7 @@ type TestType string
 
 // TestOptions contains test runner options.
 type TestOptions struct {
+	Profile            *profile.Profile
 	TestFolder         TestFolder
 	PackageRootPath    string
 	GenerateTestResult bool
@@ -30,8 +31,6 @@ type TestOptions struct {
 	DeferCleanup   time.Duration
 	ServiceVariant string
 	WithCoverage   bool
-
-	Profile *profile.Profile
 }
 
 // TestRunner is the interface all test runners must implement.

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -29,7 +29,7 @@ cleanup() {
       elastic-package clean -v
     )
   done
-  
+
   exit $r
 }
 


### PR DESCRIPTION
Based on #1230

This allows us to use the profile information to be able to start different profiles at the same time. Profile information is used to set a different name for the Docker Compose Project.

This PR also adds profile flag to these commands:
- benchmark
- service


## How to test

1. Build elastic-package from this branch
2. Start different Elastic stacks in different profiles, they should be using different container names (Docker Compose projects)

```shell
# New profile parameters available in benchmark and service commands
elastic-package benchmark -h
elastic-package service -h

elastic-package stack up -v --version 8.8.2
# this should show this output for the containers and network
# ✔ Network elastic-package-stack_default                        Created                                                                                                                                       0.1s 
# ✔ Container elastic-package-stack-elasticsearch-1              Healthy                                                                                                                                      18.0s 
# ✔ Container elastic-package-stack-package-registry-1           Healthy                                                                                                                                       6.5s 
# ✔ Container elastic-package-stack-package-registry_is_ready-1  Started                                                                                                                                       6.7s 
# ✔ Container elastic-package-stack-elasticsearch_is_ready-1     Started                                                                                                                                      17.3s 
# ✔ Container elastic-package-stack-kibana-1                     Healthy                                                                                                                                      39.4s 
# ✔ Container elastic-package-stack-kibana_is_ready-1            Started                                                                                                                                      40.1s 
# ✔ Container elastic-package-stack-fleet-server-1               Healthy                                                                                                                                      65.7s 
# ✔ Container elastic-package-stack-elastic-agent-1              Healthy                                                                                                                                      76.4s 
# ✔ Container elastic-package-stack-fleet-server_is_ready-1      Started                                                                                                                                      65.9s 
# ✔ Container elastic-package-stack-elastic-agent_is_ready-1     Started                                                                                                                                      76.6s
elastic-package stack status
elastic-package stack down

# Create a new profile
elastic-package profiles create --from default other
elastic-package profiles use other

# Start a new elastic stack in the new profile
elastic-package stack up -v -d --version 8.8.1
# this should show this output for the containers and network 
# ✔ Network elastic-package-stack-other_default                        Created                                                                                                                                 0.1s 
# ✔ Container elastic-package-stack-other-elasticsearch-1              Healthy                                                                                                                                17.3s 
# ✔ Container elastic-package-stack-other-package-registry-1           Healthy                                                                                                                                 5.9s 
# ✔ Container elastic-package-stack-other-elasticsearch_is_ready-1     Started                                                                                                                                16.7s 
# ✔ Container elastic-package-stack-other-kibana-1                     Healthy                                                                                                                                38.2s 
# ✔ Container elastic-package-stack-other-package-registry_is_ready-1  Started                                                                                                                                 6.5s 
# ✔ Container elastic-package-stack-other-kibana_is_ready-1            Started                                                                                                                                39.3s 
# ✔ Container elastic-package-stack-other-fleet-server-1               Healthy                                                                                                                                65.3s 
# ✔ Container elastic-package-stack-other-fleet-server_is_ready-1      Started                                                                                                                                65.8s 
# ✔ Container elastic-package-stack-other-elastic-agent-1              Healthy                                                                                                                                71.3s 
# ✔ Container elastic-package-stack-other-elastic-agent_is_ready-1     Started                                                                                                                                71.5s 
elastic-package stack status
elastic-package stack down
```