### PR TITLE
Support routing_rules.yml with optional config options

### DIFF
--- a/internal/elasticsearch/ingest/datastream.go
+++ b/internal/elasticsearch/ingest/datastream.go
@@ -28,9 +28,9 @@ var (
 )
 
 type Rule struct {
-	TargetDataset interface{} `yaml:"target_dataset"`
-	If            string      `yaml:"if"`
-	Namespace     interface{} `yaml:"namespace"`
+	TargetDataset *interface{} `yaml:"target_dataset"`
+	If            *string      `yaml:"if"`
+	Namespace     *interface{} `yaml:"namespace"`
 }
 
 type RoutingRule struct {
@@ -192,20 +192,27 @@ func loadRoutingRuleFile(dataStreamPath string) ([]map[string]interface{}, error
 			}
 
 			processor := make(map[string]interface{})
-			processor["reroute"] = RerouteProcessor{
+			rp := RerouteProcessor{
 				Tag:       r.SourceDataset,
-				If:        rule.If,
 				Dataset:   td,
 				Namespace: ns,
 			}
+			if rule.If != nil {
+				rp.If = *rule.If
+			}
+			processor["reroute"] = rp
 			rerouteProcessors = append(rerouteProcessors, processor)
 		}
 	}
 	return rerouteProcessors, nil
 }
 
-func convertValue(value interface{}, label string) ([]string, error) {
-	switch value := value.(type) {
+func convertValue(originalValue *interface{}, label string) ([]string, error) {
+	if originalValue == nil {
+		return nil, nil
+	}
+
+	switch value := (*originalValue).(type) {
 	case string:
 		return []string{value}, nil
 	case []string:

--- a/internal/elasticsearch/ingest/datastream.go
+++ b/internal/elasticsearch/ingest/datastream.go
@@ -208,10 +208,6 @@ func loadRoutingRuleFile(dataStreamPath string) ([]map[string]interface{}, error
 }
 
 func convertValue(originalValue interface{}, label string) ([]string, error) {
-	if originalValue == nil {
-		return nil, nil
-	}
-
 	switch value := originalValue.(type) {
 	case string:
 		return []string{value}, nil
@@ -227,6 +223,8 @@ func convertValue(originalValue interface{}, label string) ([]string, error) {
 			}
 		}
 		return result, nil
+	case nil:
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("%s in routing_rules.yml has to be a string or an array of strings: %v", label, value)
 	}

--- a/internal/elasticsearch/ingest/datastream.go
+++ b/internal/elasticsearch/ingest/datastream.go
@@ -192,23 +192,20 @@ func loadRoutingRuleFile(dataStreamPath string) ([]map[string]interface{}, error
 			}
 
 			processor := make(map[string]interface{})
-			rp := RerouteProcessor{
+			processor["reroute"] = RerouteProcessor{
 				Tag:       r.SourceDataset,
+				If:        rule.If,
 				Dataset:   td,
 				Namespace: ns,
 			}
-			if rule.If != "" {
-				rp.If = rule.If
-			}
-			processor["reroute"] = rp
 			rerouteProcessors = append(rerouteProcessors, processor)
 		}
 	}
 	return rerouteProcessors, nil
 }
 
-func convertValue(originalValue interface{}, label string) ([]string, error) {
-	switch value := originalValue.(type) {
+func convertValue(value interface{}, label string) ([]string, error) {
+	switch value := value.(type) {
 	case string:
 		return []string{value}, nil
 	case []string:

--- a/internal/elasticsearch/ingest/datastream.go
+++ b/internal/elasticsearch/ingest/datastream.go
@@ -224,6 +224,10 @@ func convertValue(originalValue interface{}, label string) ([]string, error) {
 		}
 		return result, nil
 	case nil:
+		// namespace is not required in routing_rules.yml
+		if label != "namespace" {
+			return nil, fmt.Errorf("%s in routing_rules.yml cannot be empty", label)
+		}
 		return nil, nil
 	default:
 		return nil, fmt.Errorf("%s in routing_rules.yml has to be a string or an array of strings: %v", label, value)

--- a/internal/elasticsearch/ingest/datastream.go
+++ b/internal/elasticsearch/ingest/datastream.go
@@ -28,9 +28,9 @@ var (
 )
 
 type Rule struct {
-	TargetDataset *interface{} `yaml:"target_dataset"`
-	If            *string      `yaml:"if"`
-	Namespace     *interface{} `yaml:"namespace"`
+	TargetDataset interface{} `yaml:"target_dataset"`
+	If            string      `yaml:"if"`
+	Namespace     interface{} `yaml:"namespace"`
 }
 
 type RoutingRule struct {
@@ -197,8 +197,8 @@ func loadRoutingRuleFile(dataStreamPath string) ([]map[string]interface{}, error
 				Dataset:   td,
 				Namespace: ns,
 			}
-			if rule.If != nil {
-				rp.If = *rule.If
+			if rule.If != "" {
+				rp.If = rule.If
 			}
 			processor["reroute"] = rp
 			rerouteProcessors = append(rerouteProcessors, processor)
@@ -207,12 +207,12 @@ func loadRoutingRuleFile(dataStreamPath string) ([]map[string]interface{}, error
 	return rerouteProcessors, nil
 }
 
-func convertValue(originalValue *interface{}, label string) ([]string, error) {
+func convertValue(originalValue interface{}, label string) ([]string, error) {
 	if originalValue == nil {
 		return nil, nil
 	}
 
-	switch value := (*originalValue).(type) {
+	switch value := originalValue.(type) {
 	case string:
 		return []string{value}, nil
 	case []string:

--- a/internal/elasticsearch/ingest/datastream_test.go
+++ b/internal/elasticsearch/ingest/datastream_test.go
@@ -85,29 +85,19 @@ func TestLoadRoutingRuleFileGoodEmpty(t *testing.T) {
 }
 
 func TestLoadRoutingRuleFileGoodOptionalConfigs(t *testing.T) {
-	mockDataStreamPath := "../testdata/routing_rules/good/no_target_dataset_namespace_if"
+	mockDataStreamPath := "../testdata/routing_rules/good/no_namespace"
 	rerouteProcessors, err := loadRoutingRuleFile(mockDataStreamPath)
 	assert.NoError(t, err)
-	assert.Equal(t, 3, len(rerouteProcessors))
+	assert.Equal(t, 1, len(rerouteProcessors))
 
 	expectedProcessors := map[string]struct {
 		expectedIf        string
 		expectedDataset   []string
 		expectedNamespace []string
 	}{
-		"missing_target_dataset": {
-			"ctx['aws.cloudwatch.log_stream'].contains('Test1')",
-			nil,
-			[]string{"default"},
-		},
 		"missing_namespace": {
 			"ctx['aws.cloudwatch.log_stream'].contains('Test2')",
 			[]string{"aws.test2_logs"},
-			nil,
-		},
-		"missing_if_namespace": {
-			"",
-			[]string{"aws.test3_logs"},
 			nil,
 		},
 	}
@@ -129,6 +119,13 @@ func TestLoadRoutingRuleFileBadMultipleSourceDataset(t *testing.T) {
 
 func TestLoadRoutingRuleFileBadNotString(t *testing.T) {
 	mockDataStreamPath := "../testdata/routing_rules/bad/not_string"
+	rerouteProcessors, err := loadRoutingRuleFile(mockDataStreamPath)
+	assert.Equal(t, 0, len(rerouteProcessors))
+	assert.Error(t, err)
+}
+
+func TestLoadRoutingRuleFileBadMissingConfigs(t *testing.T) {
+	mockDataStreamPath := "../testdata/routing_rules/bad/missing_configs"
 	rerouteProcessors, err := loadRoutingRuleFile(mockDataStreamPath)
 	assert.Equal(t, 0, len(rerouteProcessors))
 	assert.Error(t, err)

--- a/internal/elasticsearch/testdata/routing_rules/bad/missing_configs/routing_rules.yml
+++ b/internal/elasticsearch/testdata/routing_rules/bad/missing_configs/routing_rules.yml
@@ -2,10 +2,6 @@
   rules:
     - if: ctx['aws.cloudwatch.log_stream'].contains('Test1')
       namespace: default
-- source_dataset: missing_namespace
-  rules:
-    - target_dataset: aws.test2_logs
-      if: ctx['aws.cloudwatch.log_stream'].contains('Test2')
 - source_dataset: missing_if_namespace
   rules:
     - target_dataset: aws.test3_logs

--- a/internal/elasticsearch/testdata/routing_rules/good/no_namespace/routing_rules.yml
+++ b/internal/elasticsearch/testdata/routing_rules/good/no_namespace/routing_rules.yml
@@ -1,0 +1,4 @@
+- source_dataset: missing_namespace
+  rules:
+    - target_dataset: aws.test2_logs
+      if: ctx['aws.cloudwatch.log_stream'].contains('Test2')

--- a/internal/elasticsearch/testdata/routing_rules/good/no_target_dataset_namespace_if/routing_rules.yml
+++ b/internal/elasticsearch/testdata/routing_rules/good/no_target_dataset_namespace_if/routing_rules.yml
@@ -1,0 +1,11 @@
+- source_dataset: missing_target_dataset
+  rules:
+    - if: ctx['aws.cloudwatch.log_stream'].contains('Test1')
+      namespace: default
+- source_dataset: missing_namespace
+  rules:
+    - target_dataset: aws.test2_logs
+      if: ctx['aws.cloudwatch.log_stream'].contains('Test2')
+- source_dataset: missing_if_namespace
+  rules:
+    - target_dataset: aws.test3_logs


### PR DESCRIPTION
`source_dataset`, `if` condition, `target_dataset` and `namespace` are all optional according to reroute processor documentation. This PR is to add support in elastic-package for routing_rules.yml to have optional configs. 

closes https://github.com/elastic/elastic-package/issues/1389