### PR TITLE
Mark flag --benchmark as required in system benchmarks

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -244,6 +244,7 @@ func getRallyCommand() *cobra.Command {
 	cmd.Flags().BoolP(cobraext.BenchCorpusRallyDryRunFlagName, "", false, cobraext.BenchCorpusRallyDryRunFlagDescription)
 	cmd.Flags().StringP(cobraext.BenchCorpusRallyUseCorpusAtPathFlagName, "", "", cobraext.BenchCorpusRallyUseCorpusAtPathFlagDescription)
 	cmd.Flags().StringP(cobraext.BenchCorpusRallyPackageFromRegistryFlagName, "", "", cobraext.BenchCorpusRallyPackageFromRegistryFlagDescription)
+	cmd.MarkFlagRequired(cobraext.BenchNameFlagName)
 
 	return cmd
 }

--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -533,6 +533,7 @@ func getSystemCommand() *cobra.Command {
 	cmd.Flags().DurationP(cobraext.BenchMetricsIntervalFlagName, "", time.Second, cobraext.BenchMetricsIntervalFlagDescription)
 	cmd.Flags().DurationP(cobraext.DeferCleanupFlagName, "", 0, cobraext.DeferCleanupFlagDescription)
 	cmd.Flags().String(cobraext.VariantFlagName, "", cobraext.VariantFlagDescription)
+	cmd.MarkFlagRequired(cobraext.BenchNameFlagName)
 
 	return cmd
 }


### PR DESCRIPTION
The `--benchmark` flag seems to be required in system benchmarks. If not passed, this error is returned:
```
2024/02/23 21:07:45 ERROR Error: running package system benchmarks: could not set up benchmark runner: unable to find system benchmark configuration file: _dev/benchmark/system/.yml: open _dev/benchmark/system/.yml: no such file or directory
```