### PR TITLE
Fix import of object type from ECS

### DIFF
--- a/internal/fields/dependency_manager.go
+++ b/internal/fields/dependency_manager.go
@@ -311,6 +311,10 @@ func transformImportedField(fd FieldDefinition, options InjectFieldsOptions) com
 		"type": fd.Type,
 	}
 
+	if fd.ObjectType != "" {
+		m["object_type"] = fd.ObjectType
+	}
+
 	// Multi-fields don't have descriptions.
 	if fd.Description != "" {
 		m["description"] = fd.Description

--- a/internal/fields/dependency_manager_test.go
+++ b/internal/fields/dependency_manager_test.go
@@ -707,7 +707,8 @@ func TestDependencyManagerWithECS(t *testing.T) {
 		{
 			title: "object type is imported",
 			defs: []common.MapStr{
-				{"name": "container.labels",
+				{
+					"name":     "container.labels",
 					"external": "ecs",
 				},
 			},

--- a/internal/fields/dependency_manager_test.go
+++ b/internal/fields/dependency_manager_test.go
@@ -704,6 +704,26 @@ func TestDependencyManagerWithECS(t *testing.T) {
 				assert.False(t, ok)
 			},
 		},
+		{
+			title: "object type is imported",
+			defs: []common.MapStr{
+				{"name": "container.labels",
+					"external": "ecs",
+				},
+			},
+			options: InjectFieldsOptions{
+				IncludeValidationSettings: true,
+			},
+			valid: true,
+			result: []common.MapStr{
+				{
+					"name":        "container.labels",
+					"description": "Image labels.",
+					"type":        "object",
+					"object_type": "keyword",
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Not including object type in object fields can lead to ambiguous interpretations
when installing the mappings. ECS fields of type object include this information,
import it for fields when available.

Object fields must have an object type in Package Spec v3, so this change is
required to import objects from ECS without workarounds.