### PR TITLE
Disable elastic agent self monitoring by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,9 @@ test-stack-command-8x:
 test-stack-command-with-apm-server:
 	APM_SERVER_ENABLED=true ./scripts/test-stack-command.sh
 
+test-stack-command-with-self-monitor:
+	SELF_MONITOR_ENABLED=true ./scripts/test-stack-command.sh
+
 test-stack-command: test-stack-command-default test-stack-command-7x test-stack-command-800 test-stack-command-8x test-stack-command-with-apm-server
 
 test-check-packages: test-check-packages-with-kind test-check-packages-other test-check-packages-parallel test-check-packages-with-custom-agent test-check-packages-benchmarks test-check-packages-false-positives test-check-packages-with-logstash

--- a/README.md
+++ b/README.md
@@ -620,8 +620,8 @@ The following settings are available per profile:
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.
-* `stack.self_monitor_enabled` enables monitoring and the system package for the managed
-  Elastic Agent. Defaults to false.
+* `stack.self_monitor_enabled` enables monitoring and the system package for the default
+  policy assigned to the managed Elastic Agent. Defaults to false.
 * `stack.serverless.type` selects the type of serverless project to start when using
   the serverless stack provider.
 * `stack.serverless.region` can be used to select the region to use when starting

--- a/README.md
+++ b/README.md
@@ -620,6 +620,8 @@ The following settings are available per profile:
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.
+* `stack.self_monitor_enabled` enables monitoring and the system package for the managed
+  Elastic Agent. Defaults to false.
 * `stack.serverless.type` selects the type of serverless project to start when using
   the serverless stack provider.
 * `stack.serverless.region` can be used to select the region to use when starting

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -47,10 +47,13 @@ xpack.encryptedSavedObjects.encryptionKey: "12345678901234567890123456789012"
 xpack.cloudSecurityPosture.enabled: true
 {{ end }}
 
+{{ $self_monitor_enabled := fact "self_monitor_enabled" }}
 {{ if not (semverLessThan $version "8.0.0") }}
 xpack.fleet.packages:
+  {{ if eq $self_monitor_enabled "true" }}
   - name: system
     version: latest
+  {{ end }}
   - name: elastic_agent
     version: latest
   - name: fleet_server
@@ -65,6 +68,7 @@ xpack.fleet.agentPolicies:
     is_default: true
     is_managed: false
     namespace: default
+  {{ if eq $self_monitor_enabled "true" }}
     monitoring_enabled:
       - logs
       - metrics
@@ -73,6 +77,10 @@ xpack.fleet.agentPolicies:
         id: default-system
         package:
           name: system
+  {{ else }}
+    monitoring_enabled: []
+    package_policies: []
+  {{ end }}
   - name: Fleet Server (elastic-package)
     id: fleet-server-policy
     is_default_fleet_server: true

--- a/internal/stack/resources.go
+++ b/internal/stack/resources.go
@@ -51,6 +51,11 @@ const (
 
 	elasticsearchUsername = "elastic"
 	elasticsearchPassword = "changeme"
+
+	configAPMEnabled         = "stack.apm_enabled"
+	configGeoIPDir           = "stack.geoip_dir"
+	configLogstashEnabled    = "stack.logstash_enabled"
+	configSelfMonitorEnabled = "stack.self_monitor_enabled"
 )
 
 var (
@@ -130,9 +135,10 @@ func applyResources(profile *profile.Profile, stackVersion string) error {
 		"username": elasticsearchUsername,
 		"password": elasticsearchPassword,
 
-		"geoip_dir":        profile.Config("stack.geoip_dir", "./ingest-geoip"),
-		"apm_enabled":      profile.Config("stack.apm_enabled", "false"),
-		"logstash_enabled": profile.Config("stack.logstash_enabled", "false"),
+		"apm_enabled":          profile.Config(configAPMEnabled, "false"),
+		"geoip_dir":            profile.Config(configGeoIPDir, "./ingest-geoip"),
+		"logstash_enabled":     profile.Config(configLogstashEnabled, "false"),
+		"self_monitor_enabled": profile.Config(configSelfMonitorEnabled, "false"),
 	})
 
 	os.MkdirAll(stackDir, 0755)

--- a/scripts/test-stack-command.sh
+++ b/scripts/test-stack-command.sh
@@ -61,7 +61,7 @@ EOF
 fi
 
 if [ "${SELF_MONITOR_ENABLED}" = true ]; then
-  # Create an self-monitor profile and use it
+  # Create a self-monitor profile and use it
   profile=with-self-monitor
   elastic-package profiles create -v ${profile}
   elastic-package profiles use ${profile}

--- a/scripts/test-stack-command.sh
+++ b/scripts/test-stack-command.sh
@@ -20,7 +20,6 @@ cleanup() {
   fi
 
   if [ "${SELF_MONITOR_ENABLED}" = true ]; then
-    # Create an apm-server profile and use it
     elastic-package profiles delete with-self-monitor
   fi
 
@@ -67,7 +66,6 @@ if [ "${SELF_MONITOR_ENABLED}" = true ]; then
   elastic-package profiles create -v ${profile}
   elastic-package profiles use ${profile}
 
-  # Create the config and enable apm-server
   cat ~/.elastic-package/profiles/${profile}/config.yml.example - <<EOF > ~/.elastic-package/profiles/${profile}/config.yml
 stack.self_monitor_enabled: true
 EOF

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -173,8 +173,8 @@ The following settings are available per profile:
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.
-* `stack.self_monitor_enabled` enables monitoring and the system package for the managed
-  Elastic Agent. Defaults to false.
+* `stack.self_monitor_enabled` enables monitoring and the system package for the default
+  policy assigned to the managed Elastic Agent. Defaults to false.
 * `stack.serverless.type` selects the type of serverless project to start when using
   the serverless stack provider.
 * `stack.serverless.region` can be used to select the region to use when starting

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -173,6 +173,8 @@ The following settings are available per profile:
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.
+* `stack.self_monitor_enabled` enables monitoring and the system package for the managed
+  Elastic Agent. Defaults to false.
 * `stack.serverless.type` selects the type of serverless project to start when using
   the serverless stack provider.
 * `stack.serverless.region` can be used to select the region to use when starting


### PR DESCRIPTION
Configure elastic-agent by default with an empty policy to avoid affecting tests with uncontrolled versions of the system package. A new user parameter `stack.self_monitor_enabled` can be set to true to revert back to the previous behaviour.

We are configuring monitoring and the system package for the default policy in Elastic Agent managed by `elastic-package stack`, but this is not required for tests or package development, and it slightly slows down startup, consumes resources unnecessarily and is a source of flakiness.

For example in https://github.com/elastic/elastic-package/pull/1670 the tests for the system package are affected by the pre-installed system package. They are failing because a missing pipeline for system package 1.53.1, but the version being tested is 1.53.0.
```
pipeline with id [metrics-system.memory-1.53.1] does not exist
```
