### PR TITLE
Clean up debug messages in stack status command

### DIFF
--- a/internal/stack/status.go
+++ b/internal/stack/status.go
@@ -7,8 +7,6 @@ package stack
 import (
 	"sort"
 	"strings"
-
-	"github.com/elastic/elastic-package/internal/logger"
 )
 
 // Status shows the status for each service
@@ -21,7 +19,6 @@ func Status(options Options) ([]ServiceStatus, error) {
 	var services []ServiceStatus
 	for _, status := range servicesStatus {
 		if strings.Contains(status.Name, readyServicesSuffix) {
-			logger.Debugf("Filtering out service: %s", status.Name)
 			continue
 		}
 		services = append(services, status)


### PR DESCRIPTION
This PR cleans up debug messages from stack command like these ones:
```
2023/09/11 10:33:03 DEBUG Filtering out service: elastic-agent_is_ready
2023/09/11 10:33:03 DEBUG Filtering out service: fleet-server_is_ready
2023/09/11 10:33:03 DEBUG Filtering out service: kibana_is_ready
2023/09/11 10:33:03 DEBUG Filtering out service: package-registry_is_ready
2023/09/11 10:33:03 DEBUG Filtering out service: elasticsearch_is_ready
```