### PR TITLE
Accept 503 as valid response for Kibana status endpoint

### DIFF
--- a/internal/kibana/status.go
+++ b/internal/kibana/status.go
@@ -49,7 +49,8 @@ func (c *Client) requestStatus() (statusType, error) {
 		return status, fmt.Errorf("could not reach status endpoint: %w", err)
 	}
 
-	if statusCode != http.StatusOK {
+	// Kibana can respond with 503 when it is unavailable, but its status response is valid.
+	if statusCode != http.StatusOK && statusCode != http.StatusServiceUnavailable {
 		return status, fmt.Errorf("could not get status data; API status code = %d; response body = %s", statusCode, respBody)
 	}
 


### PR DESCRIPTION
To initialize a Kibana client we request the status endpoint to get the version.
If the status code of the response is 503, we should accept the response, as
it is the status code given by Kibana when it is initializing or otherwise running
but unavailable.