### PR TITLE
Add platform package-registry container

### DIFF
--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -63,6 +63,8 @@ services:
       dockerfile: "./profiles/${PROFILE_NAME}/stack/Dockerfile.package-registry"
       args:
         PROFILE: "${PROFILE_NAME}"
+      platforms:
+        - linux/amd64
     platform: linux/amd64
     healthcheck:
       test: ["CMD", "curl", "--cacert", "/etc/ssl/package-registry/ca-cert.pem", "-f", "https://localhost:8080"]

--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -63,6 +63,7 @@ services:
       dockerfile: "./profiles/${PROFILE_NAME}/stack/Dockerfile.package-registry"
       args:
         PROFILE: "${PROFILE_NAME}"
+    platform: linux/amd64
     healthcheck:
       test: ["CMD", "curl", "--cacert", "/etc/ssl/package-registry/ca-cert.pem", "-f", "https://localhost:8080"]
       start_period: 300s


### PR DESCRIPTION
Add platform `linux/amd64` as platform in Elastic Package Registry container, to avoid errors like this:
> The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8


This is following the same approach as it was done for `tianon/true` docker images #1694 

It's likely that this change could be removed if this PR is merged: https://github.com/elastic/package-registry/pull/1162