### PR TITLE
Support validation of arrays of arrays of nested objects

### DIFF
--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -797,6 +797,13 @@ func (v *Validator) parseSingleElementValue(key string, definition FieldDefiniti
 				return nil
 			}
 			return errs
+		case []interface{}:
+			// This can be an array of array of objects. Elasticsearh will probably
+			// flatten this. So even if this is quite unexpected, let's try to handle it.
+			if v.specVersion.LessThan(semver3_0_1) {
+				break
+			}
+			return forEachElementValue(key, definition, val, doc, v.parseSingleElementValue)
 		default:
 			return fmt.Errorf("field %q is a group of fields, it cannot store values", key)
 		}

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -679,6 +679,63 @@ func Test_parseElementValue(t *testing.T) {
 				}
 			},
 		},
+		// arrays of elements in nested objects
+		{
+			key: "good_array_of_nested",
+			value: []interface{}{
+				[]interface{}{
+					map[string]interface{}{
+						"id":       "somehost-id",
+						"hostname": "somehost",
+					},
+				},
+			},
+			definition: FieldDefinition{
+				Name: "good_array_of_nested",
+				Type: "nested",
+				Fields: []FieldDefinition{
+					{
+						Name: "id",
+						Type: "keyword",
+					},
+					{
+						Name: "hostname",
+						Type: "keyword",
+					},
+				},
+			},
+			specVersion: *semver3_0_1,
+		},
+		{
+			key: "array_of_nested",
+			value: []interface{}{
+				[]interface{}{
+					map[string]interface{}{
+						"id":       "somehost-id",
+						"hostname": "somehost",
+					},
+				},
+			},
+			definition: FieldDefinition{
+				Name: "array_of_nested",
+				Type: "nested",
+				Fields: []FieldDefinition{
+					{
+						Name: "id",
+						Type: "keyword",
+					},
+				},
+			},
+			specVersion: *semver3_0_1,
+			fail:        true,
+			assertError: func(t *testing.T, err error) {
+				var errs multierror.Error
+				require.ErrorAs(t, err, &errs)
+				if assert.Len(t, errs, 1) {
+					assert.Contains(t, errs[0].Error(), `"array_of_nested.hostname" is undefined`)
+				}
+			},
+		},
 	} {
 
 		t.Run(test.key, func(t *testing.T) {


### PR DESCRIPTION
Handle https://github.com/elastic/integrations/pull/8115#issuecomment-1753082456, where nested objects are stored inside an array of arrays.