### PR TITLE
Reduce verbosity when checking if package embeds ECS

### DIFF
--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -320,7 +320,7 @@ func initDependencyManagement(packageRoot string, specVersion semver.Version, im
 		if err != nil {
 			return nil, nil, err
 		}
-		logger.Debug("Imported ECS fields definition from external schema for validation (package: %v, stack: %v)", packageEmbedsEcsMappings, stackSupportsEcsMapping)
+		logger.Debugf("Imported ECS fields definition from external schema for validation (package: %v, stack: %v)", packageEmbedsEcsMappings, stackSupportsEcsMapping)
 		schema = ecsSchema
 	}
 

--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -320,7 +320,7 @@ func initDependencyManagement(packageRoot string, specVersion semver.Version, im
 		if err != nil {
 			return nil, nil, err
 		}
-		logger.Debugf("Imported ECS fields definition from external schema for validation (package: %v, stack: %v)", packageEmbedsEcsMappings, stackSupportsEcsMapping)
+		logger.Debugf("Imported ECS fields definition from external schema for validation (embedded in package: %v, stack uses ecs@mappings template: %v)", packageEmbedsEcsMappings, stackSupportsEcsMapping)
 		schema = ecsSchema
 	}
 

--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -303,9 +303,6 @@ func initDependencyManagement(packageRoot string, specVersion semver.Version, im
 
 	// Check if the package embeds ECS mappings
 	packageEmbedsEcsMappings := buildManifest.ImportMappings() && !specVersion.LessThan(semver2_3_0)
-	if !packageEmbedsEcsMappings {
-		logger.Debugf("Package does not embed ECS mappings")
-	}
 
 	// Check if all stack versions support ECS mappings
 	stackSupportsEcsMapping, err := supportsECSMappings(packageRoot)
@@ -323,7 +320,7 @@ func initDependencyManagement(packageRoot string, specVersion semver.Version, im
 		if err != nil {
 			return nil, nil, err
 		}
-		logger.Debug("Imported ECS fields definition from external schema for validation")
+		logger.Debug("Imported ECS fields definition from external schema for validation (package: %v, stack: %v)", packageEmbedsEcsMappings, stackSupportsEcsMapping)
 		schema = ecsSchema
 	}
 


### PR DESCRIPTION
We are logging now `Package does not embed ECS mappings` every time we check if we should embed ECS mappings because they are referenced in the package.
This is not so relevant because the final reason to import ECS schema during validation depends on two other variables at the moment, but it sometimes floods the logs. For example when running the pipeline tests of the Azure package, this line is printed [33 times in a row](https://buildkite.com/elastic/integrations/builds/10450#018ee48b-d9f0-4ff5-ae38-260bdaaeedd4/857-945), and is not deterministic on its own for the actual result.

This change removes this debug log, and when the mappings are effectively considered for fields validation, the possible reasons for importing are printed too.