### PR TITLE
Allow to override ECS objects to group or nested

### DIFF
--- a/internal/fields/dependency_manager.go
+++ b/internal/fields/dependency_manager.go
@@ -271,9 +271,6 @@ func allowedTypeOverride(fromType, toType string) bool {
 		// Support the case of setting the value already in the mappings.
 		{"keyword", "constant_keyword"},
 
-		// Not sure why, but was allowed in legacy implementations.
-		{"long", "keyword"},
-
 		// Support objects in ECS where the developer must decide if using
 		// a group or nested object.
 		{"object", "group"},

--- a/internal/fields/dependency_manager.go
+++ b/internal/fields/dependency_manager.go
@@ -201,7 +201,7 @@ func (dm *DependencyManager) injectFieldsWithOptions(defs []common.MapStr, optio
 				transformed.Delete("external")
 			}
 
-			// Set the type back to the one imported, unless it it one of the allowed overrides.
+			// Set the type back to the one imported, unless it is one of the allowed overrides.
 			if ttype, _ := transformed["type"].(string); !allowedTypeOverride(imported.Type, ttype) {
 				transformed["type"] = imported.Type
 			}

--- a/internal/fields/dependency_manager_test.go
+++ b/internal/fields/dependency_manager_test.go
@@ -725,6 +725,44 @@ func TestDependencyManagerWithECS(t *testing.T) {
 				},
 			},
 		},
+		{
+			title: "object to nested override",
+			defs: []common.MapStr{
+				{
+					"name":     "dns.answers",
+					"external": "ecs",
+					"type":     "nested",
+				},
+			},
+			options: InjectFieldsOptions{},
+			valid:   true,
+			result: []common.MapStr{
+				{
+					"name":        "dns.answers",
+					"description": "An array containing an object for each answer section returned by the server.\nThe main keys that should be present in these objects are defined by ECS. Records that have more information may contain more keys than what ECS defines.\nNot all DNS data sources give all details about DNS answers. At minimum, answer objects must contain the `data` key. If more information is available, map as much of it to ECS as possible, and add any additional fields to the answer objects as custom fields.",
+					"type":        "nested",
+				},
+			},
+		},
+		{
+			title: "object to group override",
+			defs: []common.MapStr{
+				{
+					"name":     "dns.answers",
+					"external": "ecs",
+					"type":     "group",
+				},
+			},
+			options: InjectFieldsOptions{},
+			valid:   true,
+			result: []common.MapStr{
+				{
+					"name":        "dns.answers",
+					"description": "An array containing an object for each answer section returned by the server.\nThe main keys that should be present in these objects are defined by ECS. Records that have more information may contain more keys than what ECS defines.\nNot all DNS data sources give all details about DNS answers. At minimum, answer objects must contain the `data` key. If more information is available, map as much of it to ECS as possible, and add any additional fields to the answer objects as custom fields.",
+					"type":        "group",
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Package Spec v3 is more strict with the validation of objects. They
cannot be used now just to group fields, as is done in ECS.

When it is used only to group fields, the developers needs to decide
if it should be interpreted by Fleet as a `group`, so no mapping is installed
for the field itself, but for its subfields, or as a `nested`, so the object
is installed as `nested`, usually intended for arrays of objects.

Needed for https://github.com/elastic/integrations/pull/8115.