### PR TITLE
Revert requirement of using nested type for arrays of objects

### DIFF
--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -35,8 +35,6 @@ var (
 	semver3_0_0 = semver.MustParse("3.0.0")
 
 	defaultExternal = "ecs"
-
-	errArrayOfObjects = errors.New("array of objects not used as nested type can lead to unexpected results")
 )
 
 // Validator is responsible for fields validation.
@@ -795,9 +793,6 @@ func (v *Validator) parseSingleElementValue(key string, definition FieldDefiniti
 				break
 			}
 			errs := v.validateMapElement(key, common.MapStr(val), doc)
-			if definition.Type == "group" {
-				errs = append(errs, errArrayOfObjects)
-			}
 			if len(errs) == 0 {
 				return nil
 			}

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -646,9 +646,8 @@ func Test_parseElementValue(t *testing.T) {
 			fail:        true,
 			assertError: func(t *testing.T, err error) {
 				errs := err.(multierror.Error)
-				if assert.Len(t, errs, 2) {
+				if assert.Len(t, errs, 1) {
 					assert.Contains(t, errs[0].Error(), `"details.hostname" is undefined`)
-					assert.ErrorIs(t, errs[1], errArrayOfObjects)
 				}
 			},
 		},


### PR DESCRIPTION
Revert change introduced in https://github.com/elastic/elastic-package/pull/1489 to require `nested` type for arrays of objects, as it is causing many conflicts with existing packages.