### PR TITLE
Remove support for Docker Compose v1

### DIFF
--- a/docs/howto/system_benchmarking.md
+++ b/docs/howto/system_benchmarking.md
@@ -156,7 +156,6 @@ To use environment variables within the Terraform service deployer a `env.yml` f
 The file should be structured like this:
 
 ```yaml
-version: '2.3'
 services:
   terraform:
     environment:

--- a/docs/howto/system_testing.md
+++ b/docs/howto/system_testing.md
@@ -76,7 +76,6 @@ the log files from your package's integration service must be written to a volum
 the following definition in it's integration service's `docker-compose.yml` file.
 
 ```yaml
-version: '2.3'
 services:
   apache:
     # Other properties such as build, ports, etc.
@@ -95,7 +94,6 @@ For example docker images for MySQL include a volume for the data directory
 tests are executed, a volume can be added to the `docker-compose.yml`:
 
 ```yaml
-version: '2.3'
 services:
   mysql:
     # Other properties such as build, ports, etc.
@@ -118,7 +116,6 @@ This is useful if you need different capabilities than the provided by the
 
 `custom-agent.yml`
 ```yaml
-version: '2.3'
 services:
   docker-custom-agent:
     pid: host
@@ -131,7 +128,6 @@ services:
 This will result in an agent configuration such as:
 
 ```yaml
-version: '2.3'
 services:
   docker-custom-agent:
     hostname: docker-custom-agent
@@ -196,7 +192,6 @@ RUN apt-get update && apt-get -y install \
 ```
 An example for `custom-agent.yml` in multi-service setup is as below
 ```yaml
-version: '2.3'
 services:
   docker-custom-agent:
     build:
@@ -328,7 +323,6 @@ To use environment variables within the Terraform service deployer a `env.yml` f
 The file should be structured like this:
 
 ```yaml
-version: '2.3'
 services:
   terraform:
     environment:

--- a/internal/agentdeployer/_static/docker-agent-base.yml.tmpl
+++ b/internal/agentdeployer/_static/docker-agent-base.yml.tmpl
@@ -1,4 +1,3 @@
-version: "2.3"
 services:
   elastic-agent:
     hostname: ${AGENT_HOSTNAME}

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -195,16 +195,13 @@ func NewProject(name string, paths ...string) (*Project, error) {
 		c.dockerComposeStandalone = c.dockerComposeStandaloneRequired()
 	}
 
-	if logger.IsDebugMode() {
-		// Passing a nil context here because we are on initialization.
-		ver, err := c.dockerComposeVersion(context.Background())
-		if err != nil {
-			logger.Errorf("Unable to determine Docker Compose version: %v", err)
-			return &c, nil
-		}
-		versionMessage := fmt.Sprintf("Determined Docker Compose version: %v", ver)
-		logger.Debug(versionMessage)
+	// Passing a nil context here because we are on initialization.
+	ver, err := c.dockerComposeVersion(context.Background())
+	if err != nil {
+		logger.Errorf("Unable to determine Docker Compose version: %v", err)
+		return &c, nil
 	}
+	logger.Debugf("Determined Docker Compose version: %v", ver)
 
 	v, ok = os.LookupEnv(DisableVerboseOutputComposeEnv)
 	if ok && strings.ToLower(v) != "false" {

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -47,7 +47,6 @@ type Project struct {
 	name             string
 	composeFilePaths []string
 
-	dockerComposeV1                bool
 	dockerComposeStandalone        bool
 	disableANSI                    bool
 	disablePullProgressInformation bool
@@ -196,23 +195,19 @@ func NewProject(name string, paths ...string) (*Project, error) {
 		c.dockerComposeStandalone = c.dockerComposeStandaloneRequired()
 	}
 
-	// Passing a nil context here because we are on initialization.
-	ver, err := c.dockerComposeVersion(context.Background())
-	if err != nil {
-		logger.Errorf("Unable to determine Docker Compose version: %v. Defaulting to 1.x", err)
-		c.dockerComposeV1 = true
-		return &c, nil
+	if logger.IsDebugMode() {
+		// Passing a nil context here because we are on initialization.
+		ver, err := c.dockerComposeVersion(context.Background())
+		if err != nil {
+			logger.Errorf("Unable to determine Docker Compose version: %v. Defaulting to 1.x", err)
+			return &c, nil
+		}
+		versionMessage := fmt.Sprintf("Determined Docker Compose version: %v", ver)
+		logger.Debug(versionMessage)
 	}
-
-	versionMessage := fmt.Sprintf("Determined Docker Compose version: %v", ver)
-	if ver.Major() == 1 {
-		versionMessage = fmt.Sprintf("%s, the tool will use Compose V1", versionMessage)
-		c.dockerComposeV1 = true
-	}
-	logger.Debug(versionMessage)
 
 	v, ok = os.LookupEnv(DisableVerboseOutputComposeEnv)
-	if !c.dockerComposeV1 && ok && strings.ToLower(v) != "false" {
+	if ok && strings.ToLower(v) != "false" {
 		if c.composeVersion.LessThan(semver.MustParse("2.19.0")) {
 			c.disableANSI = true
 		} else {
@@ -543,8 +538,5 @@ func (p *Project) dockerComposeVersion(ctx context.Context) (*semver.Version, er
 
 // ContainerName method the container name for the service.
 func (p *Project) ContainerName(serviceName string) string {
-	if p.dockerComposeV1 {
-		return fmt.Sprintf("%s_%s_1", p.name, serviceName)
-	}
 	return fmt.Sprintf("%s-%s-1", p.name, serviceName)
 }

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -198,8 +198,10 @@ func NewProject(name string, paths ...string) (*Project, error) {
 	// Passing a nil context here because we are on initialization.
 	ver, err := c.dockerComposeVersion(context.Background())
 	if err != nil {
-		logger.Errorf("Unable to determine Docker Compose version: %v", err)
-		return &c, nil
+		return nil, fmt.Errorf("unable to determine Docker Compose version: %w", err)
+	}
+	if ver.Major() < 2 {
+		return nil, fmt.Errorf("required Docker Compose v2, found %s", ver.String())
 	}
 	logger.Debugf("Determined Docker Compose version: %v", ver)
 

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -199,7 +199,7 @@ func NewProject(name string, paths ...string) (*Project, error) {
 		// Passing a nil context here because we are on initialization.
 		ver, err := c.dockerComposeVersion(context.Background())
 		if err != nil {
-			logger.Errorf("Unable to determine Docker Compose version: %v. Defaulting to 1.x", err)
+			logger.Errorf("Unable to determine Docker Compose version: %v", err)
 			return &c, nil
 		}
 		versionMessage := fmt.Sprintf("Determined Docker Compose version: %v", ver)

--- a/internal/servicedeployer/_static/docker-custom-agent-base.yml
+++ b/internal/servicedeployer/_static/docker-custom-agent-base.yml
@@ -1,4 +1,3 @@
-version: "2.3"
 services:
   docker-custom-agent:
     image: "${ELASTIC_AGENT_IMAGE_REF}"

--- a/internal/servicedeployer/_static/terraform_deployer.yml
+++ b/internal/servicedeployer/_static/terraform_deployer.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   terraform:
     build: .

--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -1,7 +1,6 @@
 {{ $username := fact "username" }}
 {{ $password := fact "password" }}
 {{ $apm_enabled := fact "apm_enabled" }}
-version: '2.4'
 services:
   elasticsearch:
     image: "${ELASTICSEARCH_IMAGE_REF}"

--- a/internal/stack/_static/serverless-docker-compose.yml.tmpl
+++ b/internal/stack/_static/serverless-docker-compose.yml.tmpl
@@ -1,4 +1,3 @@
-version: '2.4'
 services:
   elastic-agent:
     image: "{{ fact "agent_image" }}"

--- a/test/packages/false_positives/cisco_asa/_dev/deploy/docker/docker-compose.yml
+++ b/test/packages/false_positives/cisco_asa/_dev/deploy/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2.3"
 services:
   cisco-logfile:
     image: alpine


### PR DESCRIPTION
elastic-package is likely not working with Docker Compose v1 at this point, and it is discontinued since last year. Completely remove support for it.