### PR TITLE
Add validators for package and datastream names

### DIFF
--- a/cmd/create_data_stream.go
+++ b/cmd/create_data_stream.go
@@ -56,7 +56,7 @@ func createDataStreamCommandAction(cmd *cobra.Command, args []string) error {
 				Message: "Data stream name:",
 				Default: "new_data_stream",
 			},
-			Validate: survey.ComposeValidators(survey.Required, surveyext.DataStreamDoesNotExistValidator),
+			Validate: survey.ComposeValidators(survey.Required, surveyext.DataStreamDoesNotExistValidator, surveyext.DataStreamNameValidator),
 		},
 		{
 			Name: "title",

--- a/cmd/create_package.go
+++ b/cmd/create_package.go
@@ -68,7 +68,7 @@ func createPackageCommandAction(cmd *cobra.Command, args []string) error {
 				Message: "Package name:",
 				Default: "new_package",
 			},
-			Validate: survey.ComposeValidators(survey.Required, surveyext.PackageDoesNotExistValidator),
+			Validate: survey.ComposeValidators(survey.Required, surveyext.PackageDoesNotExistValidator, surveyext.PackageNameValidator),
 		},
 		{
 			Name: "version",

--- a/internal/surveyext/validators.go
+++ b/internal/surveyext/validators.go
@@ -16,6 +16,9 @@ import (
 
 var (
 	githubOwnerRegexp = regexp.MustCompile(`^(([a-zA-Z0-9-]+)|([a-zA-Z0-9-]+\/[a-zA-Z0-9-]+))$`)
+
+	packageNameRegexp    = regexp.MustCompile(`^[a-z0-9_]+$`)
+	dataStreamNameRegexp = regexp.MustCompile(`^([a-z0-9]{2}|[a-z0-9][a-z0-9_]+[a-z0-9])$`)
 )
 
 // PackageDoesNotExistValidator function checks if the package hasn't been already created.
@@ -81,6 +84,30 @@ func GithubOwnerValidator(val interface{}) error {
 
 	if !githubOwnerRegexp.MatchString(githubOwner) {
 		return fmt.Errorf("value doesn't match the regular expression (organization/group or username): %s", githubOwnerRegexp.String())
+	}
+	return nil
+}
+
+func PackageNameValidator(val interface{}) error {
+	packageName, ok := val.(string)
+	if !ok {
+		return errors.New("string type expected")
+	}
+
+	if !packageNameRegexp.MatchString(packageName) {
+		return fmt.Errorf("value doesn't match the regular expression (package name): %s", packageNameRegexp.String())
+	}
+	return nil
+}
+
+func DataStreamNameValidator(val interface{}) error {
+	dataStreamFolderName, ok := val.(string)
+	if !ok {
+		return errors.New("string type expected")
+	}
+
+	if !dataStreamNameRegexp.MatchString(dataStreamFolderName) {
+		return fmt.Errorf("value doesn't match the regular expression (datastream name): %s", dataStreamNameRegexp.String())
 	}
 	return nil
 }


### PR DESCRIPTION
Fix #1346 

This PR adds new validators in `elastic-package create` command to ensure that package and data stream names are the valid ones.

Regular expressions for these validators are copied from package-spec
- Package spec pattern: https://github.com/elastic/package-spec/blob/037631bddaffe6519b61eb41c186fb929675d6e1/spec/integration/manifest.spec.yml#L268
- Data stream name: https://github.com/elastic/package-spec/blob/037631bddaffe6519b61eb41c186fb929675d6e1/spec/integration/data_stream/spec.yml#L7

Examples:
- When trying to set as package name `AA`:
```shell
 $ elastic-package create package
Create a new package
? Package type: integration
X Sorry, your reply was invalid: value doesn't match the regular expression (package name): ^[a-z0-9_]+$
```

- When trying to set as data stream name `aa-`:
```shell
 $ elastic-package create data-stream
Create a new data stream
X Sorry, your reply was invalid: value doesn't match the regular expression (datastream name): ^([a-z0-9]{2}|[a-z0-9][a-z0-9_]+[a-z0-9])$
? Data stream name: (new_data_stream) 
```