### PR TITLE
Update Elastic Package Registry version to v1.21.0

### DIFF
--- a/internal/stack/resources.go
+++ b/internal/stack/resources.go
@@ -39,7 +39,7 @@ const (
 	PackageRegistryConfigFile = "package-registry.yml"
 
 	// PackageRegistryBaseImage is the base Docker image of the Elastic Package Registry.
-	PackageRegistryBaseImage = "docker.elastic.co/package-registry/package-registry:v1.20.0"
+	PackageRegistryBaseImage = "docker.elastic.co/package-registry/package-registry:v1.21.0"
 
 	// ElasticAgentEnvFile is the elastic agent environment variables file.
 	ElasticAgentEnvFile = "elastic-agent.env"


### PR DESCRIPTION
Update Docker tag of Elastic Package Registry to v1.21.0. Automated by [Jenkins build](https://internal-ci.elastic.co/job/package_storage/job/update-package-registry-job/job/main/201/)