### PR TITLE
Fix test for creating input packages

### DIFF
--- a/internal/packages/archetype/data_stream_test.go
+++ b/internal/packages/archetype/data_stream_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestDataStream(t *testing.T) {
 	t.Run("valid-logs", func(t *testing.T) {
-		pd := createPackageDescriptorForTest("integration")
+		pd := createPackageDescriptorForTest("integration", "^7.13.0")
 		dd := createDataStreamDescriptorForTest()
 		dd.Manifest.Type = "logs"
 
@@ -24,7 +24,7 @@ func TestDataStream(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run("valid-metrics", func(t *testing.T) {
-		pd := createPackageDescriptorForTest("integration")
+		pd := createPackageDescriptorForTest("integration", "^7.13.0")
 		dd := createDataStreamDescriptorForTest()
 		dd.Manifest.Type = "metrics"
 
@@ -32,7 +32,7 @@ func TestDataStream(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run("missing-type", func(t *testing.T) {
-		pd := createPackageDescriptorForTest("integration")
+		pd := createPackageDescriptorForTest("integration", "^7.13.0")
 		dd := createDataStreamDescriptorForTest()
 		dd.Manifest.Type = ""
 

--- a/internal/packages/archetype/package_test.go
+++ b/internal/packages/archetype/package_test.go
@@ -19,23 +19,23 @@ import (
 
 func TestPackage(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
-		pd := createPackageDescriptorForTest("integration")
+		pd := createPackageDescriptorForTest("integration", "^7.13.0")
 
 		err := createAndCheckPackage(t, pd)
 		require.NoError(t, err)
 	})
 	t.Run("missing-version", func(t *testing.T) {
-		pd := createPackageDescriptorForTest("integration")
+		pd := createPackageDescriptorForTest("integration", "^7.13.0")
 		pd.Manifest.Version = ""
 
 		err := createAndCheckPackage(t, pd)
 		require.Error(t, err)
 	})
-	t.Run("input-pacakge", func(t *testing.T) {
-		pd := createPackageDescriptorForTest("input")
+	t.Run("input-package", func(t *testing.T) {
+		pd := createPackageDescriptorForTest("input", "^8.9.0")
 
 		err := createAndCheckPackage(t, pd)
-		require.Error(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -59,7 +59,7 @@ func createAndCheckPackage(t require.TestingT, pd PackageDescriptor) error {
 	return err
 }
 
-func createPackageDescriptorForTest(packageType string) PackageDescriptor {
+func createPackageDescriptorForTest(packageType, kibanaVersion string) PackageDescriptor {
 	inputDataStreamType := ""
 	if packageType == "input" {
 		inputDataStreamType = "logs"
@@ -72,7 +72,7 @@ func createPackageDescriptorForTest(packageType string) PackageDescriptor {
 			Version: "1.2.3",
 			Conditions: packages.Conditions{
 				Kibana: packages.KibanaConditions{
-					Version: "^7.13.0",
+					Version: kibanaVersion,
 				},
 				Elastic: packages.ElasticConditions{
 					Subscription: "basic",


### PR DESCRIPTION
Relates #1361

This PR fixes the test for `elastic-package create package` for input packages.

The test requires to have a kibana.version >= 8.9 in order to be a valid (non-experimental) input package.

For input packages created in the CLI, it is used the default stack version. Support of creating input packages will be released in the next version. As in the next version, the default stack version is bumped to 8.9.1 (https://github.com/elastic/elastic-package/pull/1425), input packages created are going to be valid.
