### PR TITLE
Fix generic cobertura merge

### DIFF
--- a/internal/testrunner/genericcobertura.go
+++ b/internal/testrunner/genericcobertura.go
@@ -56,14 +56,18 @@ func (c *GenericFile) merge(b *GenericFile) error {
 	// Merge files
 	for _, coverageLine := range b.Lines {
 		found := false
-		for _, existingLine := range c.Lines {
+		foundId := 0
+		for idx, existingLine := range c.Lines {
 			if existingLine.LineNumber == coverageLine.LineNumber {
 				found = true
+				foundId = idx
 				break
 			}
 		}
 		if !found {
 			c.Lines = append(c.Lines, coverageLine)
+		} else {
+			c.Lines[foundId].Covered = c.Lines[foundId].Covered || coverageLine.Covered
 		}
 	}
 	return nil

--- a/internal/testrunner/genericcobertura_test.go
+++ b/internal/testrunner/genericcobertura_test.go
@@ -73,6 +73,71 @@ func TestGenericCoverage_Merge(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "merge files with same lines",
+			rhs: GenericCoverage{
+				Files: []*GenericFile{
+					{
+						Path: "/a",
+						Lines: []*GenericLine{
+							{LineNumber: 1, Covered: true},
+							{LineNumber: 2, Covered: false},
+							{LineNumber: 4, Covered: false},
+						},
+					},
+					{
+						Path: "/c",
+						Lines: []*GenericLine{
+							{LineNumber: 1, Covered: false},
+							{LineNumber: 2, Covered: true},
+							{LineNumber: 4, Covered: true},
+						},
+					},
+				},
+			},
+			lhs: GenericCoverage{
+				Files: []*GenericFile{
+					{
+						Path: "/a",
+						Lines: []*GenericLine{
+							{LineNumber: 1, Covered: true},
+							{LineNumber: 2, Covered: true},
+							{LineNumber: 3, Covered: false},
+						},
+					},
+					{
+						Path: "/c",
+						Lines: []*GenericLine{
+							{LineNumber: 1, Covered: false},
+							{LineNumber: 2, Covered: false},
+							{LineNumber: 3, Covered: true},
+						},
+					},
+				},
+			},
+			expected: GenericCoverage{
+				Files: []*GenericFile{
+					{
+						Path: "/a",
+						Lines: []*GenericLine{
+							{LineNumber: 1, Covered: true},
+							{LineNumber: 2, Covered: true},
+							{LineNumber: 4, Covered: false},
+							{LineNumber: 3, Covered: false},
+						},
+					},
+					{
+						Path: "/c",
+						Lines: []*GenericLine{
+							{LineNumber: 1, Covered: false},
+							{LineNumber: 2, Covered: true},
+							{LineNumber: 4, Covered: true},
+							{LineNumber: 3, Covered: true},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #1666

This PR fixes a bug in how Generic reports are merged. 

Checked running test pipeline with zoom package from the integrations repository

Before (everything false):
```xml
  <file path="packages/zoom/data_stream/webhook/elasticsearch/ingest_pipeline/zoomroom.yml">
    <lineToCover lineNumber="4" covered="false"></lineToCover>
    <lineToCover lineNumber="5" covered="false"></lineToCover>
    <lineToCover lineNumber="6" covered="false"></lineToCover>
    <lineToCover lineNumber="7" covered="false"></lineToCover>
    <lineToCover lineNumber="8" covered="false"></lineToCover>
    <lineToCover lineNumber="9" covered="false"></lineToCover>
    <lineToCover lineNumber="10" covered="false"></lineToCover>
    <lineToCover lineNumber="11" covered="false"></lineToCover>
    <lineToCover lineNumber="12" covered="false"></lineToCover>
    <lineToCover lineNumber="13" covered="false"></lineToCover>
    <lineToCover lineNumber="14" covered="false"></lineToCover>
    <lineToCover lineNumber="15" covered="false"></lineToCover>
    <lineToCover lineNumber="16" covered="false"></lineToCover>
    <lineToCover lineNumber="17" covered="false"></lineToCover>
    <lineToCover lineNumber="18" covered="false"></lineToCover>
    <lineToCover lineNumber="19" covered="false"></lineToCover>
  </file>
```

After:
```xml
  <file path="packages/zoom/data_stream/webhook/elasticsearch/ingest_pipeline/zoomroom.yml">
    <lineToCover lineNumber="4" covered="true"></lineToCover>
    <lineToCover lineNumber="5" covered="true"></lineToCover>
    <lineToCover lineNumber="6" covered="true"></lineToCover>
    <lineToCover lineNumber="7" covered="true"></lineToCover>
    <lineToCover lineNumber="8" covered="true"></lineToCover>
    <lineToCover lineNumber="9" covered="true"></lineToCover>
    <lineToCover lineNumber="10" covered="true"></lineToCover>
    <lineToCover lineNumber="11" covered="true"></lineToCover>
    <lineToCover lineNumber="12" covered="false"></lineToCover>
    <lineToCover lineNumber="13" covered="false"></lineToCover>
    <lineToCover lineNumber="14" covered="false"></lineToCover>
    <lineToCover lineNumber="15" covered="false"></lineToCover>
    <lineToCover lineNumber="16" covered="true"></lineToCover>
    <lineToCover lineNumber="17" covered="true"></lineToCover>
    <lineToCover lineNumber="18" covered="true"></lineToCover>
    <lineToCover lineNumber="19" covered="true"></lineToCover>
  </file>
```

To compare, this is the result for that data stream using Cobertura:
```xml
        <class name="zoomroom" filename="packages/zoom/data_stream/webhook/elasticsearch/ingest_pipeline/zoomroom.yml" line-rate="0" branch-rate="0" complexity="0">
          <methods>
            <method name="append" signature="" line-rate="0" branch-rate="0" complexity="0">
              <lines>
                <line number="4" hits="2"></line>
                <line number="5" hits="2"></line>
                <line number="6" hits="2"></line>
                <line number="7" hits="2"></line>
              </lines>
            </method>
            <method name="append" signature="" line-rate="0" branch-rate="0" complexity="0">
              <lines>
                <line number="8" hits="2"></line>
                <line number="9" hits="2"></line>
                <line number="10" hits="2"></line>
                <line number="11" hits="2"></line>
              </lines>
            </method>
            <method name="append" signature="" line-rate="0" branch-rate="0" complexity="0">
              <lines>
                <line number="12" hits="0"></line>
                <line number="13" hits="0"></line>
                <line number="14" hits="0"></line>
                <line number="15" hits="0"></line>
              </lines>
            </method>
            <method name="rename" signature="" line-rate="0" branch-rate="0" complexity="0">
              <lines>
                <line number="16" hits="4"></line>
                <line number="17" hits="4"></line>
                <line number="18" hits="4"></line>
                <line number="19" hits="4"></line>
              </lines>
            </method>
          </methods>
          <lines>
            <line number="4" hits="2"></line>
            <line number="5" hits="2"></line>
            <line number="6" hits="2"></line>
            <line number="7" hits="2"></line>
            <line number="8" hits="2"></line>
            <line number="9" hits="2"></line>
            <line number="10" hits="2"></line>
            <line number="11" hits="2"></line>
            <line number="12" hits="0"></line>
            <line number="13" hits="0"></line>
            <line number="14" hits="0"></line>
            <line number="15" hits="0"></line>
            <line number="16" hits="4"></line>
            <line number="17" hits="4"></line>
            <line number="18" hits="4"></line>
            <line number="19" hits="4"></line>
          </lines>
        </class>
```