### PR TITLE
Remove xpack.fleet.agents.elasticsearch.hosts config entry from kibana.yml

### DIFF
--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -20,7 +20,9 @@ xpack.fleet.agents.elasticsearch.host: "https://elasticsearch:9200"
 elasticsearch.serviceAccountToken: "AAEAAWVsYXN0aWMva2liYW5hL2VsYXN0aWMtcGFja2FnZS1raWJhbmEtdG9rZW46b2x4b051SWNRa0tYMHdXazdLWmFBdw"
 
 monitoring.ui.container.elasticsearch.enabled: true
+{{ end }}
 
+{{ if and (not (semverLessThan $version "8.0.0")) (semverLessThan $version "8.11.0-SNAPSHOT") }}
 xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch:9200"]
 {{ end }}
 


### PR DESCRIPTION
This PR removes the fleet server config `xpack.fleet.agents.elasticsearch.hosts`as mentioned in https://github.com/elastic/kibana/issues/160002

That config entry would be kept for backwards compatibility for kibana versions < 8.11.0-SNAPSHOT.

Starting with 8.11.0-SNAPSHOT it will just use `xpack.fleet.outputs`

Tested with these versions
```shell
elastic-package stack up -v -d --version 8.11.0-SNAPSHOT  # just used xpack.fleet.outputs in kibana.yml
elastic-package stack down -v
elastic-package stack up -v -d --version 8.10.0-SNAPSHOT  # both configs are set in kibana.yml
elastic-package stack down -v
```