### PR TITLE
Refactors for safer handling of strings

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -369,20 +369,12 @@ func rallyCommandAction(cmd *cobra.Command, args []string) error {
 }
 
 func getPackageNameAndVersion(packageFromRegistry string) (string, string, error) {
-	packageData := strings.SplitN(packageFromRegistry, "-", 2)
-
-	if len(packageData) != 2 {
+	name, version, valid := strings.Cut(packageFromRegistry, "-")
+	if !valid || name == "" || version == "" {
 		return "", "", fmt.Errorf("package name and version from registry not valid (%s)", packageFromRegistry)
 	}
 
-	packageName := packageData[0]
-	packageVersion := packageData[1]
-
-	if len(packageName) > 0 && len(packageVersion) == 0 {
-		return "", "", fmt.Errorf("package name and version from registry not valid (%s)", packageFromRegistry)
-	}
-
-	return packageName, packageVersion, nil
+	return name, version, nil
 }
 
 func getSystemCommand() *cobra.Command {

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -114,11 +114,14 @@ func (p *portMapping) UnmarshalYAML(node *yaml.Node) error {
 	}
 
 	// First, parse out the protocol.
-	parts := strings.Split(str, "/")
-	p.Protocol = parts[1]
+	mapping, protocol, found := strings.Cut(str, "/")
+	if !found {
+		return errors.New("could not find protocol in port mapping")
+	}
+	p.Protocol = protocol
 
 	// Now, try to parse out external host, external IP, and internal port.
-	parts = strings.Split(parts[0], ":")
+	parts := strings.Split(mapping, ":")
 	var externalIP, internalPortStr, externalPortStr string
 	switch len(parts) {
 	case 1:

--- a/internal/packages/conditions.go
+++ b/internal/packages/conditions.go
@@ -51,14 +51,14 @@ func parsePackageRequirements(keyValuePairs []string) (*packageRequirements, err
 	var pr packageRequirements
 
 	for _, keyPair := range keyValuePairs {
-		s := strings.SplitN(keyPair, "=", 2)
-		if len(s) != 2 {
+		key, value, valid := strings.Cut(keyPair, "=")
+		if !valid {
 			return nil, fmt.Errorf("invalid key-value pair: %s", keyPair)
 		}
 
-		switch s[0] {
+		switch key {
 		case kibanaVersionRequirement:
-			ver, err := semver.NewVersion(s[1])
+			ver, err := semver.NewVersion(value)
 			if err != nil {
 				return nil, fmt.Errorf("can't parse kibana.version as valid semver: %w", err)
 			}
@@ -73,7 +73,7 @@ func parsePackageRequirements(keyValuePairs []string) (*packageRequirements, err
 			}
 			pr.kibana.version = &withoutPrerelease
 		default:
-			return nil, fmt.Errorf("unknown package requirement: %s", s[0])
+			return nil, fmt.Errorf("unknown package requirement: %s", value)
 		}
 	}
 	return &pr, nil

--- a/internal/packages/conditions.go
+++ b/internal/packages/conditions.go
@@ -73,7 +73,7 @@ func parsePackageRequirements(keyValuePairs []string) (*packageRequirements, err
 			}
 			pr.kibana.version = &withoutPrerelease
 		default:
-			return nil, fmt.Errorf("unknown package requirement: %s", value)
+			return nil, fmt.Errorf("unknown package requirement: %s", key)
 		}
 	}
 	return &pr, nil

--- a/internal/stack/compose.go
+++ b/internal/stack/compose.go
@@ -231,9 +231,9 @@ func newServiceStatus(description *docker.ContainerDescription) (*ServiceStatus,
 }
 
 func getVersionFromDockerImage(dockerImage string) string {
-	fields := strings.Split(dockerImage, ":")
-	if len(fields) == 2 {
-		return fields[1]
+	_, version, found := strings.Cut(dockerImage, ":")
+	if found {
+		return version
 	}
 	return "latest"
 }

--- a/internal/stack/parselogs.go
+++ b/internal/stack/parselogs.go
@@ -39,14 +39,11 @@ func ParseLogs(options ParseLogsOptions, process func(log LogLine) error) error 
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		messageSlice := strings.SplitN(line, "|", 2)
-
-		if len(messageSlice) != 2 {
+		_, messageLog, valid := strings.Cut(line, "|")
+		if !valid {
 			logger.Debugf("skipped malformed docker-compose log line: %s", line)
 			continue
 		}
-
-		messageLog := messageSlice[1]
 
 		var log LogLine
 		err := json.Unmarshal([]byte(messageLog), &log)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -110,14 +110,14 @@ func (prs PackageVersions) Strings() []string {
 func ParsePackageVersions(packageVersions []string) (PackageVersions, error) {
 	var parsed PackageVersions
 	for _, pv := range packageVersions {
-		s := strings.Split(pv, "-")
-		if len(s) != 2 {
+		name, version, valid := strings.Cut(pv, "-")
+		if !valid || name == "" || version == "" {
 			return nil, fmt.Errorf("invalid package revision format (expected: <package_name>-<version>): %s", pv)
 		}
 
-		revision, err := NewPackageVersion(s[0], s[1])
+		revision, err := NewPackageVersion(name, version)
 		if err != nil {
-			return nil, fmt.Errorf("can't create package version (%s): %w", s, err)
+			return nil, fmt.Errorf("can't create package version (name: %s, version: %s): %w", name, version, err)
 		}
 		parsed = append(parsed, *revision)
 	}


### PR DESCRIPTION
`strings.Cut()` was introduced in Go 1.18 for the common use case of splitting a string
in two parts. In these cases it allows to directly assign each one of the parts to variables
with more meaningful names, avoiding the risk of accessing indexes that may not exist,
and improving readability.

Leverage this function in some applicable uses cases we have here.