### PR TITLE
Allow to run multiple independent agents in kubernetes

### DIFF
--- a/internal/agentdeployer/_static/elastic-agent-managed.yaml.tmpl
+++ b/internal/agentdeployer/_static/elastic-agent-managed.yaml.tmpl
@@ -9,14 +9,14 @@ data:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: elastic-agent
+  name: {{ .agentName }}
   namespace: kube-system
   labels:
-    app: elastic-agent
+    app:  {{ .agentName }}
 spec:
   selector:
     matchLabels:
-      app: elastic-agent
+      app: {{ .agentName }}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -25,12 +25,12 @@ spec:
   template:
     metadata:
       labels:
-        app: elastic-agent
+        app: {{ .agentName }}
     spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-      serviceAccountName: elastic-agent
+      serviceAccountName: {{ .agentName }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:
@@ -143,50 +143,50 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: elastic-agent
+  name: {{ .agentName }}
 subjects:
   - kind: ServiceAccount
-    name: elastic-agent
+    name: {{ .agentName }}
     namespace: kube-system
 roleRef:
   kind: ClusterRole
-  name: elastic-agent
+  name: {{ .agentName }}
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: kube-system
-  name: elastic-agent
+  name: {{ .agentName }}
 subjects:
   - kind: ServiceAccount
-    name: elastic-agent
+    name: {{ .agentName }}
     namespace: kube-system
 roleRef:
   kind: Role
-  name: elastic-agent
+  name: {{ .agentName }}
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: elastic-agent-kubeadm-config
+  name: {{ .agentName }}-kubeadm-config
   namespace: kube-system
 subjects:
   - kind: ServiceAccount
-    name: elastic-agent
+    name: {{ .agentName }}
     namespace: kube-system
 roleRef:
   kind: Role
-  name: elastic-agent-kubeadm-config
+  name: {{ .agentName }}-kubeadm-config
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: elastic-agent
+  name: {{ .agentName }}
   labels:
-    k8s-app: elastic-agent
+    k8s-app: {{ .agentName }}
 rules:
   - apiGroups: [""]
     resources:
@@ -256,11 +256,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: elastic-agent
+  name: {{ .agentName }}
   # should be the namespace where elastic-agent is running
   namespace: kube-system
   labels:
-    k8s-app: elastic-agent
+    k8s-app: {{ .agentName }}
 rules:
   - apiGroups:
       - coordination.k8s.io
@@ -271,10 +271,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: elastic-agent-kubeadm-config
+  name: {{ .agentName }}-kubeadm-config
   namespace: kube-system
   labels:
-    k8s-app: elastic-agent
+    k8s-app: {{ .agentName }}
 rules:
   - apiGroups: [""]
     resources:
@@ -286,8 +286,8 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: elastic-agent
+  name: {{ .agentName }}
   namespace: kube-system
   labels:
-    k8s-app: elastic-agent
+    k8s-app: {{ .agentName }}
 ---

--- a/internal/agentdeployer/factory.go
+++ b/internal/agentdeployer/factory.go
@@ -115,6 +115,7 @@ func Factory(options FactoryOptions) (AgentDeployer, error) {
 				DefinitionsDir: agentDeployerPath,
 				StackVersion:   options.StackVersion,
 				PolicyName:     options.PolicyName,
+				DataStream:     options.DataStream,
 				RunSetup:       options.RunSetup,
 				RunTestsOnly:   options.RunTestsOnly,
 				RunTearDown:    options.RunTearDown,


### PR DESCRIPTION
Relates #787 
Follows #1724

Allow to run several independent agents in kubernetes. For that, agent name daemonset (and related resources) have been named adding the Data Stream and agent Run ID as suffixes. All these Elastic Agent are run in the same `kube-system` namespace.

It could be added each elastic agent in a different namespace. But this would require to update current packages. It would require to update the `kube-state-metrics` service URL in the test system configuration since they are running in different namespaces. For instance in the test package from this repository, these changes would be required:

```diff
diff --git test/packages/with-kind/kubernetes/data_stream/state_cronjob/_dev/test/system/test-default-config.yml test/packages/with-kind/kubernetes/data_stream/state_cronjob/_dev/test/system/test-default-config.yml
index 0f4bd620..ec4b9f3a 100644
--- test/packages/with-kind/kubernetes/data_stream/state_cronjob/_dev/test/system/test-default-config.yml
+++ test/packages/with-kind/kubernetes/data_stream/state_cronjob/_dev/test/system/test-default-config.yml
@@ -3,4 +3,4 @@ data_stream:
   vars:
     hosts:
       # this is the DNS name of the k8s service for kube-state-metrics deployment
-      - http://kube-state-metrics:8080
+      - http://kube-state-metrics.kube-system:8080
diff --git test/packages/with-kind/kubernetes/data_stream/state_pod/_dev/test/system/test-default-config.yml test/packages/with-kind/kubernetes/data_stream/state_pod/_dev/test/system/test-default-config.yml
index 0f4bd620..ec4b9f3a 100644
--- test/packages/with-kind/kubernetes/data_stream/state_pod/_dev/test/system/test-default-config.yml
+++ test/packages/with-kind/kubernetes/data_stream/state_pod/_dev/test/system/test-default-config.yml
@@ -3,4 +3,4 @@ data_stream:
   vars:
     hosts:
       # this is the DNS name of the k8s service for kube-state-metrics deployment
-      - http://kube-state-metrics:8080
+      - http://kube-state-metrics.kube-system:8080
```