### PR TITLE
List packages with benchmarks

### DIFF
--- a/scripts/list_benchmark_packages.py
+++ b/scripts/list_benchmark_packages.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+import os
+
+integrations_repo_path = "../../integrations"
+packages_path = os.path.join(integrations_repo_path, "packages")
+
+# Iterate through all packages
+for package_path in os.listdir(packages_path):
+
+    rally_path = os.path.join(packages_path, package_path, "_dev", "benchmark", "rally")
+
+    # Find packages with a rally directory
+    if os.path.isdir(rally_path):
+        print("Package: " + package_path)
+
+        benchmarks = os.listdir(rally_path)
+        # List benchmarks
+        for b in benchmarks:
+            if not os.path.isdir(os.path.join(rally_path, b)):
+                continue
+            print("* " + b + "")
+
+        print("")


### PR DESCRIPTION
For someone to run benchmarks or ingest sample data it is currently not easy to find the packages that have templates for benchmarks available. This is a quick POC on how the list of integrations with benchmarks can be generated. Some ideas on how this could be used:

* Add the list to the docs page around streaming data. Downside is that it needs to be manually (or automatically) updated from time to time
* Add some command to elastic-package to list the packages with templates
* Other ideas?

The current output of the script looks as following:

```
python list_benchmark_packages.py

Package: nginx
* stubstatus-benchmark
* error-benchmark

Package: mysql
* performance-benchmark

Package: aws
* sqs-benchmark
* ec2metrics-benchmark
* billing-benchmark
* ec2logs-benchmark

Package: kubernetes
* container-benchmark
* pod-benchmark