### PR TITLE
add config to enable apm-server

### DIFF
--- a/.buildkite/pipeline.trigger.integration.tests.sh
+++ b/.buildkite/pipeline.trigger.integration.tests.sh
@@ -16,6 +16,7 @@ STACK_COMMAND_TESTS=(
     test-stack-command-7x
     test-stack-command-86
     test-stack-command-8x
+    test-stack-command-with-apm-server
 )
 
 for test in ${STACK_COMMAND_TESTS[@]}; do

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,10 @@ test-stack-command-86:
 test-stack-command-8x:
 	./scripts/test-stack-command.sh 8.11.0-SNAPSHOT
 
-test-stack-command: test-stack-command-default test-stack-command-7x test-stack-command-800 test-stack-command-8x
+test-stack-command-with-apm-server:
+	APM_SERVER_ENABLED=true ./scripts/test-stack-command.sh
+
+test-stack-command: test-stack-command-default test-stack-command-7x test-stack-command-800 test-stack-command-8x test-stack-command-with-apm-server
 
 test-check-packages: test-check-packages-with-kind test-check-packages-other test-check-packages-parallel test-check-packages-with-custom-agent test-check-packages-benchmarks test-check-packages-false-positives test-check-packages-with-logstash
 

--- a/internal/profile/_static/config.yml.example
+++ b/internal/profile/_static/config.yml.example
@@ -10,6 +10,10 @@
 # Region where the Serverless project is going to be created
 # stack.serverless.region: aws-us-east-1
 
+## Enable apm-server
+# Flag to enable apm-server in elastic-package stack profile config
+# stack.apm_server_enabled: true
+
 ## Enable logstash for testing
 # Flag to enable logstash in elastic-package stack profile config
 # stack.logstash_enabled: true

--- a/internal/profile/_testdata/config.yml
+++ b/internal/profile/_testdata/config.yml
@@ -1,5 +1,6 @@
 # An expected setting.
 stack.geoip_dir: "/home/foo/Documents/ingest-geoip"
+stack.apm_server_enabled: true
 stack.logstash_enabled: true
 
 # An empty string, should exist, but return empty.

--- a/internal/profile/config_test.go
+++ b/internal/profile/config_test.go
@@ -48,6 +48,11 @@ func TestLoadProfileConfig(t *testing.T) {
 			found:    true,
 		},
 		{
+			name:     "stack.apm_server_enabled",
+			expected: "true",
+			found:    true,
+		},
+		{
 			name:     "stack.logstash_enabled",
 			expected: "true",
 			found:    true,

--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -112,6 +112,10 @@ services:
       - "../certs/fleet-server:/etc/ssl/elastic-agent"
     ports:
       - "127.0.0.1:8220:8220"
+      {{ $apm_server_enabled := fact "apm_server_enabled" }}
+      {{ if eq $apm_server_enabled "true" }}
+      - "127.0.0.1:8200:8200"
+      {{ end }}
 
   fleet-server_is_ready:
     image: tianon/true

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -48,6 +48,11 @@ xpack.fleet.packages:
     version: latest
   - name: fleet_server
     version: latest
+  {{ $apm_server_enabled := fact "apm_server_enabled" }}
+  {{ if eq $apm_server_enabled "true" }}
+  - name: apm
+    version: latest
+  {{ end }}
 xpack.fleet.agentPolicies:
   - name: Elastic-Agent (elastic-package)
     id: elastic-agent-managed-ep
@@ -72,6 +77,19 @@ xpack.fleet.agentPolicies:
         id: default-fleet-server
         package:
           name: fleet_server
+      {{ $apm_server_enabled := fact "apm_server_enabled" }}
+      {{ if eq $apm_server_enabled "true" }}
+      - name: apm-1
+        package:
+          name: apm
+        inputs:
+          - type: apm
+            vars:
+              - name: host
+                value: "0.0.0.0:8200"
+              - name: secret_token
+                value: ""
+      {{ end }}
 xpack.fleet.outputs:
   - id: fleet-default-output
     name: default

--- a/internal/stack/resources.go
+++ b/internal/stack/resources.go
@@ -129,8 +129,9 @@ func applyResources(profile *profile.Profile, stackVersion string) error {
 		"username": elasticsearchUsername,
 		"password": elasticsearchPassword,
 
-		"geoip_dir":        profile.Config("stack.geoip_dir", "./ingest-geoip"),
-		"logstash_enabled": profile.Config("stack.logstash_enabled", "false"),
+		"geoip_dir":          profile.Config("stack.geoip_dir", "./ingest-geoip"),
+		"apm_server_enabled": profile.Config("stack.apm_server_enabled", "false"),
+		"logstash_enabled":   profile.Config("stack.logstash_enabled", "false"),
 	})
 
 	os.MkdirAll(stackDir, 0755)

--- a/scripts/test-stack-command.sh
+++ b/scripts/test-stack-command.sh
@@ -3,6 +3,7 @@
 set -euxo pipefail
 
 VERSION=${1:-default}
+APM_SERVER_ENABLED=${APM_SERVER_ENABLED:-false}
 
 cleanup() {
   r=$?
@@ -12,6 +13,11 @@ cleanup() {
 
   # Take down the stack
   elastic-package stack down -v
+
+  if [ "${APM_SERVER_ENABLED}" = true ]; then
+    # Create an apm-server profile and use it
+    elastic-package profiles delete with-apm-server
+  fi
 
   exit $r
 }
@@ -34,7 +40,22 @@ if [ "${VERSION}" != "default" ]; then
   EXPECTED_VERSION=${VERSION}
 fi
 
+if [ "${APM_SERVER_ENABLED}" = true ]; then
+  # Create an apm-server profile and use it
+  profile=with-apm-server
+  elastic-package profiles create -v ${profile}
+  elastic-package profiles use ${profile}
+
+  # Create the config and enable apm-server
+  cat ~/.elastic-package/profiles/${profile}/config.yml.example - <<EOF > ~/.elastic-package/profiles/${profile}/config.yml
+stack.apm_server_enabled: true
+EOF
+fi
+
 OUTPUT_PATH_STATUS="build/elastic-stack-status/${VERSION}"
+if [ "${APM_SERVER_ENABLED}" = true ]; then
+  OUTPUT_PATH_STATUS="build/elastic-stack-status/${VERSION}_with_apm_server"
+fi
 mkdir -p ${OUTPUT_PATH_STATUS}
 
 # Initial status empty
@@ -70,5 +91,9 @@ elastic-package stack status -v 2> ${OUTPUT_PATH_STATUS}/running.txt
 # Remove spaces to avoid issues with spaces between columns
 clean_status_output "${OUTPUT_PATH_STATUS}/expected_running.txt" > ${OUTPUT_PATH_STATUS}/expected_no_spaces.txt
 clean_status_output "${OUTPUT_PATH_STATUS}/running.txt" > ${OUTPUT_PATH_STATUS}/running_no_spaces.txt
+
+if [ "${APM_SERVER_ENABLED}" = true ]; then
+  curl --fail-with-body http://localhost:8200/
+fi
 
 diff -q ${OUTPUT_PATH_STATUS}/running_no_spaces.txt ${OUTPUT_PATH_STATUS}/expected_no_spaces.txt

--- a/scripts/test-stack-command.sh
+++ b/scripts/test-stack-command.sh
@@ -93,7 +93,7 @@ clean_status_output "${OUTPUT_PATH_STATUS}/expected_running.txt" > ${OUTPUT_PATH
 clean_status_output "${OUTPUT_PATH_STATUS}/running.txt" > ${OUTPUT_PATH_STATUS}/running_no_spaces.txt
 
 if [ "${APM_SERVER_ENABLED}" = true ]; then
-  curl --fail-with-body http://localhost:8200/
+  curl http://localhost:8200/
 fi
 
 diff -q ${OUTPUT_PATH_STATUS}/running_no_spaces.txt ${OUTPUT_PATH_STATUS}/expected_no_spaces.txt


### PR DESCRIPTION
Start and expose an APM Server under Elastic Agent when enabled in the config with:

```yml
stack.apm_server_enabled: true
```