### PR TITLE
Fix environment variable reported in error

### DIFF
--- a/internal/stack/clients.go
+++ b/internal/stack/clients.go
@@ -40,7 +40,7 @@ func NewKibanaClient(customOptions ...kibana.ClientOption) (*kibana.Client, erro
 	client, err := kibana.NewClient(options...)
 
 	if errors.Is(err, kibana.ErrUndefinedHost) {
-		return nil, UndefinedEnvError(ElasticsearchHostEnv)
+		return nil, UndefinedEnvError(KibanaHostEnv)
 	}
 
 	return client, err


### PR DESCRIPTION
Follow-up #1403

Update environment variable used when reporting the error if Kibana Host environment variable is not defined.