### PR TITLE
Update default stack version to 8.10.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test-stack-command-86:
 	./scripts/test-stack-command.sh 8.6.2
 
 test-stack-command-8x:
-	./scripts/test-stack-command.sh 8.10.0-SNAPSHOT
+	./scripts/test-stack-command.sh 8.11.0-SNAPSHOT
 
 test-stack-command: test-stack-command-default test-stack-command-7x test-stack-command-800 test-stack-command-8x
 

--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "8.9.1"
+	DefaultStackVersion = "8.10.1"
 )

--- a/internal/version/check_update.go
+++ b/internal/version/check_update.go
@@ -37,6 +37,10 @@ type versionLatest struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
+func (v versionLatest) String() string {
+	return fmt.Sprintf("%s. Download from: %s (Timestamp %s)", v.TagName, v.HtmlURL, v.Timestamp)
+}
+
 // CheckUpdate function checks using Github Release API if newer version is available.
 func CheckUpdate() {
 	if Tag == "" {
@@ -63,7 +67,7 @@ func CheckUpdate() {
 	var release *versionLatest
 	switch {
 	case !expired:
-		logger.Debugf("latest version (cached): %s", latestVersion)
+		logger.Debugf("latest version (cached): %s", latestVersion.String())
 		release = latestVersion
 	default:
 		logger.Debugf("checking latest release in Github")


### PR DESCRIPTION
This PR updates the default stack version to 8.10.1

In tests, it has also been updated to 8.11.0-SNAPSHOT the target `test-stack-command-8x`

Additional:
- it has been updated the debug message about version cached:
```
#Before
2023/09/19 21:51:09 DEBUG latest version (cached): &{v0.87.1 https://github.com/elastic/elastic-package/releases/tag/v0.87.1 2023-09-19 21:38:49.561771091 +0200 CEST}
#Now
2023/09/20 12:39:13 DEBUG latest version (cached): v0.87.1. Download from: https://github.com/elastic/elastic-package/releases/tag/v0.87.1 (Timestamp 2023-09-20 12:30:26.593876097 +0200 CEST)
```