### PR TITLE
Properly disable Logstash monitoring after recent Logstash docker changes.

### DIFF
--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -178,7 +178,7 @@ services:
        - "127.0.0.1:5044:5044"
        - "127.0.0.1:9600:9600"
     environment:
-      - xpack.monitoring.enabled=false
+      - XPACK_MONITORING_ENABLED=false
       - ELASTIC_USER=elastic
       - ELASTIC_PASSWORD=changeme
       - ELASTIC_HOSTS=https://127.0.0.1:9200


### PR DESCRIPTION
### Description

Recently, Logstash docker side has number of changes which caused the docker container crash when `elastic-package` spins. There are several related changes but this PR properly sets the ENV var for disabling the monitoring.
- https://github.com/elastic/logstash/pull/15980
- https://github.com/elastic/logstash/pull/14364
- https://github.com/elastic/logstash/pull/16026

This is a short term fix to bring all CIs 🟢. I will deep dive to see if we have potential long term solution. Quick thought is, it seems `Dockerfile.logstash` needs to pass params now and we don't need this file anymore since we bundled the `elastic_integration` plugin.