### PR TITLE
Review serverless teardown

### DIFF
--- a/internal/stack/serverless.go
+++ b/internal/stack/serverless.go
@@ -136,8 +136,8 @@ func (sp *serverlessProvider) currentProjectWithClientsAndFleetEndpoint(config C
 		return nil, err
 	}
 
-	fleetURL := config.Parameters[paramServerlessFleetURL]
-	if true {
+	fleetURL, found := config.Parameters[paramServerlessFleetURL]
+	if !found {
 		fleetURL, err = project.DefaultFleetServerURL(sp.kibanaClient)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get fleet URL: %w", err)


### PR DESCRIPTION
This PR allows to delete project even if the local docker-compose project fails.

This could happen if the `elastic-package stack up --provider serverless` fails while it is being initialized the project.

At that moment the local docker-compose project (local agents) has not been created. And it probably could not be connected to Kibana to create the golang struct client.

## How to test
1. Define EC_API_KEY, EC_HOST environment variables needed (and update region config if needed)
1. Create a new serverless project
2. While it's being initialized, press Ctrl-C. That causes:
    1. local docker-compose project is not created
    2. Elasticsearch, Kibana, Fleet could not be accessible yet
3. Execute elastic-package stack down
    1. This command would fail, since `docker-compose` would fail (there is no `snaphost.yml` created yet)
    2. Serverless project is deleted

Example of `elastic-package stack down -v` output (this command fails, exit code != 0):

```shell
 $ elastic-package stack down -v 
2023/10/19 12:09:05 DEBUG Enable verbose logging
2023/10/19 12:09:05 DEBUG Distribution built without a version tag, can't determine release chronology. Please consider using official releases at https://github.com/elastic/elastic-package/releases
Take down the Elastic stack
2023/10/19 12:09:05 DEBUG Using Elastic Cloud URL: https://console.qa.cld.elstc.co/
2023/10/19 12:09:05 ERROR failed to destroy local agent: could not initialize local agent compose project
2023/10/19 12:09:05 DEBUG GET https://console.qa.cld.elstc.co/api/v1/serverless/projects/observability/d42ec313d54840a58e87e5b4e8873f19
2023/10/19 12:09:06 DEBUG Deleting project "elastic-package-test-serverless" (d42ec313d54840a58e87e5b4e8873f19)
2023/10/19 12:09:06 DEBUG DELETE https://console.qa.cld.elstc.co/api/v1/serverless/projects/observability/d42ec313d54840a58e87e5b4e8873f19
Error: tearing down the stack failed: failed to destroy local agent: could not initialize local agent compose project
```