### PR TITLE
Add more geo ip keys to filter for serverless

### DIFF
--- a/internal/testrunner/runners/pipeline/test_result.go
+++ b/internal/testrunner/runners/pipeline/test_result.go
@@ -41,6 +41,9 @@ var geoIPKeys = []string{
 	"threat.enrichments.indicateor.geo",
 	"threat.indicateor.as",
 	"threat.indicateor.geo",
+	// packages using geo fields in nested objects
+	"netskope.alerts.user.geo",
+	"netskope.events.user.geo",
 }
 
 type testResult struct {


### PR DESCRIPTION
This PR adds two more keys to the filetered GeoIP keys.
Found that `netskope` package is using GeoIP fields under `netskope.alerts` and `netskope.events` objects

Example of the errors found while executing `elastic-package test pipeline -v`:

```diff
netskope/alerts test-alerts.log:
--- want
+++ got
@@ -671,16 +671,16 @@
                     },
                     "user": {
                         "geo": {
-                            "city_name": "London",
+                            "city_name": "Cheltenham",
                             "continent_name": "Europe",
                             "country_iso_code": "GB",
                             "country_name": "United Kingdom",
                             "location": {
-                                "lat": 51.5142,
-                                "lon": -0.0931
+                                "lat": 51.9037,
+                                "lon": -2.0848
                             },
-                            "region_iso_code": "GB-ENG",
-                            "region_name": "England"
+                            "region_iso_code": "GB-GLS",
+                            "region_name": "Gloucestershire"
                         },
                         "ip": "81.2.69.143"
```