### PR TITLE
Explicitly handle uninstalled and input packages when dumping installed objects

### DIFF
--- a/internal/kibana/packages.go
+++ b/internal/kibana/packages.go
@@ -69,7 +69,7 @@ type FleetPackage struct {
 	Status string `json:"status"`
 }
 
-// GetPackage obtains information about an installed package.
+// GetPackage obtains information about a package from Fleet.
 func (c *Client) GetPackage(name string) (*FleetPackage, error) {
 	path := c.epmPackageUrl(name, "")
 	statusCode, respBody, err := c.get(path)

--- a/internal/kibana/packages.go
+++ b/internal/kibana/packages.go
@@ -62,7 +62,41 @@ func (c *Client) RemovePackage(name, version string) ([]packages.Asset, error) {
 	return processResults("remove", statusCode, respBody)
 }
 
+// FleetPackage contains information about a package in Fleet.
+type FleetPackage struct {
+	Name   string `json:"string"`
+	Type   string `json:"type"`
+	Status string `json:"status"`
+}
+
+// GetPackage obtains information about an installed package.
+func (c *Client) GetPackage(name string) (*FleetPackage, error) {
+	path := c.epmPackageUrl(name, "")
+	statusCode, respBody, err := c.get(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not get package: %w", err)
+	}
+	if statusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("package %s not found", name)
+	}
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf("could not get package; API status code = %d; response body = %s", statusCode, string(respBody))
+	}
+
+	var response struct {
+		Item FleetPackage `json:"item"`
+	}
+	err = json.Unmarshal(respBody, &response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode package response: %w", err)
+	}
+	return &response.Item, err
+}
+
 func (c *Client) epmPackageUrl(name, version string) string {
+	if version == "" {
+		return fmt.Sprintf("%s/epm/packages/%s", FleetAPI, name)
+	}
 	switch {
 	case c.semver.Major() < 8:
 		return fmt.Sprintf("%s/epm/packages/%s-%s", FleetAPI, name, version)


### PR DESCRIPTION
Provide more information when no objects can be dumped for a given package:
* When an input package is installed, no objects are created unless a policy is created with them, in that case `dump` prints now:
  ```
  No objects installed for input package sql unless a policy is created.
  ```
* When a package is not installed:
  ```
  Package apache is not installed.
  ```
* If the package cannot be found an error is returned.
```
Error: failed to get package status: package delorean not found
```
* If the package is expected to have installed objects, and no object is found, an error is returned.
```
Error: no objects found for package apache
```

The current message for all these cases was:
```
No objects were dumped for package apache, is it installed?
```

Close https://github.com/elastic/elastic-package/issues/1050