### PR TITLE
Update URI for gcloud CLI distribution

### DIFF
--- a/internal/servicedeployer/_static/Dockerfile.terraform_deployer
+++ b/internal/servicedeployer/_static/Dockerfile.terraform_deployer
@@ -5,7 +5,7 @@ ENV TERRAFORM_VERSION 1.1.4
 RUN apt-get -qq update \
   && apt-get install -yq curl apt-transport-https ca-certificates gnupg
 
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - \
   && apt-get update -qq \
   && apt-get install google-cloud-sdk=${GCLOUD_SDK_VERSION} -yq


### PR DESCRIPTION
Update URI used to install google cloud SDK (gcloud CLI).
Current documentation uses "https" as scheme in the APT sources: https://cloud.google.com/sdk/docs/install#deb


There were also failing some Buildkite builds when running the command to build the docker image (with "http"):

> 2.460 W: Failed to fetch http://packages.cloud.google.com/apt/dists/cloud-sdk/main/binary-amd64/Packages  502  Bad Gateway [IP: 173.194.74.138 80]
> 2.460 W: Failed to fetch http://packages.cloud.google.com/apt/dists/cloud-sdk/main/binary-all/Packages
> 2.460 W: Some index files failed to download. They have been ignored, or old ones used instead.

https://buildkite.com/elastic/elastic-package/builds/2512#018e09df-6296-47bb-b89d-b0023bbdd022/132-900

Relates #1700 