### PR TITLE
Automatically format nested objects in YAML files

### DIFF
--- a/docs/howto/update_major_package_spec.md
+++ b/docs/howto/update_major_package_spec.md
@@ -42,8 +42,10 @@ setting was included with and withoud dotted notation.
 
 This is commonly found in `conditions` or in `elasticsearch` settings.
 
-To solve this, please use nested dotations. So if for example your package has
-something like the following:
+`elastic-package` `check` and `format` subcommands will try to fix this
+automatically. If you are still finding this issue, you will need to fix it
+manually. For that, please use nested dotations. So if for example your package
+has something like the following:
 ```
 conditions:
   elastic.subscription: basic

--- a/internal/builder/dynamic_mappings.go
+++ b/internal/builder/dynamic_mappings.go
@@ -240,7 +240,8 @@ func formatResult(result interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, errors.New("failed to encode")
 	}
-	d, _, err = formatter.YAMLFormatter(d)
+	yamlFormatter := &formatter.YAMLFormatter{}
+	d, _, err = yamlFormatter.Format(d)
 	if err != nil {
 		return nil, errors.New("failed to format")
 	}

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -21,7 +21,7 @@ func newFormatter(specVersion semver.Version, ext string) formatter {
 	case ".json":
 		return JSONFormatterBuilder(specVersion).Format
 	case ".yaml", ".yml":
-		return YAMLFormatter
+		return NewYAMLFormatter(specVersion).Format
 	default:
 		return nil
 	}

--- a/internal/formatter/yaml_formatter.go
+++ b/internal/formatter/yaml_formatter.go
@@ -100,4 +100,29 @@ func extendMapNode(node *yaml.Node) {
 		// Recurse on the current value.
 		extendNestedObjects(node.Content[i+1])
 	}
+
+	mergeNodes(node)
+}
+
+// mergeNodes merges the contents of keys with the same name.
+func mergeNodes(node *yaml.Node) {
+	keys := make(map[string]*yaml.Node)
+	k := 0
+	for i := 0; i < len(node.Content); i += 2 {
+		key := node.Content[i]
+		value := node.Content[i+1]
+
+		merged, found := keys[key.Value]
+		if !found {
+			keys[key.Value] = value
+			node.Content[k] = key
+			node.Content[k+1] = value
+			k += 2
+			continue
+		}
+
+		merged.Content = append(merged.Content, value.Content...)
+	}
+
+	node.Content = node.Content[:k]
 }

--- a/internal/formatter/yaml_formatter.go
+++ b/internal/formatter/yaml_formatter.go
@@ -73,23 +73,31 @@ func extendMapNode(node *yaml.Node) {
 
 		// Insert nested objects only when the key has a dot, and is not quoted.
 		if found && key.Style == 0 {
+			// Copy key to create the new parent with the first part of the path.
 			newKey := *key
 			newKey.Value = base
 			newKey.FootComment = ""
 			newKey.HeadComment = ""
 			newKey.LineComment = ""
+
+			// Copy key also to create the key of the child value.
 			newChildKey := *key
 			newChildKey.Value = rest
+
+			// Copy the parent node to create the nested object, that contains the new
+			// child key and the original value.
 			newNode := *node
 			newNode.Content = []*yaml.Node{
 				&newChildKey,
 				value,
 			}
 
+			// Replace current key and value.
 			node.Content[i] = &newKey
 			node.Content[i+1] = &newNode
 		}
 
+		// Recurse on the current value.
 		extendNestedObjects(node.Content[i+1])
 	}
 }

--- a/internal/formatter/yaml_formatter_test.go
+++ b/internal/formatter/yaml_formatter_test.go
@@ -5,7 +5,6 @@
 package formatter
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -15,23 +14,27 @@ import (
 
 func TestYAMLFormatterNestedObjects(t *testing.T) {
 	cases := []struct {
+		title    string
 		doc      string
 		expected string
 	}{
 		{
-			doc: `foo.bar: 3`,
+			title: "one-level nested setting",
+			doc:   `foo.bar: 3`,
 			expected: `foo:
   bar: 3
 `,
 		},
 		{
-			doc: `foo.bar.baz: 3`,
+			title: "two-level nested setting",
+			doc:   `foo.bar.baz: 3`,
 			expected: `foo:
   bar:
     baz: 3
 `,
 		},
 		{
+			title: "nested setting at second level",
 			doc: `foo:
   bar.baz: 3`,
 			expected: `foo:
@@ -40,6 +43,7 @@ func TestYAMLFormatterNestedObjects(t *testing.T) {
 `,
 		},
 		{
+			title: "two two-level nested settings",
 			doc: `foo.bar.baz: 3
 a.b.c: 42`,
 			expected: `foo:
@@ -51,6 +55,7 @@ a:
 `,
 		},
 		{
+			title: "keep comments with the leaf value",
 			doc: `foo.bar.baz: 3 # baz
 # Mistery of life and everything else.
 a.b.c: 42`,
@@ -64,16 +69,34 @@ a:
 `,
 		},
 		{
+			title:    "keep double-quoted keys",
 			doc:      `"foo.bar.baz": 3`,
 			expected: "\"foo.bar.baz\": 3\n",
+		},
+		{
+			title:    "keep single-quoted keys",
+			doc:      `"foo.bar.baz": 3`,
+			expected: "\"foo.bar.baz\": 3\n",
+		},
+		{
+			title: "array of maps",
+			doc: `foo:
+  - foo.bar: 1
+  - foo.bar: 2`,
+			expected: `foo:
+  - foo:
+      bar: 1
+  - foo:
+      bar: 2
+`,
 		},
 	}
 
 	sv := semver.MustParse("3.0.0")
 	formatter := NewYAMLFormatter(*sv).Format
 
-	for i, c := range cases {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
 			result, _, err := formatter([]byte(c.doc))
 			require.NoError(t, err)
 			assert.Equal(t, c.expected, string(result))

--- a/internal/formatter/yaml_formatter_test.go
+++ b/internal/formatter/yaml_formatter_test.go
@@ -90,6 +90,18 @@ a:
       bar: 2
 `,
 		},
+		{
+			title: "merge keys",
+			doc: `es.something: true
+es.other.thing: false
+es.other.level: 13`,
+			expected: `es:
+  something: true
+  other:
+    thing: false
+    level: 13
+`,
+		},
 	}
 
 	sv := semver.MustParse("3.0.0")

--- a/internal/formatter/yaml_formatter_test.go
+++ b/internal/formatter/yaml_formatter_test.go
@@ -1,0 +1,83 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package formatter
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestYAMLFormatterNestedObjects(t *testing.T) {
+	cases := []struct {
+		doc      string
+		expected string
+	}{
+		{
+			doc: `foo.bar: 3`,
+			expected: `foo:
+  bar: 3
+`,
+		},
+		{
+			doc: `foo.bar.baz: 3`,
+			expected: `foo:
+  bar:
+    baz: 3
+`,
+		},
+		{
+			doc: `foo:
+  bar.baz: 3`,
+			expected: `foo:
+  bar:
+    baz: 3
+`,
+		},
+		{
+			doc: `foo.bar.baz: 3
+a.b.c: 42`,
+			expected: `foo:
+  bar:
+    baz: 3
+a:
+  b:
+    c: 42
+`,
+		},
+		{
+			doc: `foo.bar.baz: 3 # baz
+# Mistery of life and everything else.
+a.b.c: 42`,
+			expected: `foo:
+  bar:
+    baz: 3 # baz
+a:
+  b:
+    # Mistery of life and everything else.
+    c: 42
+`,
+		},
+		{
+			doc:      `"foo.bar.baz": 3`,
+			expected: "\"foo.bar.baz\": 3\n",
+		},
+	}
+
+	sv := semver.MustParse("3.0.0")
+	formatter := NewYAMLFormatter(*sv).Format
+
+	for i, c := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			result, _, err := formatter([]byte(c.doc))
+			require.NoError(t, err)
+			assert.Equal(t, c.expected, string(result))
+		})
+	}
+
+}

--- a/internal/packages/changelog/yaml.go
+++ b/internal/packages/changelog/yaml.go
@@ -125,7 +125,8 @@ func formatResult(result interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, errors.New("failed to encode")
 	}
-	d, _, err = formatter.YAMLFormatter(d)
+	yamlFormatter := &formatter.YAMLFormatter{}
+	d, _, err = yamlFormatter.Format(d)
 	if err != nil {
 		return nil, errors.New("failed to format")
 	}


### PR DESCRIPTION
Package Spec v3 doesn't allow to include names with dots in YAMLs, these
cases need to be migrated to nested objects.

Automate this migration step.

Related to https://github.com/elastic/package-spec/issues/538
Related to https://github.com/elastic/package-spec/issues/539
Fix https://github.com/elastic/elastic-package/issues/1470