### PR TITLE
Fix parsing of install response

### DIFF
--- a/internal/kibana/packages.go
+++ b/internal/kibana/packages.go
@@ -76,12 +76,20 @@ func processResults(action string, statusCode int, respBody []byte) ([]packages.
 	}
 
 	var resp struct {
-		Assets []packages.Asset `json:"response"`
+		// Assets are here when old API is used.
+		Response []packages.Asset `json:"response"`
+
+		// Assets are here when new API is used.
+		Items []packages.Asset `json:"items"`
 	}
 
 	if err := json.Unmarshal(respBody, &resp); err != nil {
 		return nil, fmt.Errorf("could not convert %s package (response) to JSON: %w", action, err)
 	}
 
-	return resp.Assets, nil
+	if len(resp.Response) > 0 {
+		return resp.Response, nil
+	}
+
+	return resp.Items, nil
 }

--- a/internal/kibana/packages.go
+++ b/internal/kibana/packages.go
@@ -76,10 +76,10 @@ func processResults(action string, statusCode int, respBody []byte) ([]packages.
 	}
 
 	var resp struct {
-		// Assets are here when old API is used.
+		// Assets are here when old packages API is used (with hyphen, before 8.0).
 		Response []packages.Asset `json:"response"`
 
-		// Assets are here when new API is used.
+		// Assets are here when new packages API is used (with slash, since 8.0).
 		Items []packages.Asset `json:"items"`
 	}
 


### PR DESCRIPTION
New and old APIs for packages include the assets in different fields. Old API uses `response`, while new API uses `items`.