### PR TITLE
skip package and version validtion on empty value

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -369,6 +369,10 @@ func rallyCommandAction(cmd *cobra.Command, args []string) error {
 }
 
 func getPackageNameAndVersion(packageFromRegistry string) (string, string, error) {
+	if len(packageFromRegistry) == 0 {
+		return "", "", nil
+	}
+
 	name, version, valid := strings.Cut(packageFromRegistry, "-")
 	if !valid || name == "" || version == "" {
 		return "", "", fmt.Errorf("package name and version from registry not valid (%s)", packageFromRegistry)


### PR DESCRIPTION
Validation of `--package-from-registry` flag value didn't cover the case of an empty value, that's a possible case since the flag is optional.

Fixes #1587 

to code reviewers: feel free to merge the PR if you approve it without extra changes (I will be in PTO since tomorrow :))