### PR TITLE
Remove created agents in service deployer

### DIFF
--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -111,7 +111,7 @@ type runner struct {
 	serviceStateFilePath string
 
 	// Execution order of following handlers is defined in runner.TearDown() method.
-	unenrollAgentHandler      func(context.Context) error
+	removeAgentHandler        func(context.Context) error
 	deleteTestPolicyHandler   func(context.Context) error
 	deletePackageHandler      func(context.Context) error
 	resetAgentPolicyHandler   func(context.Context) error
@@ -374,11 +374,11 @@ func (r *runner) tearDownTest(ctx context.Context) error {
 		r.resetAgentLogLevelHandler = nil
 	}
 
-	if r.unenrollAgentHandler != nil {
-		if err := r.unenrollAgentHandler(cleanupCtx); err != nil {
+	if r.removeAgentHandler != nil {
+		if err := r.removeAgentHandler(cleanupCtx); err != nil {
 			return err
 		}
-		r.unenrollAgentHandler = nil
+		r.removeAgentHandler = nil
 	}
 
 	if r.deleteTestPolicyHandler != nil {
@@ -933,7 +933,7 @@ func (r *runner) prepareScenario(ctx context.Context, config *testConfig, svcInf
 	agent := agents[0]
 	logger.Debugf("Selected enrolled agent %q", agent.ID)
 
-	r.unenrollAgentHandler = func(ctx context.Context) error {
+	r.removeAgentHandler = func(ctx context.Context) error {
 		// When not using independent agents, service deployers like kubernetes or custom agents create new Elastic Agent
 		createdNewAgent := svcInfo.Agent.Host.NamePrefix == "docker-custom-agent" || svcInfo.Agent.Host.NamePrefix == "kind-control-plane"
 		if !r.options.RunIndependentElasticAgent && !createdNewAgent {


### PR DESCRIPTION
Part of #787

Currently, service deployers like `custom_agent` or `kubernetes` create new Elastic Agent instances and those agents are never removed (or unenrolled) from Fleet once the tests are finished (system tests).

This PR removes these Elastic Agents created during tests from Fleet, so the stack state after running the tests is always without those Elastic Agents.