### PR TITLE
Add JSON format to status subcommand

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -393,9 +393,10 @@ func releaseFromVersion(version string) string {
 }
 
 type statusJSON struct {
-	Package  string              `json:"package"`
-	Owner    string              `json:"owner,omitempty"`
-	Versions []statusJSONVersion `json:"versions,omitempty"`
+	Package        string              `json:"package"`
+	Owner          string              `json:"owner,omitempty"`
+	Versions       []statusJSONVersion `json:"versions,omitempty"`
+	PendingChanges *changelog.Revision `json:"pending_changes,omitempty"`
 }
 
 type statusJSONVersion struct {
@@ -453,6 +454,7 @@ func printJSON(p *status.PackageStatus, w io.Writer, extraParameters []string) e
 	if manifest := p.Local; manifest != nil {
 		version := newStatusJSONVersion("local", *manifest, extraParameters)
 		info.Versions = append(info.Versions, version)
+		info.PendingChanges = p.PendingChanges
 	}
 
 	for _, manifest := range p.Production {

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -187,6 +187,14 @@ func TestStatusFormatAndPrint(t *testing.T) {
 
 			assertOutputWithFile(t, c.expected, buf.String())
 		})
+
+		t.Run(c.title+"/JSON", func(t *testing.T) {
+			var buf bytes.Buffer
+			err := printJSON(c.pkgStatus, &buf, c.extraParameters)
+			require.NoError(t, err)
+
+			assertOutputWithFile(t, c.expected+".json", buf.String())
+		})
 	}
 }
 

--- a/cmd/testdata/status-beta-versions.json
+++ b/cmd/testdata/status-beta-versions.json
@@ -1,0 +1,19 @@
+{
+  "package": "foo",
+  "versions": [
+    {
+      "environment": "production",
+      "version": "1.0.0",
+      "release": "ga",
+      "title": "Foo",
+      "description": "Foo integration"
+    },
+    {
+      "environment": "production",
+      "version": "1.1.0-beta1",
+      "release": "beta",
+      "title": "Foo",
+      "description": "Foo integration"
+    }
+  ]
+}

--- a/cmd/testdata/status-extra-parameters.json
+++ b/cmd/testdata/status-extra-parameters.json
@@ -1,0 +1,28 @@
+{
+  "package": "foo",
+  "owner": "team",
+  "versions": [
+    {
+      "environment": "local",
+      "version": "2.0.0-rc1",
+      "release": "release candidate",
+      "title": "Foo",
+      "description": "Foo integration",
+      "kibana_version": "^8.9.0",
+      "categories": [
+        "custom"
+      ]
+    },
+    {
+      "environment": "production",
+      "version": "1.0.0",
+      "release": "ga",
+      "title": "Foo",
+      "description": "Foo integration",
+      "kibana_version": "^8.8.0",
+      "categories": [
+        "custom"
+      ]
+    }
+  ]
+}

--- a/cmd/testdata/status-local-version-stage.json
+++ b/cmd/testdata/status-local-version-stage.json
@@ -1,0 +1,41 @@
+{
+  "package": "foo",
+  "owner": "team",
+  "versions": [
+    {
+      "environment": "local",
+      "version": "2.0.0-rc1",
+      "release": "release candidate",
+      "title": "Foo",
+      "description": "Foo integration"
+    },
+    {
+      "environment": "production",
+      "version": "1.0.0",
+      "release": "ga",
+      "title": "Foo",
+      "description": "Foo integration"
+    },
+    {
+      "environment": "production",
+      "version": "1.0.1",
+      "release": "ga",
+      "title": "Foo",
+      "description": "Foo integration"
+    },
+    {
+      "environment": "production",
+      "version": "1.0.2",
+      "release": "ga",
+      "title": "Foo",
+      "description": "Foo integration"
+    },
+    {
+      "environment": "production",
+      "version": "1.1.0-beta1",
+      "release": "beta",
+      "title": "Foo",
+      "description": "Foo integration"
+    }
+  ]
+}

--- a/cmd/testdata/status-no-versions.json
+++ b/cmd/testdata/status-no-versions.json
@@ -1,0 +1,3 @@
+{
+  "package": "foo"
+}

--- a/cmd/testdata/status-pending-changes.json
+++ b/cmd/testdata/status-pending-changes.json
@@ -1,0 +1,20 @@
+{
+  "package": "foo",
+  "owner": "team",
+  "versions": [
+    {
+      "environment": "local",
+      "version": "2.0.0-rc1",
+      "release": "release candidate",
+      "title": "Foo",
+      "description": "Foo integration"
+    },
+    {
+      "environment": "production",
+      "version": "1.0.0",
+      "release": "ga",
+      "title": "Foo",
+      "description": "Foo integration"
+    }
+  ]
+}

--- a/cmd/testdata/status-pending-changes.json
+++ b/cmd/testdata/status-pending-changes.json
@@ -16,5 +16,15 @@
       "title": "Foo",
       "description": "Foo integration"
     }
-  ]
+  ],
+  "pending_changes": {
+    "version": "2.0.0-rc2",
+    "changes": [
+      {
+        "description": "New feature",
+        "type": "enhancement",
+        "link": "http:github.com/org/repo/pull/2"
+      }
+    ]
+  }
 }

--- a/cmd/testdata/status-preview-versions.json
+++ b/cmd/testdata/status-preview-versions.json
@@ -1,0 +1,26 @@
+{
+  "package": "foo",
+  "versions": [
+    {
+      "environment": "production",
+      "version": "0.9.0",
+      "release": "technical preview",
+      "title": "Foo",
+      "description": "Foo integration"
+    },
+    {
+      "environment": "production",
+      "version": "1.0.0-preview1",
+      "release": "technical preview",
+      "title": "Foo",
+      "description": "Foo integration"
+    },
+    {
+      "environment": "production",
+      "version": "1.0.0-preview5",
+      "release": "technical preview",
+      "title": "Foo",
+      "description": "Foo integration"
+    }
+  ]
+}

--- a/cmd/testdata/status-release-candidate-versions.json
+++ b/cmd/testdata/status-release-candidate-versions.json
@@ -1,0 +1,26 @@
+{
+  "package": "foo",
+  "versions": [
+    {
+      "environment": "production",
+      "version": "1.0.0",
+      "release": "ga",
+      "title": "Foo",
+      "description": "Foo integration"
+    },
+    {
+      "environment": "production",
+      "version": "1.1.0-beta1",
+      "release": "beta",
+      "title": "Foo",
+      "description": "Foo integration"
+    },
+    {
+      "environment": "production",
+      "version": "2.0.0-rc1",
+      "release": "release candidate",
+      "title": "Foo",
+      "description": "Foo integration"
+    }
+  ]
+}

--- a/cmd/testdata/status-serverless-projects.json
+++ b/cmd/testdata/status-serverless-projects.json
@@ -1,0 +1,36 @@
+{
+  "package": "foo",
+  "owner": "team",
+  "versions": [
+    {
+      "environment": "local",
+      "version": "2.0.0-rc1",
+      "release": "release candidate",
+      "title": "Foo",
+      "description": "Foo integration"
+    },
+    {
+      "environment": "production",
+      "version": "1.0.0",
+      "release": "ga",
+      "title": "Foo",
+      "description": "Foo integration"
+    },
+    {
+      "environment": "production",
+      "version": "1.0.0",
+      "release": "ga",
+      "title": "Foo",
+      "description": "Foo integration",
+      "serverless_project_type": "observability"
+    },
+    {
+      "environment": "production",
+      "version": "1.0.0",
+      "release": "ga",
+      "title": "Foo",
+      "description": "Foo integration",
+      "serverless_project_type": "security"
+    }
+  ]
+}

--- a/cmd/testdata/status-version-one-stage.json
+++ b/cmd/testdata/status-version-one-stage.json
@@ -1,0 +1,12 @@
+{
+  "package": "foo",
+  "versions": [
+    {
+      "environment": "production",
+      "version": "1.0.0",
+      "release": "ga",
+      "title": "Foo",
+      "description": "Foo integration"
+    }
+  ]
+}

--- a/internal/cobraext/flags.go
+++ b/internal/cobraext/flags.go
@@ -189,6 +189,9 @@ const (
 	StatusExtraInfoFlagName        = "info"
 	StatusExtraInfoFlagDescription = "show additional information (comma-separated values: \"%s\")"
 
+	StatusFormatFlagName        = "format"
+	StatusFormatFlagDescription = "output format (\"%s\")"
+
 	TestCoverageFlagName        = "test-coverage"
 	TestCoverageFlagDescription = "enable test coverage reports"
 


### PR DESCRIPTION
Add a `--format json` option to `elastic-package status`, that shows the same information but in JSON format.

See sample outputs in the test files.

Fixes https://github.com/elastic/elastic-package/issues/1519