### PR TITLE
Avoid encoding html entities in JSON documents

### DIFF
--- a/internal/docs/readme_test.go
+++ b/internal/docs/readme_test.go
@@ -9,9 +9,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-package/internal/packages"
 )
 
 func TestGenerateReadme(t *testing.T) {

--- a/internal/docs/readme_test.go
+++ b/internal/docs/readme_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -152,6 +153,9 @@ An example event for ` + "`example`" + ` looks as following:
 			err = createSampleEventFile(c.packageRoot, c.dataStreamName, c.sampleEventJsonContents)
 			require.NoError(t, err)
 
+			err = createManifestFile(c.packageRoot)
+			require.NoError(t, err)
+
 			rendered, err := renderReadme(filename, c.packageRoot, templatePath, linksMap)
 			require.NoError(t, err)
 
@@ -291,6 +295,13 @@ func createSampleEventFile(packageRoot, dataStreamName, contents string) error {
 		return err
 	}
 	return nil
+}
+
+func createManifestFile(packageRoot string) error {
+	// Minimal content needed to render readme.
+	manifest := `format_version: 2.10.0`
+	manifestFile := filepath.Join(packageRoot, packages.PackageManifestFile)
+	return os.WriteFile(manifestFile, []byte(manifest), 0644)
 }
 
 func createDataStreamFolder(packageRoot, dataStreamName string) (string, error) {

--- a/internal/docs/sample_event.go
+++ b/internal/docs/sample_event.go
@@ -36,7 +36,7 @@ func renderSampleEvent(packageRoot, dataStreamName string) (string, error) {
 	}
 
 	jsonFormatter := formatter.JSONFormatterBuilder(*specVersion)
-	formatted, _, err := jsonFormatter(body)
+	formatted, _, err := jsonFormatter.Format(body)
 	if err != nil {
 		return "", fmt.Errorf("formatting sample event file failed (path: %s): %w", eventPath, err)
 	}

--- a/internal/docs/sample_event.go
+++ b/internal/docs/sample_event.go
@@ -10,7 +10,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
+
 	"github.com/elastic/elastic-package/internal/formatter"
+	"github.com/elastic/elastic-package/internal/packages"
 )
 
 const sampleEventFile = "sample_event.json"
@@ -23,7 +26,17 @@ func renderSampleEvent(packageRoot, dataStreamName string) (string, error) {
 		return "", fmt.Errorf("reading sample event file failed (path: %s): %w", eventPath, err)
 	}
 
-	formatted, _, err := formatter.JSONFormatter(body)
+	manifest, err := packages.ReadPackageManifestFromPackageRoot(packageRoot)
+	if err != nil {
+		return "", fmt.Errorf("reading package manifest failed: %w", err)
+	}
+	specVersion, err := semver.NewVersion(manifest.SpecVersion)
+	if err != nil {
+		return "", fmt.Errorf("parsing format version %q failed: %w", manifest.SpecVersion, err)
+	}
+
+	jsonFormatter := formatter.JSONFormatterBuilder(*specVersion)
+	formatted, _, err := jsonFormatter(body)
 	if err != nil {
 		return "", fmt.Errorf("formatting sample event file failed (path: %s): %w", eventPath, err)
 	}

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -18,7 +18,7 @@ type formatter func(content []byte) ([]byte, bool, error)
 func newFormatter(specVersion semver.Version, ext string) formatter {
 	switch ext {
 	case ".json":
-		return JSONFormatterBuilder(specVersion)
+		return JSONFormatterBuilder(specVersion).Format
 	case ".yaml", ".yml":
 		return YAMLFormatter
 	default:

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/Masterminds/semver/v3"
+
 	"github.com/elastic/elastic-package/internal/packages"
 )
 

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -8,19 +8,35 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/elastic/elastic-package/internal/packages"
 )
 
 type formatter func(content []byte) ([]byte, bool, error)
 
-var formatters = map[string]formatter{
-	".json": JSONFormatter,
-	".yaml": YAMLFormatter,
-	".yml":  YAMLFormatter,
+func newFormatter(specVersion semver.Version, ext string) formatter {
+	switch ext {
+	case ".json":
+		return JSONFormatterBuilder(specVersion)
+	case ".yaml", ".yml":
+		return YAMLFormatter
+	default:
+		return nil
+	}
 }
 
 // Format method formats files inside of the integration directory.
 func Format(packageRoot string, failFast bool) error {
-	err := filepath.Walk(packageRoot, func(path string, info os.FileInfo, err error) error {
+	manifest, err := packages.ReadPackageManifestFromPackageRoot(packageRoot)
+	if err != nil {
+		return fmt.Errorf("failed to read package manifest: %w", err)
+	}
+	specVersion, err := semver.NewVersion(manifest.SpecVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse package format version %q: %w", manifest.SpecVersion, err)
+	}
+	err = filepath.Walk(packageRoot, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -31,7 +47,7 @@ func Format(packageRoot string, failFast bool) error {
 		if info.IsDir() {
 			return nil
 		}
-		err = formatFile(path, failFast)
+		err = formatFile(path, failFast, *specVersion)
 		if err != nil {
 			return fmt.Errorf("formatting file failed (path: %s): %w", path, err)
 		}
@@ -44,17 +60,15 @@ func Format(packageRoot string, failFast bool) error {
 	return nil
 }
 
-func formatFile(path string, failFast bool) error {
-	file := filepath.Base(path)
-	ext := filepath.Ext(file)
-
+func formatFile(path string, failFast bool, specVersion semver.Version) error {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("reading file content failed: %w", err)
 	}
 
-	format, defined := formatters[ext]
-	if !defined {
+	ext := filepath.Ext(filepath.Base(path))
+	format := newFormatter(specVersion, ext)
+	if format == nil {
 		return nil // no errors returned as we have few files that will be never formatted (png, svg, log, etc.)
 	}
 

--- a/internal/formatter/json_formatter_test.go
+++ b/internal/formatter/json_formatter_test.go
@@ -1,0 +1,71 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package formatter_test
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-package/internal/formatter"
+)
+
+func TestJSONFormatter(t *testing.T) {
+	cases := []struct {
+		title    string
+		version  *semver.Version
+		content  string
+		expected string
+		valid    bool
+	}{
+		{
+			title:   "invalid json 2.0",
+			version: semver.MustParse("2.0.0"),
+			content: `{"foo":}`,
+			valid:   false,
+		},
+		{
+			title:   "invalid json 3.0",
+			version: semver.MustParse("3.0.0"),
+			content: `{"foo":}`,
+			valid:   false,
+		},
+		{
+			title:   "encode html in old versions",
+			version: semver.MustParse("2.0.0"),
+			content: `{"a": "<script></script>"}`,
+			expected: `{
+    "a": "\u003cscript\u003e\u003c/script\u003e"
+}`,
+			valid: true,
+		},
+		{
+			title:   "don't encode html since 2.12.0",
+			version: semver.MustParse("2.12.0"),
+			content: `{"a": "<script></script>"}`,
+			expected: `{
+    "a": "<script></script>"
+}`,
+			valid: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			jsonFormat := formatter.JSONFormatterBuilder(*c.version)
+			formatted, equal, err := jsonFormat([]byte(c.content))
+			if !c.valid {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Equal(t, c.expected, string(formatted))
+			assert.Equal(t, c.content == c.expected, equal)
+		})
+	}
+}

--- a/internal/testrunner/runners/pipeline/test_result.go
+++ b/internal/testrunner/runners/pipeline/test_result.go
@@ -285,10 +285,8 @@ func marshalNormalizedJSON(v interface{}, specVersion semver.Version) ([]byte, e
 	if err != nil {
 		return msg, err
 	}
-	return json.MarshalIndent(obj, "", "    ")
 
-	formatted, _, err := jsonFormatter.Format(msg)
-	return formatted, err
+	return jsonFormatter.Encode(obj)
 }
 
 func expectedTestResultFile(testFile string) string {

--- a/internal/testrunner/runners/pipeline/test_result.go
+++ b/internal/testrunner/runners/pipeline/test_result.go
@@ -13,11 +13,12 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-cmp/cmp"
-
 	"github.com/pmezard/go-difflib/difflib"
 
 	"github.com/elastic/elastic-package/internal/common"
+	"github.com/elastic/elastic-package/internal/formatter"
 	"github.com/elastic/elastic-package/internal/testrunner"
 )
 
@@ -50,11 +51,11 @@ type testResultDefinition struct {
 	Expected []json.RawMessage `json:"expected"`
 }
 
-func writeTestResult(testCasePath string, result *testResult) error {
+func writeTestResult(testCasePath string, result *testResult, specVersion semver.Version) error {
 	testCaseDir := filepath.Dir(testCasePath)
 	testCaseFile := filepath.Base(testCasePath)
 
-	data, err := marshalTestResultDefinition(result)
+	data, err := marshalTestResultDefinition(result, specVersion)
 	if err != nil {
 		return fmt.Errorf("marshalling test result failed: %w", err)
 	}
@@ -65,13 +66,13 @@ func writeTestResult(testCasePath string, result *testResult) error {
 	return nil
 }
 
-func compareResults(testCasePath string, config *testConfig, result *testResult, skipGeoip bool) error {
+func compareResults(testCasePath string, config *testConfig, result *testResult, skipGeoip bool, specVersion semver.Version) error {
 	resultsWithoutDynamicFields, err := adjustTestResult(result, config, skipGeoip)
 	if err != nil {
 		return fmt.Errorf("can't adjust test results: %w", err)
 	}
 
-	actual, err := marshalTestResultDefinition(resultsWithoutDynamicFields)
+	actual, err := marshalTestResultDefinition(resultsWithoutDynamicFields, specVersion)
 	if err != nil {
 		return fmt.Errorf("marshalling actual test results failed: %w", err)
 	}
@@ -81,12 +82,12 @@ func compareResults(testCasePath string, config *testConfig, result *testResult,
 		return fmt.Errorf("reading expected test result failed: %w", err)
 	}
 
-	expected, err := marshalTestResultDefinition(expectedResults)
+	expected, err := marshalTestResultDefinition(expectedResults, specVersion)
 	if err != nil {
 		return fmt.Errorf("marshalling expected test results failed: %w", err)
 	}
 
-	report, err := diffJson(expected, actual)
+	report, err := diffJson(expected, actual, specVersion)
 	if err != nil {
 		return fmt.Errorf("comparing expected test result: %w", err)
 	}
@@ -123,7 +124,7 @@ func compareJsonNumbers(a, b json.Number) bool {
 	return false
 }
 
-func diffJson(want, got []byte) (string, error) {
+func diffJson(want, got []byte, specVersion semver.Version) (string, error) {
 	var gotVal, wantVal interface{}
 	err := jsonUnmarshalUsingNumber(want, &wantVal)
 	if err != nil {
@@ -137,11 +138,11 @@ func diffJson(want, got []byte) (string, error) {
 		return "", nil
 	}
 
-	got, err = marshalNormalizedJSON(gotVal)
+	got, err = marshalNormalizedJSON(gotVal, specVersion)
 	if err != nil {
 		return "", err
 	}
-	want, err = marshalNormalizedJSON(wantVal)
+	want, err = marshalNormalizedJSON(wantVal, specVersion)
 	if err != nil {
 		return "", err
 	}
@@ -259,10 +260,10 @@ func jsonUnmarshalUsingNumber(data []byte, v interface{}) error {
 	return nil
 }
 
-func marshalTestResultDefinition(result *testResult) ([]byte, error) {
+func marshalTestResultDefinition(result *testResult, specVersion semver.Version) ([]byte, error) {
 	var trd testResultDefinition
 	trd.Expected = result.events
-	body, err := marshalNormalizedJSON(trd)
+	body, err := marshalNormalizedJSON(trd, specVersion)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling test result definition failed: %w", err)
 	}
@@ -272,17 +273,22 @@ func marshalTestResultDefinition(result *testResult) ([]byte, error) {
 // marshalNormalizedJSON marshals test results ensuring that field
 // order remains consistent independent of field order returned by
 // ES to minimize diff noise during changes.
-func marshalNormalizedJSON(v interface{}) ([]byte, error) {
-	msg, err := json.Marshal(v)
+func marshalNormalizedJSON(v interface{}, specVersion semver.Version) ([]byte, error) {
+	jsonFormatter := formatter.JSONFormatterBuilder(specVersion)
+	msg, err := jsonFormatter.Encode(v)
 	if err != nil {
 		return msg, err
 	}
+
 	var obj interface{}
 	err = jsonUnmarshalUsingNumber(msg, &obj)
 	if err != nil {
 		return msg, err
 	}
 	return json.MarshalIndent(obj, "", "    ")
+
+	formatted, _, err := jsonFormatter.Format(msg)
+	return formatted, err
 }
 
 func expectedTestResultFile(testFile string) string {


### PR DESCRIPTION
Avoid encoding HTML entities in JSON documents generated by tests.

The main JSON "Marshaling" helpers also encode HTML entities to reduce
the risk of injections through JSON documents embedded in HTML.
In documents generated by package tests, we want to have the raw document,
as found in Elasticsearch.

This change changes the rendering behaviour for packages starting on 2.12.0,
so these entities are not encoded.

Fix https://github.com/elastic/elastic-package/issues/320.