### PR TITLE
Use kibana and elasticsearch from stack module

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/elastic/elastic-package/internal/corpusgenerator"
 	"github.com/elastic/elastic-package/internal/install"
-	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/stack"
 
 	"github.com/spf13/cobra"
@@ -267,7 +266,7 @@ func systemCommandAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	kc, err := kibana.NewClient()
+	kc, err := stack.NewKibanaClient()
 	if err != nil {
 		return fmt.Errorf("can't create Kibana client: %w", err)
 	}

--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elastic/elastic-package/internal/corpusgenerator"
 	"github.com/elastic/elastic-package/internal/install"
 	"github.com/elastic/elastic-package/internal/kibana"
+	"github.com/elastic/elastic-package/internal/stack"
 
 	"github.com/spf13/cobra"
 
@@ -25,7 +26,6 @@ import (
 	"github.com/elastic/elastic-package/internal/benchrunner/runners/system"
 	"github.com/elastic/elastic-package/internal/cobraext"
 	"github.com/elastic/elastic-package/internal/common"
-	"github.com/elastic/elastic-package/internal/elasticsearch"
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/signal"
 	"github.com/elastic/elastic-package/internal/testrunner"
@@ -161,7 +161,7 @@ func pipelineCommandAction(cmd *cobra.Command, args []string) error {
 		return errors.New("no pipeline benchmarks found")
 	}
 
-	esClient, err := elasticsearch.NewClient()
+	esClient, err := stack.NewElasticsearchClient()
 	if err != nil {
 		return fmt.Errorf("can't create Elasticsearch client: %w", err)
 	}
@@ -258,7 +258,7 @@ func systemCommandAction(cmd *cobra.Command, args []string) error {
 
 	signal.Enable()
 
-	esClient, err := elasticsearch.NewClient()
+	esClient, err := stack.NewElasticsearchClient()
 	if err != nil {
 		return fmt.Errorf("can't create Elasticsearch client: %w", err)
 	}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elastic/elastic-package/internal/dump"
 	"github.com/elastic/elastic-package/internal/elasticsearch"
 	"github.com/elastic/elastic-package/internal/kibana"
+	"github.com/elastic/elastic-package/internal/stack"
 )
 
 const dumpLongDescription = `Use this command as an exploratory tool to dump resources from Elastic Stack (objects installed as part of package and agent policies).`
@@ -79,7 +80,7 @@ func dumpInstalledObjectsCmdAction(cmd *cobra.Command, args []string) error {
 	if tlsSkipVerify {
 		clientOptions = append(clientOptions, elasticsearch.OptionWithSkipTLSVerify())
 	}
-	client, err := elasticsearch.NewClient(clientOptions...)
+	client, err := stack.NewElasticsearchClient(clientOptions...)
 	if err != nil {
 		return fmt.Errorf("failed to initialize Elasticsearch client: %w", err)
 	}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -120,7 +120,7 @@ func dumpAgentPoliciesCmdAction(cmd *cobra.Command, args []string) error {
 	if tlsSkipVerify {
 		clientOptions = append(clientOptions, kibana.TLSSkipVerify())
 	}
-	kibanaClient, err := kibana.NewClient(clientOptions...)
+	kibanaClient, err := stack.NewKibanaClient(clientOptions...)
 	if err != nil {
 		return fmt.Errorf("failed to initialize Kibana client: %w", err)
 	}

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elastic/elastic-package/internal/common"
 	"github.com/elastic/elastic-package/internal/export"
 	"github.com/elastic/elastic-package/internal/kibana"
+	"github.com/elastic/elastic-package/internal/stack"
 )
 
 const exportLongDescription = `Use this command to export assets relevant for the package, e.g. Kibana dashboards.`
@@ -65,7 +66,7 @@ func exportDashboardsCmd(cmd *cobra.Command, args []string) error {
 		return cobraext.FlagParsingError(err, cobraext.AllowSnapshotFlagName)
 	}
 
-	kibanaClient, err := kibana.NewClient(opts...)
+	kibanaClient, err := stack.NewKibanaClient(opts...)
 	if err != nil {
 		return fmt.Errorf("can't create Kibana client: %w", err)
 	}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -11,9 +11,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cobraext"
-	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/packages/installer"
+	"github.com/elastic/elastic-package/internal/stack"
 )
 
 const installLongDescription = `Use this command to install the package in Kibana.
@@ -49,7 +49,7 @@ func installCommandAction(cmd *cobra.Command, _ []string) error {
 		return cobraext.FlagParsingError(err, cobraext.BuildSkipValidationFlagName)
 	}
 
-	kibanaClient, err := kibana.NewClient()
+	kibanaClient, err := stack.NewKibanaClient()
 	if err != nil {
 		return fmt.Errorf("could not create kibana client: %w", err)
 	}

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -15,10 +15,10 @@ import (
 
 	"github.com/elastic/elastic-package/internal/cobraext"
 	"github.com/elastic/elastic-package/internal/common"
-	"github.com/elastic/elastic-package/internal/elasticsearch"
 	"github.com/elastic/elastic-package/internal/install"
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/signal"
+	"github.com/elastic/elastic-package/internal/stack"
 	"github.com/elastic/elastic-package/internal/testrunner"
 	"github.com/elastic/elastic-package/internal/testrunner/reporters/formats"
 	"github.com/elastic/elastic-package/internal/testrunner/reporters/outputs"
@@ -214,7 +214,7 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 			return err
 		}
 
-		esClient, err := elasticsearch.NewClient()
+		esClient, err := stack.NewElasticsearchClient()
 		if err != nil {
 			return fmt.Errorf("can't create Elasticsearch client: %w", err)
 		}

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -11,9 +11,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cobraext"
-	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/packages/installer"
+	"github.com/elastic/elastic-package/internal/stack"
 )
 
 const uninstallLongDescription = `Use this command to uninstall the package in Kibana.
@@ -40,7 +40,7 @@ func uninstallCommandAction(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("locating package root failed: %w", err)
 	}
 
-	kibanaClient, err := kibana.NewClient()
+	kibanaClient, err := stack.NewKibanaClient()
 	if err != nil {
 		return fmt.Errorf("could not create kibana client: %w", err)
 	}

--- a/internal/dump/agentpolicies_test.go
+++ b/internal/dump/agentpolicies_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/elastic/elastic-package/internal/kibana"
+	"github.com/elastic/elastic-package/internal/stack"
 )
 
 func TestDumpAgentPolicies(t *testing.T) {
@@ -72,7 +73,7 @@ type agentPoliciesDumpSuite struct {
 func (s *agentPoliciesDumpSuite) SetupTest() {
 	_, err := os.Stat(s.DumpDirAll)
 	if errors.Is(err, os.ErrNotExist) {
-		client, err := kibana.NewClient()
+		client, err := stack.NewKibanaClient()
 		s.Require().NoError(err)
 
 		dumper := NewAgentPoliciesDumper(client)
@@ -85,7 +86,7 @@ func (s *agentPoliciesDumpSuite) SetupTest() {
 
 	_, err = os.Stat(s.DumpDirPackage)
 	if errors.Is(err, os.ErrNotExist) {
-		client, err := kibana.NewClient()
+		client, err := stack.NewKibanaClient()
 		s.Require().NoError(err)
 
 		dumper := NewAgentPoliciesDumper(client)
@@ -98,7 +99,7 @@ func (s *agentPoliciesDumpSuite) SetupTest() {
 
 	_, err = os.Stat(s.DumpDirAgentPolicy)
 	if errors.Is(err, os.ErrNotExist) {
-		client, err := kibana.NewClient()
+		client, err := stack.NewKibanaClient()
 		s.Require().NoError(err)
 
 		dumper := NewAgentPoliciesDumper(client)

--- a/internal/dump/installedobjects_test.go
+++ b/internal/dump/installedobjects_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/elastic/elastic-package/internal/elasticsearch"
 	estest "github.com/elastic/elastic-package/internal/elasticsearch/test"
 	"github.com/elastic/elastic-package/internal/files"
+	"github.com/elastic/elastic-package/internal/stack"
 )
 
 func TestDumpInstalledObjects(t *testing.T) {
@@ -64,7 +64,7 @@ type installedObjectsDumpSuite struct {
 func (s *installedObjectsDumpSuite) SetupTest() {
 	_, err := os.Stat(s.DumpDir)
 	if errors.Is(err, os.ErrNotExist) {
-		client, err := elasticsearch.NewClient()
+		client, err := stack.NewElasticsearchClient()
 		s.Require().NoError(err)
 
 		dumper := NewInstalledObjectsDumper(client.API, s.PackageName)

--- a/internal/elasticsearch/error.go
+++ b/internal/elasticsearch/error.go
@@ -7,6 +7,7 @@ package elasticsearch
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -74,3 +75,5 @@ func NewError(body []byte) error {
 	// Fall back to including to raw body if it cannot be parsed.
 	return fmt.Errorf("elasticsearch error: %v", string(body))
 }
+
+var ErrUndefinedAddress = errors.New("missing elasticsearch address")

--- a/internal/elasticsearch/error.go
+++ b/internal/elasticsearch/error.go
@@ -76,4 +76,4 @@ func NewError(body []byte) error {
 	return fmt.Errorf("elasticsearch error: %v", string(body))
 }
 
-var ErrUndefinedAddress = errors.New("missing elasticsearch address")
+var ErrUndefinedAddress = errors.New("missing Elasticsearch address")

--- a/internal/elasticsearch/test/httptest.go
+++ b/internal/elasticsearch/test/httptest.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-package/internal/elasticsearch"
+	"github.com/elastic/elastic-package/internal/stack"
 )
 
 // NewClient returns a client for a testing http server that uses prerecorded
@@ -26,7 +27,7 @@ func NewClient(t *testing.T, serverDataDir string) *elasticsearch.Client {
 	server := testElasticsearchServer(t, serverDataDir)
 	t.Cleanup(func() { server.Close() })
 
-	client, err := elasticsearch.NewClient(
+	client, err := stack.NewElasticsearchClient(
 		elasticsearch.OptionWithAddress(server.URL),
 	)
 	require.NoError(t, err)
@@ -56,7 +57,7 @@ func pathForURL(url string) string {
 }
 
 func recordRequest(t *testing.T, r *http.Request, path string) {
-	client, err := elasticsearch.NewClient()
+	client, err := stack.NewElasticsearchClient()
 	require.NoError(t, err)
 
 	t.Logf("Recording %s in %s", r.URL.Path, path)

--- a/internal/stack/clients.go
+++ b/internal/stack/clients.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package stack
 
 import (

--- a/internal/stack/clients.go
+++ b/internal/stack/clients.go
@@ -1,0 +1,26 @@
+package stack
+
+import (
+	"errors"
+	"os"
+
+	"github.com/elastic/elastic-package/internal/elasticsearch"
+)
+
+func NewElasticsearchClient(customOptions ...elasticsearch.ClientOption) (*elasticsearch.Client, error) {
+
+	options := []elasticsearch.ClientOption{
+		elasticsearch.OptionWithAddress(os.Getenv(ElasticsearchHostEnv)),
+		elasticsearch.OptionWithPassword(os.Getenv(ElasticsearchPasswordEnv)),
+		elasticsearch.OptionWithUsername(os.Getenv(ElasticsearchUsernameEnv)),
+		elasticsearch.OptionWithCertificateAuthority(os.Getenv(CACertificateEnv)),
+	}
+	options = append(options, customOptions...)
+	client, err := elasticsearch.NewClient(options...)
+
+	if errors.Is(err, elasticsearch.ErrUndefinedAddress) {
+		return nil, UndefinedEnvError(ElasticsearchHostEnv)
+	}
+
+	return client, err
+}

--- a/internal/stack/clients.go
+++ b/internal/stack/clients.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/elastic/elastic-package/internal/elasticsearch"
+	"github.com/elastic/elastic-package/internal/kibana"
 )
 
 func NewElasticsearchClient(customOptions ...elasticsearch.ClientOption) (*elasticsearch.Client, error) {
@@ -19,6 +20,23 @@ func NewElasticsearchClient(customOptions ...elasticsearch.ClientOption) (*elast
 	client, err := elasticsearch.NewClient(options...)
 
 	if errors.Is(err, elasticsearch.ErrUndefinedAddress) {
+		return nil, UndefinedEnvError(ElasticsearchHostEnv)
+	}
+
+	return client, err
+}
+
+func NewKibanaClient(customOptions ...kibana.ClientOption) (*kibana.Client, error) {
+	options := []kibana.ClientOption{
+		kibana.Address(os.Getenv(KibanaHostEnv)),
+		kibana.Password(os.Getenv(ElasticsearchPasswordEnv)),
+		kibana.Username(os.Getenv(ElasticsearchUsernameEnv)),
+		kibana.CertificateAuthority(os.Getenv(CACertificateEnv)),
+	}
+	options = append(options, customOptions...)
+	client, err := kibana.NewClient(options...)
+
+	if errors.Is(err, kibana.ErrUndefinedHost) {
 		return nil, UndefinedEnvError(ElasticsearchHostEnv)
 	}
 

--- a/internal/stack/clients.go
+++ b/internal/stack/clients.go
@@ -13,7 +13,6 @@ import (
 )
 
 func NewElasticsearchClient(customOptions ...elasticsearch.ClientOption) (*elasticsearch.Client, error) {
-
 	options := []elasticsearch.ClientOption{
 		elasticsearch.OptionWithAddress(os.Getenv(ElasticsearchHostEnv)),
 		elasticsearch.OptionWithPassword(os.Getenv(ElasticsearchPasswordEnv)),

--- a/internal/testrunner/runners/asset/runner.go
+++ b/internal/testrunner/runners/asset/runner.go
@@ -8,10 +8,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/packages/installer"
+	"github.com/elastic/elastic-package/internal/stack"
 	"github.com/elastic/elastic-package/internal/testrunner"
 )
 
@@ -76,7 +76,7 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 	}
 
 	logger.Debug("installing package...")
-	kibanaClient, err := kibana.NewClient()
+	kibanaClient, err := stack.NewKibanaClient()
 	if err != nil {
 		return result.WithError(fmt.Errorf("could not create kibana client: %w", err))
 	}

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -479,7 +479,7 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 		return result.WithError(fmt.Errorf("unable to reload system test case configuration: %w", err))
 	}
 
-	kib, err := kibana.NewClient()
+	kib, err := stack.NewKibanaClient()
 	if err != nil {
 		return result.WithError(fmt.Errorf("can't create Kibana client: %w", err))
 	}

--- a/internal/testrunner/runners/system/servicedeployer/custom_agent.go
+++ b/internal/testrunner/runners/system/servicedeployer/custom_agent.go
@@ -15,7 +15,6 @@ import (
 	"github.com/elastic/elastic-package/internal/docker"
 	"github.com/elastic/elastic-package/internal/files"
 	"github.com/elastic/elastic-package/internal/install"
-	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/profile"
 	"github.com/elastic/elastic-package/internal/stack"
@@ -54,7 +53,7 @@ func (d *CustomAgentDeployer) SetUp(inCtxt ServiceContext) (DeployedService, err
 		return nil, fmt.Errorf("can't read application configuration: %w", err)
 	}
 
-	kibanaClient, err := kibana.NewClient()
+	kibanaClient, err := stack.NewKibanaClient()
 	if err != nil {
 		return nil, fmt.Errorf("can't create Kibana client: %w", err)
 	}

--- a/internal/testrunner/runners/system/servicedeployer/kubernetes.go
+++ b/internal/testrunner/runners/system/servicedeployer/kubernetes.go
@@ -16,7 +16,6 @@ import (
 	"text/template"
 
 	"github.com/elastic/elastic-package/internal/install"
-	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/kind"
 	"github.com/elastic/elastic-package/internal/kubectl"
 	"github.com/elastic/elastic-package/internal/logger"
@@ -149,7 +148,7 @@ func findKubernetesDefinitions(definitionsDir string) ([]string, error) {
 func installElasticAgentInCluster() error {
 	logger.Debug("install Elastic Agent in the Kubernetes cluster")
 
-	kibanaClient, err := kibana.NewClient()
+	kibanaClient, err := stack.NewKibanaClient()
 	if err != nil {
 		return fmt.Errorf("can't create Kibana client: %w", err)
 	}


### PR DESCRIPTION
This PR changes how Kibana and Elasticsearch clients are used around internal modules.

The aim is to create those clients with the options (address, username, password or CA certificate authority) related to each stack within the `stack` module. `kibana` and `elasticsearch` modules keep a generic implementation of the clients.