### PR TITLE
Skip by default compareResults in pipeline tests for serverless

### DIFF
--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -79,7 +79,7 @@ func (r *runner) Run(options testrunner.TestOptions) ([]testrunner.TestResult, e
 		r.runCompareResults = true
 
 		v, ok := os.LookupEnv(serverlessDisableCompareResults)
-		if ok && strings.ToLower(v) != "false" {
+		if ok && strings.ToLower(v) == "true" {
 			r.runCompareResults = false
 		}
 	}

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -35,7 +35,7 @@ const (
 )
 
 var (
-	serverlessEnableCompareResults = environment.WithElasticPackagePrefix("SERVERLESS_PIPELINE_TEST_ENABLE_COMPARE_RESULTS")
+	serverlessDisableCompareResults = environment.WithElasticPackagePrefix("SERVERLESS_PIPELINE_TEST_DISABLE_COMPARE_RESULTS")
 )
 
 type runner struct {
@@ -76,11 +76,11 @@ func (r *runner) Run(options testrunner.TestOptions) ([]testrunner.TestResult, e
 
 	r.runCompareResults = true
 	if stackConfig.Provider == stack.ProviderServerless {
-		r.runCompareResults = false
+		r.runCompareResults = true
 
-		v, ok := os.LookupEnv(serverlessEnableCompareResults)
+		v, ok := os.LookupEnv(serverlessDisableCompareResults)
 		if ok && strings.ToLower(v) != "false" {
-			r.runCompareResults = true
+			r.runCompareResults = false
 		}
 	}
 

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -325,7 +325,7 @@ func (r *runner) verifyResults(testCaseFile string, config *testConfig, result *
 		}
 	}
 
-	// TODO: currently GeoIP related fields are being removed when the serverless provider is used.
+	// TODO: temporary workaround untill there could be implemented other approach for deterministic geoip in serverless.
 	if r.runCompareResults {
 		err = compareResults(testCasePath, config, result, *specVersion)
 		if _, ok := err.(testrunner.ErrTestCaseFailed); ok {

--- a/internal/testrunner/runners/pipeline/test_result.go
+++ b/internal/testrunner/runners/pipeline/test_result.go
@@ -24,28 +24,6 @@ import (
 
 const expectedTestResultSuffix = "-expected.json"
 
-var geoIPKeys = []string{
-	"as",
-	"geo",
-	"client.as",
-	"client.geo",
-	"destination.as",
-	"destination.geo",
-	"host.geo",     // not defined host.as in ECS
-	"observer.geo", // not defined observer.as in ECS
-	"server.as",
-	"server.geo",
-	"source.as",
-	"source.geo",
-	"threat.enrichments.indicateor.as",
-	"threat.enrichments.indicateor.geo",
-	"threat.indicateor.as",
-	"threat.indicateor.geo",
-	// packages using geo fields in nested objects
-	"netskope.alerts.user.geo",
-	"netskope.events.user.geo",
-}
-
 type testResult struct {
 	events []json.RawMessage
 }
@@ -69,8 +47,8 @@ func writeTestResult(testCasePath string, result *testResult, specVersion semver
 	return nil
 }
 
-func compareResults(testCasePath string, config *testConfig, result *testResult, skipGeoip bool, specVersion semver.Version) error {
-	resultsWithoutDynamicFields, err := adjustTestResult(result, config, skipGeoip)
+func compareResults(testCasePath string, config *testConfig, result *testResult, specVersion semver.Version) error {
+	resultsWithoutDynamicFields, err := adjustTestResult(result, config)
 	if err != nil {
 		return fmt.Errorf("can't adjust test results: %w", err)
 	}
@@ -80,7 +58,7 @@ func compareResults(testCasePath string, config *testConfig, result *testResult,
 		return fmt.Errorf("marshalling actual test results failed: %w", err)
 	}
 
-	expectedResults, err := readExpectedTestResult(testCasePath, config, skipGeoip)
+	expectedResults, err := readExpectedTestResult(testCasePath, config)
 	if err != nil {
 		return fmt.Errorf("reading expected test result failed: %w", err)
 	}
@@ -161,7 +139,7 @@ func diffJson(want, got []byte, specVersion semver.Version) (string, error) {
 	return buf.String(), err
 }
 
-func readExpectedTestResult(testCasePath string, config *testConfig, skipGeoIP bool) (*testResult, error) {
+func readExpectedTestResult(testCasePath string, config *testConfig) (*testResult, error) {
 	testCaseDir := filepath.Dir(testCasePath)
 	testCaseFile := filepath.Base(testCasePath)
 
@@ -176,15 +154,15 @@ func readExpectedTestResult(testCasePath string, config *testConfig, skipGeoIP b
 		return nil, fmt.Errorf("unmarshalling expected test result failed: %w", err)
 	}
 
-	adjusted, err := adjustTestResult(u, config, skipGeoIP)
+	adjusted, err := adjustTestResult(u, config)
 	if err != nil {
 		return nil, fmt.Errorf("adjusting test result failed: %w", err)
 	}
 	return adjusted, nil
 }
 
-func adjustTestResult(result *testResult, config *testConfig, skipGeoIP bool) (*testResult, error) {
-	if !skipGeoIP && (config == nil || config.DynamicFields == nil) {
+func adjustTestResult(result *testResult, config *testConfig) (*testResult, error) {
+	if config == nil || config.DynamicFields == nil {
 		return result, nil
 	}
 	var stripped testResult
@@ -206,15 +184,6 @@ func adjustTestResult(result *testResult, config *testConfig, skipGeoIP bool) (*
 				err := m.Delete(key)
 				if err != nil && err != common.ErrKeyNotFound {
 					return nil, fmt.Errorf("can't remove dynamic field: %w", err)
-				}
-			}
-		}
-
-		if skipGeoIP {
-			for _, key := range geoIPKeys {
-				err := m.Delete(key)
-				if err != nil && err != common.ErrKeyNotFound {
-					return nil, fmt.Errorf("can't remove geoIP field: %w", err)
 				}
 			}
 		}


### PR DESCRIPTION
This PR skips the compare results function for serverless by default. This function is in charge of comparing the documents received by elasticsearch with the samples. The issue is in Serverless, since there are fields related to Geo IP database that cannot be checked properly.

It also adds a new environment variable ELASTIC_PACKAGE_SERVERLESS_PIPELINE_TEST_ENABLE_COMPARE_RESULTS. This new environment variable can be defined to force to run this `compareResults` function.

When `elastic-package test pipeline` is executed with a local stack, there are no changes. The complete pipeline tests are run.

Examples to execute with this new environment variable:

```shell
 $ elastic-package stack up -v -d --version 8.10.4 --provider serverless

 $ ELASTIC_PACKAGE_SERVERLESS_PIPELINE_TEST_ENABLE_COMPARE_RESULTS=true elastic-package test pipeline -v

 $ ELASTIC_PACKAGE_SERVERLESS_PIPELINE_TEST_ENABLE_COMPARE_RESULTS=false elastic-package test pipeline -v
``` 