### PR TITLE
Add linux/amd64 platform for tianon/true service

### DIFF
--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -21,7 +21,7 @@ services:
       - "127.0.0.1:9200:9200"
 
   elasticsearch_is_ready:
-    image: tianon/true
+    image: tianon/true:multiarch
     depends_on:
       elasticsearch:
         condition: service_healthy
@@ -50,7 +50,7 @@ services:
       - "127.0.0.1:5601:5601"
 
   kibana_is_ready:
-    image: tianon/true
+    image: tianon/true:multiarch
     depends_on:
       kibana:
         condition: service_healthy
@@ -82,7 +82,7 @@ services:
       - "127.0.0.1:9000:9000"
 
   package-registry_is_ready:
-    image: tianon/true
+    image: tianon/true:multiarch
     depends_on:
       package-registry:
         condition: service_healthy
@@ -122,7 +122,7 @@ services:
       {{ end }}
 
   fleet-server_is_ready:
-    image: tianon/true
+    image: tianon/true:multiarch
     depends_on:
       fleet-server:
         condition: service_healthy
@@ -151,7 +151,7 @@ services:
       target: /run/service_logs/
 
   elastic-agent_is_ready:
-    image: tianon/true
+    image: tianon/true:multiarch
     depends_on:
       elastic-agent:
         condition: service_healthy
@@ -184,7 +184,7 @@ services:
       - ELASTIC_HOSTS=https://127.0.0.1:9200
 
   logstash_is_ready:
-    image: tianon/true
+    image: tianon/true:multiarch
     depends_on:
       logstash:
         condition: service_healthy

--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -1,7 +1,7 @@
 {{ $username := fact "username" }}
 {{ $password := fact "password" }}
 {{ $apm_enabled := fact "apm_enabled" }}
-version: '2.3'
+version: '2.4'
 services:
   elasticsearch:
     image: "${ELASTICSEARCH_IMAGE_REF}"
@@ -21,7 +21,8 @@ services:
       - "127.0.0.1:9200:9200"
 
   elasticsearch_is_ready:
-    image: tianon/true:multiarch
+    image: tianon/true
+    platform: linux/amd64
     depends_on:
       elasticsearch:
         condition: service_healthy
@@ -50,7 +51,8 @@ services:
       - "127.0.0.1:5601:5601"
 
   kibana_is_ready:
-    image: tianon/true:multiarch
+    image: tianon/true
+    platform: linux/amd64
     depends_on:
       kibana:
         condition: service_healthy
@@ -82,7 +84,8 @@ services:
       - "127.0.0.1:9000:9000"
 
   package-registry_is_ready:
-    image: tianon/true:multiarch
+    image: tianon/true
+    platform: linux/amd64
     depends_on:
       package-registry:
         condition: service_healthy
@@ -122,7 +125,8 @@ services:
       {{ end }}
 
   fleet-server_is_ready:
-    image: tianon/true:multiarch
+    image: tianon/true
+    platform: linux/amd64
     depends_on:
       fleet-server:
         condition: service_healthy
@@ -151,7 +155,8 @@ services:
       target: /run/service_logs/
 
   elastic-agent_is_ready:
-    image: tianon/true:multiarch
+    image: tianon/true
+    platform: linux/amd64
     depends_on:
       elastic-agent:
         condition: service_healthy
@@ -184,7 +189,8 @@ services:
       - ELASTIC_HOSTS=https://127.0.0.1:9200
 
   logstash_is_ready:
-    image: tianon/true:multiarch
+    image: tianon/true
+    platform: linux/amd64
     depends_on:
       logstash:
         condition: service_healthy

--- a/internal/stack/_static/serverless-docker-compose.yml.tmpl
+++ b/internal/stack/_static/serverless-docker-compose.yml.tmpl
@@ -21,7 +21,8 @@ services:
     - "../certs/ca-cert.pem:/etc/ssl/certs/elastic-package.pem"
 
   elastic-agent_is_ready:
-    image: tianon/true:multiarch
+    image: tianon/true
+    platform: linux/amd64
     depends_on:
       elastic-agent:
         condition: service_healthy
@@ -51,7 +52,8 @@ services:
       - ELASTIC_HOSTS={{ fact "elasticsearch_host" }}
 
   logstash_is_ready:
-    image: tianon/true:multiarch
+    image: tianon/true
+    platform: linux/amd64
     depends_on:
       logstash:
         condition: service_healthy

--- a/internal/stack/_static/serverless-docker-compose.yml.tmpl
+++ b/internal/stack/_static/serverless-docker-compose.yml.tmpl
@@ -21,7 +21,7 @@ services:
     - "../certs/ca-cert.pem:/etc/ssl/certs/elastic-package.pem"
 
   elastic-agent_is_ready:
-    image: tianon/true
+    image: tianon/true:multiarch
     depends_on:
       elastic-agent:
         condition: service_healthy
@@ -51,7 +51,7 @@ services:
       - ELASTIC_HOSTS={{ fact "elasticsearch_host" }}
 
   logstash_is_ready:
-    image: tianon/true
+    image: tianon/true:multiarch
     depends_on:
       logstash:
         condition: service_healthy

--- a/internal/stack/_static/serverless-docker-compose.yml.tmpl
+++ b/internal/stack/_static/serverless-docker-compose.yml.tmpl
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.4'
 services:
   elastic-agent:
     image: "{{ fact "agent_image" }}"

--- a/test/packages/parallel/sql_input/_dev/deploy/docker/docker-compose.yml
+++ b/test/packages/parallel/sql_input/_dev/deploy/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.4'
 services:
   sql_input:
     build: .
@@ -9,6 +9,7 @@ services:
       - mysqldata:/var/lib/mysql
   sql_input_is_ready:
     image: tianon/true
+    platform: linux/amd64
     depends_on:
       sql_input:
         condition: service_healthy


### PR DESCRIPTION
When trying to run `elastic-package stack up -v -d` command in Mac (M1/M2), this error was raised for all the services/containers `*_is_ready`:
- `no matching manifest for linux/arm64/v8 in the manifest list entries`

This PR updates the docker-compose version format to 2.4 to be able to set [`format`](https://docs.docker.com/compose/compose-file/compose-file-v2/#platform) and specify `linux/amd64` in those containers.

Closes #1693