### PR TITLE
Revert "Ignore error log when a component goes to a degraded state (#1533)"

### DIFF
--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -87,11 +87,6 @@ var (
 				},
 				logsRegexp{
 					includes: regexp.MustCompile("->(FAILED|DEGRADED)"),
-
-					// this regex is excluded to avoid a regresion in 8.11 that can make a component to pass to a degraded state during some seconds after reassigning or removing a policy
-					excludes: []*regexp.Regexp{
-						regexp.MustCompile(`Component state changed .* \(HEALTHY->DEGRADED\): Degraded: pid .* missed .* check-in`),
-					},
 				},
 			},
 		},


### PR DESCRIPTION
This reverts commit f9a1c907d8361318238cb78345e1ea2f3c454676.

Intended for testing, **don't merge**.

I will check with integrations repo that packages using 8.11.0 fail, but the issue is fixed if these versions are increased.