### PR TITLE
Update go version in go.mod for dependabot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/elastic-package
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
This PR updates Go version set in `go.mod` to include `.0`

This fixes the errors raised by Dependabot:
```
Dependabot encountered the following error:

go: downloading go1.21 (linux/amd64)
go: download go1.21 for linux/amd64: toolchain not available
```