### PR TITLE
Logstash Improvements.

### DIFF
--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -170,13 +170,14 @@ services:
       interval: 60s
       timeout: 50s
       retries: 5
-    command: bash -c "bin/logstash-plugin install logstash-filter-elastic_integration && logstash -f /usr/share/logstash/pipeline/logstash.conf"
+    command: bash -c 'if [[ ! $(bin/logstash-plugin list) == *"logstash-filter-elastic_integration"* ]]; then echo "Missing plugin logstash-filter-elastic_integration, installing now" && bin/logstash-plugin install logstash-filter-elastic_integration; fi && bin/logstash -f /usr/share/logstash/pipeline/logstash.conf'
     volumes:
       - "../certs/logstash:/usr/share/logstash/config/certs"
       - "../certs/elasticsearch/cert.pem:/usr/share/logstash/config/certs/elasticsearch.pem"
       - "./logstash.conf:/usr/share/logstash/pipeline/logstash.conf:ro"
     ports:
        - "127.0.0.1:5044:5044"
+       - "127.0.0.1:9600:9600"
     environment:
       - xpack.monitoring.enabled=false
       - ELASTIC_USER=elastic


### PR DESCRIPTION
### Description
1) Logstash team is aiming to create an E2E test using integration packages. During the tests, we would need a verification task which Logstash stats API will be helpful. We are introducing the port add to the docker network so that we can access stats API.
2) We are [packaging `elastic_integration` plugin](https://github.com/elastic/logstash/pull/15769) with Logstash and from LS 8.13 (planned) Logstash carries specific versions of the plugin. If we always install the plugin when LS container starts, we may lose the compatibility issue since it always installs the recent one. Introducing a logic to check if plugin is not bundled yet and install if so.

### How to test
- Run `make build`
- `./elastic-package stack up -d`
- Go to the LS docker and check for following logs
```
Missing plugin logstash-filter-elastic_integration, installing now
Using bundled JDK: /usr/share/logstash/jdk
Validating logstash-filter-elastic_integration
Resolving mixin dependencies
Installing logstash-filter-elastic_integration
```
- to check the exposed port, run `curl localhost:9600/_node/stats?pretty`. It should show current LS node stats.