### PR TITLE
Use custom shutdown time for service deployer compose

### DIFF
--- a/internal/servicedeployer/compose.go
+++ b/internal/servicedeployer/compose.go
@@ -42,6 +42,8 @@ type DockerComposeServiceDeployerOptions struct {
 type dockerComposeDeployedService struct {
 	ctxt ServiceContext
 
+	shutdownTimeout string // default shutdown timeout 10 seconds
+
 	ymlPaths []string
 	project  string
 	variant  ServiceVariant
@@ -225,9 +227,14 @@ func (s *dockerComposeDeployedService) TearDown() error {
 			s.env,
 			s.variant.Env...),
 	}
+
+	extraArgs := []string{}
+	if s.shutdownTimeout != "" {
+		extraArgs = append(extraArgs, "-t", s.shutdownTimeout)
+	}
 	if err := p.Stop(compose.CommandOptions{
 		Env:       opts.Env,
-		ExtraArgs: []string{"-t", "300"}, // default shutdown timeout 10 seconds
+		ExtraArgs: extraArgs,
 	}); err != nil {
 		return fmt.Errorf("could not stop service using Docker Compose: %w", err)
 	}

--- a/internal/servicedeployer/compose.go
+++ b/internal/servicedeployer/compose.go
@@ -232,8 +232,8 @@ func (s *dockerComposeDeployedService) TearDown() error {
 	extraArgs := []string{}
 	// if not set "-t" , default shutdown timeout is 10 seconds
 	// https://docs.docker.com/compose/faq/#why-do-my-services-take-10-seconds-to-recreate-or-stop
-	if s.shutdownTimeout.Seconds() > 0 {
-		extraArgs = append(extraArgs, "-t", fmt.Sprintf("%d", int(math.Round(s.shutdownTimeout.Seconds()))))
+	if seconds := s.shutdownTimeout.Seconds(); seconds > 0 {
+		extraArgs = append(extraArgs, "-t", fmt.Sprintf("%d", int(math.Round(seconds))))
 	}
 	if err := p.Stop(compose.CommandOptions{
 		Env:       opts.Env,

--- a/internal/servicedeployer/compose.go
+++ b/internal/servicedeployer/compose.go
@@ -6,6 +6,7 @@ package servicedeployer
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"time"
@@ -42,7 +43,7 @@ type DockerComposeServiceDeployerOptions struct {
 type dockerComposeDeployedService struct {
 	ctxt ServiceContext
 
-	shutdownTimeout string // default shutdown timeout 10 seconds
+	shutdownTimeout time.Duration
 
 	ymlPaths []string
 	project  string
@@ -229,8 +230,10 @@ func (s *dockerComposeDeployedService) TearDown() error {
 	}
 
 	extraArgs := []string{}
-	if s.shutdownTimeout != "" {
-		extraArgs = append(extraArgs, "-t", s.shutdownTimeout)
+	// if not set "-t" , default shutdown timeout is 10 seconds
+	// https://docs.docker.com/compose/faq/#why-do-my-services-take-10-seconds-to-recreate-or-stop
+	if s.shutdownTimeout.Seconds() > 0 {
+		extraArgs = append(extraArgs, "-t", fmt.Sprintf("%d", int(math.Round(s.shutdownTimeout.Seconds()))))
 	}
 	if err := p.Stop(compose.CommandOptions{
 		Env:       opts.Env,

--- a/internal/servicedeployer/terraform.go
+++ b/internal/servicedeployer/terraform.go
@@ -106,9 +106,10 @@ func (tsd TerraformServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedServic
 	tfEnvironment := tsd.buildTerraformExecutorEnvironment(inCtxt)
 
 	service := dockerComposeDeployedService{
-		ymlPaths: ymlPaths,
-		project:  "elastic-package-service",
-		env:      tfEnvironment,
+		ymlPaths:        ymlPaths,
+		project:         "elastic-package-service",
+		env:             tfEnvironment,
+		shutdownTimeout: "300",
 	}
 	outCtxt := inCtxt
 

--- a/internal/servicedeployer/terraform.go
+++ b/internal/servicedeployer/terraform.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/elastic/go-resource"
 
@@ -109,7 +110,7 @@ func (tsd TerraformServiceDeployer) SetUp(inCtxt ServiceContext) (DeployedServic
 		ymlPaths:        ymlPaths,
 		project:         "elastic-package-service",
 		env:             tfEnvironment,
-		shutdownTimeout: "300",
+		shutdownTimeout: 300 * time.Second,
 	}
 	outCtxt := inCtxt
 


### PR DESCRIPTION
Set the shutdown timeout in docker-compose stop and docker-compose down customizable depending on the service deployer used.

Difference in times for `ti_anomali` test package:
- Before approx. 18 min:  https://buildkite.com/elastic/elastic-package/builds/2596#018e3955-cafd-45f0-ac31-e2faec7ded0d
- In this PR 9 min:  https://buildkite.com/elastic/elastic-package/builds/2606#018e3d1c-ebdc-4e50-9140-e940dba84cce

For packages using terraform, it still uses the timeout of 300 seconds:

https://buildkite.com/elastic/elastic-package/builds/2606#018e3d1c-ebdf-4d9c-bbfe-2ce7864a2bb5/115-1105