### PR TITLE
Restore append before checking error

### DIFF
--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -365,11 +365,15 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 				RunTestsOnly:               runTestsOnly,
 				RunIndependentElasticAgent: runIndependentElasticAgent,
 			})
+
+			// Results must be appended even if there is an error, since there could be
+			// tests (e.g. system tests) that return both error and results.
+			results = append(results, r...)
+
 			if err != nil {
 				return fmt.Errorf("error running package %s tests: %w", testType, err)
 			}
 
-			results = append(results, r...)
 		}
 
 		format := testrunner.TestReportFormat(reportFormat)


### PR DESCRIPTION
Restore appending results even if there is an error.

For instance, system tests could exit using `result.WithError()` method and that method could return both results and error:
https://github.com/elastic/elastic-package/blob/6eda8fe74f7d014cfbbc49a382f4c3096f1cb98b/internal/testrunner/testrunner.go#L145