### PR TITLE
Benchmark rally add flags

### DIFF
--- a/docs/howto/rally_benchmarking.md
+++ b/docs/howto/rally_benchmarking.md
@@ -289,5 +289,5 @@ You still need to run the command from the root of the local package in order to
 
 ## Running benchmark with the same corpus against different versions of the package
 If you use both the `use-corpus-at-path` flag and the `package-from-registry` flag multiple times, you can ran benchmark with the same corpus against different versions of the same package, just updating the package version in the relevant flag between executions.  
-
+If you add the `rally-track-output-dir` flag and the `dry-run` flag, you can persist multiple rally tracks with the same corpus for different package versions, using different values for the `rally-track-output-dir` flag. 
 

--- a/docs/howto/rally_benchmarking.md
+++ b/docs/howto/rally_benchmarking.md
@@ -279,3 +279,15 @@ esrally --target-hosts='{"defauelt":["%es_cluster_host:es_cluster_port%"]}' --tr
 
 Please refer to [esrally CLI reference](https://esrally.readthedocs.io/en/stable/command_line_reference.html) for more details.
 
+## Replaying an existing corpus
+If the `use-corpus-at-path` flag is used, the corpus will not be generated but rather loaded from the file passed as value of the flag.
+If the `rally-track-output-dir` flag is used alongside the `use-corpus-at-path` flag, the persisted rally track will reference a copy of the existing corpus saved in the directory passed as value of the `rally-track-output-dir` flag.
+
+## Loading a package from registry
+If the `package-from-registry` flag is used, the package installed in Kibana and its assets referenced in the track will be loaded from registry. The format of the flag value is `%packageName%-%packageVersion%`.
+You still need to run the command from the root of the local package in order to read the benchmark scenario (`benchmark` flag).
+
+## Running benchmark with the same corpus against different versions of the package
+If you use both the `use-corpus-at-path` flag and the `package-from-registry` flag multiple times, you can ran benchmark with the same corpus against different versions of the same package, just updating the package version in the relevant flag between executions.  
+
+

--- a/internal/benchrunner/runners/rally/options.go
+++ b/internal/benchrunner/runners/rally/options.go
@@ -26,6 +26,8 @@ type Options struct {
 	Profile             *profile.Profile
 	RallyTrackOutputDir string
 	DryRun              bool
+	PackageFromRegistry string
+	CorpusAtPath        string
 }
 
 type ClientOptions struct {
@@ -100,5 +102,17 @@ func WithRallyTrackOutputDir(r string) OptionFunc {
 func WithRallyDryRun(d bool) OptionFunc {
 	return func(opts *Options) {
 		opts.DryRun = d
+	}
+}
+
+func WithRallyPackageFromRegistry(p string) OptionFunc {
+	return func(opts *Options) {
+		opts.PackageFromRegistry = p
+	}
+}
+
+func WithRallyCorpusAtPath(c string) OptionFunc {
+	return func(opts *Options) {
+		opts.CorpusAtPath = c
 	}
 }

--- a/internal/cobraext/flags.go
+++ b/internal/cobraext/flags.go
@@ -57,7 +57,13 @@ const (
 	BenchCorpusRallyTrackOutputDirFlagDescription = "output dir of the rally track: if present the command will save the generated rally track"
 
 	BenchCorpusRallyDryRunFlagName        = "dry-run"
-	BenchCorpusRallyDryRunFlagDescription = "Do not run rally but just generate the rally track"
+	BenchCorpusRallyDryRunFlagDescription = "do not run rally but just generate the rally track"
+
+	BenchCorpusRallyPackageFromRegistryFlagName        = "package-from-registry"
+	BenchCorpusRallyPackageFromRegistryFlagDescription = "fetch package from registry instead of local directory"
+
+	BenchCorpusRallyUseCorpusAtPathFlagName        = "use-corpus-at-path"
+	BenchCorpusRallyUseCorpusAtPathFlagDescription = "path of the corpus to use for the benchmark: if present no new corpus will be generated"
 
 	BuildSkipValidationFlagName        = "skip-validation"
 	BuildSkipValidationFlagDescription = "skip validation of the built package, use only if all validation issues have been acknowledged"


### PR DESCRIPTION
Add `package-from-registry` and `use-corpus-at-path` flags.
See updated docs for usage.