### PR TITLE
Enable APM in services managed by elastic-package stack

### DIFF
--- a/internal/profile/_static/config.yml.example
+++ b/internal/profile/_static/config.yml.example
@@ -12,7 +12,7 @@
 
 ## Enable apm-server
 # Flag to enable apm-server in elastic-package stack profile config
-# stack.apm_server_enabled: true
+# stack.apm_enabled: true
 
 ## Enable logstash for testing
 # Flag to enable logstash in elastic-package stack profile config

--- a/internal/profile/_testdata/config.yml
+++ b/internal/profile/_testdata/config.yml
@@ -1,6 +1,6 @@
 # An expected setting.
 stack.geoip_dir: "/home/foo/Documents/ingest-geoip"
-stack.apm_server_enabled: true
+stack.apm_enabled: true
 stack.logstash_enabled: true
 
 # An empty string, should exist, but return empty.

--- a/internal/profile/config_test.go
+++ b/internal/profile/config_test.go
@@ -48,7 +48,7 @@ func TestLoadProfileConfig(t *testing.T) {
 			found:    true,
 		},
 		{
-			name:     "stack.apm_server_enabled",
+			name:     "stack.apm_enabled",
 			expected: "true",
 			found:    true,
 		},

--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -1,5 +1,6 @@
 {{ $username := fact "username" }}
 {{ $password := fact "password" }}
+{{ $apm_server_enabled := fact "apm_server_enabled" }}
 version: '2.3'
 services:
   elasticsearch:
@@ -70,6 +71,9 @@ services:
       - "EPR_METRICS_ADDRESS=0.0.0.0:9000"
       - "EPR_TLS_KEY=/etc/ssl/package-registry/key.pem"
       - "EPR_TLS_CERT=/etc/ssl/package-registry/cert.pem"
+    {{ if eq $apm_server_enabled "true" }}
+      - "ELASTIC_APM_SERVER_URL=http://fleet-server:8200"
+    {{ end }}
     volumes:
       - "../certs/package-registry:/etc/ssl/package-registry"
     ports:
@@ -112,7 +116,6 @@ services:
       - "../certs/fleet-server:/etc/ssl/elastic-agent"
     ports:
       - "127.0.0.1:8220:8220"
-      {{ $apm_server_enabled := fact "apm_server_enabled" }}
       {{ if eq $apm_server_enabled "true" }}
       - "127.0.0.1:8200:8200"
       {{ end }}

--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -73,6 +73,7 @@ services:
       - "EPR_TLS_CERT=/etc/ssl/package-registry/cert.pem"
     {{ if eq $apm_server_enabled "true" }}
       - "ELASTIC_APM_SERVER_URL=http://fleet-server:8200"
+      - "ELASTIC_APM_ENVIRONMENT=dev"
     {{ end }}
     volumes:
       - "../certs/package-registry:/etc/ssl/package-registry"

--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -1,6 +1,6 @@
 {{ $username := fact "username" }}
 {{ $password := fact "password" }}
-{{ $apm_server_enabled := fact "apm_server_enabled" }}
+{{ $apm_enabled := fact "apm_enabled" }}
 version: '2.3'
 services:
   elasticsearch:
@@ -71,7 +71,7 @@ services:
       - "EPR_METRICS_ADDRESS=0.0.0.0:9000"
       - "EPR_TLS_KEY=/etc/ssl/package-registry/key.pem"
       - "EPR_TLS_CERT=/etc/ssl/package-registry/cert.pem"
-    {{ if eq $apm_server_enabled "true" }}
+    {{ if eq $apm_enabled "true" }}
       - "ELASTIC_APM_SERVER_URL=http://fleet-server:8200"
       - "ELASTIC_APM_ENVIRONMENT=dev"
     {{ end }}
@@ -117,7 +117,7 @@ services:
       - "../certs/fleet-server:/etc/ssl/elastic-agent"
     ports:
       - "127.0.0.1:8220:8220"
-      {{ if eq $apm_server_enabled "true" }}
+      {{ if eq $apm_enabled "true" }}
       - "127.0.0.1:8200:8200"
       {{ end }}
 

--- a/internal/stack/_static/elasticsearch.yml.tmpl
+++ b/internal/stack/_static/elasticsearch.yml.tmpl
@@ -22,8 +22,8 @@ script.context.processor_conditional.cache_max_size: 2000
 script.context.template.cache_max_size: 2000
 {{ end }}
 
-{{ $apm_server_enabled := fact "apm_server_enabled" }}
-{{ if eq $apm_server_enabled "true" }}
+{{ $apm_enabled := fact "apm_enabled" }}
+{{ if eq $apm_enabled "true" }}
 tracing.apm.enabled: true
 tracing.apm.agent.server_url: "http://fleet-server:8200"
 tracing.apm.agent.environment: "dev"

--- a/internal/stack/_static/elasticsearch.yml.tmpl
+++ b/internal/stack/_static/elasticsearch.yml.tmpl
@@ -25,5 +25,6 @@ script.context.template.cache_max_size: 2000
 {{ $apm_server_enabled := fact "apm_server_enabled" }}
 {{ if eq $apm_server_enabled "true" }}
 tracing.apm.enabled: true
-tracing.apm.agent.server_url: http://fleet-server:8200
+tracing.apm.agent.server_url: "http://fleet-server:8200"
+tracing.apm.agent.environment: "dev"
 {{ end }}

--- a/internal/stack/_static/elasticsearch.yml.tmpl
+++ b/internal/stack/_static/elasticsearch.yml.tmpl
@@ -21,3 +21,9 @@ script.context.ingest.cache_max_size: 2000
 script.context.processor_conditional.cache_max_size: 2000
 script.context.template.cache_max_size: 2000
 {{ end }}
+
+{{ $apm_server_enabled := fact "apm_server_enabled" }}
+{{ if eq $apm_server_enabled "true" }}
+tracing.apm.enabled: true
+tracing.apm.agent.server_url: http://fleet-server:8200
+{{ end }}

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -9,8 +9,8 @@ server.ssl.certificateAuthorities: ["/usr/share/kibana/config/certs/ca-cert.pem"
 elasticsearch.hosts: [ "https://elasticsearch:9200" ]
 elasticsearch.ssl.certificateAuthorities: "/usr/share/kibana/config/certs/ca-cert.pem"
 
-{{ $apm_server_enabled := fact "apm_server_enabled" }}
-{{ if eq $apm_server_enabled "true" }}
+{{ $apm_enabled := fact "apm_enabled" }}
+{{ if eq $apm_enabled "true" }}
 elastic.apm.active: true
 elastic.apm.serverUrl: "http://fleet-server:8200"
 elastic.apm.environment: "dev"
@@ -55,7 +55,7 @@ xpack.fleet.packages:
     version: latest
   - name: fleet_server
     version: latest
-  {{ if eq $apm_server_enabled "true" }}
+  {{ if eq $apm_enabled "true" }}
   - name: apm
     version: latest
   {{ end }}
@@ -83,7 +83,7 @@ xpack.fleet.agentPolicies:
         id: default-fleet-server
         package:
           name: fleet_server
-      {{ if eq $apm_server_enabled "true" }}
+      {{ if eq $apm_enabled "true" }}
         inputs:
           - type: fleet-server
             vars:

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -9,6 +9,12 @@ server.ssl.certificateAuthorities: ["/usr/share/kibana/config/certs/ca-cert.pem"
 elasticsearch.hosts: [ "https://elasticsearch:9200" ]
 elasticsearch.ssl.certificateAuthorities: "/usr/share/kibana/config/certs/ca-cert.pem"
 
+{{ $apm_server_enabled := fact "apm_server_enabled" }}
+{{ if eq $apm_server_enabled "true" }}
+elastic.apm.active: true
+elastic.apm.serverUrl: "http://fleet-server:8200"
+{{ end }}
+
 {{ if semverLessThan $version "8.0.0" }}
 elasticsearch.username: {{ fact "username" }}
 elasticsearch.password: {{ fact "password" }}
@@ -48,7 +54,6 @@ xpack.fleet.packages:
     version: latest
   - name: fleet_server
     version: latest
-  {{ $apm_server_enabled := fact "apm_server_enabled" }}
   {{ if eq $apm_server_enabled "true" }}
   - name: apm
     version: latest
@@ -77,8 +82,14 @@ xpack.fleet.agentPolicies:
         id: default-fleet-server
         package:
           name: fleet_server
-      {{ $apm_server_enabled := fact "apm_server_enabled" }}
       {{ if eq $apm_server_enabled "true" }}
+        inputs:
+          - type: fleet-server
+            vars:
+              - name: custom
+                value: |
+                  server.instrumentation.enabled: true
+                  server.instrumentation.hosts: ["http://fleet-server:8200"]
       - name: apm-1
         package:
           name: apm

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -13,6 +13,7 @@ elasticsearch.ssl.certificateAuthorities: "/usr/share/kibana/config/certs/ca-cer
 {{ if eq $apm_server_enabled "true" }}
 elastic.apm.active: true
 elastic.apm.serverUrl: "http://fleet-server:8200"
+elastic.apm.environment: "dev"
 {{ end }}
 
 {{ if semverLessThan $version "8.0.0" }}
@@ -88,8 +89,11 @@ xpack.fleet.agentPolicies:
             vars:
               - name: custom
                 value: |
-                  server.instrumentation.enabled: true
-                  server.instrumentation.hosts: ["http://fleet-server:8200"]
+                  server:
+                    instrumentation:
+                      enabled: true
+                      hosts: ["http://fleet-server:8200"]
+                      environment: "dev"
       - name: apm-1
         package:
           name: apm

--- a/internal/stack/resources.go
+++ b/internal/stack/resources.go
@@ -129,9 +129,9 @@ func applyResources(profile *profile.Profile, stackVersion string) error {
 		"username": elasticsearchUsername,
 		"password": elasticsearchPassword,
 
-		"geoip_dir":          profile.Config("stack.geoip_dir", "./ingest-geoip"),
-		"apm_server_enabled": profile.Config("stack.apm_server_enabled", "false"),
-		"logstash_enabled":   profile.Config("stack.logstash_enabled", "false"),
+		"geoip_dir":        profile.Config("stack.geoip_dir", "./ingest-geoip"),
+		"apm_enabled":      profile.Config("stack.apm_enabled", "false"),
+		"logstash_enabled": profile.Config("stack.logstash_enabled", "false"),
 	})
 
 	os.MkdirAll(stackDir, 0755)

--- a/scripts/test-stack-command.sh
+++ b/scripts/test-stack-command.sh
@@ -48,7 +48,7 @@ if [ "${APM_SERVER_ENABLED}" = true ]; then
 
   # Create the config and enable apm-server
   cat ~/.elastic-package/profiles/${profile}/config.yml.example - <<EOF > ~/.elastic-package/profiles/${profile}/config.yml
-stack.apm_server_enabled: true
+stack.apm_enabled: true
 EOF
 fi
 


### PR DESCRIPTION
Leveraging https://github.com/elastic/elastic-package/pull/1593 (thanks @graphaelli!), configure APM in the services managed by `elastic-package stack` locally with Docker Compose. By now this is only optionally enabled, when the APM server is enabled.

This allows to use APM UI for these services:
![image](https://github.com/elastic/elastic-package/assets/15763/192cecbd-d117-48aa-bae1-b7a73aead68e)

cc @aspacca @ruflin in case this can be useful in benchmarking scenarios.