### PR TITLE
Allow snapshot stack versions to query EPR for serverless

### DIFF
--- a/internal/serverless/project.go
+++ b/internal/serverless/project.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/elastic/elastic-package/internal/elasticsearch"
@@ -178,13 +179,13 @@ func (p *Project) getFleetHealth(ctx context.Context) error {
 
 func (p *Project) CreateAgentPolicy(stackVersion string, kibanaClient *kibana.Client) error {
 	systemPackages, err := registry.Production.Revisions("system", registry.SearchOptions{
-		KibanaVersion: stackVersion,
+		KibanaVersion: strings.TrimSuffix(stackVersion, kibana.SNAPSHOT_SUFFIX),
 	})
 	if err != nil {
-		return fmt.Errorf("could not get the system package version for kibana %v: %w", stackVersion, err)
+		return fmt.Errorf("could not get the system package version for Kibana %v: %w", stackVersion, err)
 	}
 	if len(systemPackages) != 1 {
-		return fmt.Errorf("unexpected number of system package versions - found %d expected 1", len(systemPackages))
+		return fmt.Errorf("unexpected number of system package versions for Kibana %s - found %d expected 1", stackVersion, len(systemPackages))
 	}
 	logger.Debugf("Found %s package - version %s", systemPackages[0].Name, systemPackages[0].Version)
 


### PR DESCRIPTION
This PR allows to use stack SNAPSHOT versions. In order to query to EPR (Elastic Package Registry), it removes the SNAPSHOT prefix for the `kibana.version` query parameter.

Currently, if a SNAPSHOT version is used , for instance 8.11.0-SNAPSHOT, elastic-package fails creating the agent policy, because it does not find any system package:

```
 $ elastic-package stack up -v -d --version 8.11.0-SNAPSHOT --provider serverless
...
2023/10/03 18:28:05  INFO Creating agent policy
Error: booting up the stack failed: failed to create agent policy: unexpected number of system package versions - found 0 expected 1
```

