### PR TITLE
Update branch name label for Terraform

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -16,11 +16,27 @@ export ENVIRONMENT="ci"
 REPO=$(repo_name "${BUILDKITE_REPO}")
 export REPO
 
-# From Jenkins
-# BRANCH_NAME_LOWER_CASE = "${env.BRANCH_NAME.toLowerCase().replaceAll('[^a-z0-9-]', '-')}"
-BRANCH_NAME_LOWER_CASE=$(echo "$BUILDKITE_BRANCH" | tr '[:upper:]' '[:lower:]' | tr '_/\:. ' '-')
+branch_name_label() {
+    local branch="$1"
+
+    if [[ "${BUILDKITE_PULL_REQUEST}" != "false" ]] ; then
+        # remove fork from branch name
+        branch=$(echo $branch | cut -d : -f 2)
+    fi
+
+    # From Jenkins
+    # BRANCH_NAME_LOWER_CASE = "${env.BRANCH_NAME.toLowerCase().replaceAll('[^a-z0-9-]', '-')}"
+    # to lower case and replace characters
+    branch=$(echo "$branch" | tr '[:upper:]' '[:lower:]' | tr '_/\:. ' '-')
+
+    # truncate up to 63 characters limit
+    echo $branch | head -c 63
+}
+
+BRANCH_NAME_LOWER_CASE=$(branch_name_label "$BUILDKITE_BRANCH")
 export BRANCH_NAME_LOWER_CASE
-export BUILD_ID="${BUILDKITE_BUILD_ID}"
+# This variable contains the build number https://buildkite.com/elastic/elastic-package/<number>
+export BUILD_ID="${BUILDKITE_BUILD_NUMBER}"
 # get current timestamp in milliseconds
 # From Jenkins
 # CREATED_DATE = "${new Date().getTime()}"


### PR DESCRIPTION
Update terraform label used for GCP resources

```
terraform-1  | Error: Error creating instance: googleapi: Error 400: Invalid value for field 'resource.labels': ''. Label value 'elastic-dependabot-go-modules-github-com-elastic-package-spec-v3-3-1-2' violates format constraints. The value can only contain lowercase letters, numeric characters, underscores and dashes. The value can be at most 63 characters long. International characters are allowed., invalid
```

Branch variable looks like this:
```
BUILDKITE_BRANCH="elastic:dependabot/go_modules/helm.sh/helm/v3-3.14.1"
```

Tests:

```
 $ branch_name_label "main"
main
 $ branch_name_label "elastic:dependabot/go_modules/github.com/elastic/package-spec/v3-3.1.2"
dependabot-go-modules-github-com-elastic-package-spec-v3-3-1-2
 $ branch_name_label "elastic:dependabot/go_modules/github.com/elastic/package-spec/v3-3.1.2.123456789"
dependabot-go-modules-github-com-elastic-package-spec-v3-3-1-2-
```