### PR TITLE
[Buildkite] Use Go version defined in .go-version

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -22,6 +22,8 @@ function retry {
     return 0
 }
 
+export GO_VERSION=$(cat .go-version)
+
 GCP_SERVICE_ACCOUNT_SECRET_PATH=secret/ci/elastic-elastic-package/gcp-service-account
 AWS_SERVICE_ACCOUNT_SECRET_PATH=kv/ci-shared/platform-ingest/aws_account_auth
 GITHUB_TOKEN_VAULT_PATH=kv/ci-shared/platform-ingest/github_token

--- a/.buildkite/pipeline.package-storage-publish.yml
+++ b/.buildkite/pipeline.package-storage-publish.yml
@@ -1,5 +1,6 @@
 env:
   SETUP_GVM_VERSION: 'v0.5.0' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
+  LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
 
 steps:
   - label: ":go: Build package"
@@ -8,7 +9,7 @@ steps:
       - "make install"
       - "cd test/packages/package-storage/package_storage_candidate; elastic-package build -v --zip"
     agents:
-      image: "golang:1.20.3"
+      image: "${LINUX_AGENT_IMAGE}"
       cpu: "8"
       memory: "4G"
     artifact_paths:

--- a/.buildkite/pipeline.test-with-integrations-repo.yml
+++ b/.buildkite/pipeline.test-with-integrations-repo.yml
@@ -1,6 +1,6 @@
 env:
   SETUP_GVM_VERSION: 'v0.5.0' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
-  GOLANG_VERSION: "1.20.3"
+  LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
   GH_CLI_VERSION: "2.29.0"
   JQ_VERSION: "1.6"
 
@@ -9,7 +9,7 @@ steps:
     key: check-static
     command: "make check-static"
     agents:
-      image: "golang:${GOLANG_VERSION}"
+      image: "${LINUX_AGENT_IMAGE}"
       cpu: "8"
       memory: "4G"
   - label: ":go: :linux: Run unit tests"
@@ -19,7 +19,7 @@ steps:
       - "build/test-results/*.xml"
       - "build/test-coverage/*.xml"
     agents:
-      image: "golang:${GOLANG_VERSION}"
+      image: "${LINUX_AGENT_IMAGE}"
       cpu: "8"
       memory: "4G"
   - label: ":hammer: Create PR in integrations"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,6 +6,7 @@ env:
   KIND_VERSION: 'v0.20.0'
   K8S_VERSION: 'v1.27.3'
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
+  WINDOWS_AGENT_IMAGE: "family/ci-windows-2022"
 
 steps:
   - label: ":go: Run check-static"
@@ -32,7 +33,7 @@ steps:
     command: ".buildkite/scripts/unit_tests_windows.ps1"
     agents:
       provider: "gcp"
-      image: "family/ci-windows-2022"
+      image: "${WINDOWS_AGENT_IMAGE}"
     artifact_paths:
       - "TEST-unit.xml"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,13 +5,14 @@ env:
   ELASTIC_PACKAGE_COMPOSE_DISABLE_PULL_PROGRESS_INFORMATION: "true"
   KIND_VERSION: 'v0.20.0'
   K8S_VERSION: 'v1.27.3'
+  LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
 
 steps:
   - label: ":go: Run check-static"
     key: check-static
     command: "make check-static"
     agents:
-      image: "golang:1.20.3"
+      image: "${LINUX_AGENT_IMAGE}"
       cpu: "8"
       memory: "4G"
 
@@ -22,7 +23,7 @@ steps:
       - "build/test-results/*.xml"
       - "build/test-coverage/*.xml"
     agents:
-      image: "golang:1.20.3"
+      image: "${LINUX_AGENT_IMAGE}"
       cpu: "8"
       memory: "4G"
 
@@ -32,6 +33,8 @@ steps:
     agents:
       provider: "gcp"
       image: "family/ci-windows-2022"
+    artifact_paths:
+      - "TEST-unit.xml"
 
   - wait: ~
     continue_on_failure: true
@@ -52,7 +55,7 @@ steps:
   - label: ":junit: Junit annotate"
     plugins:
       - junit-annotate#v2.4.1:
-          artifacts: "build/test-results/*.xml"
+          artifacts: "*.xml"
     agents:
       provider: "gcp"  # junit plugin requires docker
 

--- a/.buildkite/scripts/unit_tests_windows.ps1
+++ b/.buildkite/scripts/unit_tests_windows.ps1
@@ -32,7 +32,7 @@ function installGoDependencies {
 }
 
 fixCRLF
-withGolang $env::GOLANG_VERSION
+withGolang $env:GOLANG_VERSION
 
 
 echo "--- Downloading Go modules"

--- a/.buildkite/scripts/unit_tests_windows.ps1
+++ b/.buildkite/scripts/unit_tests_windows.ps1
@@ -32,7 +32,7 @@ function installGoDependencies {
 }
 
 fixCRLF
-withGolang $env:GOLANG_VERSION
+withGolang $env:GO_VERSION
 
 
 echo "--- Downloading Go modules"

--- a/.buildkite/scripts/unit_tests_windows.ps1
+++ b/.buildkite/scripts/unit_tests_windows.ps1
@@ -1,19 +1,39 @@
-echo "--- Fixing CRLF in git checkout"
+$ErrorActionPreference = "Stop" # set -e
+
 # Forcing to checkout again all the files with a correct autocrlf.
 # Doing this here because we cannot set git clone options before.
-git config core.autocrlf input
-git rm --quiet --cached -r .
-git reset --quiet --hard
+function fixCRLF {
+    Write-Host "-- Fixing CRLF in git checkout --"
+    git config core.autocrlf input
+    git rm --quiet --cached -r .
+    git reset --quiet --hard
+}
 
-echo "--- Installing golang"
-choco install -y golang --version 1.20.3
+function withGolang($version) {
+    Write-Host "-- Install golang $version --"
+    choco install -y golang --version $version
+    $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
+    Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+    refreshenv
+    go version
+    go env
+}
 
-echo "--- Updating session environment"
-# refreshenv requires to have chocolatey profile installed
-$env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
-Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+function installGoDependencies {
+    $installPackages = @(
+        "github.com/elastic/go-licenser"
+        "golang.org/x/tools/cmd/goimports"
+        "github.com/jstemmer/go-junit-report/v2"
+        "gotest.tools/gotestsum"
+    )
+    foreach ($pkg in $installPackages) {
+        go install "$pkg@latest"
+    }
+}
 
-refreshenv
+fixCRLF
+withGolang $env::GOLANG_VERSION
+
 
 echo "--- Downloading Go modules"
 go version
@@ -21,4 +41,9 @@ go mod download -x
 
 echo "--- Running unit tests"
 go version
-go test ./...
+$ErrorActionPreference = "Continue" # set +e
+go run gotest.tools/gotestsum --junitfile "$(PWD)/TEST-unit.xml" -- -count=1 ./...
+$EXITCODE=$LASTEXITCODE
+$ErrorActionPreference = "Stop"
+
+Exit $EXITCODE

--- a/internal/stack/shellinit_internal_test.go
+++ b/internal/stack/shellinit_internal_test.go
@@ -50,7 +50,7 @@ func Test_getShellName(t *testing.T) {
 		want string
 	}{
 		{"linux exec", args{exe: "bash"}, "bash"},
-		{"windows exec", args{exe: "cmd.exe"}, "cmd2"},
+		{"windows exec", args{exe: "cmd.exe"}, "cmd"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/stack/shellinit_internal_test.go
+++ b/internal/stack/shellinit_internal_test.go
@@ -50,7 +50,7 @@ func Test_getShellName(t *testing.T) {
 		want string
 	}{
 		{"linux exec", args{exe: "bash"}, "bash"},
-		{"windows exec", args{exe: "cmd.exe"}, "cmd"},
+		{"windows exec", args{exe: "cmd.exe"}, "cmd2"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR ensures that all the steps in Buildkite use the same version as the one defined in `.go-version` file.

Checked junit failures here: https://buildkite.com/elastic/elastic-package/builds/1392