### PR TITLE
Check if first call is already zero documents

### DIFF
--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -1251,6 +1251,10 @@ func (r *runner) deleteOldDocumentsDataStreamAndWait(ctx context.Context, dataSt
 	if err != nil {
 		return err
 	}
+	// First call already reports zero documents
+	if startHits.size() == 0 {
+		return nil
+	}
 	cleared, err := wait.UntilTrue(ctx, func(ctx context.Context) (bool, error) {
 		hits, err := r.getDocs(ctx, dataStream)
 		if err != nil {


### PR DESCRIPTION
When deleting old documents in a data stream (system tests) and wait to be zero or a lower number of documents, it should be checked if the first call is already zero documents. 

In that scenario, there is no need to go into the loop `wait.UntilTrue`, data stream is already empty.