### PR TITLE
Avoid dotted fields when creating new package

### DIFF
--- a/internal/packages/archetype/_static/package-manifest.yml.tmpl
+++ b/internal/packages/archetype/_static/package-manifest.yml.tmpl
@@ -12,8 +12,10 @@ categories:{{range $category := .Manifest.Categories}}
   - {{$category}}
 {{- end}}
 conditions:
-  kibana.version: "{{.Manifest.Conditions.Kibana.Version}}"
-  elastic.subscription: "{{.Manifest.Conditions.Elastic.Subscription}}"
+  kibana:
+    version: "{{.Manifest.Conditions.Kibana.Version}}"
+  elastic:
+    subscription: "{{.Manifest.Conditions.Elastic.Subscription}}"
 screenshots:
   - src: /img/sample-screenshot.png
     title: Sample screenshot


### PR DESCRIPTION
This PR avoids creating package manifest using dotted fields.
These fields would not be allowed in package-spec v3

Relates https://github.com/elastic/package-spec/issues/538