### PR TITLE
Move service status check just after data collection.

### DIFF
--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -668,8 +668,7 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 			return result.WithError(err)
 		}
 		if exited && code > 0 {
-			result.FailureMsg = fmt.Sprintf("the test service %s unexpectedly exited with code %d", config.Service, code)
-			return result.WithError(fmt.Errorf("%s", result.FailureMsg))
+			return result.WithError(testrunner.ErrTestCaseFailed{Reason: fmt.Sprintf("the test service %s unexpectedly exited with code %d", config.Service, code)})
 		}
 	}
 

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -638,7 +638,7 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 	logger.Debug("checking for expected data in data stream...")
 	var hits *hits
 	oldHits := 0
-	passed, err := waitUntilTrue(func() (bool, error) {
+	passed, waitErr := waitUntilTrue(func() (bool, error) {
 		if signal.SIGINT() {
 			return true, errors.New("SIGINT: cancel waiting for policy assigned")
 		}
@@ -673,8 +673,8 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 		}
 	}
 
-	if err != nil {
-		return result.WithError(err)
+	if waitErr != nil {
+		return result.WithError(waitErr)
 	}
 
 	if !passed {


### PR DESCRIPTION
This way if no data is collected we know if it was due to the test service exiting. Otherwise the specific error gets hidden by the no data collected one.