### PR TITLE
Apply automatic formatting only to manifests

### DIFF
--- a/internal/builder/dynamic_mappings.go
+++ b/internal/builder/dynamic_mappings.go
@@ -240,7 +240,7 @@ func formatResult(result interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, errors.New("failed to encode")
 	}
-	yamlFormatter := &formatter.YAMLFormatter{}
+	yamlFormatter := formatter.NewYAMLFormatter(formatter.KeysWithDotActionNone)
 	d, _, err = yamlFormatter.Format(d)
 	if err != nil {
 		return nil, errors.New("failed to format")

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -16,7 +16,6 @@ import (
 
 const (
 	KeysWithDotActionNone int = iota
-	KeysWithDotActionQuote
 	KeysWithDotActionNested
 )
 

--- a/internal/formatter/yaml_formatter.go
+++ b/internal/formatter/yaml_formatter.go
@@ -56,8 +56,6 @@ func applyActionOnKeysWithDots(node *yaml.Node, action int) {
 	switch action {
 	case KeysWithDotActionNested:
 		extendNestedObjects(node)
-	case KeysWithDotActionQuote:
-		quoteKeysWithDot(node)
 	case KeysWithDotActionNone:
 		// Nothing to do.
 	}
@@ -133,25 +131,4 @@ func mergeNodes(node *yaml.Node) {
 	}
 
 	node.Content = node.Content[:k]
-}
-
-func quoteKeysWithDot(node *yaml.Node) {
-	if node.Kind == yaml.MappingNode {
-		quoteKeysInMap(node)
-	}
-	for _, child := range node.Content {
-		quoteKeysWithDot(child)
-	}
-}
-
-func quoteKeysInMap(node *yaml.Node) {
-	for i := 0; i < len(node.Content); i += 2 {
-		key := node.Content[i]
-		value := node.Content[i+1]
-
-		if key.Style == 0 && strings.Contains(key.Value, ".") {
-			key.Style = yaml.SingleQuotedStyle
-			quoteKeysWithDot(value)
-		}
-	}
 }

--- a/internal/formatter/yaml_formatter_test.go
+++ b/internal/formatter/yaml_formatter_test.go
@@ -13,53 +13,44 @@ import (
 
 func TestYAMLFormatterNestedObjects(t *testing.T) {
 	cases := []struct {
-		title  string
-		doc    string
-		nested string
-		quoted string
+		title    string
+		doc      string
+		expected string
 	}{
 		{
 			title: "one-level nested setting",
 			doc:   `foo.bar: 3`,
-			nested: `foo:
+			expected: `foo:
   bar: 3
 `,
-			quoted: "'foo.bar': 3\n",
 		},
 		{
 			title: "two-level nested setting",
 			doc:   `foo.bar.baz: 3`,
-			nested: `foo:
+			expected: `foo:
   bar:
     baz: 3
 `,
-			quoted: "'foo.bar.baz': 3\n",
 		},
 		{
 			title: "nested setting at second level",
 			doc: `foo:
   bar.baz: 3`,
-			nested: `foo:
+			expected: `foo:
   bar:
     baz: 3
-`,
-			quoted: `foo:
-  'bar.baz': 3
 `,
 		},
 		{
 			title: "two two-level nested settings",
 			doc: `foo.bar.baz: 3
 a.b.c: 42`,
-			nested: `foo:
+			expected: `foo:
   bar:
     baz: 3
 a:
   b:
     c: 42
-`,
-			quoted: `'foo.bar.baz': 3
-'a.b.c': 42
 `,
 		},
 		{
@@ -67,7 +58,7 @@ a:
 			doc: `foo.bar.baz: 3 # baz
 # Mistery of life and everything else.
 a.b.c: 42`,
-			nested: `foo:
+			expected: `foo:
   bar:
     baz: 3 # baz
 a:
@@ -75,37 +66,27 @@ a:
     # Mistery of life and everything else.
     c: 42
 `,
-			quoted: `'foo.bar.baz': 3 # baz
-# Mistery of life and everything else.
-'a.b.c': 42
-`,
 		},
 		{
-			title:  "keep double-quoted keys",
-			doc:    `"foo.bar.baz": 3`,
-			nested: "\"foo.bar.baz\": 3\n",
-			quoted: "\"foo.bar.baz\": 3\n",
+			title:    "keep double-quoted keys",
+			doc:      `"foo.bar.baz": 3`,
+			expected: "\"foo.bar.baz\": 3\n",
 		},
 		{
-			title:  "keep single-quoted keys",
-			doc:    `'foo.bar.baz': 3`,
-			nested: "'foo.bar.baz': 3\n",
-			quoted: "'foo.bar.baz': 3\n",
+			title:    "keep single-quoted keys",
+			doc:      `"foo.bar.baz": 3`,
+			expected: "\"foo.bar.baz\": 3\n",
 		},
 		{
 			title: "array of maps",
 			doc: `foo:
   - foo.bar: 1
   - foo.bar: 2`,
-			nested: `foo:
+			expected: `foo:
   - foo:
       bar: 1
   - foo:
       bar: 2
-`,
-			quoted: `foo:
-  - 'foo.bar': 1
-  - 'foo.bar': 2
 `,
 		},
 		{
@@ -113,34 +94,21 @@ a:
 			doc: `es.something: true
 es.other.thing: false
 es.other.level: 13`,
-			nested: `es:
+			expected: `es:
   something: true
   other:
     thing: false
     level: 13
 `,
-			quoted: `'es.something': true
-'es.other.thing': false
-'es.other.level': 13
-`,
 		},
 	}
 
+	formatter := NewYAMLFormatter(KeysWithDotActionNested).Format
 	for _, c := range cases {
 		t.Run(c.title, func(t *testing.T) {
-			t.Run("nested", func(t *testing.T) {
-				formatter := NewYAMLFormatter(KeysWithDotActionNested).Format
-				result, _, err := formatter([]byte(c.doc))
-				require.NoError(t, err)
-				assert.Equal(t, c.nested, string(result))
-			})
-
-			t.Run("quoted", func(t *testing.T) {
-				formatter := NewYAMLFormatter(KeysWithDotActionQuote).Format
-				result, _, err := formatter([]byte(c.doc))
-				require.NoError(t, err)
-				assert.Equal(t, c.quoted, string(result))
-			})
+			result, _, err := formatter([]byte(c.doc))
+			require.NoError(t, err)
+			assert.Equal(t, c.expected, string(result))
 		})
 	}
 

--- a/internal/packages/changelog/yaml.go
+++ b/internal/packages/changelog/yaml.go
@@ -125,7 +125,7 @@ func formatResult(result interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, errors.New("failed to encode")
 	}
-	yamlFormatter := &formatter.YAMLFormatter{}
+	yamlFormatter := formatter.NewYAMLFormatter(formatter.KeysWithDotActionNone)
 	d, _, err = yamlFormatter.Format(d)
 	if err != nil {
 		return nil, errors.New("failed to format")


### PR DESCRIPTION
Modifies automation introduced in https://github.com/elastic/elastic-package/pull/1485 so it is only applied to manifests by now.

Applying it to other files like transforms or test configuration files may lead to obscure errors.
