### PR TITLE
Remove exception for uninstalling system package in tests

### DIFF
--- a/internal/testrunner/runners/asset/runner.go
+++ b/internal/testrunner/runners/asset/runner.go
@@ -105,9 +105,7 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 		logger.Debug("removing package...")
 		err = packageInstaller.Uninstall()
 
-		// by default system package is part of an agent policy and it cannot be uninstalled
-		// https://github.com/elastic/elastic-package/blob/5f65dc29811c57454bc7142aaf73725b6d4dc8e6/internal/stack/_static/kibana.yml.tmpl#L62
-		if err != nil && pkgManifest.Name != "system" {
+		if err != nil {
 			logger.Warnf("failed to uninstall package %q: %s", pkgManifest.Name, err.Error())
 		}
 		return nil

--- a/internal/testrunner/runners/asset/runner.go
+++ b/internal/testrunner/runners/asset/runner.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
+
 	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/packages"
@@ -102,10 +104,27 @@ func (r *runner) run() ([]testrunner.TestResult, error) {
 			return fmt.Errorf("reading package manifest failed: %w", err)
 		}
 
+		kibanaVersion, err := r.kibanaClient.Version()
+		if err != nil {
+			return fmt.Errorf("failed to retrieve kibana version: %w", err)
+		}
+		stackVersion, err := semver.NewVersion(kibanaVersion.Version())
+		if err != nil {
+			return fmt.Errorf("failed to parse kibana version: %w", err)
+		}
+
+		if stackVersion.LessThan(semver.MustParse("8.0.0")) && pkgManifest.Name == "system" {
+			// in Elastic stack 7.* , system package is installed in the default Agent policy and it cannot be deleted
+			// error: system is installed by default and cannot be removed
+			logger.Debugf("skip uninstalling %s package", pkgManifest.Name)
+			return nil
+		}
+
 		logger.Debug("removing package...")
 		err = packageInstaller.Uninstall()
-
 		if err != nil {
+			// logging the error as a warning and not returning it since there could be other reasons that could make fail this process
+			// for instance being defined a test agent policy where this package is used for debugging purposes
 			logger.Warnf("failed to uninstall package %q: %s", pkgManifest.Name, err.Error())
 		}
 		return nil

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -543,9 +543,7 @@ func (r *runner) runTest(config *testConfig, ctxt servicedeployer.ServiceContext
 	r.deletePackageHandler = func() error {
 		err := installer.Uninstall()
 
-		// by default system package is part of an agent policy and it cannot be uninstalled
-		// https://github.com/elastic/elastic-package/blob/5f65dc29811c57454bc7142aaf73725b6d4dc8e6/internal/stack/_static/kibana.yml.tmpl#L62
-		if err != nil && pkgManifest.Name != "system" {
+		if err != nil {
 			// logging the error as a warning and not returning it since there could be other reasons that could make fail this process
 			// for instance being defined a test agent policy where this package is used for debugging purposes
 			logger.Warnf("failed to uninstall package %q: %s", pkgManifest.Name, err.Error())


### PR DESCRIPTION
This PR removes the exception that was set in place for `system` package when packages were uninstalled in the tear down process (asset and system tests).

In #1672, `system` package is no longer installed in the default Agent policy, so there should not be any error when `system` package is uninstalled from now on.

- [x] Run all tests for current `system` package in integrations repository locally (Elastic stack 8.12.1)
    - system package is deleted
- [x] Run all tests for latest version supporting Elastic stack 7.17.* (version 1.11.0) - https://github.com/elastic/integrations/commit/792a55c90066756d99dbb878be2b38e6feee59fb
    - deletion of the system package is skipped


Relates:
- #1672 
- #1315

