### PR TITLE
Replace the usage of tianon/true images with docker compose up --wait

### DIFF
--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -20,13 +20,6 @@ services:
     ports:
       - "127.0.0.1:9200:9200"
 
-  elasticsearch_is_ready:
-    image: tianon/true
-    platform: linux/amd64
-    depends_on:
-      elasticsearch:
-        condition: service_healthy
-
   kibana:
     image: "${KIBANA_IMAGE_REF}"
     depends_on:
@@ -49,13 +42,6 @@ services:
       - "./kibana_healthcheck.sh:/usr/share/kibana/healthcheck.sh"
     ports:
       - "127.0.0.1:5601:5601"
-
-  kibana_is_ready:
-    image: tianon/true
-    platform: linux/amd64
-    depends_on:
-      kibana:
-        condition: service_healthy
 
   package-registry:
     build:
@@ -82,13 +68,6 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
       - "127.0.0.1:9000:9000"
-
-  package-registry_is_ready:
-    image: tianon/true
-    platform: linux/amd64
-    depends_on:
-      package-registry:
-        condition: service_healthy
 
   fleet-server:
     image: "${ELASTIC_AGENT_IMAGE_REF}"
@@ -124,13 +103,6 @@ services:
       - "127.0.0.1:8200:8200"
       {{ end }}
 
-  fleet-server_is_ready:
-    image: tianon/true
-    platform: linux/amd64
-    depends_on:
-      fleet-server:
-        condition: service_healthy
-
   elastic-agent:
     image: "${ELASTIC_AGENT_IMAGE_REF}"
     depends_on:
@@ -153,13 +125,6 @@ services:
     - type: bind
       source: ../../../tmp/service_logs/
       target: /run/service_logs/
-
-  elastic-agent_is_ready:
-    image: tianon/true
-    platform: linux/amd64
-    depends_on:
-      elastic-agent:
-        condition: service_healthy
 
 {{ $logstash_enabled := fact "logstash_enabled" }}
 {{ if eq $logstash_enabled "true" }}
@@ -187,11 +152,4 @@ services:
       - ELASTIC_USER=elastic
       - ELASTIC_PASSWORD=changeme
       - ELASTIC_HOSTS=https://127.0.0.1:9200
-
-  logstash_is_ready:
-    image: tianon/true
-    platform: linux/amd64
-    depends_on:
-      logstash:
-        condition: service_healthy
 {{ end }}

--- a/internal/stack/_static/serverless-docker-compose.yml.tmpl
+++ b/internal/stack/_static/serverless-docker-compose.yml.tmpl
@@ -20,13 +20,6 @@ services:
       target: /run/service_logs/
     - "../certs/ca-cert.pem:/etc/ssl/certs/elastic-package.pem"
 
-  elastic-agent_is_ready:
-    image: tianon/true
-    platform: linux/amd64
-    depends_on:
-      elastic-agent:
-        condition: service_healthy
-
 {{ $logstash_enabled := fact "logstash_enabled" }}
 {{ if eq $logstash_enabled "true" }}
   logstash:
@@ -50,11 +43,4 @@ services:
       - ELASTIC_USER={{ fact "username" }}
       - ELASTIC_PASSWORD={{ fact "password" }}
       - ELASTIC_HOSTS={{ fact "elasticsearch_host" }}
-
-  logstash_is_ready:
-    image: tianon/true
-    platform: linux/amd64
-    depends_on:
-      logstash:
-        condition: service_healthy
 {{ end }}

--- a/internal/stack/compose.go
+++ b/internal/stack/compose.go
@@ -69,7 +69,7 @@ func dockerComposeBuild(ctx context.Context, options Options) error {
 			withEnv(stackVariantAsEnv(options.StackVersion)).
 			withEnvs(options.Profile.ComposeEnvVars()).
 			build(),
-		Services: withIsReadyServices(withDependentServices(options.Services)),
+		Services: withDependentServices(options.Services),
 	}
 
 	if err := c.Build(ctx, opts); err != nil {
@@ -95,7 +95,7 @@ func dockerComposePull(ctx context.Context, options Options) error {
 			withEnv(stackVariantAsEnv(options.StackVersion)).
 			withEnvs(options.Profile.ComposeEnvVars()).
 			build(),
-		Services: withIsReadyServices(withDependentServices(options.Services)),
+		Services: withDependentServices(options.Services),
 	}
 
 	if err := c.Pull(ctx, opts); err != nil {
@@ -112,7 +112,7 @@ func dockerComposeUp(ctx context.Context, options Options) error {
 
 	var args []string
 	if options.DaemonMode {
-		args = append(args, "-d")
+		args = append(args, "-d", "--wait", "--wait-timeout", fmt.Sprintf("%d", 600))
 	}
 
 	appConfig, err := install.Configuration()
@@ -127,7 +127,7 @@ func dockerComposeUp(ctx context.Context, options Options) error {
 			withEnvs(options.Profile.ComposeEnvVars()).
 			build(),
 		ExtraArgs: args,
-		Services:  withIsReadyServices(withDependentServices(options.Services)),
+		Services:  withDependentServices(options.Services),
 	}
 
 	if err := c.Up(ctx, opts); err != nil {
@@ -169,18 +169,6 @@ func withDependentServices(services []string) []string {
 		}
 	}
 	return services
-}
-
-func withIsReadyServices(services []string) []string {
-	if len(services) == 0 {
-		return services // load all defined services
-	}
-
-	var allServices []string
-	for _, aService := range services {
-		allServices = append(allServices, aService, fmt.Sprintf("%s_%s", aService, readyServicesSuffix))
-	}
-	return allServices
 }
 
 func dockerComposeStatus(ctx context.Context, options Options) ([]ServiceStatus, error) {

--- a/internal/stack/serverless.go
+++ b/internal/stack/serverless.go
@@ -336,7 +336,7 @@ func (sp *serverlessProvider) startLocalServices(ctx context.Context, options Op
 	}
 
 	if options.DaemonMode {
-		opts.ExtraArgs = append(opts.ExtraArgs, "-d")
+		opts.ExtraArgs = append(opts.ExtraArgs, "-d", "--wait", "--wait-timeout", fmt.Sprintf("%d", 600))
 	}
 	if err := project.Up(ctx, opts); err != nil {
 		// At least starting on 8.6.0, fleet-server may be reconfigured or


### PR DESCRIPTION
After having a look at the code I realised that the `tianon/true` images, as well as the respective docker compose `*_is_ready` services, are required only in the detached mode of `docker compose up`. Specifically, based on the dependencies of services, docker compose will detach when all services are reported as healthy and only `*_is_ready` ones are in the state of `Started`. So `elastic-package stack up -d -v` would look like this image 

<img width="1447" alt="Screenshot 2024-03-13 at 1 28 14 AM" src="https://github.com/elastic/elastic-package/assets/12166023/42a3d590-18c8-48f4-ad16-68374af48221">

Notice that `Done` is being printed while `*_is_ready` services are at `Started`

This PR substitutes the usage of such former services with the built-in `docker compose --wait` for detached mode which results in the following image
<img width="1449" alt="Screenshot 2024-03-13 at 1 41 20 AM" src="https://github.com/elastic/elastic-package/assets/12166023/38e79e2a-9289-461e-b3ba-566f782af618">

Notice that `Done` is being printed when all services are reported `Healthy`

As for the compose up attached mode this essentially remains the same. As before the invocation will immediately transition to the container logs.

Why we should try to avoid `tianon/true` images?! Because many devs employ Apple-silicon macbooks and this will get us a step closer running natively without any ISA emulation. This last bit, assuming this PR will make it, requires only `elastic-package-registry` and `fleet-server` to offer arm64 images and native execution here we go.

As always I may have missed something in my logic above so please feel free to correct me 🙂

This PR closes https://github.com/elastic/elastic-package/issues/1708 (PS: @mrodm I told you in EAH that I didn't open an issue because I wanted to open a PR, but aside joking, thanks for capturing this in an issue 😄)



