### PR TITLE
Add retries to kibana client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/google/go-github/v32 v32.1.0
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.4.0
+	github.com/hashicorp/go-retryablehttp v0.7.5
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/magefile/mage v1.15.0
 	github.com/mholt/archiver/v3 v3.5.1
@@ -93,6 +94,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect

--- a/go.sum
+++ b/go.sum
@@ -301,8 +301,14 @@ github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:Fecb
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/go-retryablehttp v0.7.5 h1:bJj+Pj19UZMIweq/iie+1u5YCdGrnxCT9yvm0e+Nd5M=
+github.com/hashicorp/go-retryablehttp v0.7.5/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=

--- a/internal/retry/http.go
+++ b/internal/retry/http.go
@@ -58,14 +58,14 @@ func WrapHTTPClient(client *http.Client, opts HTTPOptions) *http.Client {
 }
 
 var (
-	maxRedirects   = 10
-	redirectsError = fmt.Errorf("stopped after %d redirects", maxRedirects)
+	maxRedirects        = 10
+	errTooManyRedirects = fmt.Errorf("stopped after %d redirects", maxRedirects)
 )
 
 // checkRedirect reimplements default http redirect policy but returning a typed error.
 func checkRedirect(req *http.Request, via []*http.Request) error {
 	if len(via) >= maxRedirects {
-		return redirectsError
+		return errTooManyRedirects
 	}
 	return nil
 }
@@ -77,7 +77,7 @@ func checkRetry(ctx context.Context, resp *http.Response, err error) (bool, erro
 	}
 
 	if err != nil {
-		if errors.Is(err, redirectsError) {
+		if errors.Is(err, errTooManyRedirects) {
 			// Too many redirects, let's stop here.
 			return false, nil
 		}

--- a/internal/retry/http.go
+++ b/internal/retry/http.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"time"
@@ -55,6 +56,9 @@ func WrapHTTPClient(client *http.Client, opts HTTPOptions) *http.Client {
 	retryClient.RetryMax = opts.RetryMax
 	retryClient.RetryWaitMin = retryWaitMin
 	retryClient.RetryWaitMax = retryWaitMax
+
+	// It needs to be a logger with support for attributes as key-value pairs.
+	retryClient.Logger = slog.Default()
 	return retryClient.StandardClient()
 }
 

--- a/internal/retry/http.go
+++ b/internal/retry/http.go
@@ -1,0 +1,126 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package retry
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+const (
+	defaultRetryWaitMin = 1 * time.Second
+	defaultRetryWaitMax = 5 * time.Second
+)
+
+type HTTPOptions struct {
+	RetryMax int
+
+	retryWaitMin time.Duration
+	retryWaitMax time.Duration
+}
+
+func WrapHTTPClient(client *http.Client, opts HTTPOptions) *http.Client {
+	if opts.RetryMax <= 0 {
+		return client
+	}
+	retryWaitMin := opts.retryWaitMin
+	if retryWaitMin == 0 {
+		retryWaitMin = defaultRetryWaitMin
+	}
+	retryWaitMax := opts.retryWaitMax
+	if retryWaitMax == 0 {
+		retryWaitMax = defaultRetryWaitMax
+	}
+
+	if client == nil {
+		client = &http.Client{}
+	}
+	if client.CheckRedirect == nil {
+		client.CheckRedirect = checkRedirect
+	}
+	retryClient := retryablehttp.NewClient()
+	retryClient.HTTPClient = client
+	retryClient.CheckRetry = checkRetry
+	retryClient.ErrorHandler = retryablehttp.PassthroughErrorHandler
+	retryClient.RetryMax = opts.RetryMax
+	retryClient.RetryWaitMin = retryWaitMin
+	retryClient.RetryWaitMax = retryWaitMax
+	return retryClient.StandardClient()
+}
+
+var (
+	maxRedirects   = 10
+	redirectsError = fmt.Errorf("stopped after %d redirects", maxRedirects)
+)
+
+// checkRedirect reimplements default http redirect policy but returning a typed error.
+func checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= maxRedirects {
+		return redirectsError
+	}
+	return nil
+}
+
+// checkRetry reimplements retryablehttp.DefaultRetryPolicy with better error checking.
+func checkRetry(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+
+	if err != nil {
+		if errors.Is(err, redirectsError) {
+			// Too many redirects, let's stop here.
+			return false, nil
+		}
+
+		var urlError *url.Error
+		if errors.As(err, &urlError) {
+			// URL is invalid, not recoverable.
+			return false, nil
+		}
+
+		var certError *x509.CertificateInvalidError
+		if errors.As(err, &certError) {
+			// Invalid certificate, not recoverable.
+			return false, nil
+		}
+
+		var caError *x509.UnknownAuthorityError
+		if errors.As(err, &caError) {
+			// Unknown CA, not recoverable.
+			return false, nil
+		}
+
+		// Consider other errors as recoverable.
+		return true, nil
+	}
+
+	// 429 Too Many Requests is recoverable. Sometimes the server puts
+	// a Retry-After response header to indicate when the server is
+	// available to start processing request from client.
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return true, nil
+	}
+
+	// Check the response code. We retry on 500-range responses to allow
+	// the server time to recover, as 500's are typically not permanent
+	// errors and may relate to outages on the server side. This will catch
+	// invalid response codes as well, like 0 and 999.
+	if resp.StatusCode == 0 || (resp.StatusCode >= 500 && resp.StatusCode != http.StatusNotImplemented) {
+		// Return the underlying error, that will probably be nil.
+		// retryablehttp.DefaultRetryPolicy did generate an error for these cases,
+		// but this is not what the default HTTP client does.
+		return true, err
+	}
+
+	return false, nil
+}

--- a/internal/retry/http_test.go
+++ b/internal/retry/http_test.go
@@ -1,0 +1,190 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package retry
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	fastRetryWaitMin = 1 * time.Millisecond
+	fastRetryWaitMax = 5 * time.Millisecond
+)
+
+func TestRetryHTTPStatus(t *testing.T) {
+	cases := []struct {
+		title          string
+		okHandler      http.Handler
+		koHandler      http.Handler
+		successRate    int
+		retryMax       int
+		expectedStatus int
+	}{
+		{
+			title:          "eventually succeeds",
+			retryMax:       10,
+			successRate:    5,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			title:          "no retries",
+			retryMax:       0,
+			successRate:    5,
+			expectedStatus: http.StatusServiceUnavailable,
+		},
+		{
+			title:          "not enough retries",
+			retryMax:       2,
+			successRate:    5,
+			expectedStatus: http.StatusServiceUnavailable,
+		},
+		{
+			title:          "retries on non-fatal error",
+			koHandler:      http.NotFoundHandler(),
+			retryMax:       10,
+			successRate:    5,
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			title:          "no retries non-fatal error",
+			koHandler:      http.NotFoundHandler(),
+			retryMax:       0,
+			successRate:    5,
+			expectedStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			opts := HTTPOptions{
+				RetryMax:     c.retryMax,
+				retryWaitMin: fastRetryWaitMin,
+				retryWaitMax: fastRetryWaitMax,
+			}
+			client := WrapHTTPClient(&http.Client{}, opts)
+
+			server := newFlakyTestServer(c.okHandler, c.koHandler, c.successRate)
+			defer server.Close()
+
+			resp, err := client.Get(server.URL)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, c.expectedStatus, resp.StatusCode)
+		})
+	}
+}
+
+func TestUnrecoverableErrors(t *testing.T) {
+	opts := HTTPOptions{
+		RetryMax:     5,
+		retryWaitMin: fastRetryWaitMin,
+		retryWaitMax: fastRetryWaitMax,
+	}
+
+	t.Run("invalid URL", func(t *testing.T) {
+		client := WrapHTTPClient(&http.Client{}, opts)
+		_, err := client.Get("http::\\localhost")
+		assert.Error(t, err)
+	})
+
+	t.Run("infinite redirects", func(t *testing.T) {
+		server := httptest.NewServer(infiniteRedirectsHandler())
+		defer server.Close()
+		client := WrapHTTPClient(&http.Client{}, opts)
+
+		_, err := client.Get(server.URL)
+		assert.Error(t, err)
+	})
+
+	t.Run("unknown CA", func(t *testing.T) {
+		server := httptest.NewTLSServer(newStatusHandler("OK", http.StatusOK))
+		defer server.Close()
+		client := WrapHTTPClient(&http.Client{}, opts)
+
+		_, err := client.Get(server.URL)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid certificate", func(t *testing.T) {
+		t.Skip("TODO")
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		brokenClient := http.Client{
+			Transport: &brokenTransport{},
+		}
+		client := WrapHTTPClient(&brokenClient, opts)
+
+		server := httptest.NewServer(newStatusHandler("OK", http.StatusOK))
+		defer server.Close()
+
+		_, err := client.Get(server.URL)
+		assert.Error(t, err)
+	})
+}
+
+// flakyTestHandler deterministically succeeds only once every rate requests.
+type flakyTestHandler struct {
+	okHandler http.Handler
+	koHanlder http.Handler
+	rate      int
+
+	mutex sync.Mutex
+	count int
+}
+
+func (s *flakyTestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.count++
+
+	if s.rate == 0 || s.count%s.rate != 0 {
+		s.koHanlder.ServeHTTP(w, r)
+	}
+
+	s.okHandler.ServeHTTP(w, r)
+}
+
+func newFlakyTestServer(ok, ko http.Handler, rate int) *httptest.Server {
+	if ok == nil {
+		ok = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	}
+	if ko == nil {
+		ko = newStatusHandler("not available", http.StatusServiceUnavailable)
+	}
+	handler := flakyTestHandler{
+		okHandler: ok,
+		koHanlder: ko,
+		rate:      rate,
+	}
+	return httptest.NewServer(&handler)
+}
+
+func newStatusHandler(msg string, code int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, msg, code)
+	})
+}
+
+func infiniteRedirectsHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, r.URL.String(), http.StatusMovedPermanently)
+	})
+}
+
+type brokenTransport struct{}
+
+func (*brokenTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("network error")
+}


### PR DESCRIPTION
Adding it by now only to kibana client because for elasticsearch client we rely on the Go SDK, that has its own retry mechanisms.

As it is implemented, we can later consider using it in more places where an http client is used now.