### PR TITLE
Enable GCP Test

### DIFF
--- a/test/packages/parallel/gcp/data_stream/compute/_dev/test/system/test-default-config.yml
+++ b/test/packages/parallel/gcp/data_stream/compute/_dev/test/system/test-default-config.yml
@@ -6,5 +6,3 @@ data_stream:
   vars:
     zone: "{{GCP_ZONE}}"
     region: "{{GCP_REGION}}"
-skip.link: https://github.com/elastic/elastic-package/issues/1381
-skip.reason: GCP test package keep failing with could not find hits in metrics-gcp.compute-ep data stream


### PR DESCRIPTION
We believe the problem with the failing test has been identified and addressed in this [PR](https://github.com/elastic/elastic-package/issues/1381). 

For more context about this issue, please see #1381. 