### PR TITLE
Add --path option for loading system benchmark scenarios from elsewhere

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -527,6 +527,7 @@ func getSystemCommand() *cobra.Command {
 		RunE:  systemCommandAction,
 	}
 
+	cmd.Flags().StringP(cobraext.BenchPathFlagName, "", "", cobraext.BenchPathFlagDescription)
 	cmd.Flags().StringP(cobraext.BenchNameFlagName, "", "", cobraext.BenchNameFlagDescription)
 	cmd.Flags().BoolP(cobraext.BenchReindexToMetricstoreFlagName, "", false, cobraext.BenchReindexToMetricstoreFlagDescription)
 	cmd.Flags().DurationP(cobraext.BenchMetricsIntervalFlagName, "", time.Second, cobraext.BenchMetricsIntervalFlagDescription)
@@ -542,6 +543,11 @@ func systemCommandAction(cmd *cobra.Command, args []string) error {
 	variant, err := cmd.Flags().GetString(cobraext.VariantFlagName)
 	if err != nil {
 		return cobraext.FlagParsingError(err, cobraext.VariantFlagName)
+	}
+
+	benchPath, err := cmd.Flags().GetString(cobraext.BenchPathFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.BenchPathFlagName)
 	}
 
 	benchName, err := cmd.Flags().GetString(cobraext.BenchNameFlagName)
@@ -595,6 +601,7 @@ func systemCommandAction(cmd *cobra.Command, args []string) error {
 
 	withOpts := []system.OptionFunc{
 		system.WithVariant(variant),
+		system.WithBenchmarkPath(benchPath),
 		system.WithBenchmarkName(benchName),
 		system.WithDeferCleanup(deferCleanup),
 		system.WithMetricsInterval(metricsInterval),

--- a/internal/benchrunner/runners/system/options.go
+++ b/internal/benchrunner/runners/system/options.go
@@ -20,6 +20,7 @@ type Options struct {
 	MetricsInterval time.Duration
 	ReindexData     bool
 	ESMetricsAPI    *elasticsearch.API
+	BenchPath       string
 	BenchName       string
 	PackageRootPath string
 	Variant         string
@@ -51,6 +52,12 @@ func WithKibanaClient(c *kibana.Client) OptionFunc {
 func WithPackageRootPath(path string) OptionFunc {
 	return func(opts *Options) {
 		opts.PackageRootPath = path
+	}
+}
+
+func WithBenchmarkPath(path string) OptionFunc {
+	return func(opts *Options) {
+		opts.BenchPath = path
 	}
 }
 

--- a/internal/benchrunner/runners/system/runner.go
+++ b/internal/benchrunner/runners/system/runner.go
@@ -40,7 +40,7 @@ const (
 	// ServiceLogsAgentDir is folder path where log files produced by the service
 	// are stored on the Agent container's filesystem.
 	ServiceLogsAgentDir = "/tmp/service_logs"
-	devDeployDir        = "_dev/benchmark/system/deploy"
+	defaultDevDeployDir = "_dev/benchmark/system/deploy"
 
 	// BenchType defining system benchmark
 	BenchType benchrunner.Type = "system"
@@ -145,7 +145,7 @@ func (r *runner) setUp() error {
 	}
 	r.ctxt.OutputDir = outputDir
 
-	scenario, err := readConfig(r.options.PackageRootPath, r.options.BenchName, r.ctxt)
+	scenario, err := readConfig(r.options.PackageRootPath, r.options.BenchPath, r.options.BenchName, r.ctxt)
 	if err != nil {
 		return err
 	}
@@ -237,6 +237,12 @@ func (r *runner) run() (report reporters.Reportable, err error) {
 
 		// Setup service.
 		logger.Debug("setting up service...")
+		var devDeployDir string
+		if r.options.BenchPath != "" {
+			devDeployDir = filepath.Clean(filepath.Join(r.options.BenchPath, "deploy"))
+		} else {
+			devDeployDir = defaultDevDeployDir
+		}
 		opts := servicedeployer.FactoryOptions{
 			PackageRootPath: r.options.PackageRootPath,
 			DevDeployDir:    devDeployDir,
@@ -484,7 +490,12 @@ func (r *runner) getGeneratorConfig() (*config.Config, error) {
 	)
 
 	if r.scenario.Corpora.Generator.Config.Path != "" {
-		configPath := filepath.Clean(filepath.Join(devPath, r.scenario.Corpora.Generator.Config.Path))
+		var configPath string
+		if r.options.BenchPath != "" {
+			configPath = filepath.Clean(filepath.Join(r.options.BenchPath, r.scenario.Corpora.Generator.Config.Path))
+		} else {
+			configPath = filepath.Clean(filepath.Join(devPath, r.scenario.Corpora.Generator.Config.Path))
+		}
 		configPath = os.ExpandEnv(configPath)
 		if _, err := os.Stat(configPath); err != nil {
 			return nil, fmt.Errorf("can't find config file %s: %w", configPath, err)
@@ -515,7 +526,12 @@ func (r *runner) getGeneratorFields() (fields.Fields, error) {
 	)
 
 	if r.scenario.Corpora.Generator.Fields.Path != "" {
-		fieldsPath := filepath.Clean(filepath.Join(devPath, r.scenario.Corpora.Generator.Fields.Path))
+		var fieldsPath string
+		if r.options.BenchPath != "" {
+			fieldsPath = filepath.Clean(filepath.Join(r.options.BenchPath, r.scenario.Corpora.Generator.Config.Path))
+		} else {
+			fieldsPath = filepath.Clean(filepath.Join(devPath, r.scenario.Corpora.Generator.Fields.Path))
+		}
 		fieldsPath = os.ExpandEnv(fieldsPath)
 		if _, err := os.Stat(fieldsPath); err != nil {
 			return nil, fmt.Errorf("can't find fields file %s: %w", fieldsPath, err)
@@ -547,7 +563,12 @@ func (r *runner) getGeneratorTemplate() ([]byte, error) {
 	)
 
 	if r.scenario.Corpora.Generator.Template.Path != "" {
-		tplPath := filepath.Clean(filepath.Join(devPath, r.scenario.Corpora.Generator.Template.Path))
+		var tplPath string
+		if r.options.BenchPath != "" {
+			tplPath = filepath.Clean(filepath.Join(r.options.BenchPath, r.scenario.Corpora.Generator.Template.Path))
+		} else {
+			tplPath = filepath.Clean(filepath.Join(devPath, r.scenario.Corpora.Generator.Template.Path))
+		}
 		tplPath = os.ExpandEnv(tplPath)
 		if _, err := os.Stat(tplPath); err != nil {
 			return nil, fmt.Errorf("can't find template file %s: %w", tplPath, err)

--- a/internal/benchrunner/runners/system/scenario.go
+++ b/internal/benchrunner/runners/system/scenario.go
@@ -79,8 +79,13 @@ func defaultConfig() *scenario {
 	}
 }
 
-func readConfig(path, scenario string, ctxt servicedeployer.ServiceContext) (*scenario, error) {
-	configPath := filepath.Join(path, devPath, fmt.Sprintf("%s.yml", scenario))
+func readConfig(path, benchPath string, scenario string, ctxt servicedeployer.ServiceContext) (*scenario, error) {
+	var configPath string
+	if benchPath != "" {
+		configPath = filepath.Join(benchPath, fmt.Sprintf("%s.yml", scenario))
+	} else {
+		configPath = filepath.Join(path, devPath, fmt.Sprintf("%s.yml", scenario))
+	}
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/internal/benchrunner/runners/system/scenario.go
+++ b/internal/benchrunner/runners/system/scenario.go
@@ -97,7 +97,6 @@ func readConfig(path, scenario string, ctxt servicedeployer.ServiceContext) (*sc
 	cfg, err := yaml.NewConfig(data, ucfg.PathSep("."))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			configPath = filepath.Join(path, devPath, fmt.Sprintf("%s.yaml", scenario))
 			cfg, err = yaml.NewConfigWithFile(configPath)
 		}
 		if err != nil {

--- a/internal/cobraext/flags.go
+++ b/internal/cobraext/flags.go
@@ -29,6 +29,9 @@ const (
 	AllowSnapshotFlagName    = "allow-snapshot"
 	AllowSnapshotDescription = "allow to export dashboards from a Elastic stack SNAPSHOT version"
 
+	BenchPathFlagName        = "path"
+	BenchPathFlagDescription = "path of the benchmark scenario to run"
+
 	BenchNameFlagName        = "benchmark"
 	BenchNameFlagDescription = "name of the benchmark scenario to run"
 


### PR DESCRIPTION
Currently, a system benchmark run started from the package root as follows:
```
elastic-package benchmark system --benchmark logs-benchmark
```
Will load the scenario defined in:
```
<package root>/_dev/benchmark/system/logs-benchmark.yml
```

This PR allows loading system benchmark scenarios from elsewhere on the filesystem by adding a `--path` option to the `elastic-package benchmark system` command.

This system benchmark run:
```
elastic-package benchmark system --benchmark logs-benchmark --path /tmp/scenariodirectory
```
Will load the scenario defined in:
```
/tmp/scenariodirectory/logs-benchmark.yml
```
The change includes loading other related files correctly, including from the `deploy/` subdirectory.

## Related issues

- Related #1317