### PR TITLE
Ignore error log when a component goes to a degraded state

### DIFF
--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -82,13 +82,15 @@ var (
 					excludes: []*regexp.Regexp{
 						// this regex is excluded to ensure that logs coming from the `system` package installed by default are not taken into account
 						regexp.MustCompile(`action \[indices:data\/write\/bulk\[s\]\] is unauthorized for API key id \[.*\] of user \[.*\] on indices \[.*\], this action is granted by the index privileges \[.*\]`),
-
-						// this regex is excluded to avoid a regresion in 8.11 that can make a component to pass to a degraded state during some seconds after reassigning or removing a policy
-						regexp.MustCompile(`Component state changed .* (HEALTHY->DEGRADED): Degraded: pid .* missed .* check-in`),
 					},
 				},
 				logsRegexp{
 					includes: regexp.MustCompile("->(FAILED|DEGRADED)"),
+
+					// this regex is excluded to avoid a regresion in 8.11 that can make a component to pass to a degraded state during some seconds after reassigning or removing a policy
+					excludes: []*regexp.Regexp{
+						regexp.MustCompile(`Component state changed .* \(HEALTHY->DEGRADED\): Degraded: pid .* missed .* check-in`),
+					},
 				},
 			},
 		},

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -82,6 +82,9 @@ var (
 					excludes: []*regexp.Regexp{
 						// this regex is excluded to ensure that logs coming from the `system` package installed by default are not taken into account
 						regexp.MustCompile(`action \[indices:data\/write\/bulk\[s\]\] is unauthorized for API key id \[.*\] of user \[.*\] on indices \[.*\], this action is granted by the index privileges \[.*\]`),
+
+						// this regex is excluded to avoid a regresion in 8.11 that can make a component to pass to a degraded state during some seconds after reassigning or removing a policy
+						regexp.MustCompile(`Component state changed .* (HEALTHY->DEGRADED): Degraded: pid .* missed .* check-in`),
 					},
 				},
 				logsRegexp{


### PR DESCRIPTION
This error is unexpectedly happening with 8.11 stacks, but is a temporary issue, component recovers after some seconds. The issue is under investigation.