### PR TITLE
Add flag for user-defined parameters in stack up

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,8 @@ To expose local packages in the Package Registry, build them first and boot up t
 
 For details on how to connect the service with the Elastic stack, see the [service command](https://github.com/elastic/elastic-package/blob/main/README.md#elastic-package-service).
 
+You can customize your stack using profile settings, see [Elastic Package profiles](https://github.com/elastic/elastic-package/blob/main/README.md#elastic-package-profiles-1) section. These settings can be also overriden with the --parameter flag. Settings configured this way are not persisted.
+
 ### `elastic-package stack update`
 
 _Context: global_

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -86,14 +86,20 @@ func setupStackCommand() *cobraext.Command {
 				return err
 			}
 
+			userParameters, err := cobraext.GetStackUserParameterFlags(cmd)
+			if err != nil {
+				return err
+			}
+
 			cmd.Printf("Using profile %s.\n", profile.ProfilePath)
 			cmd.Println(`Remember to load stack environment variables using 'eval "$(elastic-package stack shellinit)"'.`)
 			err = provider.BootUp(stack.Options{
-				DaemonMode:   daemonMode,
-				StackVersion: stackVersion,
-				Services:     services,
-				Profile:      profile,
-				Printer:      cmd,
+				DaemonMode:     daemonMode,
+				StackVersion:   stackVersion,
+				Services:       services,
+				Profile:        profile,
+				Printer:        cmd,
+				UserParameters: userParameters,
 			})
 			if err != nil {
 				return fmt.Errorf("booting up the stack failed: %w", err)
@@ -108,6 +114,7 @@ func setupStackCommand() *cobraext.Command {
 		fmt.Sprintf(cobraext.StackServicesFlagDescription, strings.Join(availableServicesAsList(), ",")))
 	upCommand.Flags().StringP(cobraext.StackVersionFlagName, "", install.DefaultStackVersion, cobraext.StackVersionFlagDescription)
 	upCommand.Flags().String(cobraext.StackProviderFlagName, "", fmt.Sprintf(cobraext.StackProviderFlagDescription, strings.Join(stack.SupportedProviders, ", ")))
+	upCommand.Flags().StringSliceP(cobraext.StackUserParameterFlagName, cobraext.StackUserParameterFlagShorthand, nil, cobraext.StackUserParameterDescription)
 
 	downCommand := &cobra.Command{
 		Use:   "down",

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -86,20 +86,23 @@ func setupStackCommand() *cobraext.Command {
 				return err
 			}
 
+			// Parameters provided through the CLI are not persisted.
+			// Stack providers can get them with `profile.Config`, and they
+			// need to handle and store them if they need it.
 			userParameters, err := cobraext.GetStackUserParameterFlags(cmd)
 			if err != nil {
 				return err
 			}
+			profile.RuntimeOverrides(userParameters)
 
 			cmd.Printf("Using profile %s.\n", profile.ProfilePath)
 			cmd.Println(`Remember to load stack environment variables using 'eval "$(elastic-package stack shellinit)"'.`)
 			err = provider.BootUp(stack.Options{
-				DaemonMode:     daemonMode,
-				StackVersion:   stackVersion,
-				Services:       services,
-				Profile:        profile,
-				Printer:        cmd,
-				UserParameters: userParameters,
+				DaemonMode:   daemonMode,
+				StackVersion: stackVersion,
+				Services:     services,
+				Profile:      profile,
+				Printer:      cmd,
 			})
 			if err != nil {
 				return fmt.Errorf("booting up the stack failed: %w", err)

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -44,7 +44,9 @@ Be aware that a common issue while trying to boot up the stack is that your Dock
 
 To expose local packages in the Package Registry, build them first and boot up the stack from inside of the Git repository containing the package (e.g. elastic/integrations). They will be copied to the development stack (~/.elastic-package/stack/development) and used to build a custom Docker image of the Package Registry. Starting with Elastic stack version >= 8.7.0, it is not mandatory to be available local packages in the Package Registry to run the tests.
 
-For details on how to connect the service with the Elastic stack, see the [service command](https://github.com/elastic/elastic-package/blob/main/README.md#elastic-package-service).`
+For details on how to connect the service with the Elastic stack, see the [service command](https://github.com/elastic/elastic-package/blob/main/README.md#elastic-package-service).
+
+You can customize your stack using profile settings, see [Elastic Package profiles](https://github.com/elastic/elastic-package/blob/main/README.md#elastic-package-profiles-1) section. These settings can be also overriden with the --parameter flag. Settings configured this way are not persisted.`
 
 func setupStackCommand() *cobraext.Command {
 	upCommand := &cobra.Command{

--- a/internal/cobraext/flags.go
+++ b/internal/cobraext/flags.go
@@ -166,6 +166,10 @@ const (
 	StackDumpOutputFlagName        = "output"
 	StackDumpOutputFlagDescription = "output location for the stack dump"
 
+	StackUserParameterFlagName      = "parameter"
+	StackUserParameterFlagShorthand = "U"
+	StackUserParameterDescription   = "optional parameter for the stack provider, as key=value"
+
 	StatusKibanaVersionFlagName        = "kibana-version"
 	StatusKibanaVersionFlagDescription = "show packages for the given kibana version"
 

--- a/internal/cobraext/profiles.go
+++ b/internal/cobraext/profiles.go
@@ -90,3 +90,22 @@ func GetStackProviderFromProfile(cmd *cobra.Command, profile *profile.Profile, c
 
 	return stack.BuildProvider(providerName, profile)
 }
+
+// GetStackUserParameterFlags returns the parameters defined by the user in the command line
+func GetStackUserParameterFlags(cmd *cobra.Command) (map[string]string, error) {
+	parameters, err := cmd.Flags().GetStringSlice(StackUserParameterFlagName)
+	if err != nil {
+		return nil, FlagParsingError(err, StackUserParameterFlagName)
+	}
+
+	var values map[string]string
+	for _, p := range parameters {
+		k, v, valid := strings.Cut(p, "=")
+		if !valid {
+			return nil, fmt.Errorf("invalid format for user parameter, expected key=value, found %q", p)
+		}
+		values[k] = v
+	}
+
+	return values, nil
+}

--- a/internal/cobraext/profiles.go
+++ b/internal/cobraext/profiles.go
@@ -98,7 +98,7 @@ func GetStackUserParameterFlags(cmd *cobra.Command) (map[string]string, error) {
 		return nil, FlagParsingError(err, StackUserParameterFlagName)
 	}
 
-	var values map[string]string
+	values := make(map[string]string)
 	for _, p := range parameters {
 		k, v, valid := strings.Cut(p, "=")
 		if !valid {

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -136,7 +136,8 @@ type Profile struct {
 	ProfilePath string
 	ProfileName string
 
-	config config
+	config    config
+	overrides map[string]string
 }
 
 // Path returns an absolute path to the given file
@@ -147,11 +148,22 @@ func (profile Profile) Path(names ...string) string {
 
 // Config returns a configuration setting, or its default if setting not found
 func (profile Profile) Config(name string, def string) string {
-	v, found := profile.config.get(name)
-	if !found {
-		return def
+	v, found := profile.overrides[name]
+	if found {
+		return v
 	}
-	return v
+
+	v, found = profile.config.get(name)
+	if found {
+		return v
+	}
+
+	return def
+}
+
+// RuntimeOverrides defines configuration overrides for the current session.
+func (profile *Profile) RuntimeOverrides(overrides map[string]string) {
+	profile.overrides = overrides
 }
 
 // ErrNotAProfile is returned in cases where we don't have a valid profile directory

--- a/internal/stack/options.go
+++ b/internal/stack/options.go
@@ -17,9 +17,4 @@ type Options struct {
 
 	Profile *profile.Profile
 	Printer Printer
-
-	// User parameters can be passed from flags to the stack provider.
-	// The stack provider has the responsibility of validating and storing
-	// them if needed.
-	UserParameters map[string]string
 }

--- a/internal/stack/options.go
+++ b/internal/stack/options.go
@@ -17,4 +17,9 @@ type Options struct {
 
 	Profile *profile.Profile
 	Printer Printer
+
+	// User parameters can be passed from flags to the stack provider.
+	// The stack provider has the responsibility of validating and storing
+	// them if needed.
+	UserParameters map[string]string
 }


### PR DESCRIPTION
Allow to define additional parameters for `elastic-package stack up` from the command line.

Stack providers can access these settings using `profile.Config()`, they have to provide their own handling and persistence if required.

If the user wants to persist the setting, they need to write it into the `config.yml` file in the profile.

For example this could be used by the serverless stack provider (https://github.com/elastic/elastic-package/pull/1374) to select the project type:
```
elastic-package stack up --provider serverless -U stack.serverless.project_type=observability
```