### PR TITLE
Avoid using coverage XML files for junit step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,7 +55,7 @@ steps:
 
   - label: ":junit: Transform windows paths to linux for Junit plugin"
     commands:
-      - buildkite-agent artifact download "*.xml" --step unit-test-windows
+      - buildkite-agent artifact download "*-windows.xml" . --step unit-test-windows
       - mkdir -p build/test-results
       - for file in $(ls *-windows.xml); do mv $$file build/test-results/; done
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,7 +35,7 @@ steps:
       provider: "gcp"
       image: "${WINDOWS_AGENT_IMAGE}"
     artifact_paths:
-      - "*.xml"
+      - "TEST-unit-windows.xml"
 
   - wait: ~
     continue_on_failure: true
@@ -55,7 +55,7 @@ steps:
 
   - label: ":junit: Transform windows paths to linux for Junit plugin"
     commands:
-      - buildkite-agent artifact download "*-windows.xml"
+      - buildkite-agent artifact download "*.xml" --step unit-test-windows
       - mkdir -p build/test-results
       - for file in $(ls *-windows.xml); do mv $$file build/test-results/; done
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,15 +40,15 @@ steps:
   - wait: ~
     continue_on_failure: true
 
-  # - label: ":pipeline: Trigger Integration tests"
-  #   command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
-  #   depends_on:
-  #     - step: check-static
-  #       allow_failure: false
-  #     - step: unit-tests-linux
-  #       allow_failure: false
-  #     - step: unit-tests-windows
-  #       allow_failure: false
+  - label: ":pipeline: Trigger Integration tests"
+    command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
+    depends_on:
+      - step: check-static
+        allow_failure: false
+      - step: unit-tests-linux
+        allow_failure: false
+      - step: unit-tests-windows
+        allow_failure: false
 
   - wait: ~
     continue_on_failure: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,7 +35,7 @@ steps:
       provider: "gcp"
       image: "${WINDOWS_AGENT_IMAGE}"
     artifact_paths:
-      - "TEST-unit.xml"
+      - "build/test-results/*.xml"
 
   - wait: ~
     continue_on_failure: true
@@ -56,7 +56,7 @@ steps:
   - label: ":junit: Junit annotate"
     plugins:
       - junit-annotate#v2.4.1:
-          artifacts: "*.xml"
+          artifacts: "build/test-results/*.xml"
     agents:
       provider: "gcp"  # junit plugin requires docker
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,7 +35,7 @@ steps:
       provider: "gcp"
       image: "${WINDOWS_AGENT_IMAGE}"
     artifact_paths:
-      - "build/test-results/*.xml"
+      - "*.xml"
 
   - wait: ~
     continue_on_failure: true
@@ -55,10 +55,9 @@ steps:
 
   - label: ":junit: Transform windows paths to linux for Junit plugin"
     commands:
-      - buildkite-agent artifact download "*-win.xml"
-      - ls -l
-      - ls -l build/
-      - ls -l build/test-results
+      - buildkite-agent artifact download "*-windows.xml"
+      - mkdir -p build/test-results
+      - for file in $(ls *-windows.xml); do mv $$file build/test-results/; done
     agents:
       image: "${LINUX_AGENT_IMAGE}"
       cpu: "8"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,7 +55,7 @@ steps:
 
   - label: ":junit: Transform windows paths to linux for Junit plugin"
     commands:
-      - buildkite-agent artifact download "*-windows.xml" . --step unit-test-windows
+      - buildkite-agent artifact download "*-windows.xml" . --step unit-tests-windows
       - mkdir -p build/test-results
       - for file in $(ls *-windows.xml); do mv $$file build/test-results/; done
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,7 +55,7 @@ steps:
 
   - label: ":junit: Transform windows paths to linux for Junit plugin"
     commands:
-      - buildkite-agent artifact download "build\\test-results\\TEST-unit-win.xml"
+      - buildkite-agent artifact download "*-win.xml"
       - ls -l
       - ls -l build/
       - ls -l build/test-results

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,9 +55,10 @@ steps:
 
   - label: ":junit: Transform windows paths to linux for Junit plugin"
     commands:
-      - buildkite-agent artifact download "build\\test-result\\TEST-unit-win.xml"
+      - buildkite-agent artifact download "build\\test-results\\TEST-unit-win.xml"
       - ls -l
-      - ls -l build/test-result
+      - ls -l build/
+      - ls -l build/test-results
     agents:
       image: "${LINUX_AGENT_IMAGE}"
       cpu: "8"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,15 +40,30 @@ steps:
   - wait: ~
     continue_on_failure: true
 
-  - label: ":pipeline: Trigger Integration tests"
-    command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
-    depends_on:
-      - step: check-static
-        allow_failure: false
-      - step: unit-tests-linux
-        allow_failure: false
-      - step: unit-tests-windows
-        allow_failure: false
+  # - label: ":pipeline: Trigger Integration tests"
+  #   command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
+  #   depends_on:
+  #     - step: check-static
+  #       allow_failure: false
+  #     - step: unit-tests-linux
+  #       allow_failure: false
+  #     - step: unit-tests-windows
+  #       allow_failure: false
+
+  - wait: ~
+    continue_on_failure: true
+
+  - label: ":junit: Transform windows paths to linux for Junit plugin"
+    commands:
+      - buildkite-agent artifact download "build\\test-result\\TEST-unit-win.xml"
+      - ls -l
+      - ls -l build/test-result
+    agents:
+      image: "${LINUX_AGENT_IMAGE}"
+      cpu: "8"
+      memory: "4G"
+    artifact_paths:
+      - "build/test-results/*.xml"
 
   - wait: ~
     continue_on_failure: true

--- a/.buildkite/scripts/unit_tests_windows.ps1
+++ b/.buildkite/scripts/unit_tests_windows.ps1
@@ -48,6 +48,6 @@ $ErrorActionPreference = "Stop"
 
 mkdir -p build/test-results/
 
-cp "$(PWD)/TEST-unit.xml" build/test-results/TEST-unit.xml
+cp "$(PWD)/TEST-unit.xml" build/test-results/TEST-unit-win.xml
 
 Exit $EXITCODE

--- a/.buildkite/scripts/unit_tests_windows.ps1
+++ b/.buildkite/scripts/unit_tests_windows.ps1
@@ -46,4 +46,8 @@ go run gotest.tools/gotestsum --junitfile "$(PWD)/TEST-unit.xml" -- -count=1 ./.
 $EXITCODE=$LASTEXITCODE
 $ErrorActionPreference = "Stop"
 
+mkdir -p build/test-results/
+
+cp "$(PWD)/TEST-unit.xml" build/test-results/TEST-unit.xml
+
 Exit $EXITCODE

--- a/.buildkite/scripts/unit_tests_windows.ps1
+++ b/.buildkite/scripts/unit_tests_windows.ps1
@@ -42,12 +42,8 @@ go mod download -x
 echo "--- Running unit tests"
 go version
 $ErrorActionPreference = "Continue" # set +e
-go run gotest.tools/gotestsum --junitfile "$(PWD)/TEST-unit.xml" -- -count=1 ./...
+go run gotest.tools/gotestsum --junitfile "$(PWD)/TEST-unit-windows.xml" -- -count=1 ./...
 $EXITCODE=$LASTEXITCODE
 $ErrorActionPreference = "Stop"
-
-mkdir -p build/test-results/
-
-cp "$(PWD)/TEST-unit.xml" build/test-results/TEST-unit-win.xml
 
 Exit $EXITCODE


### PR DESCRIPTION
Currently, junit step last around 7 minutes:

![junit step before](https://github.com/elastic/elastic-package/assets/5330827/5272c59c-6536-4ef6-8968-96a90ee6e534)

In this PR, it is removed from this step the XML files related to coverage reports.
After changing this the time spent in this step is around 10-15 secs:
![junit step after](https://github.com/elastic/elastic-package/assets/5330827/104f8f33-f4ba-4b73-8f7e-09abe85e4dac)
