### PR TITLE
Include positional arguments help for profile command

### DIFF
--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -6,7 +6,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -45,10 +44,6 @@ User profiles can be configured with a "config.yml" file in the profile director
 		Short: "Create a new profile",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			if len(args) == 0 {
-				return errors.New("create requires an argument")
-			}
 			newProfileName := args[0]
 
 			fromName, err := cmd.Flags().GetString(cobraext.ProfileFromFlagName)
@@ -80,9 +75,6 @@ User profiles can be configured with a "config.yml" file in the profile director
 		Short: "Delete a profile",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				return errors.New("delete requires an argument")
-			}
 			profileName := args[0]
 
 			config, err := install.Configuration()
@@ -159,9 +151,6 @@ User profiles can be configured with a "config.yml" file in the profile director
 		Short: "Sets the profile to use when no other is specified",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				return errors.New("use requires an argument")
-			}
 			profileName := args[0]
 
 			_, err := profile.LoadProfile(profileName)

--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -111,6 +111,7 @@ User profiles can be configured with a "config.yml" file in the profile director
 	profileListCommand := &cobra.Command{
 		Use:   "list",
 		Short: "List available profiles",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			loc, err := locations.NewLocationManager()
 			if err != nil {

--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -41,8 +41,9 @@ User profiles can be configured with a "config.yml" file in the profile director
 	}
 
 	profileNewCommand := &cobra.Command{
-		Use:   "create",
+		Use:   "create [profile]",
 		Short: "Create a new profile",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if len(args) == 0 {
@@ -75,8 +76,9 @@ User profiles can be configured with a "config.yml" file in the profile director
 	profileNewCommand.Flags().String(cobraext.ProfileFromFlagName, "", cobraext.ProfileFromFlagDescription)
 
 	profileDeleteCommand := &cobra.Command{
-		Use:   "delete",
+		Use:   "delete [profile]",
 		Short: "Delete a profile",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("delete requires an argument")
@@ -153,8 +155,9 @@ User profiles can be configured with a "config.yml" file in the profile director
 	profileListCommand.Flags().String(cobraext.ProfileFormatFlagName, tableFormat, cobraext.ProfileFormatFlagDescription)
 
 	profileUseCommand := &cobra.Command{
-		Use:   "use",
+		Use:   "use [profile]",
 		Short: "Sets the profile to use when no other is specified",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("use requires an argument")


### PR DESCRIPTION
Fixes #1249 

This PR adds the required checks and documentation for positional arguments under `elastic-package profiles`  sub-commands.

Followed the same approach as in the example of the cobra documentation: https://umarcor.github.io/cobra/#positional-and-custom-arguments

Updated sub-commands:
- `elastic-package profiles create` allowed just 1 argument
- `elastic-package profiles delete` allowed just 1 argument
- `elastic-package profiles use` allowed just 1 argument
- `elastic-package profiles list` no args allowed

Example:
- New documentation:
```shell
 $ elastic-package profiles create -h
Create a new profile

Usage:
  elastic-package profiles create [profile] [flags]

Flags:
      --from string   copy profile from the specified existing profile
  -h, --help          help for create

Global Flags:
  -v, --verbose   verbose mode
```
- Add validation to ensure the required positional arguments are set:
```shell
 $ elastic-package profiles create
Error: accepts 1 arg(s), received 0
```

For `elastic-package profiles list` subcommand, this was not failing previously:
```shell
 $ elastic-package profiles list a
+-------------------+---------------------------+----------------+----------------+--------------------------------------------------------+
|       NAME        |       DATE CREATED        |      USER      |    VERSION     |                          PATH                          |
+-------------------+---------------------------+----------------+----------------+--------------------------------------------------------+
| default (current) | 2023-07-04T10:27:59+02:00 | mariorodriguez | f5a280a5-dirty | /home/mariorodriguez/.elastic-package/profiles/default |
+-------------------+---------------------------+----------------+----------------+--------------------------------------------------------+
| other             | 2023-07-25T11:17:46+02:00 | mariorodriguez | a564198e-dirty | /home/mariorodriguez/.elastic-package/profiles/other   |
+-------------------+---------------------------+----------------+----------------+--------------------------------------------------------+
```
Now, it reports an error if an unknown parameter is set:
```shell
 $ elastic-package profiles list a
Error: unknown command "a" for "elastic-package profiles list"
```