### PR TITLE
Bump stack version to 8.9.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test-stack-command-86:
 	./scripts/test-stack-command.sh 8.6.2
 
 test-stack-command-8x:
-	./scripts/test-stack-command.sh 8.9.0-SNAPSHOT
+	./scripts/test-stack-command.sh 8.10.0-SNAPSHOT
 
 test-stack-command: test-stack-command-default test-stack-command-7x test-stack-command-800 test-stack-command-8x
 

--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "8.8.2"
+	DefaultStackVersion = "8.9.1"
 )


### PR DESCRIPTION
This PR updates default stack version used by elastic-package to be 8.9.1
It also updates the SNAPSHOT image used in tests for 8.x version to be 8.10.0-SNAPSHOT