### PR TITLE
Replace agent names in condition to remove agent handler

### DIFF
--- a/internal/servicedeployer/custom_agent.go
+++ b/internal/servicedeployer/custom_agent.go
@@ -189,6 +189,7 @@ func (d *CustomAgentDeployer) SetUp(ctx context.Context, svcInfo ServiceInfo) (D
 		svcInfo.Port = svcInfo.Ports[0]
 	}
 
+	svcInfo.Agent.Independent = true
 	svcInfo.Agent.Host.NamePrefix = svcInfo.Name
 	service.svcInfo = svcInfo
 	return &service, nil

--- a/internal/servicedeployer/info.go
+++ b/internal/servicedeployer/info.go
@@ -63,6 +63,10 @@ type ServiceInfo struct {
 			// Name prefix for the host's name
 			NamePrefix string
 		}
+
+		// Independent indicates whether or not the Agent assigned to this service is set
+		// independently from the Elastic Agent running in the stack (elastic-package stack up)
+		Independent bool
 	}
 
 	// CustomProperties store additional data used to boot up the service, e.g. AWS credentials.

--- a/internal/servicedeployer/kubernetes.go
+++ b/internal/servicedeployer/kubernetes.go
@@ -159,6 +159,7 @@ func (ksd KubernetesServiceDeployer) SetUp(ctx context.Context, svcInfo ServiceI
 		}
 	}
 
+	svcInfo.Agent.Independent = true
 	svcInfo.Name = kind.ControlPlaneContainerName
 	svcInfo.Hostname = kind.ControlPlaneContainerName
 	// kind-control-plane is the name of the kind host where Pod is running since we use hostNetwork setting

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -340,6 +340,8 @@ func (r *runner) createServiceInfo() (servicedeployer.ServiceInfo, error) {
 		svcInfo.OutputDir = outputDir
 	}
 
+	svcInfo.Agent.Independent = false
+
 	return svcInfo, nil
 }
 
@@ -935,8 +937,7 @@ func (r *runner) prepareScenario(ctx context.Context, config *testConfig, svcInf
 
 	r.removeAgentHandler = func(ctx context.Context) error {
 		// When not using independent agents, service deployers like kubernetes or custom agents create new Elastic Agent
-		createdNewAgent := svcInfo.Agent.Host.NamePrefix == "docker-custom-agent" || svcInfo.Agent.Host.NamePrefix == "kind-control-plane"
-		if !r.options.RunIndependentElasticAgent && !createdNewAgent {
+		if !r.options.RunIndependentElasticAgent && !svcInfo.Agent.Independent {
 			return nil
 		}
 		logger.Debug("removing agent...")


### PR DESCRIPTION
Follows #1771 

This PR removes the usage of Elastic Agent names as part of the condition used in the remove Agent handler.

A new field is added in the `Info` struct to set whether or not that service uses an independent Elastic Agent. Currently, this happens for packages using custom and k8s agents.