### PR TITLE
Inject kibana clients from the command builders

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elastic/elastic-package/internal/install"
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/service"
+	"github.com/elastic/elastic-package/internal/stack"
 	"github.com/elastic/elastic-package/internal/testrunner/runners/system"
 )
 
@@ -66,6 +67,15 @@ func upCommandAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	kibanaClient, err := stack.NewKibanaClient()
+	if err != nil {
+		return fmt.Errorf("cannot create Kibana client: %w", err)
+	}
+	stackVersion, err := kibanaClient.Version()
+	if err != nil {
+		return fmt.Errorf("cannot request Kibana version: %w", err)
+	}
+
 	_, serviceName := filepath.Split(packageRoot)
 	err = service.BootUp(service.Options{
 		Profile:            profile,
@@ -74,6 +84,7 @@ func upCommandAction(cmd *cobra.Command, args []string) error {
 		DevDeployDir:       system.DevDeployDir,
 		DataStreamRootPath: dataStreamPath,
 		Variant:            variantFlag,
+		StackVersion:       stackVersion.Version(),
 	})
 	if err != nil {
 		return fmt.Errorf("up command failed: %w", err)

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -223,6 +223,11 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 			return err
 		}
 
+		kibanaClient, err := stack.NewKibanaClient()
+		if err != nil {
+			return fmt.Errorf("can't create Kibana client: %w", err)
+		}
+
 		var results []testrunner.TestResult
 		for _, folder := range testFolders {
 			r, err := testrunner.Run(testType, testrunner.TestOptions{
@@ -231,6 +236,7 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 				PackageRootPath:    packageRootPath,
 				GenerateTestResult: generateTestResult,
 				API:                esClient.API,
+				KibanaClient:       kibanaClient,
 				DeferCleanup:       deferCleanup,
 				ServiceVariant:     variantFlag,
 				WithCoverage:       testCoverage,

--- a/internal/benchrunner/runners/system/runner.go
+++ b/internal/benchrunner/runners/system/runner.go
@@ -230,6 +230,11 @@ func (r *runner) setUp() error {
 func (r *runner) run() (report reporters.Reportable, err error) {
 	var service servicedeployer.DeployedService
 	if r.scenario.Corpora.InputService != nil {
+		stackVersion, err := r.options.KibanaClient.Version()
+		if err != nil {
+			return nil, fmt.Errorf("cannot request Kibana version: %w", err)
+		}
+
 		// Setup service.
 		logger.Debug("setting up service...")
 		opts := servicedeployer.FactoryOptions{
@@ -238,6 +243,7 @@ func (r *runner) run() (report reporters.Reportable, err error) {
 			Variant:         r.options.Variant,
 			Profile:         r.options.Profile,
 			Type:            servicedeployer.TypeBench,
+			StackVersion:    stackVersion.Version(),
 		}
 		serviceDeployer, err := servicedeployer.Factory(opts)
 

--- a/internal/service/boot.go
+++ b/internal/service/boot.go
@@ -26,6 +26,7 @@ type Options struct {
 	PackageRootPath    string
 	DevDeployDir       string
 	DataStreamRootPath string
+	StackVersion       string
 
 	Variant string
 }
@@ -39,6 +40,7 @@ func BootUp(options Options) error {
 		DataStreamRootPath: options.DataStreamRootPath,
 		DevDeployDir:       options.DevDeployDir,
 		Variant:            options.Variant,
+		StackVersion:       options.StackVersion,
 	})
 	if err != nil {
 		return fmt.Errorf("can't create the service deployer instance: %w", err)

--- a/internal/servicedeployer/factory.go
+++ b/internal/servicedeployer/factory.go
@@ -26,6 +26,7 @@ type FactoryOptions struct {
 	DataStreamRootPath string
 	DevDeployDir       string
 	Type               string
+	StackVersion       string
 
 	Variant string
 }
@@ -48,7 +49,7 @@ func Factory(options FactoryOptions) (ServiceDeployer, error) {
 	switch serviceDeployerName {
 	case "k8s":
 		if _, err := os.Stat(serviceDeployerPath); err == nil {
-			return NewKubernetesServiceDeployer(options.Profile, serviceDeployerPath)
+			return NewKubernetesServiceDeployer(options.Profile, serviceDeployerPath, options.StackVersion)
 		}
 	case "docker":
 		dockerComposeYMLPath := filepath.Join(serviceDeployerPath, "docker-compose.yml")
@@ -67,8 +68,7 @@ func Factory(options FactoryOptions) (ServiceDeployer, error) {
 		if _, err := os.Stat(customAgentCfgYMLPath); err != nil {
 			return nil, fmt.Errorf("can't find expected file custom-agent.yml: %w", err)
 		}
-		return NewCustomAgentDeployer(options.Profile, customAgentCfgYMLPath)
-
+		return NewCustomAgentDeployer(options.Profile, customAgentCfgYMLPath, options.StackVersion)
 	case "tf":
 		if _, err := os.Stat(serviceDeployerPath); err == nil {
 			return NewTerraformServiceDeployer(serviceDeployerPath)

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/elastic/elastic-package/internal/elasticsearch"
+	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/profile"
 )
 
@@ -27,6 +28,7 @@ type TestOptions struct {
 	PackageRootPath    string
 	GenerateTestResult bool
 	API                *elasticsearch.API
+	KibanaClient       *kibana.Client
 
 	DeferCleanup   time.Duration
 	ServiceVariant string


### PR DESCRIPTION
Refactor pending runners that were instantiating their own kibana clients and inject them from the command builders.

Fixes #163.