### PR TITLE
feat: introduce multiarch tianon images

### DIFF
--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -21,8 +21,7 @@ services:
       - "127.0.0.1:9200:9200"
 
   elasticsearch_is_ready:
-    image: tianon/true
-    platform: linux/amd64
+    image: tianon/true:multiarch
     depends_on:
       elasticsearch:
         condition: service_healthy
@@ -51,8 +50,7 @@ services:
       - "127.0.0.1:5601:5601"
 
   kibana_is_ready:
-    image: tianon/true
-    platform: linux/amd64
+    image: tianon/true:multiarch
     depends_on:
       kibana:
         condition: service_healthy
@@ -84,8 +82,7 @@ services:
       - "127.0.0.1:9000:9000"
 
   package-registry_is_ready:
-    image: tianon/true
-    platform: linux/amd64
+    image: tianon/true:multiarch
     depends_on:
       package-registry:
         condition: service_healthy
@@ -125,8 +122,7 @@ services:
       {{ end }}
 
   fleet-server_is_ready:
-    image: tianon/true
-    platform: linux/amd64
+    image: tianon/true:multiarch
     depends_on:
       fleet-server:
         condition: service_healthy
@@ -155,8 +151,7 @@ services:
       target: /run/service_logs/
 
   elastic-agent_is_ready:
-    image: tianon/true
-    platform: linux/amd64
+    image: tianon/true:multiarch
     depends_on:
       elastic-agent:
         condition: service_healthy
@@ -189,8 +184,7 @@ services:
       - ELASTIC_HOSTS=https://127.0.0.1:9200
 
   logstash_is_ready:
-    image: tianon/true
-    platform: linux/amd64
+    image: tianon/true:multiarch
     depends_on:
       logstash:
         condition: service_healthy

--- a/internal/stack/_static/serverless-docker-compose.yml.tmpl
+++ b/internal/stack/_static/serverless-docker-compose.yml.tmpl
@@ -21,8 +21,7 @@ services:
     - "../certs/ca-cert.pem:/etc/ssl/certs/elastic-package.pem"
 
   elastic-agent_is_ready:
-    image: tianon/true
-    platform: linux/amd64
+    image: tianon/true:multiarch
     depends_on:
       elastic-agent:
         condition: service_healthy
@@ -52,8 +51,7 @@ services:
       - ELASTIC_HOSTS={{ fact "elasticsearch_host" }}
 
   logstash_is_ready:
-    image: tianon/true
-    platform: linux/amd64
+    image: tianon/true:multiarch
     depends_on:
       logstash:
         condition: service_healthy

--- a/test/packages/parallel/sql_input/_dev/deploy/docker/docker-compose.yml
+++ b/test/packages/parallel/sql_input/_dev/deploy/docker/docker-compose.yml
@@ -8,8 +8,7 @@ services:
       - ${SERVICE_LOGS_DIR}/sql_input:/var/log/mysql
       - mysqldata:/var/lib/mysql
   sql_input_is_ready:
-    image: tianon/true
-    platform: linux/amd64
+    image: tianon/true:multiarch
     depends_on:
       sql_input:
         condition: service_healthy


### PR DESCRIPTION
this PR alternates the used `tianon/true` images to point at the multiarch tag and thus allow native execution on amd64 and arm64 archs