### PR TITLE
Fix busy wait loop in benchmark stream

### DIFF
--- a/internal/benchrunner/runners/stream/runner.go
+++ b/internal/benchrunner/runners/stream/runner.go
@@ -206,12 +206,14 @@ func (r *runner) wipeDataStreamsOnSetup() error {
 func (r *runner) run() (err error) {
 	r.streamData()
 
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
 	for {
 		select {
 		case err = <-r.errChanGenerators:
 			close(r.done)
 			return err
-		default:
+		case <-ticker.C:
 			if signal.SIGINT() {
 				close(r.done)
 				return nil


### PR DESCRIPTION
This loop didn't have any blocking condition so it was looping forever consuming a whole CPU.

Introduce a ticker by now. Longer term solution in https://github.com/elastic/elastic-package/pull/1679/files#diff-a08e76793f75adeeac003dac9478256aaca336cd00f8051709949e269a081a54R204