### PR TITLE
Add context to Elasticsearch calls

### DIFF
--- a/internal/benchrunner/runners/pipeline/benchmark.go
+++ b/internal/benchrunner/runners/pipeline/benchmark.go
@@ -5,6 +5,7 @@
 package pipeline
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -75,9 +76,9 @@ func (p BenchmarkValue) String() (r string) {
 	return r
 }
 
-func (r *runner) benchmarkPipeline(b *benchmark, entryPipeline string) (*BenchmarkResult, error) {
+func (r *runner) benchmarkPipeline(ctx context.Context, b *benchmark, entryPipeline string) (*BenchmarkResult, error) {
 	// Run benchmark
-	bench, err := r.benchmarkIngest(b, entryPipeline)
+	bench, err := r.benchmarkIngest(ctx, b, entryPipeline)
 	if err != nil {
 		return nil, fmt.Errorf("failed running benchmark: %w", err)
 	}
@@ -196,9 +197,9 @@ type ingestResult struct {
 	numDocs   int
 }
 
-func (r *runner) benchmarkIngest(b *benchmark, entryPipeline string) (ingestResult, error) {
+func (r *runner) benchmarkIngest(ctx context.Context, b *benchmark, entryPipeline string) (ingestResult, error) {
 	baseDocs := resizeDocs(b.events, b.config.NumDocs)
-	return r.runSingleBenchmark(entryPipeline, baseDocs)
+	return r.runSingleBenchmark(ctx, entryPipeline, baseDocs)
 }
 
 type processorPerformance struct {
@@ -298,12 +299,12 @@ func (agg aggregation) collect(fn mapFn) ([]BenchmarkValue, error) {
 	return r, nil
 }
 
-func (r *runner) runSingleBenchmark(entryPipeline string, docs []json.RawMessage) (ingestResult, error) {
+func (r *runner) runSingleBenchmark(ctx context.Context, entryPipeline string, docs []json.RawMessage) (ingestResult, error) {
 	if len(docs) == 0 {
 		return ingestResult{}, errors.New("no docs supplied for benchmark")
 	}
 
-	if _, err := ingest.SimulatePipeline(r.options.API, entryPipeline, docs, "test-generic-default"); err != nil {
+	if _, err := ingest.SimulatePipeline(ctx, r.options.API, entryPipeline, docs, "test-generic-default"); err != nil {
 		return ingestResult{}, fmt.Errorf("simulate failed: %w", err)
 	}
 

--- a/internal/benchrunner/runners/pipeline/runner.go
+++ b/internal/benchrunner/runners/pipeline/runner.go
@@ -58,7 +58,7 @@ func (r *runner) SetUp(ctx context.Context) error {
 
 // TearDown shuts down the pipeline benchmark runner.
 func (r *runner) TearDown(ctx context.Context) error {
-	if err := ingest.UninstallPipelines(r.options.API, r.pipelines); err != nil {
+	if err := ingest.UninstallPipelines(ctx, r.options.API, r.pipelines); err != nil {
 		return fmt.Errorf("uninstalling ingest pipelines failed: %w", err)
 	}
 	return nil
@@ -66,16 +66,16 @@ func (r *runner) TearDown(ctx context.Context) error {
 
 // Run runs the pipeline benchmarks defined under the given folder
 func (r *runner) Run(ctx context.Context) (reporters.Reportable, error) {
-	return r.run()
+	return r.run(ctx)
 }
 
-func (r *runner) run() (reporters.Reportable, error) {
+func (r *runner) run(ctx context.Context) (reporters.Reportable, error) {
 	b, err := r.loadBenchmark()
 	if err != nil {
 		return nil, fmt.Errorf("loading benchmark failed: %w", err)
 	}
 
-	benchmark, err := r.benchmarkPipeline(b, r.entryPipeline)
+	benchmark, err := r.benchmarkPipeline(ctx, b, r.entryPipeline)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/benchrunner/runners/rally/runner.go
+++ b/internal/benchrunner/runners/rally/runner.go
@@ -1085,8 +1085,7 @@ func (r *runner) bulkMetrics(ctx context.Context, indexName string, sr searchRes
 
 	logger.Debugf("bulk request of %d events...", len(sr.Hits))
 
-	resp, err := r.options.ESMetricsAPI.Bulk(
-		strings.NewReader(bulkBodyBuilder.String()),
+	resp, err := r.options.ESMetricsAPI.Bulk(strings.NewReader(bulkBodyBuilder.String()),
 		r.options.ESMetricsAPI.Bulk.WithContext(ctx),
 	)
 	if err != nil {

--- a/internal/benchrunner/runners/rally/runner.go
+++ b/internal/benchrunner/runners/rally/runner.go
@@ -319,13 +319,13 @@ func (r *runner) setUp(ctx context.Context) error {
 			dataStreamManifest.Name,
 		)
 
-		r.indexTemplateBody, err = r.extractSimulatedTemplate(indexTemplate)
+		r.indexTemplateBody, err = r.extractSimulatedTemplate(ctx, indexTemplate)
 		if err != nil {
 			return fmt.Errorf("error extracting routing path: %s: %w", indexTemplate, err)
 		}
 	}
 
-	if err := r.wipeDataStreamOnSetup(); err != nil {
+	if err := r.wipeDataStreamOnSetup(ctx); err != nil {
 		return fmt.Errorf("error deleting old data in data stream: %s: %w", r.runtimeDataStream, err)
 	}
 
@@ -343,8 +343,11 @@ func (r *runner) setUp(ctx context.Context) error {
 	return nil
 }
 
-func (r *runner) extractSimulatedTemplate(indexTemplate string) (string, error) {
-	simulateTemplate, err := r.options.ESAPI.Indices.SimulateTemplate(r.options.ESAPI.Indices.SimulateTemplate.WithName(indexTemplate))
+func (r *runner) extractSimulatedTemplate(ctx context.Context, indexTemplate string) (string, error) {
+	simulateTemplate, err := r.options.ESAPI.Indices.SimulateTemplate(
+		r.options.ESAPI.Indices.SimulateTemplate.WithContext(ctx),
+		r.options.ESAPI.Indices.SimulateTemplate.WithName(indexTemplate),
+	)
 	if err != nil {
 		return "", fmt.Errorf("error simulating template from composable template: %s: %w", indexTemplate, err)
 	}
@@ -384,18 +387,18 @@ func (r *runner) extractSimulatedTemplate(indexTemplate string) (string, error) 
 	return string(newTemplate), nil
 }
 
-func (r *runner) wipeDataStreamOnSetup() error {
+func (r *runner) wipeDataStreamOnSetup(ctx context.Context) error {
 	// Delete old data
 	logger.Debug("deleting old data in data stream...")
 	r.wipeDataStreamHandler = func(ctx context.Context) error {
 		logger.Debugf("deleting data in data stream...")
-		if err := r.deleteDataStreamDocs(r.runtimeDataStream); err != nil {
+		if err := r.deleteDataStreamDocs(ctx, r.runtimeDataStream); err != nil {
 			return fmt.Errorf("error deleting data in data stream: %w", err)
 		}
 		return nil
 	}
 
-	return r.deleteDataStreamDocs(r.runtimeDataStream)
+	return r.deleteDataStreamDocs(ctx, r.runtimeDataStream)
 }
 
 func (r *runner) run(ctx context.Context) (report reporters.Reportable, err error) {
@@ -443,7 +446,7 @@ func (r *runner) run(ctx context.Context) (report reporters.Reportable, err erro
 		return nil, fmt.Errorf("can't summarize metrics: %w", err)
 	}
 
-	if err := r.reindexData(); err != nil {
+	if err := r.reindexData(ctx); err != nil {
 		return nil, fmt.Errorf("can't reindex data: %w", err)
 	}
 
@@ -529,9 +532,11 @@ func (r *runner) collectAndSummarizeMetrics() (*metricsSummary, error) {
 	return sum, err
 }
 
-func (r *runner) deleteDataStreamDocs(dataStream string) error {
+func (r *runner) deleteDataStreamDocs(ctx context.Context, dataStream string) error {
 	body := strings.NewReader(`{ "query": { "match_all": {} } }`)
-	resp, err := r.options.ESAPI.DeleteByQuery([]string{dataStream}, body)
+	resp, err := r.options.ESAPI.DeleteByQuery([]string{dataStream}, body,
+		r.options.ESAPI.DeleteByQuery.WithContext(ctx),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to delete data stream docs for data stream %s: %w", dataStream, err)
 	}
@@ -941,7 +946,7 @@ func (r *runner) runRally(ctx context.Context) ([]rallyStat, error) {
 }
 
 // reindexData will read all data generated during the benchmark and will reindex it to the metrisctore
-func (r *runner) reindexData() error {
+func (r *runner) reindexData(ctx context.Context) error {
 	if !r.options.ReindexData {
 		return nil
 	}
@@ -954,6 +959,7 @@ func (r *runner) reindexData() error {
 	logger.Debug("getting orignal mappings...")
 	// Get the mapping from the source data stream
 	mappingRes, err := r.options.ESAPI.Indices.GetMapping(
+		r.options.ESAPI.Indices.GetMapping.WithContext(ctx),
 		r.options.ESAPI.Indices.GetMapping.WithIndex(r.runtimeDataStream),
 	)
 	if err != nil {
@@ -999,6 +1005,7 @@ func (r *runner) reindexData() error {
 
 	createRes, err := r.options.ESMetricsAPI.Indices.Create(
 		indexName,
+		r.options.ESMetricsAPI.Indices.Create.WithContext(ctx),
 		r.options.ESMetricsAPI.Indices.Create.WithBody(reader),
 	)
 	if err != nil {
@@ -1014,6 +1021,7 @@ func (r *runner) reindexData() error {
 
 	logger.Debug("starting scrolling of events...")
 	res, err := r.options.ESAPI.Search(
+		r.options.ESAPI.Search.WithContext(ctx),
 		r.options.ESAPI.Search.WithIndex(r.runtimeDataStream),
 		r.options.ESAPI.Search.WithBody(bodyReader),
 		r.options.ESAPI.Search.WithScroll(time.Minute),
@@ -1042,7 +1050,7 @@ func (r *runner) reindexData() error {
 			break
 		}
 
-		err := r.bulkMetrics(indexName, sr)
+		err := r.bulkMetrics(ctx, indexName, sr)
 		if err != nil {
 			return err
 		}
@@ -1063,7 +1071,7 @@ type searchResponse struct {
 	} `json:"hits"`
 }
 
-func (r *runner) bulkMetrics(indexName string, sr searchResponse) error {
+func (r *runner) bulkMetrics(ctx context.Context, indexName string, sr searchResponse) error {
 	var bulkBodyBuilder strings.Builder
 	for _, hit := range sr.Hits {
 		bulkBodyBuilder.WriteString(fmt.Sprintf("{\"index\":{\"_index\":\"%s\",\"_id\":\"%s\"}}\n", indexName, hit.ID))
@@ -1077,7 +1085,10 @@ func (r *runner) bulkMetrics(indexName string, sr searchResponse) error {
 
 	logger.Debugf("bulk request of %d events...", len(sr.Hits))
 
-	resp, err := r.options.ESMetricsAPI.Bulk(strings.NewReader(bulkBodyBuilder.String()))
+	resp, err := r.options.ESMetricsAPI.Bulk(
+		strings.NewReader(bulkBodyBuilder.String()),
+		r.options.ESMetricsAPI.Bulk.WithContext(ctx),
+	)
 	if err != nil {
 		return fmt.Errorf("error performing the bulk index request: %w", err)
 	}
@@ -1091,6 +1102,7 @@ func (r *runner) bulkMetrics(indexName string, sr searchResponse) error {
 	}
 
 	resp, err = r.options.ESAPI.Scroll(
+		r.options.ESAPI.Scroll.WithContext(ctx),
 		r.options.ESAPI.Scroll.WithScrollID(sr.ScrollID),
 		r.options.ESAPI.Scroll.WithScroll(time.Minute),
 	)

--- a/internal/benchrunner/runners/system/runner.go
+++ b/internal/benchrunner/runners/system/runner.go
@@ -751,8 +751,8 @@ func (r *runner) reindexData(ctx context.Context) error {
 	logger.Debug("getting orignal mappings...")
 	// Get the mapping from the source data stream
 	mappingRes, err := r.options.ESAPI.Indices.GetMapping(
-		r.options.ESAPI.Indices.GetMapping.WithIndex(r.runtimeDataStream),
 		r.options.ESAPI.Indices.GetMapping.WithContext(ctx),
+		r.options.ESAPI.Indices.GetMapping.WithIndex(r.runtimeDataStream),
 	)
 	if err != nil {
 		return fmt.Errorf("error getting mapping: %w", err)
@@ -797,8 +797,8 @@ func (r *runner) reindexData(ctx context.Context) error {
 
 	createRes, err := r.options.ESMetricsAPI.Indices.Create(
 		indexName,
-		r.options.ESMetricsAPI.Indices.Create.WithBody(reader),
 		r.options.ESMetricsAPI.Indices.Create.WithContext(ctx),
+		r.options.ESMetricsAPI.Indices.Create.WithBody(reader),
 	)
 	if err != nil {
 		return fmt.Errorf("could not create index: %w", err)
@@ -813,11 +813,11 @@ func (r *runner) reindexData(ctx context.Context) error {
 
 	logger.Debug("starting scrolling of events...")
 	resp, err := r.options.ESAPI.Search(
+		r.options.ESAPI.Search.WithContext(ctx),
 		r.options.ESAPI.Search.WithIndex(r.runtimeDataStream),
 		r.options.ESAPI.Search.WithBody(bodyReader),
 		r.options.ESAPI.Search.WithScroll(time.Minute),
 		r.options.ESAPI.Search.WithSize(10000),
-		r.options.ESAPI.Search.WithContext(ctx),
 	)
 	if err != nil {
 		return fmt.Errorf("error executing search: %w", err)
@@ -895,9 +895,9 @@ func (r *runner) bulkMetrics(ctx context.Context, indexName string, sr searchRes
 	}
 
 	resp, err = r.options.ESAPI.Scroll(
+		r.options.ESAPI.Scroll.WithContext(ctx),
 		r.options.ESAPI.Scroll.WithScrollID(sr.ScrollID),
 		r.options.ESAPI.Scroll.WithScroll(time.Minute),
-		r.options.ESAPI.Scroll.WithContext(ctx),
 	)
 	if err != nil {
 		return fmt.Errorf("error executing scroll: %s", err)

--- a/internal/benchrunner/runners/system/runner.go
+++ b/internal/benchrunner/runners/system/runner.go
@@ -878,8 +878,7 @@ func (r *runner) bulkMetrics(ctx context.Context, indexName string, sr searchRes
 
 	logger.Debugf("bulk request of %d events...", len(sr.Hits))
 
-	resp, err := r.options.ESMetricsAPI.Bulk(
-		strings.NewReader(bulkBodyBuilder.String()),
+	resp, err := r.options.ESMetricsAPI.Bulk(strings.NewReader(bulkBodyBuilder.String()),
 		r.options.ESMetricsAPI.Bulk.WithContext(ctx),
 	)
 	if err != nil {

--- a/internal/elasticsearch/ingest/pipeline.go
+++ b/internal/elasticsearch/ingest/pipeline.go
@@ -90,7 +90,7 @@ func SimulatePipeline(ctx context.Context, api *elasticsearch.API, pipelineName 
 	r, err := api.Ingest.Simulate(bytes.NewReader(requestBody),
 		api.Ingest.Simulate.WithContext(ctx),
 		api.Ingest.Simulate.WithPipelineID(pipelineName),
-	})
+	)
 	if err != nil {
 		return nil, fmt.Errorf("simulate API call failed (pipelineName: %s): %w", pipelineName, err)
 	}

--- a/internal/elasticsearch/ingest/pipeline.go
+++ b/internal/elasticsearch/ingest/pipeline.go
@@ -87,8 +87,9 @@ func SimulatePipeline(ctx context.Context, api *elasticsearch.API, pipelineName 
 		return nil, fmt.Errorf("marshalling simulate request failed: %w", err)
 	}
 
-	r, err := api.Ingest.Simulate(bytes.NewReader(requestBody), api.Ingest.Simulate.WithContext(ctx), func(request *elasticsearch.IngestSimulateRequest) {
-		request.PipelineID = pipelineName
+	r, err := api.Ingest.Simulate(bytes.NewReader(requestBody),
+		api.Ingest.Simulate.WithContext(ctx),
+		api.Ingest.Simulate.WithPipelineID(pipelineName),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("simulate API call failed (pipelineName: %s): %w", pipelineName, err)

--- a/internal/elasticsearch/ingest/pipeline.go
+++ b/internal/elasticsearch/ingest/pipeline.go
@@ -6,6 +6,7 @@ package ingest
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -72,7 +73,7 @@ func (p *Pipeline) MarshalJSON() (asJSON []byte, err error) {
 	return asJSON, nil
 }
 
-func SimulatePipeline(api *elasticsearch.API, pipelineName string, events []json.RawMessage, simulateDataStream string) ([]json.RawMessage, error) {
+func SimulatePipeline(ctx context.Context, api *elasticsearch.API, pipelineName string, events []json.RawMessage, simulateDataStream string) ([]json.RawMessage, error) {
 	var request simulatePipelineRequest
 	for _, event := range events {
 		request.Docs = append(request.Docs, pipelineDocument{
@@ -86,7 +87,7 @@ func SimulatePipeline(api *elasticsearch.API, pipelineName string, events []json
 		return nil, fmt.Errorf("marshalling simulate request failed: %w", err)
 	}
 
-	r, err := api.Ingest.Simulate(bytes.NewReader(requestBody), func(request *elasticsearch.IngestSimulateRequest) {
+	r, err := api.Ingest.Simulate(bytes.NewReader(requestBody), api.Ingest.Simulate.WithContext(ctx), func(request *elasticsearch.IngestSimulateRequest) {
 		request.PipelineID = pipelineName
 	})
 	if err != nil {
@@ -116,9 +117,9 @@ func SimulatePipeline(api *elasticsearch.API, pipelineName string, events []json
 	return processedEvents, nil
 }
 
-func UninstallPipelines(api *elasticsearch.API, pipelines []Pipeline) error {
+func UninstallPipelines(ctx context.Context, api *elasticsearch.API, pipelines []Pipeline) error {
 	for _, p := range pipelines {
-		err := uninstallPipeline(api, p.Name)
+		err := uninstallPipeline(ctx, api, p.Name)
 		if err != nil {
 			return err
 		}
@@ -126,8 +127,8 @@ func UninstallPipelines(api *elasticsearch.API, pipelines []Pipeline) error {
 	return nil
 }
 
-func uninstallPipeline(api *elasticsearch.API, name string) error {
-	resp, err := api.Ingest.DeletePipeline(name)
+func uninstallPipeline(ctx context.Context, api *elasticsearch.API, name string) error {
+	resp, err := api.Ingest.DeletePipeline(name, api.Ingest.DeletePipeline.WithContext(ctx))
 	if err != nil {
 		return fmt.Errorf("delete pipeline API call failed (pipelineName: %s): %w", name, err)
 	}

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -101,7 +101,7 @@ func (r *runner) TearDown(ctx context.Context) error {
 		}
 	}
 
-	if err := ingest.UninstallPipelines(r.options.API, r.pipelines); err != nil {
+	if err := ingest.UninstallPipelines(ctx, r.options.API, r.pipelines); err != nil {
 		return fmt.Errorf("uninstalling ingest pipelines failed: %w", err)
 	}
 	return nil
@@ -187,7 +187,7 @@ func (r *runner) run(ctx context.Context) ([]testrunner.TestResult, error) {
 			fields.WithExpectedDatasets(expectedDatasets),
 			fields.WithEnabledImportAllECSSChema(true),
 		}
-		result, err := r.runTestCase(testCaseFile, dataStreamPath, dsManifest.Type, entryPipeline, validatorOptions)
+		result, err := r.runTestCase(ctx, testCaseFile, dataStreamPath, dsManifest.Type, entryPipeline, validatorOptions)
 		if err != nil {
 			return nil, err
 		}
@@ -259,7 +259,7 @@ func (r *runner) checkElasticsearchLogs(ctx context.Context, startTesting time.T
 
 }
 
-func (r *runner) runTestCase(testCaseFile string, dsPath string, dsType string, pipeline string, validatorOptions []fields.ValidatorOption) (testrunner.TestResult, error) {
+func (r *runner) runTestCase(ctx context.Context, testCaseFile string, dsPath string, dsType string, pipeline string, validatorOptions []fields.ValidatorOption) (testrunner.TestResult, error) {
 	tr := testrunner.TestResult{
 		TestType:   TestType,
 		Package:    r.options.TestFolder.Package,
@@ -285,7 +285,7 @@ func (r *runner) runTestCase(testCaseFile string, dsPath string, dsType string, 
 	}
 
 	simulateDataStream := dsType + "-" + r.options.TestFolder.Package + "." + r.options.TestFolder.DataStream + "-default"
-	processedEvents, err := ingest.SimulatePipeline(r.options.API, pipeline, tc.events, simulateDataStream)
+	processedEvents, err := ingest.SimulatePipeline(ctx, r.options.API, pipeline, tc.events, simulateDataStream)
 	if err != nil {
 		err := fmt.Errorf("simulating pipeline processing failed: %w", err)
 		tr.ErrorMsg = err.Error()


### PR DESCRIPTION
Leverage the usage of contexts in some Elasticsearch calls found in benchrunner and testrunner.