### PR TITLE
Do not create kibana client for pipeline and static tests

### DIFF
--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -16,6 +16,7 @@ import (
 	"github.com/elastic/elastic-package/internal/cobraext"
 	"github.com/elastic/elastic-package/internal/common"
 	"github.com/elastic/elastic-package/internal/install"
+	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/signal"
 	"github.com/elastic/elastic-package/internal/stack"
@@ -224,9 +225,12 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 			return err
 		}
 
-		kibanaClient, err := stack.NewKibanaClientFromProfile(profile)
-		if err != nil {
-			return fmt.Errorf("can't create Kibana client: %w", err)
+		var kibanaClient *kibana.Client
+		if testType != "pipeline" {
+			kibanaClient, err = stack.NewKibanaClientFromProfile(profile)
+			if err != nil {
+				return fmt.Errorf("can't create Kibana client: %w", err)
+			}
 		}
 
 		var results []testrunner.TestResult

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -227,7 +227,7 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 
 		var kibanaClient *kibana.Client
 		if testType == "system" || testType == "asset" {
-			// pipeline tests do not require a kibana client to perform the required operations
+			// pipeline and static tests do not require a kibana client to perform their required operations
 			kibanaClient, err = stack.NewKibanaClientFromProfile(profile)
 			if err != nil {
 				return fmt.Errorf("can't create Kibana client: %w", err)

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -226,7 +226,8 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 		}
 
 		var kibanaClient *kibana.Client
-		if testType != "pipeline" {
+		if testType == "system" || testType == "asset" {
+			// pipeline tests do not require a kibana client to perform the required operations
 			kibanaClient, err = stack.NewKibanaClientFromProfile(profile)
 			if err != nil {
 				return fmt.Errorf("can't create Kibana client: %w", err)

--- a/internal/testrunner/runners/asset/runner.go
+++ b/internal/testrunner/runners/asset/runner.go
@@ -5,6 +5,7 @@
 package asset
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -63,6 +64,10 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 		TestType: TestType,
 		Package:  r.testFolder.Package,
 	})
+
+	if r.kibanaClient == nil {
+		return result.WithError(errors.New("missing Kibana client"))
+	}
 
 	testConfig, err := newConfig(r.testFolder.Path)
 	if err != nil {

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -112,6 +112,10 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 		return nil, fmt.Errorf("listing test case definitions failed: %w", err)
 	}
 
+	if r.options.API == nil {
+		return nil, errors.New("missing elasticsearch client")
+	}
+
 	dataStreamPath, found, err := packages.FindDataStreamRootForPath(r.options.TestFolder.Path)
 	if err != nil {
 		return nil, fmt.Errorf("locating data_stream root failed: %w", err)

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -113,7 +113,7 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 	}
 
 	if r.options.API == nil {
-		return nil, errors.New("missing elasticsearch client")
+		return nil, errors.New("missing Elasticsearch client")
 	}
 
 	dataStreamPath, found, err := packages.FindDataStreamRootForPath(r.options.TestFolder.Path)

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -210,6 +210,13 @@ func (r *runner) run() (results []testrunner.TestResult, err error) {
 		logger.Debug("Running system tests for package")
 	}
 
+	if r.options.API == nil {
+		return result.WithError(errors.New("missing elasticsearch client"))
+	}
+	if r.options.KibanaClient == nil {
+		return result.WithError(errors.New("missing kibana client"))
+	}
+
 	stackVersion, err := r.options.KibanaClient.Version()
 	if err != nil {
 		return result.WithError(fmt.Errorf("cannot request Kibana version: %w", err))

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -211,10 +211,10 @@ func (r *runner) run() (results []testrunner.TestResult, err error) {
 	}
 
 	if r.options.API == nil {
-		return result.WithError(errors.New("missing elasticsearch client"))
+		return result.WithError(errors.New("missing Elasticsearch client"))
 	}
 	if r.options.KibanaClient == nil {
-		return result.WithError(errors.New("missing kibana client"))
+		return result.WithError(errors.New("missing Kibana client"))
 	}
 
 	stackVersion, err := r.options.KibanaClient.Version()


### PR DESCRIPTION
This PR avoids creating the kibana client for the pipeline and static tests.

These pipeline tests just need the Simulate API from elasticsearch, so it is not required there to have a Kibana client. And the static tests are verifying the sample events.

Related docs about pipeline and static tests:
- https://github.com/elastic/elastic-package/blob/main/docs/howto/pipeline_testing.md#conceptual-process
- https://github.com/elastic/elastic-package/blob/main/docs/howto/static_testing.md