### PR TITLE
Load stack configuration from profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,20 @@ Dump stack data for debug purposes.
 
 _Context: global_
 
-Export environment variables.
+Use this command to export to the current shell the configuration of the stack managed by elastic-package.
+
+The output of this command is intended to be evaluated by the current shell. For example in bash: 'eval $(elastic-package stack shellinit)'.
+
+Relevant environment variables are:
+
+- ELASTIC_PACKAGE_ELASTICSEARCH_HOST
+- ELASTIC_PACKAGE_ELASTICSEARCH_USERNAME
+- ELASTIC_PACKAGE_ELASTICSEARCH_PASSWORD
+- ELASTIC_PACKAGE_KIBANA_HOST
+- ELASTIC_PACKAGE_CA_CERT
+
+You can also provide these environment variables manually. In that case elastic-package commands will use these settings.
+
 
 ### `elastic-package stack status`
 

--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -165,6 +165,11 @@ func pipelineCommandAction(cmd *cobra.Command, args []string) error {
 		return errors.New("no pipeline benchmarks found")
 	}
 
+	profile, err := cobraext.GetProfileFlag(cmd)
+	if err != nil {
+		return err
+	}
+
 	esClient, err := stack.NewElasticsearchClientFromProfile(profile)
 	if err != nil {
 		return fmt.Errorf("can't create Elasticsearch client: %w", err)

--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -165,7 +165,7 @@ func pipelineCommandAction(cmd *cobra.Command, args []string) error {
 		return errors.New("no pipeline benchmarks found")
 	}
 
-	esClient, err := stack.NewElasticsearchClient()
+	esClient, err := stack.NewElasticsearchClientFromProfile(profile)
 	if err != nil {
 		return fmt.Errorf("can't create Elasticsearch client: %w", err)
 	}
@@ -269,7 +269,7 @@ func systemCommandAction(cmd *cobra.Command, args []string) error {
 
 	signal.Enable()
 
-	esClient, err := stack.NewElasticsearchClient()
+	esClient, err := stack.NewElasticsearchClientFromProfile(profile)
 	if err != nil {
 		return fmt.Errorf("can't create Elasticsearch client: %w", err)
 	}
@@ -278,7 +278,7 @@ func systemCommandAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	kc, err := stack.NewKibanaClient()
+	kc, err := stack.NewKibanaClientFromProfile(profile)
 	if err != nil {
 		return fmt.Errorf("can't create Kibana client: %w", err)
 	}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elastic/elastic-package/internal/cobraext"
 	"github.com/elastic/elastic-package/internal/dump"
 	"github.com/elastic/elastic-package/internal/elasticsearch"
+	"github.com/elastic/elastic-package/internal/install"
 	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/stack"
 )
@@ -58,6 +59,7 @@ func setupDumpCommand() *cobraext.Command {
 		Long:  dumpLongDescription,
 	}
 	cmd.PersistentFlags().StringP(cobraext.DumpOutputFlagName, "o", "package-dump", cobraext.DumpOutputFlagDescription)
+	cmd.PersistentFlags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
 
 	cmd.AddCommand(dumpInstalledObjectsCmd)
 	cmd.AddCommand(dumpAgentPoliciesCmd)
@@ -82,7 +84,13 @@ func dumpInstalledObjectsCmdAction(cmd *cobra.Command, args []string) error {
 	if tlsSkipVerify {
 		clientOptions = append(clientOptions, elasticsearch.OptionWithSkipTLSVerify())
 	}
-	client, err := stack.NewElasticsearchClient(clientOptions...)
+
+	profile, err := cobraext.GetProfileFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := stack.NewElasticsearchClientFromProfile(profile, clientOptions...)
 	if err != nil {
 		return fmt.Errorf("failed to initialize Elasticsearch client: %w", err)
 	}
@@ -122,7 +130,13 @@ func dumpAgentPoliciesCmdAction(cmd *cobra.Command, args []string) error {
 	if tlsSkipVerify {
 		clientOptions = append(clientOptions, kibana.TLSSkipVerify())
 	}
-	kibanaClient, err := stack.NewKibanaClient(clientOptions...)
+
+	profile, err := cobraext.GetProfileFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	kibanaClient, err := stack.NewKibanaClientFromProfile(profile, clientOptions...)
 	if err != nil {
 		return fmt.Errorf("failed to initialize Kibana client: %w", err)
 	}

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -14,6 +14,7 @@ import (
 	"github.com/elastic/elastic-package/internal/cobraext"
 	"github.com/elastic/elastic-package/internal/common"
 	"github.com/elastic/elastic-package/internal/export"
+	"github.com/elastic/elastic-package/internal/install"
 	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/stack"
 )
@@ -42,6 +43,7 @@ func setupExportCommand() *cobraext.Command {
 		Long:  exportLongDescription,
 	}
 	cmd.AddCommand(exportDashboardCmd)
+	cmd.PersistentFlags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
 
 	return cobraext.NewCommand(cmd, cobraext.ContextPackage)
 }
@@ -67,7 +69,12 @@ func exportDashboardsCmd(cmd *cobra.Command, args []string) error {
 		return cobraext.FlagParsingError(err, cobraext.AllowSnapshotFlagName)
 	}
 
-	kibanaClient, err := stack.NewKibanaClient(opts...)
+	profile, err := cobraext.GetProfileFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	kibanaClient, err := stack.NewKibanaClientFromProfile(profile, opts...)
 	if err != nil {
 		return fmt.Errorf("can't create Kibana client: %w", err)
 	}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cobraext"
+	"github.com/elastic/elastic-package/internal/install"
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/packages/installer"
 	"github.com/elastic/elastic-package/internal/stack"
@@ -32,6 +33,7 @@ func setupInstallCommand() *cobraext.Command {
 	cmd.Flags().StringP(cobraext.PackageRootFlagName, cobraext.PackageRootFlagShorthand, "", cobraext.PackageRootFlagDescription)
 	cmd.Flags().StringP(cobraext.ZipPackageFilePathFlagName, cobraext.ZipPackageFilePathFlagShorthand, "", cobraext.ZipPackageFilePathFlagDescription)
 	cmd.Flags().Bool(cobraext.BuildSkipValidationFlagName, false, cobraext.BuildSkipValidationFlagDescription)
+	cmd.Flags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
 
 	return cobraext.NewCommand(cmd, cobraext.ContextPackage)
 }
@@ -50,7 +52,12 @@ func installCommandAction(cmd *cobra.Command, _ []string) error {
 		return cobraext.FlagParsingError(err, cobraext.BuildSkipValidationFlagName)
 	}
 
-	kibanaClient, err := stack.NewKibanaClient()
+	profile, err := cobraext.GetProfileFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	kibanaClient, err := stack.NewKibanaClientFromProfile(profile)
 	if err != nil {
 		return fmt.Errorf("could not create kibana client: %w", err)
 	}

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -68,7 +68,7 @@ func upCommandAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	kibanaClient, err := stack.NewKibanaClient()
+	kibanaClient, err := stack.NewKibanaClientFromProfile(profile)
 	if err != nil {
 		return fmt.Errorf("cannot create Kibana client: %w", err)
 	}

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -48,6 +48,21 @@ For details on how to connect the service with the Elastic stack, see the [servi
 
 You can customize your stack using profile settings, see [Elastic Package profiles](https://github.com/elastic/elastic-package/blob/main/README.md#elastic-package-profiles-1) section. These settings can be also overriden with the --parameter flag. Settings configured this way are not persisted.`
 
+const stackShellinitLongDescription = `Use this command to export to the current shell the configuration of the stack managed by elastic-package.
+
+The output of this command is intended to be evaluated by the current shell. For example in bash: 'eval $(elastic-package stack shellinit)'.
+
+Relevant environment variables are:
+
+- ELASTIC_PACKAGE_ELASTICSEARCH_HOST
+- ELASTIC_PACKAGE_ELASTICSEARCH_USERNAME
+- ELASTIC_PACKAGE_ELASTICSEARCH_PASSWORD
+- ELASTIC_PACKAGE_KIBANA_HOST
+- ELASTIC_PACKAGE_CA_CERT
+
+You can also provide these environment variables manually. In that case elastic-package commands will use these settings.
+`
+
 func setupStackCommand() *cobraext.Command {
 	upCommand := &cobra.Command{
 		Use:   "up",
@@ -99,7 +114,6 @@ func setupStackCommand() *cobraext.Command {
 			profile.RuntimeOverrides(userParameters)
 
 			cmd.Printf("Using profile %s.\n", profile.ProfilePath)
-			cmd.Println(`Remember to load stack environment variables using 'eval "$(elastic-package stack shellinit)"'.`)
 			err = provider.BootUp(stack.Options{
 				DaemonMode:   daemonMode,
 				StackVersion: stackVersion,
@@ -192,6 +206,7 @@ func setupStackCommand() *cobraext.Command {
 	shellInitCommand := &cobra.Command{
 		Use:   "shellinit",
 		Short: "Export environment variables",
+		Long:  stackShellinitLongDescription,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			shellName, err := cmd.Flags().GetString(cobraext.ShellInitShellFlagName)

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -215,7 +215,7 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 			return err
 		}
 
-		esClient, err := stack.NewElasticsearchClient()
+		esClient, err := stack.NewElasticsearchClientFromProfile(profile)
 		if err != nil {
 			return fmt.Errorf("can't create Elasticsearch client: %w", err)
 		}
@@ -224,7 +224,7 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 			return err
 		}
 
-		kibanaClient, err := stack.NewKibanaClient()
+		kibanaClient, err := stack.NewKibanaClientFromProfile(profile)
 		if err != nil {
 			return fmt.Errorf("can't create Kibana client: %w", err)
 		}

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cobraext"
+	"github.com/elastic/elastic-package/internal/install"
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/packages/installer"
 	"github.com/elastic/elastic-package/internal/stack"
@@ -28,6 +29,7 @@ func setupUninstallCommand() *cobraext.Command {
 		Args:  cobra.NoArgs,
 		RunE:  uninstallCommandAction,
 	}
+	cmd.Flags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
 
 	return cobraext.NewCommand(cmd, cobraext.ContextPackage)
 }
@@ -41,7 +43,12 @@ func uninstallCommandAction(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("locating package root failed: %w", err)
 	}
 
-	kibanaClient, err := stack.NewKibanaClient()
+	profile, err := cobraext.GetProfileFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	kibanaClient, err := stack.NewKibanaClientFromProfile(profile)
 	if err != nil {
 		return fmt.Errorf("could not create kibana client: %w", err)
 	}

--- a/docs/howto/asset_testing.md
+++ b/docs/howto/asset_testing.md
@@ -36,12 +36,6 @@ elastic-package stack up -d
 
 For a complete listing of options available for this command, run `elastic-package stack up -h` or `elastic-package help stack up`.
 
-Next, you must set environment variables needed for further `elastic-package` commands.
-
-```
-$(elastic-package stack shellinit)
-```
-
 Next, you must invoke the asset loading test runner. This corresponds to steps 3 through 5 as described in the [_Conceptual process_](#Conceptual-process) section.
 
 Navigate to the package's root folder (or any sub-folder under it) and run the following command.

--- a/docs/howto/install_package.md
+++ b/docs/howto/install_package.md
@@ -9,7 +9,6 @@ For versions of `Kibana<8.7.0`, the packages must be exposed via the Package Reg
 In case of development, this means that the package should be built previously and then the Elastic stack must be started. Or at least, package-registry service needs to be restarted in the Elastic stack.
 
 ```shell
-eval "$(elastic-package stack shellinit)"
 elastic-package build -v
 elastic-package stack up -v -d  # elastic-package stack up -v -d --services package-registry
 elastic-package install -v
@@ -30,7 +29,6 @@ From Kibana 8.7.0 version, `elastic-package install` is able to install packages
 Example of using `--zip` parameter:
 ```shell
  $ elastic-package stack up -v -d
- $ eval "$(elastic-package stack shellinit)"
  $ elastic-package install --zip /home/user/Coding/work/integrations/build/packages/elastic_package_registry-0.0.6.zip -v
 2023/02/23 18:44:59 DEBUG Enable verbose logging
 2023/02/23 18:44:59 DEBUG Distribution built without a version tag, can't determine release chronology. Please consider using official releases at https://github.com/elastic/elastic-package/releases
@@ -50,7 +48,6 @@ Done
 Example of using `elastic-package install`
 ```shell
  $ elastic-package stack up -v -d
- $ eval "$(elastic-package stack shellinit)"
  $ elastic-package install -v
 2023/02/28 12:34:44 DEBUG Enable verbose logging
 2023/02/28 12:34:44 DEBUG Distribution built without a version tag, can't determine release chronology. Please consider using official releases at https://github.com/elastic/elastic-package/releases

--- a/docs/howto/pipeline_benchmarking.md
+++ b/docs/howto/pipeline_benchmarking.md
@@ -101,12 +101,6 @@ elastic-package stack up -d --services=elasticsearch
 
 For a complete listing of options available for this command, run `elastic-package stack up -h` or `elastic-package help stack up`.
 
-Next, you must set environment variables needed for further `elastic-package` commands.
-
-```
-$(elastic-package stack shellinit)
-```
-
 Next, you must invoke the pipeline benchmark runner. This corresponds to steps 2 through 4 as described in the [_Conceptual process_](#Conceptual-process) section.
 
 If you want to run pipeline benchmarks for **all data streams** in a package, navigate to the package's root folder (or any sub-folder under it) and run the following command.

--- a/docs/howto/pipeline_testing.md
+++ b/docs/howto/pipeline_testing.md
@@ -156,12 +156,6 @@ elastic-package stack up -d --services=elasticsearch
 
 For a complete listing of options available for this command, run `elastic-package stack up -h` or `elastic-package help stack up`.
 
-Next, you must set environment variables needed for further `elastic-package` commands.
-
-```
-$(elastic-package stack shellinit)
-```
-
 Next, you must invoke the pipeline tests runner. This corresponds to steps 2 through 4 as described in the [_Conceptual process_](#Conceptual-process) section.
 
 If you want to run pipeline tests for **all data streams** in a package, navigate to the package's root folder (or any sub-folder under it) and run the following command.

--- a/docs/howto/system_benchmarking.md
+++ b/docs/howto/system_benchmarking.md
@@ -312,12 +312,6 @@ elastic-package stack up -d
 
 For a complete listing of options available for this command, run `elastic-package stack up -h` or `elastic-package help stack up`.
 
-Next, you must set environment variables needed for further `elastic-package` commands.
-
-```
-$(elastic-package stack shellinit)
-```
-
 Next, you must invoke the system benchmark runner.
 
 ```

--- a/docs/howto/system_testing.md
+++ b/docs/howto/system_testing.md
@@ -532,12 +532,6 @@ elastic-package stack up -d
 
 For a complete listing of options available for this command, run `elastic-package stack up -h` or `elastic-package help stack up`.
 
-Next, you must set environment variables needed for further `elastic-package` commands.
-
-```
-$(elastic-package stack shellinit)
-```
-
 Next, you must invoke the system tests runner. This corresponds to steps 3 through 7 as described in the [_Conceptual process_](#Conceptual-process) section.
 
 If you want to run system tests for **all data streams** in a package, navigate to the package's root folder (or any sub-folder under it) and run the following command.

--- a/internal/servicedeployer/custom_agent.go
+++ b/internal/servicedeployer/custom_agent.go
@@ -55,9 +55,9 @@ func (d *CustomAgentDeployer) SetUp(inCtxt ServiceContext) (DeployedService, err
 		return nil, fmt.Errorf("can't read application configuration: %w", err)
 	}
 
-	caCertPath, ok := os.LookupEnv(stack.CACertificateEnv)
-	if !ok {
-		return nil, fmt.Errorf("can't locate CA certificate: %s environment variable not set", stack.CACertificateEnv)
+	caCertPath, err := stack.FindCACertificate(d.profile)
+	if err != nil {
+		return nil, fmt.Errorf("can't locate CA certificate: %w", err)
 	}
 
 	env := append(

--- a/internal/stack/clients.go
+++ b/internal/stack/clients.go
@@ -114,7 +114,7 @@ func NewKibanaClientFromProfile(profile *profile.Profile, customOptions ...kiban
 		kibana.Address(kibanaHost),
 		kibana.Password(elasticsearchPassword),
 		kibana.Username(elasticsearchUsername),
-		kibana.CertificateAuthority(caCertificateEnv),
+		kibana.CertificateAuthority(caCertificate),
 	}
 	options = append(options, customOptions...)
 	client, err := kibana.NewClient(options...)

--- a/internal/stack/clients.go
+++ b/internal/stack/clients.go
@@ -6,10 +6,12 @@ package stack
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/elastic/elastic-package/internal/elasticsearch"
 	"github.com/elastic/elastic-package/internal/kibana"
+	"github.com/elastic/elastic-package/internal/profile"
 )
 
 func NewElasticsearchClient(customOptions ...elasticsearch.ClientOption) (*elasticsearch.Client, error) {
@@ -29,12 +31,90 @@ func NewElasticsearchClient(customOptions ...elasticsearch.ClientOption) (*elast
 	return client, err
 }
 
+func NewElasticsearchClientFromProfile(profile *profile.Profile, customOptions ...elasticsearch.ClientOption) (*elasticsearch.Client, error) {
+	profileConfig, err := StackInitConfig(profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config from profile: %w", err)
+	}
+
+	elasticsearchHost, found := os.LookupEnv(ElasticsearchHostEnv)
+	if !found {
+		elasticsearchHost = profileConfig.ElasticsearchHostPort
+	}
+	elasticsearchPassword, found := os.LookupEnv(ElasticsearchPasswordEnv)
+	if !found {
+		elasticsearchPassword = profileConfig.ElasticsearchPassword
+	}
+	elasticsearchUsername, found := os.LookupEnv(ElasticsearchUsernameEnv)
+	if !found {
+		elasticsearchUsername = profileConfig.ElasticsearchUsername
+	}
+	caCertificate, found := os.LookupEnv(CACertificateEnv)
+	if !found {
+		caCertificate = profileConfig.CACertificatePath
+	}
+
+	options := []elasticsearch.ClientOption{
+		elasticsearch.OptionWithAddress(elasticsearchHost),
+		elasticsearch.OptionWithPassword(elasticsearchPassword),
+		elasticsearch.OptionWithUsername(elasticsearchUsername),
+		elasticsearch.OptionWithCertificateAuthority(caCertificate),
+	}
+	options = append(options, customOptions...)
+	client, err := elasticsearch.NewClient(options...)
+
+	if errors.Is(err, elasticsearch.ErrUndefinedAddress) {
+		return nil, UndefinedEnvError(ElasticsearchHostEnv)
+	}
+
+	return client, err
+}
+
 func NewKibanaClient(customOptions ...kibana.ClientOption) (*kibana.Client, error) {
 	options := []kibana.ClientOption{
 		kibana.Address(os.Getenv(KibanaHostEnv)),
 		kibana.Password(os.Getenv(ElasticsearchPasswordEnv)),
 		kibana.Username(os.Getenv(ElasticsearchUsernameEnv)),
 		kibana.CertificateAuthority(os.Getenv(CACertificateEnv)),
+	}
+	options = append(options, customOptions...)
+	client, err := kibana.NewClient(options...)
+
+	if errors.Is(err, kibana.ErrUndefinedHost) {
+		return nil, UndefinedEnvError(ElasticsearchHostEnv)
+	}
+
+	return client, err
+}
+
+func NewKibanaClientFromProfile(profile *profile.Profile, customOptions ...kibana.ClientOption) (*kibana.Client, error) {
+	profileConfig, err := StackInitConfig(profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config from profile: %w", err)
+	}
+
+	kibanaHost, found := os.LookupEnv(KibanaHostEnv)
+	if !found {
+		kibanaHost = profileConfig.KibanaHostPort
+	}
+	elasticsearchPassword, found := os.LookupEnv(ElasticsearchPasswordEnv)
+	if !found {
+		elasticsearchPassword = profileConfig.ElasticsearchPassword
+	}
+	elasticsearchUsername, found := os.LookupEnv(ElasticsearchUsernameEnv)
+	if !found {
+		elasticsearchUsername = profileConfig.ElasticsearchUsername
+	}
+	caCertificate, found := os.LookupEnv(CACertificateEnv)
+	if !found {
+		caCertificate = profileConfig.CACertificatePath
+	}
+
+	options := []kibana.ClientOption{
+		kibana.Address(kibanaHost),
+		kibana.Password(elasticsearchPassword),
+		kibana.Username(elasticsearchUsername),
+		kibana.CertificateAuthority(caCertificateEnv),
 	}
 	options = append(options, customOptions...)
 	client, err := kibana.NewClient(options...)

--- a/internal/stack/clients.go
+++ b/internal/stack/clients.go
@@ -14,6 +14,8 @@ import (
 	"github.com/elastic/elastic-package/internal/profile"
 )
 
+// NewElasticsearchClient creates an Elasticsearch client with the settings provided by the shellinit
+// environment variables.
 func NewElasticsearchClient(customOptions ...elasticsearch.ClientOption) (*elasticsearch.Client, error) {
 	options := []elasticsearch.ClientOption{
 		elasticsearch.OptionWithAddress(os.Getenv(ElasticsearchHostEnv)),
@@ -31,6 +33,9 @@ func NewElasticsearchClient(customOptions ...elasticsearch.ClientOption) (*elast
 	return client, err
 }
 
+// NewElasticsearchClientFromProfile creates an Elasticsearch client with the settings provided by the shellinit
+// environment variables. If these environment variables are not set, it uses the information
+// in the provided profile.
 func NewElasticsearchClientFromProfile(profile *profile.Profile, customOptions ...elasticsearch.ClientOption) (*elasticsearch.Client, error) {
 	profileConfig, err := StackInitConfig(profile)
 	if err != nil {
@@ -70,6 +75,8 @@ func NewElasticsearchClientFromProfile(profile *profile.Profile, customOptions .
 	return client, err
 }
 
+// NewKibanaClient creates a kibana client with the settings provided by the shellinit
+// environment variables.
 func NewKibanaClient(customOptions ...kibana.ClientOption) (*kibana.Client, error) {
 	options := []kibana.ClientOption{
 		kibana.Address(os.Getenv(KibanaHostEnv)),
@@ -81,12 +88,15 @@ func NewKibanaClient(customOptions ...kibana.ClientOption) (*kibana.Client, erro
 	client, err := kibana.NewClient(options...)
 
 	if errors.Is(err, kibana.ErrUndefinedHost) {
-		return nil, UndefinedEnvError(ElasticsearchHostEnv)
+		return nil, UndefinedEnvError(KibanaHostEnv)
 	}
 
 	return client, err
 }
 
+// NewKibanaClientFromProfile creates a kibana client with the settings provided by the shellinit
+// environment variables. If these environment variables are not set, it uses the information
+// in the provided profile.
 func NewKibanaClientFromProfile(profile *profile.Profile, customOptions ...kibana.ClientOption) (*kibana.Client, error) {
 	profileConfig, err := StackInitConfig(profile)
 	if err != nil {
@@ -120,7 +130,7 @@ func NewKibanaClientFromProfile(profile *profile.Profile, customOptions ...kiban
 	client, err := kibana.NewClient(options...)
 
 	if errors.Is(err, kibana.ErrUndefinedHost) {
-		return nil, UndefinedEnvError(ElasticsearchHostEnv)
+		return nil, UndefinedEnvError(KibanaHostEnv)
 	}
 
 	return client, err

--- a/internal/stack/clients.go
+++ b/internal/stack/clients.go
@@ -135,3 +135,18 @@ func NewKibanaClientFromProfile(profile *profile.Profile, customOptions ...kiban
 
 	return client, err
 }
+
+// FindCACertificate looks for the CA certificate for the stack in the current profile.
+// If not found, it uses the environment variable provided by shellinit.
+func FindCACertificate(profile *profile.Profile) (string, error) {
+	caCertPath, found := os.LookupEnv(CACertificateEnv)
+	if !found {
+		profileConfig, err := StackInitConfig(profile)
+		if err != nil {
+			return "", fmt.Errorf("failed to load config from profile: %w", err)
+		}
+		caCertPath = profileConfig.CACertificatePath
+	}
+
+	return caCertPath, nil
+}

--- a/internal/stack/errors.go
+++ b/internal/stack/errors.go
@@ -5,11 +5,25 @@
 package stack
 
 import (
+	"errors"
 	"fmt"
 )
 
+// ErrUndefinedEnv is an error about an undefined environment variable for the current profile.
+type ErrUndefinedEnv struct {
+	EnvName string
+}
+
+// Error returns the error message for this error.
+func (err *ErrUndefinedEnv) Error() string {
+	return fmt.Sprintf("undefined environment variable: %s. If you have started the Elastic Stack using the elastic-package tool, "+
+		`please load stack environment variables using '%s' or set their values manually`, err.EnvName, helpText(AutodetectShell()))
+}
+
 // UndefinedEnvError formats an error reported for undefined variable.
 func UndefinedEnvError(envName string) error {
-	return fmt.Errorf("undefined environment variable: %s. If you have started the Elastic stack using the elastic-package tool, "+
-		`please load stack environment variables using '%s' or set their values manually`, envName, helpText(AutodetectShell()))
+	return &ErrUndefinedEnv{EnvName: envName}
 }
+
+// ErrUnavailableStack is an error about an unavailable Elastic stack.
+var ErrUnavailableStack = errors.New("Elastic stack unavailable, remember to start it with 'elastic-package stack up', or configure elastic-package with environment variables")

--- a/internal/stack/errors.go
+++ b/internal/stack/errors.go
@@ -26,4 +26,4 @@ func UndefinedEnvError(envName string) error {
 }
 
 // ErrUnavailableStack is an error about an unavailable Elastic stack.
-var ErrUnavailableStack = errors.New("Elastic stack unavailable, remember to start it with 'elastic-package stack up', or configure elastic-package with environment variables")
+var ErrUnavailableStack = errors.New("the Elastic stack is unavailable, remember to start it with 'elastic-package stack up', or configure elastic-package with environment variables")

--- a/scripts/test-build-zip.sh
+++ b/scripts/test-build-zip.sh
@@ -42,7 +42,6 @@ cd -
 rm -r build/packages/*/
 
 # Boot up the stack
-eval "$(elastic-package stack shellinit)"
 elastic-package stack up -d -v
 
 # Install zipped packages

--- a/scripts/test-build-zip.sh
+++ b/scripts/test-build-zip.sh
@@ -42,6 +42,7 @@ cd -
 rm -r build/packages/*/
 
 # Boot up the stack
+eval "$(elastic-package stack shellinit)"
 elastic-package stack up -d -v
 
 # Install zipped packages

--- a/scripts/test-check-false-positives.sh
+++ b/scripts/test-check-false-positives.sh
@@ -77,8 +77,6 @@ elastic-package stack up -d -v
 elastic-package stack status
 
 # Run package tests
-eval "$(elastic-package stack shellinit)"
-
 for d in test/packages/${PACKAGE_TEST_TYPE:-false_positives}/${PACKAGE_UNDER_TEST:-*}/; do
   (
     cd $d

--- a/scripts/test-check-false-positives.sh
+++ b/scripts/test-check-false-positives.sh
@@ -77,12 +77,9 @@ elastic-package stack up -d -v
 elastic-package stack status
 
 # Run package tests
-eval "$(elastic-package stack shellinit)"
-
 for d in test/packages/${PACKAGE_TEST_TYPE:-false_positives}/${PACKAGE_UNDER_TEST:-*}/; do
   (
     cd $d
-    elastic-package install -v
 
     # defer-cleanup is set to a short period to verify that the option is available
     elastic-package test -v --report-format xUnit --report-output file --defer-cleanup 1s --test-coverage

--- a/scripts/test-check-false-positives.sh
+++ b/scripts/test-check-false-positives.sh
@@ -77,6 +77,8 @@ elastic-package stack up -d -v
 elastic-package stack status
 
 # Run package tests
+eval "$(elastic-package stack shellinit)"
+
 for d in test/packages/${PACKAGE_TEST_TYPE:-false_positives}/${PACKAGE_UNDER_TEST:-*}/; do
   (
     cd $d

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -61,8 +61,6 @@ if [ "${PACKAGE_TEST_TYPE:-other}" == "with-kind" ]; then
 fi
 
 # Run package tests
-eval "$(elastic-package stack shellinit)"
-
 for d in test/packages/${PACKAGE_TEST_TYPE:-other}/${PACKAGE_UNDER_TEST:-*}/; do
   (
     cd $d

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -61,12 +61,9 @@ if [ "${PACKAGE_TEST_TYPE:-other}" == "with-kind" ]; then
 fi
 
 # Run package tests
-eval "$(elastic-package stack shellinit)"
-
 for d in test/packages/${PACKAGE_TEST_TYPE:-other}/${PACKAGE_UNDER_TEST:-*}/; do
   (
     cd $d
-    elastic-package install -v
 
     if [ "${PACKAGE_TEST_TYPE:-other}" == "benchmarks" ]; then
       # It is not used PACKAGE_UNDER_TEST, so all benchmark packages are run in the same loop

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -61,6 +61,8 @@ if [ "${PACKAGE_TEST_TYPE:-other}" == "with-kind" ]; then
 fi
 
 # Run package tests
+eval "$(elastic-package stack shellinit)"
+
 for d in test/packages/${PACKAGE_TEST_TYPE:-other}/${PACKAGE_UNDER_TEST:-*}/; do
   (
     cd $d

--- a/scripts/test-install-zip.sh
+++ b/scripts/test-install-zip.sh
@@ -46,7 +46,7 @@ installAndVerifyPackage() {
 usage() {
     echo "${0} [-s] [-h]"
     echo "Run test-install-zip suite"
-    echo -e "\t-s: Use elastic-package stack shellinit to export environment variables. By default, they should be exported manually."
+    echo -e "\t-s: Use elastic-package stack shellinit to export environment variablles. By default, they should be exported manually."
     echo -e "\t-v <stack_version>: Speciy which Elastic Stack version to use. If not specified it will use the default version in elastic-package."
     echo -e "\t-h: Show this message"
 }

--- a/scripts/test-install-zip.sh
+++ b/scripts/test-install-zip.sh
@@ -46,7 +46,7 @@ installAndVerifyPackage() {
 usage() {
     echo "${0} [-s] [-h]"
     echo "Run test-install-zip suite"
-    echo -e "\t-s: Use elastic-package stack shellinit to export environment variablles. By default, they should be exported manually."
+    echo -e "\t-s: Use elastic-package stack shellinit to export environment variables. By default, they should be exported manually."
     echo -e "\t-v <stack_version>: Speciy which Elastic Stack version to use. If not specified it will use the default version in elastic-package."
     echo -e "\t-h: Show this message"
 }

--- a/scripts/test-stack-command.sh
+++ b/scripts/test-stack-command.sh
@@ -48,6 +48,7 @@ elastic-package stack update -v ${ARG_VERSION}
 elastic-package stack up -d -v ${ARG_VERSION}
 
 # Verify it's accessible
+eval "$(elastic-package stack shellinit)"
 curl --cacert ${ELASTIC_PACKAGE_CA_CERT} -f ${ELASTIC_PACKAGE_KIBANA_HOST}/login | grep kbn-injected-metadata >/dev/null # healthcheck
 
 # Check status with running services

--- a/scripts/test-stack-command.sh
+++ b/scripts/test-stack-command.sh
@@ -48,7 +48,6 @@ elastic-package stack update -v ${ARG_VERSION}
 elastic-package stack up -d -v ${ARG_VERSION}
 
 # Verify it's accessible
-eval "$(elastic-package stack shellinit)"
 curl --cacert ${ELASTIC_PACKAGE_CA_CERT} -f ${ELASTIC_PACKAGE_KIBANA_HOST}/login | grep kbn-injected-metadata >/dev/null # healthcheck
 
 # Check status with running services


### PR DESCRIPTION
Commands that require an stack to connect will try to connect with the
stack of the current profile by default. This behaviour can be overridden
by setting the usual environment variables provided by `elastic-package shellinit`.

With this change `elastic-package shellinit` is not necessary when working
with stacks managed by `elastic-package`. `shellinit` is still useful to export
the configuration for other commands or scripts.
The environment variables can also be used to work with stacks not managed
by `elastic-package`.