### PR TITLE
Delay checks for arrays of objects to 3.0.1

### DIFF
--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -32,7 +32,7 @@ import (
 var (
 	semver2_0_0 = semver.MustParse("2.0.0")
 	semver2_3_0 = semver.MustParse("2.3.0")
-	semver3_0_0 = semver.MustParse("3.0.0")
+	semver3_0_1 = semver.MustParse("3.0.1")
 
 	defaultExternal = "ecs"
 
@@ -791,7 +791,7 @@ func (v *Validator) parseSingleElementValue(key string, definition FieldDefiniti
 		case map[string]interface{}:
 			// This is probably an element from an array of objects,
 			// even if not recommended, it should be validated.
-			if v.specVersion.LessThan(semver3_0_0) {
+			if v.specVersion.LessThan(semver3_0_1) {
 				break
 			}
 			errs := v.validateMapElement(key, common.MapStr(val), doc)

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -642,7 +642,7 @@ func Test_parseElementValue(t *testing.T) {
 					},
 				},
 			},
-			specVersion: *semver3_0_0,
+			specVersion: *semver3_0_1,
 			fail:        true,
 			assertError: func(t *testing.T, err error) {
 				errs := err.(multierror.Error)
@@ -671,7 +671,7 @@ func Test_parseElementValue(t *testing.T) {
 					},
 				},
 			},
-			specVersion: *semver3_0_0,
+			specVersion: *semver3_0_1,
 			fail:        true,
 			assertError: func(t *testing.T, err error) {
 				errs := err.(multierror.Error)


### PR DESCRIPTION
Several packages have been already migrated to v3 and generate arrays of objects whose fields are not correctly defined, see failures in https://github.com/elastic/integrations/pull/8115.

Delay this check to 3.0.1 by now, so packages can eventually be fixed without blocking the release of Package Spec v3.