### PR TITLE
[system testing] Add docker network to stack to communicate with service deployers

### DIFF
--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -1,6 +1,6 @@
 {{ $username := fact "username" }}
 {{ $password := fact "password" }}
-version: '2.3'
+version: '3.5'
 services:
   elasticsearch:
     image: "${ELASTICSEARCH_IMAGE_REF}"
@@ -18,6 +18,8 @@ services:
       - "./service_tokens:/usr/share/elasticsearch/config/service_tokens"
     ports:
       - "127.0.0.1:9200:9200"
+    networks:
+      - shared-network
 
   elasticsearch_is_ready:
     image: tianon/true
@@ -47,6 +49,8 @@ services:
       - "./kibana_healthcheck.sh:/usr/share/kibana/healthcheck.sh"
     ports:
       - "127.0.0.1:5601:5601"
+    networks:
+      - shared-network
 
   kibana_is_ready:
     image: tianon/true
@@ -75,6 +79,8 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
       - "127.0.0.1:9000:9000"
+    networks:
+      - shared-network
 
   package-registry_is_ready:
     image: tianon/true
@@ -112,6 +118,8 @@ services:
       - "../certs/fleet-server:/etc/ssl/elastic-agent"
     ports:
       - "127.0.0.1:8220:8220"
+    networks:
+      - shared-network
 
   fleet-server_is_ready:
     image: tianon/true
@@ -141,9 +149,16 @@ services:
     - type: bind
       source: ../../../tmp/service_logs/
       target: /run/service_logs/
+    networks:
+      - shared-network
 
   elastic-agent_is_ready:
     image: tianon/true
     depends_on:
       elastic-agent:
         condition: service_healthy
+
+# This network shall be used by other services outside this docker-compose that should communicate with the stack.
+networks:
+  shared-network:
+    name: elastic_package_test_network

--- a/internal/testrunner/runners/system/servicedeployer/_static/docker-custom-agent-base.yml
+++ b/internal/testrunner/runners/system/servicedeployer/_static/docker-custom-agent-base.yml
@@ -1,4 +1,4 @@
-version: "2.3"
+version: "3.5"
 services:
   docker-custom-agent:
     image: "${ELASTIC_AGENT_IMAGE_REF}"
@@ -14,3 +14,11 @@ services:
     volumes:
       - ${SERVICE_LOGS_DIR}:/tmp/service_logs/
       - ${LOCAL_CA_CERT}:/etc/ssl/certs/elastic-package.pem
+    networks:
+      - my-shared-network
+
+# Network to communicate with the elastic stack
+networks:
+  my-shared-network:
+    name: elastic_package_test_network
+    external: true

--- a/internal/testrunner/runners/system/servicedeployer/_static/terraform_deployer.yml
+++ b/internal/testrunner/runners/system/servicedeployer/_static/terraform_deployer.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '3.5'
 services:
   terraform:
     build: .
@@ -14,3 +14,11 @@ services:
     volumes:
       - ${TF_DIR}:/stage
       - ${TF_OUTPUT_DIR}:/output
+    networks:
+      - my-shared-network
+
+# Network to communicate with the elastic stack
+networks:
+  my-shared-network:
+    name: elastic_package_test_network
+    external: true


### PR DESCRIPTION
This PR adds a docker network in the `elastic-package stack up` docker-compose so that any service deployer services can communicate with the stack from other docker container groups.

An example scenario would be :  A `localstack` container should communicate with `terraform service deployer` to write resources in localstack and in turn the `elastic-package-stack` needs to communicate with localstack to read SQS messages / S3 objects.

Hence, a network is created when the `elastic-package stack up` is run and any services that need to communicate in the group shall connect to this network. The docker-compose version is upgraded to `3.5` as well.