### PR TITLE
Add sleep before retrying stack up again

### DIFF
--- a/internal/stack/boot.go
+++ b/internal/stack/boot.go
@@ -93,7 +93,7 @@ func BootUp(options Options) error {
 		// elastic-agent failed.
 		if onlyElasticAgentFailed(options) {
 			sleepTime := 10 * time.Second
-			fmt.Println("Elastic Agent failed to start, trying again in %s.", sleepTime)
+			fmt.Printf("Elastic Agent failed to start, trying again in %s.\n", sleepTime)
 			time.Sleep(sleepTime)
 			err = dockerComposeUp(options)
 		}

--- a/internal/stack/boot.go
+++ b/internal/stack/boot.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/elastic/elastic-package/internal/builder"
 	"github.com/elastic/elastic-package/internal/configuration/locations"
@@ -91,7 +92,9 @@ func BootUp(options Options) error {
 		// As a workaround, try to give another chance to docker-compose if only
 		// elastic-agent failed.
 		if onlyElasticAgentFailed(options) {
-			fmt.Println("Elastic Agent failed to start, trying again.")
+			sleepTime := 10 * time.Second
+			fmt.Println("Elastic Agent failed to start, trying again in %s.", sleepTime)
+			time.Sleep(sleepTime)
 			err = dockerComposeUp(options)
 		}
 		if err != nil {


### PR DESCRIPTION
This PR tries to reduce the number of times `elastic-package stack up` command fails because `elastic-agent` is not ready. Example of build where it happened:
https://buildkite.com/elastic/elastic-package/builds/2300#018d89b5-7d77-46ab-8e3a-ecd05edec0f8/123-444

It adds a waiting time of 10 seconds before running the next attempt to give some more time to Fleet Server to be ready for the enrollment process.