### PR TITLE
Review positional arguments in commands

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -80,6 +80,7 @@ func getPipelineCommand() *cobra.Command {
 		Use:   "pipeline",
 		Short: "Run pipeline benchmarks",
 		Long:  "Run pipeline benchmarks for the package",
+		Args:  cobra.NoArgs,
 		RunE:  pipelineCommandAction,
 	}
 
@@ -212,6 +213,7 @@ func getSystemCommand() *cobra.Command {
 		Use:   "system",
 		Short: "Run system benchmarks",
 		Long:  "Run system benchmarks for the package",
+		Args:  cobra.NoArgs,
 		RunE:  systemCommandAction,
 	}
 
@@ -338,6 +340,7 @@ func getGenerateCorpusCommand() *cobra.Command {
 		Use:   "generate-corpus",
 		Short: "Generate benchmarks corpus data for the package",
 		Long:  generateLongDescription,
+		Args:  cobra.NoArgs,
 		RunE:  generateDataStreamCorpusCommandAction,
 	}
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -34,6 +34,7 @@ func setupBuildCommand() *cobraext.Command {
 		Use:   "build",
 		Short: "Build the package",
 		Long:  buildLongDescription,
+		Args:  cobra.NoArgs,
 		RunE:  buildCommandAction,
 	}
 	cmd.Flags().Bool(cobraext.BuildZipFlagName, true, cobraext.BuildZipFlagDescription)

--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -37,6 +37,7 @@ func setupChangelogCommand() *cobraext.Command {
 		Use:   "add",
 		Short: "Add an entry to the changelog file",
 		Long:  changelogAddLongDescription,
+		Args:  cobra.NoArgs,
 		RunE:  changelogAddCmd,
 	}
 	addChangelogCmd.Flags().String(cobraext.ChangelogAddNextFlagName, "", cobraext.ChangelogAddNextFlagDescription)

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -21,6 +21,7 @@ func setupCheckCommand() *cobraext.Command {
 		Use:   "check",
 		Short: "Check the package",
 		Long:  checkLongDescription,
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := cobraext.ComposeCommands(args,
 				setupFormatCommand(),

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -22,6 +22,7 @@ func setupCleanCommand() *cobraext.Command {
 		Use:   "clean",
 		Short: "Clean used resources",
 		Long:  cleanLongDescription,
+		Args:  cobra.NoArgs,
 		RunE:  cleanCommandAction,
 	}
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -21,6 +21,7 @@ func setupCreateCommand() *cobraext.Command {
 		Use:   "package",
 		Short: "Create new package",
 		Long:  createPackageLongDescription,
+		Args:  cobra.NoArgs,
 		RunE:  createPackageCommandAction,
 	}
 
@@ -28,6 +29,7 @@ func setupCreateCommand() *cobraext.Command {
 		Use:   "data-stream",
 		Short: "Create new data stream",
 		Long:  createDataStreamLongDescription,
+		Args:  cobra.NoArgs,
 		RunE:  createDataStreamCommandAction,
 	}
 

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -35,6 +35,7 @@ func setupDumpCommand() *cobraext.Command {
 		Use:   "installed-objects",
 		Short: "Dump objects installed in the stack",
 		Long:  dumpInstalledObjectsLongDescription,
+		Args:  cobra.NoArgs,
 		RunE:  dumpInstalledObjectsCmdAction,
 	}
 	dumpInstalledObjectsCmd.Flags().Bool(cobraext.TLSSkipVerifyFlagName, false, cobraext.TLSSkipVerifyFlagDescription)
@@ -45,6 +46,7 @@ func setupDumpCommand() *cobraext.Command {
 		Use:   "agent-policies",
 		Short: "Dump agent policies defined in the stack",
 		Long:  dumpAgentPoliciesLongDescription,
+		Args:  cobra.NoArgs,
 		RunE:  dumpAgentPoliciesCmdAction,
 	}
 	dumpAgentPoliciesCmd.Flags().StringP(cobraext.AgentPolicyFlagName, "", "", cobraext.AgentPolicyDescription)

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -29,6 +29,7 @@ func setupExportCommand() *cobraext.Command {
 		Use:   "dashboards",
 		Short: "Export dashboards from Kibana",
 		Long:  exportDashboardsLongDescription,
+		Args:  cobra.NoArgs,
 		RunE:  exportDashboardsCmd,
 	}
 	exportDashboardCmd.Flags().StringSliceP(cobraext.DashboardIDsFlagName, "d", nil, cobraext.DashboardIDsFlagDescription)

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -24,6 +24,7 @@ func setupFormatCommand() *cobraext.Command {
 		Use:   "format",
 		Short: "Format the package",
 		Long:  formatLongDescription,
+		Args:  cobra.NoArgs,
 		RunE:  formatCommandAction,
 	}
 	cmd.Flags().BoolP(cobraext.FailFastFlagName, "f", false, cobraext.FailFastFlagDescription)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -25,6 +25,7 @@ func setupInstallCommand() *cobraext.Command {
 		Use:   "install",
 		Short: "Install the package",
 		Long:  installLongDescription,
+		Args:  cobra.NoArgs,
 		RunE:  installCommandAction,
 	}
 	cmd.Flags().StringSliceP(cobraext.CheckConditionFlagName, "c", nil, cobraext.CheckConditionFlagDescription)

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -26,6 +26,7 @@ func setupLintCommand() *cobraext.Command {
 		Use:   "lint",
 		Short: "Lint the package",
 		Long:  lintLongDescription,
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := cobraext.ComposeCommandActions(cmd, args,
 				lintCommandAction,

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -65,6 +65,7 @@ func getBenchReportCommand() *cobra.Command {
 		Use:   "benchmark",
 		Short: "Generate a benchmark report",
 		Long:  "Generate a benchmark report comparing local results against ones from another benchmark run.",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.Printf("Generate benchmark reports\n")
 

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -26,6 +26,7 @@ func setupServiceCommand() *cobraext.Command {
 	upCommand := &cobra.Command{
 		Use:   "up",
 		Short: "Boot up the stack",
+		Args:  cobra.NoArgs,
 		RunE:  upCommandAction,
 	}
 	upCommand.Flags().StringP(cobraext.DataStreamFlagName, "d", "", cobraext.DataStreamFlagDescription)

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -82,6 +82,7 @@ func setupTestCommand() *cobraext.Command {
 			Use:   string(testType),
 			Short: fmt.Sprintf("Run %s tests", runner.String()),
 			Long:  fmt.Sprintf("Run %s tests for the package.", runner.String()),
+			Args:  cobra.NoArgs,
 			RunE:  action,
 		}
 

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -25,6 +25,7 @@ func setupUninstallCommand() *cobraext.Command {
 		Use:   "uninstall",
 		Short: "Uninstall the package",
 		Long:  uninstallLongDescription,
+		Args:  cobra.NoArgs,
 		RunE:  uninstallCommandAction,
 	}
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -21,6 +21,7 @@ func setupVersionCommand() *cobraext.Command {
 		Use:   "version",
 		Short: "Show application version",
 		Long:  versionLongDescription,
+		Args:  cobra.NoArgs,
 		RunE:  versionCommandAction,
 	}
 


### PR DESCRIPTION
This PR reviews usage of positional arguments in all commands and sub-commands.
Currently, if a positional argument is set in the command line, this parameter is ignored. I think that could be misleading.

This PR enforces to not use positional arguments if they are not needed.
As an example:

- Use of a positional argument where it is not used by the command:
```shell
 $ elastic-package clean aa
Clean used resources
Build resources removed: /home/mariorodriguez/Coding/work/integrations/build/packages/elastic_package_registry
Temporary service logs removed: /home/mariorodriguez/.elastic-package/tmp/service_logs
Done
``` 
- With this PR, that would raise an error:
```shell
 $ elastic-package clean aa
Error: unknown command "aa" for "elastic-package clean"
```


In case of `elastic-package test` and `elastic-package benchmark` commands the same positional arguments has been kept. Keeping that would show a more specific error for those commands.

Example:
- Current error shown:
```shell
 $ elastic-package test aaa
Run test suite for the package
Error: unsupported test type: aaa
```
- If it is used `cobra.NoArgs`:
```shell
 $ elastic-package test aaa
Error: unknown command "aaa" for "elastic-package test"
```
