### PR TITLE
Fix debug/warn log messages when checking version cached

### DIFF
--- a/internal/version/check_update.go
+++ b/internal/version/check_update.go
@@ -59,7 +59,7 @@ func CheckUpdate() {
 	latestVersion, err := loadCacheLatestVersion()
 	switch {
 	case err != nil:
-		logger.Debug("failed to load latest version from cache: %v", err)
+		logger.Debugf("failed to load latest version from cache: %v", err.Error())
 	default:
 		expired = checkCachedLatestVersion(latestVersion, defaultCacheDuration)
 	}
@@ -139,7 +139,7 @@ func loadCacheLatestVersion() (*versionLatest, error) {
 	latestVersionPath := filepath.Join(elasticPackagePath.RootDir(), latestVersionFile)
 	contents, err := os.ReadFile(latestVersionPath)
 	if err != nil {
-		logger.Warnf("reading version file failed: %w", err.Error())
+		logger.Warnf("reading version file failed: %v", err.Error())
 		return nil, fmt.Errorf("reading version file failed: %w", err)
 	}
 


### PR DESCRIPTION
This PR fixes the log messages shown when there is no version cache file

- Before:
```
2023/09/20 14:44:53  WARN reading version file failed: %!w(string=open /opt/buildkite-agent/.elastic-package/latestVersion: no such file or directory)
2023/09/20 14:44:53 DEBUG failed to load latest version from cache: %vreading version file failed: open /opt/buildkite-agent/.elastic-package/latestVersion: no such file or directory
2023/09/20 14:44:53 DEBUG checking latest release in Github
```
- With these changes
```
2023/09/20 16:52:57  WARN reading version file failed: open /home/mariorodriguez/.elastic-package/latestVersion: no such file or directory
2023/09/20 16:52:57 DEBUG failed to load latest version from cache: reading version file failed: open /home/mariorodriguez/.elastic-package/latestVersion: no such file or directory
2023/09/20 16:52:57 DEBUG checking latest release in Github
```