### PR TITLE
Use rerefence to update terraform outputs in serviceInfo struct

### DIFF
--- a/internal/servicedeployer/terraform.go
+++ b/internal/servicedeployer/terraform.go
@@ -48,7 +48,7 @@ type TerraformServiceDeployer struct {
 // addTerraformOutputs method reads the terraform outputs generated in the json format and
 // adds them to the custom properties of ServiceInfo and can be used in the handlebars template
 // like `{{TF_OUTPUT_queue_url}}` where `queue_url` is the output configured
-func addTerraformOutputs(svcInfo ServiceInfo) error {
+func addTerraformOutputs(svcInfo *ServiceInfo) error {
 	// Read the `output.json` file where terraform outputs are generated
 	outputFile := filepath.Join(svcInfo.OutputDir, terraformOutputJsonFile)
 	content, err := os.ReadFile(outputFile)
@@ -159,7 +159,7 @@ func (tsd TerraformServiceDeployer) SetUp(ctx context.Context, svcInfo ServiceIn
 
 	svcInfo.Agent.Host.NamePrefix = "docker-fleet-agent"
 
-	err = addTerraformOutputs(svcInfo)
+	err = addTerraformOutputs(&svcInfo)
 	if err != nil {
 		return nil, fmt.Errorf("could not handle terraform output: %w", err)
 	}

--- a/internal/servicedeployer/terraform_test.go
+++ b/internal/servicedeployer/terraform_test.go
@@ -65,6 +65,29 @@ func TestAddTerraformOutputs(t *testing.T) {
 			},
 		},
 		{
+			testName: "add_single_value_output",
+			runId:    "99999",
+			svcInfo: ServiceInfo{
+				Test: struct{ RunID string }{"99999"},
+				CustomProperties: map[string]interface{}{
+					"TF_foo": "bar",
+				},
+			},
+			content: []byte(
+				`{
+				"queue_url": {
+				  "sensitive": false,
+				  "type": "string",
+				  "value": "https://sqs.us-east-1.amazonaws.com/1234654/elastic-package-aws-logs-queue-someId"
+				}
+			   }`,
+			),
+			expectedProps: map[string]interface{}{
+				"TF_OUTPUT_queue_url": "https://sqs.us-east-1.amazonaws.com/1234654/elastic-package-aws-logs-queue-someId",
+				"TF_foo":              "bar",
+			},
+		},
+		{
 			testName: "multiple_value_output",
 			runId:    "23465",
 			svcInfo: ServiceInfo{
@@ -138,7 +161,10 @@ func TestAddTerraformOutputs(t *testing.T) {
 	for _, tc := range testCases {
 
 		t.Run(tc.testName, func(t *testing.T) {
-			tc.svcInfo.CustomProperties = make(map[string]interface{})
+			if tc.svcInfo.CustomProperties == nil {
+				tc.svcInfo.CustomProperties = make(map[string]interface{})
+			}
+
 			tc.svcInfo.OutputDir = t.TempDir()
 
 			if err := os.WriteFile(tc.svcInfo.OutputDir+"/tfOutputValues.json", tc.content, 0777); err != nil {
@@ -146,7 +172,7 @@ func TestAddTerraformOutputs(t *testing.T) {
 			}
 
 			// Test that the terraform output values are generated correctly
-			err := addTerraformOutputs(tc.svcInfo)
+			err := addTerraformOutputs(&tc.svcInfo)
 			if tc.expectedError {
 				require.Error(t, err)
 				return

--- a/internal/servicedeployer/terraform_test.go
+++ b/internal/servicedeployer/terraform_test.go
@@ -31,7 +31,7 @@ func TestAddTerraformOutputs(t *testing.T) {
 			content: []byte(
 				``,
 			),
-			expectedProps: map[string]interface{}{},
+			expectedProps: nil,
 			expectedError: true,
 		},
 		{
@@ -43,7 +43,7 @@ func TestAddTerraformOutputs(t *testing.T) {
 			content: []byte(
 				`{}`,
 			),
-			expectedProps: map[string]interface{}{},
+			expectedProps: nil,
 		},
 		{
 			testName: "single_value_output",
@@ -161,10 +161,6 @@ func TestAddTerraformOutputs(t *testing.T) {
 	for _, tc := range testCases {
 
 		t.Run(tc.testName, func(t *testing.T) {
-			if tc.svcInfo.CustomProperties == nil {
-				tc.svcInfo.CustomProperties = make(map[string]interface{})
-			}
-
 			tc.svcInfo.OutputDir = t.TempDir()
 
 			if err := os.WriteFile(tc.svcInfo.OutputDir+"/tfOutputValues.json", tc.content, 0777); err != nil {


### PR DESCRIPTION
This PR updates `addTerraformOutputs` to use reference instead of value parameter.

It also removes an unnecessary temporal variable (`outCtxt`).