### PR TITLE
[Benchmark] Add bulk request response body in case of errors

### DIFF
--- a/internal/benchrunner/runners/stream/runner.go
+++ b/internal/benchrunner/runners/stream/runner.go
@@ -470,6 +470,7 @@ func (r *runner) performBulkRequest(bulkRequest string) error {
 	}
 
 	if errors.Errors {
+		logger.Debug("Error in Elasticsearch bulk request: %s", string(body))
 		return fmt.Errorf("%d failed", len(errors.Items))
 	}
 


### PR DESCRIPTION
Currently it is tricky to debug issues in case a bulk request fails as the only item returned is the number of items failed. This adds a debug log message in case a bulk error shows up.