### PR TITLE
Accept null as array

### DIFF
--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -804,6 +804,9 @@ func (v *Validator) parseSingleElementValue(key string, definition FieldDefiniti
 				break
 			}
 			return forEachElementValue(key, definition, val, doc, v.parseSingleElementValue)
+		case nil:
+			// The document contains a null, let's consider this like an empty array.
+			return nil
 		default:
 			return fmt.Errorf("field %q is a group of fields, it cannot store values", key)
 		}

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -736,6 +736,21 @@ func Test_parseElementValue(t *testing.T) {
 				}
 			},
 		},
+		{
+			key:   "null_array",
+			value: nil,
+			definition: FieldDefinition{
+				Name: "null_array",
+				Type: "group",
+				Fields: []FieldDefinition{
+					{
+						Name: "id",
+						Type: "keyword",
+					},
+				},
+			},
+			specVersion: *semver3_0_1,
+		},
 	} {
 
 		t.Run(test.key, func(t *testing.T) {


### PR DESCRIPTION
Accept `null` in test documents for values when an array of objects is expected.