### PR TITLE
Update Elastic Package Registry version to v1.23.1

### DIFF
--- a/internal/stack/resources.go
+++ b/internal/stack/resources.go
@@ -43,7 +43,7 @@ const (
 	PackageRegistryConfigFile = "package-registry.yml"
 
 	// PackageRegistryBaseImage is the base Docker image of the Elastic Package Registry.
-	PackageRegistryBaseImage = "docker.elastic.co/package-registry/package-registry:v1.23.0"
+	PackageRegistryBaseImage = "docker.elastic.co/package-registry/package-registry:v1.23.1"
 
 	// ElasticAgentEnvFile is the elastic agent environment variables file.
 	ElasticAgentEnvFile = "elastic-agent.env"


### PR DESCRIPTION
Update Docker tag of Elastic Package Registry to v1.23.1. Automated by [this build](https://buildkite.com/elastic/package-storage-infra-update-package-registry/builds/9).