### PR TITLE
Fix validation of empty numeric keywords arrays with normalization

### DIFF
--- a/internal/fields/testdata/fields/fields.yml
+++ b/internal/fields/testdata/fields/fields.yml
@@ -3,6 +3,10 @@
   fields:
     - name: code
       type: keyword
+    - name: pid
+      type: keyword
+    - name: ppid
+      type: keyword
     - name: flattened
       type: group
       fields:
@@ -78,3 +82,7 @@
   multi_fields:
     - name: text
       type: text
+- name: tags
+  type: keyword
+  normalize:
+    - array

--- a/internal/fields/testdata/numeric.json
+++ b/internal/fields/testdata/numeric.json
@@ -1,11 +1,14 @@
 {
   "foo": {
     "code": 42,
+    "pid": [345, 678, 901],
+    "ppid": [],
     "flattened": {
       "request_parameters": {
         "userName": "Bob",
         "groupName": "admin"
       }
     }
-  }
+  },
+  "tags": []
 }

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -66,7 +66,13 @@ func TestValidate_WithFlattenedFields(t *testing.T) {
 
 func TestValidate_WithNumericKeywordFields(t *testing.T) {
 	validator, err := CreateValidatorForDirectory("testdata",
-		WithNumericKeywordFields([]string{"foo.code"}),
+		WithNumericKeywordFields([]string{
+			"foo.code", // Contains a number.
+			"foo.pid",  // Contains an array of numbers.
+			"foo.ppid", // Contains an empty array.
+			"tags",     // Contains an empty array, and expects normalization as array.
+		}),
+		WithSpecVersion("2.3.0"), // Needed to validate normalization.
 		WithDisabledDependencyManagement())
 	require.NoError(t, err)
 	require.NotNil(t, validator)


### PR DESCRIPTION
Fixes issues happening when validating fields defined as numeric keywords with array normalization, and documents can contain empty arrays.

Arrays of numeric keywords are converted to arrays of strings, instead of a string of the array.

This fixes validation issues like this one where the empty array should be valid:
```
field "tags" is not normalized as expected: expected array, found "[]" (string)
```

Related to https://github.com/elastic/elastic-package/pull/1746.