### PR TITLE
[Buildkite] Skip docker installation since base image was updated

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ env:
   SETUP_GVM_VERSION: 'v0.5.1' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
   ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT: "true"
   DOCKER_COMPOSE_VERSION: "v2.24.1"
-  DOCKER_VERSION: "24.0.7"
+  DOCKER_VERSION: "false"
   KIND_VERSION: 'v0.20.0'
   K8S_VERSION: 'v1.29.0'
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"

--- a/.buildkite/scripts/install_deps.sh
+++ b/.buildkite/scripts/install_deps.sh
@@ -40,10 +40,10 @@ with_docker() {
         return
     fi
 
-    echo "--- Setting up the Docker environment..."
-    echo "Current docker client version:"
+    echo "Setting up the Docker environment..."
+    echo "- Current docker client version:"
     docker version -f json  | jq -r '.Client.Version'
-    echo "Current docekr server version:"
+    echo "- Current docker server version:"
     docker version -f json  | jq -r '.Server.Version'
 
     if [[ "${DOCKER_VERSION:-"false"}" == "false" ]]; then

--- a/.buildkite/scripts/install_deps.sh
+++ b/.buildkite/scripts/install_deps.sh
@@ -35,6 +35,11 @@ add_bin_path(){
 }
 
 with_docker() {
+    if ! command -v docker &> /dev/null ; then
+        echo "Skip. Docker is not installed by default"
+        return
+    fi
+
     echo "--- Setting up the Docker environment..."
     echo "Current docker client version:"
     docker version -f json  | jq -r '.Client.Version'

--- a/.buildkite/scripts/install_deps.sh
+++ b/.buildkite/scripts/install_deps.sh
@@ -35,6 +35,12 @@ add_bin_path(){
 }
 
 with_docker() {
+    echo "--- Setting up the Docker environment..."
+    echo "Current docker client version:"
+    docker version -f json  | jq -r '.Client.Version'
+    echo "Current docekr server version:"
+    docker version -f json  | jq -r '.Server.Version'
+
     if [[ "${DOCKER_VERSION:-"false"}" == "false" ]]; then
         echo "Skip docker installation"
         return
@@ -48,7 +54,9 @@ with_docker() {
     local debian_version="5:${DOCKER_VERSION}-1~ubuntu.${ubuntu_version}~${ubuntu_codename}"
 
     sudo sudo mkdir -p /etc/apt/keyrings
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    if [ ! -f /etc/apt/keyrings/docker.gpg ]; then
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    fi
     echo "deb [arch=${architecture} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${ubuntu_codename} stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     sudo apt-get update
     sudo DEBIAN_FRONTEND=noninteractive apt-get install --allow-downgrades -y "docker-ce=${debian_version}"


### PR DESCRIPTION
Relates https://github.com/elastic/integrations/pull/8971 
Relates https://github.com/elastic/elastic-package/pull/1639

This PR skips the docker installation since the base image used by the GCP agents has already been downgraded to 24.0.7 version.