### PR TITLE
Handle detection of upgraded shell

### DIFF
--- a/internal/stack/shellinit.go
+++ b/internal/stack/shellinit.go
@@ -109,8 +109,16 @@ func helpText(shell string) string {
 
 func getShellName(exe string) string {
 	shell := filepath.Base(exe)
-	// NOTE: remove .exe extension from executable names present in Windows
-	shell = strings.TrimSuffix(shell, ".exe")
+	cleanSuffixes := []string{
+		// Remove .exe extension from executable names present in Windows.
+		".exe",
+		// Remove " (deleted)", that can appear here if the shell process has been
+		// replaced by an upgrade in Linux while the terminal was open.
+		" (deleted)",
+	}
+	for _, suffix := range cleanSuffixes {
+		shell = strings.TrimSuffix(shell, suffix)
+	}
 	return shell
 }
 

--- a/internal/stack/shellinit_internal_test.go
+++ b/internal/stack/shellinit_internal_test.go
@@ -5,6 +5,7 @@
 package stack
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -44,13 +45,22 @@ func Test_getShellName(t *testing.T) {
 	type args struct {
 		exe string
 	}
-	tests := []struct {
+	type testCase struct {
 		name string
 		args args
 		want string
-	}{
-		{"linux exec", args{exe: "bash"}, "bash"},
-		{"windows exec", args{exe: "cmd.exe"}, "cmd"},
+	}
+	var tests []testCase
+	if filepath.Separator == '\\' {
+		tests = []testCase{
+			{"windows exec", args{exe: `C:\Windows\System32\cmd.exe`}, "cmd"},
+		}
+	} else {
+		tests = []testCase{
+			{"linux exec", args{exe: "/usr/bin/bash"}, "bash"},
+			{"linux upgraded exec", args{exe: "/usr/bin/bash (deleted)"}, "bash"},
+			{"windows exec", args{exe: `C:/Windows/System32/cmd.exe`}, "cmd"},
+		}
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/stack/shellinit_internal_test.go
+++ b/internal/stack/shellinit_internal_test.go
@@ -53,12 +53,14 @@ func Test_getShellName(t *testing.T) {
 	var tests []testCase
 	if filepath.Separator == '\\' {
 		tests = []testCase{
+			{"windows relative path", args{exe: `cmd.exe`}, "cmd"}, // Not sure if this case is real.
 			{"windows exec", args{exe: `C:\Windows\System32\cmd.exe`}, "cmd"},
 		}
 	} else {
 		tests = []testCase{
 			{"linux exec", args{exe: "/usr/bin/bash"}, "bash"},
 			{"linux upgraded exec", args{exe: "/usr/bin/bash (deleted)"}, "bash"},
+			{"windows relative path", args{exe: `cmd.exe`}, "cmd"}, // Not sure if this case is real.
 			{"windows exec", args{exe: `C:/Windows/System32/cmd.exe`}, "cmd"},
 		}
 	}


### PR DESCRIPTION
If a shell process is upgraded in Linux, the link in the proc file system breaks. In this case the link can be resolved in some cases with the `(deleted)` suffix message. This is what happens with the library we use to get information from processes.

In these cases the output of `elastic-package stack shellinit` looks like that:
```sh
 $ elastic-package stack shellinit
Detected shell: bash (deleted)
Error: shellinit failed: cannot get shell init template: shell type is unknown, should be one of bash, dash, fish, sh, zsh, pwsh, 
```

Handle these cases by removing the `(deleted)` suffix.