### PR TITLE
fix mode permission on rally track output dir

### DIFF
--- a/internal/benchrunner/runners/rally/runner.go
+++ b/internal/benchrunner/runners/rally/runner.go
@@ -692,7 +692,7 @@ func (r *runner) runGenerator(destDir string) error {
 
 	if r.options.RallyTrackOutputDir != "" {
 		r.persistRallyTrackHandler = func() error {
-			err := os.MkdirAll(r.options.RallyTrackOutputDir, os.ModeDir)
+			err := os.MkdirAll(r.options.RallyTrackOutputDir, os.ModePerm)
 			if err != nil {
 				return fmt.Errorf("cannot not create rally track output dir: %w", err)
 			}

--- a/internal/benchrunner/runners/rally/runner.go
+++ b/internal/benchrunner/runners/rally/runner.go
@@ -692,7 +692,7 @@ func (r *runner) runGenerator(destDir string) error {
 
 	if r.options.RallyTrackOutputDir != "" {
 		r.persistRallyTrackHandler = func() error {
-			err := os.MkdirAll(r.options.RallyTrackOutputDir, os.ModePerm)
+			err := os.MkdirAll(r.options.RallyTrackOutputDir, 0755)
 			if err != nil {
 				return fmt.Errorf("cannot not create rally track output dir: %w", err)
 			}


### PR DESCRIPTION
`os.ModeDir` instead of `os.ModePerm` was set as mode of `os.MkdirAll` with the target of the rally track output dir: this prevented the content to be written in the directory if the directory didn't exist and was created by the command.
This PR fix this.