### PR TITLE
Validate arrays of objects

### DIFF
--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -36,7 +36,7 @@ var (
 
 	defaultExternal = "ecs"
 
-	arrayOfObjectsErr = errors.New("array of objects not used as nested type can lead to unexpected results")
+	errArrayOfObjects = errors.New("array of objects not used as nested type can lead to unexpected results")
 )
 
 // Validator is responsible for fields validation.
@@ -796,7 +796,7 @@ func (v *Validator) parseSingleElementValue(key string, definition FieldDefiniti
 			}
 			errs := v.validateMapElement(key, common.MapStr(val), doc)
 			if definition.Type == "group" {
-				errs = append(errs, arrayOfObjectsErr)
+				errs = append(errs, errArrayOfObjects)
 			}
 			if len(errs) == 0 {
 				return nil

--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -22,17 +22,12 @@ import (
 	"github.com/cbroglie/mustache"
 	"gopkg.in/yaml.v3"
 
-	"github.com/elastic/package-spec/v2/code/go/pkg/specerrors"
-
 	"github.com/elastic/elastic-package/internal/common"
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/multierror"
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/packages/buildmanifest"
 )
-
-// EPF - Elastic Package Fields [validation]
-const ArrayOfObjectsErrorCode = "EPF00001"
 
 var (
 	semver2_0_0 = semver.MustParse("2.0.0")
@@ -41,7 +36,7 @@ var (
 
 	defaultExternal = "ecs"
 
-	arrayOfObjectsErr = specerrors.NewStructuredError(errors.New("array of objects not used as nested type can lead to unexpected results"), ArrayOfObjectsErrorCode)
+	arrayOfObjectsErr = errors.New("array of objects not used as nested type can lead to unexpected results")
 )
 
 // Validator is responsible for fields validation.

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -648,7 +648,7 @@ func Test_parseElementValue(t *testing.T) {
 				errs := err.(multierror.Error)
 				if assert.Len(t, errs, 2) {
 					assert.Contains(t, errs[0].Error(), `"details.hostname" is undefined`)
-					assert.ErrorIs(t, errs[1], arrayOfObjectsErr)
+					assert.ErrorIs(t, errs[1], errArrayOfObjects)
 				}
 			},
 		},

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -11,10 +11,12 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-package/internal/common"
+	"github.com/elastic/elastic-package/internal/multierror"
 )
 
 type results struct {
@@ -309,10 +311,12 @@ func TestValidate_ExpectedDatasets(t *testing.T) {
 
 func Test_parseElementValue(t *testing.T) {
 	for _, test := range []struct {
-		key        string
-		value      interface{}
-		definition FieldDefinition
-		fail       bool
+		key         string
+		value       interface{}
+		definition  FieldDefinition
+		fail        bool
+		assertError func(t *testing.T, err error)
+		specVersion semver.Version
 	}{
 		// Arrays
 		{
@@ -619,17 +623,52 @@ func Test_parseElementValue(t *testing.T) {
 				},
 			},
 		},
+		// elements in arrays of objects should be validated
+		{
+			key: "details",
+			value: []interface{}{
+				map[string]interface{}{
+					"id":       "somehost-id",
+					"hostname": "somehost",
+				},
+			},
+			definition: FieldDefinition{
+				Name: "details",
+				Type: "group",
+				Fields: []FieldDefinition{
+					{
+						Name: "id",
+						Type: "keyword",
+					},
+				},
+			},
+			specVersion: *semver3_0_0,
+			fail:        true,
+			assertError: func(t *testing.T, err error) {
+				errs := err.(multierror.Error)
+				if assert.Len(t, errs, 2) {
+					assert.Contains(t, errs[0].Error(), `"details.hostname" is undefined`)
+					assert.ErrorIs(t, errs[1], arrayOfObjectsErr)
+				}
+			},
+		},
 	} {
-		v := Validator{
-			disabledDependencyManagement: true,
-			enabledAllowedIPCheck:        true,
-			allowedCIDRs:                 initializeAllowedCIDRsList(),
-		}
 
 		t.Run(test.key, func(t *testing.T) {
+			v := Validator{
+				Schema:                       []FieldDefinition{test.definition},
+				disabledDependencyManagement: true,
+				enabledAllowedIPCheck:        true,
+				allowedCIDRs:                 initializeAllowedCIDRsList(),
+				specVersion:                  test.specVersion,
+			}
+
 			err := v.parseElementValue(test.key, test.definition, test.value, common.MapStr{})
 			if test.fail {
 				require.Error(t, err)
+				if test.assertError != nil {
+					test.assertError(t, err)
+				}
 			} else {
 				require.NoError(t, err)
 			}

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -652,6 +652,34 @@ func Test_parseElementValue(t *testing.T) {
 				}
 			},
 		},
+		// elements in nested objects
+		{
+			key: "nested",
+			value: []interface{}{
+				map[string]interface{}{
+					"id":       "somehost-id",
+					"hostname": "somehost",
+				},
+			},
+			definition: FieldDefinition{
+				Name: "nested",
+				Type: "nested",
+				Fields: []FieldDefinition{
+					{
+						Name: "id",
+						Type: "keyword",
+					},
+				},
+			},
+			specVersion: *semver3_0_0,
+			fail:        true,
+			assertError: func(t *testing.T, err error) {
+				errs := err.(multierror.Error)
+				if assert.Len(t, errs, 1) {
+					assert.Contains(t, errs[0].Error(), `"nested.hostname" is undefined`)
+				}
+			},
+		},
 	} {
 
 		t.Run(test.key, func(t *testing.T) {


### PR DESCRIPTION
Add validation for arrays of objects, considering them as valid when they are inside `nested` or `group`.

When `group` is used, a filterable error is given, mentioning that `nested` should be used instead on this case.

Fix https://github.com/elastic/elastic-package/issues/1488