### PR TITLE
Remove leftovers after changing path for service state

### DIFF
--- a/internal/configuration/locations/locations.go
+++ b/internal/configuration/locations/locations.go
@@ -35,8 +35,6 @@ var (
 	rallyCorpusDir        = filepath.Join(temporaryDir, "rally_corpus")
 	kubernetesDeployerDir = filepath.Join(deployerDir, "kubernetes")
 	serviceOutputDir      = filepath.Join(temporaryDir, "output")
-
-	serviceSetupDir = filepath.Join(stackDir, "service_setup")
 )
 
 // LocationManager maintains an instance of a config path location
@@ -108,11 +106,6 @@ func (loc LocationManager) ServiceOutputDir() string {
 // CacheDir returns the directory with cached fields
 func (loc LocationManager) CacheDir(name string) string {
 	return filepath.Join(loc.stackPath, cacheDir, name)
-}
-
-// ServiceSetupDir returns the directory to store resources to be re-used in setup or tear-down processes
-func (loc LocationManager) ServiceSetupDir() string {
-	return filepath.Join(loc.stackPath, serviceSetupDir)
 }
 
 // configurationDir returns the configuration directory location


### PR DESCRIPTION
Follows #1250 

Remove unused methods from locations.go. Those were replaced creating the folder under the profile directory.