### PR TITLE
Honor agent properties root

### DIFF
--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -115,6 +115,12 @@ type Owner struct {
 	Type   string `config:"type" json:"type" yaml:"type"`
 }
 
+type Agent struct {
+	Privileges struct {
+		Root bool `config:"root" json:"root" yaml:"root"`
+	} `config:"privileges" json:"privileges" yaml:"privileges"`
+}
+
 // PackageManifest represents the basic structure of a package's manifest
 type PackageManifest struct {
 	SpecVersion     string           `config:"format_version" json:"format_version" yaml:"format_version"`
@@ -130,6 +136,7 @@ type PackageManifest struct {
 	Description     string           `config:"description" json:"description" yaml:"description"`
 	License         string           `config:"license" json:"license" yaml:"license"`
 	Categories      []string         `config:"categories" json:"categories" yaml:"categories"`
+	Agent           Agent            `config:"agent" json:"agent" yaml:"agent"`
 }
 
 type Elasticsearch struct {

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -313,7 +313,7 @@ func (r *runner) createServiceOptions(variantName string) servicedeployer.Factor
 	}
 }
 
-func (r *runner) createAgentInfo(policy *kibana.Policy, config *testConfig) (agentdeployer.AgentInfo, error) {
+func (r *runner) createAgentInfo(policy *kibana.Policy, config *testConfig, packageManifest *packages.PackageManifest) (agentdeployer.AgentInfo, error) {
 	var info agentdeployer.AgentInfo
 
 	info.Name = r.options.TestFolder.Package
@@ -338,6 +338,11 @@ func (r *runner) createAgentInfo(policy *kibana.Policy, config *testConfig) (age
 	info.Agent.LinuxCapabilities = config.Agent.LinuxCapabilities
 	info.Agent.Runtime = config.Agent.Runtime
 	info.Agent.PidMode = config.Agent.PidMode
+
+	// If user is defined in configuration file has preference ?
+	if info.Agent.User == "" && packageManifest.Agent.Privileges.Root {
+		info.Agent.User = "root"
+	}
 
 	return info, nil
 }
@@ -819,7 +824,7 @@ func (r *runner) prepareScenario(ctx context.Context, config *testConfig, svcInf
 		return nil
 	}
 
-	agentDeployed, agentInfo, err := r.setupAgent(ctx, config, serviceStateData, policy)
+	agentDeployed, agentInfo, err := r.setupAgent(ctx, config, serviceStateData, policy, scenario.pkgManifest)
 	if err != nil {
 		return nil, err
 	}
@@ -1127,12 +1132,12 @@ func (r *runner) setupService(ctx context.Context, config *testConfig, serviceOp
 	return service, service.Info(), nil
 }
 
-func (r *runner) setupAgent(ctx context.Context, config *testConfig, state ServiceState, policy *kibana.Policy) (agentdeployer.DeployedAgent, agentdeployer.AgentInfo, error) {
+func (r *runner) setupAgent(ctx context.Context, config *testConfig, state ServiceState, policy *kibana.Policy, packageManifest *packages.PackageManifest) (agentdeployer.DeployedAgent, agentdeployer.AgentInfo, error) {
 	if !r.options.RunIndependentElasticAgent {
 		return nil, agentdeployer.AgentInfo{}, nil
 	}
 	logger.Warn("setting up agent (technical preview)...")
-	agentInfo, err := r.createAgentInfo(policy, config)
+	agentInfo, err := r.createAgentInfo(policy, config, packageManifest)
 	if err != nil {
 		return nil, agentdeployer.AgentInfo{}, err
 	}

--- a/test/packages/with-custom-agent/auditd_manager_independent_agent/data_stream/auditd/_dev/test/system/test-default-config.yml
+++ b/test/packages/with-custom-agent/auditd_manager_independent_agent/data_stream/auditd/_dev/test/system/test-default-config.yml
@@ -5,7 +5,6 @@ data_stream:
     preserve_original_event: true
 agent:
   runtime: docker
-  user: "root"
   pid_mode: "host"
   linux_capabilities:
     - AUDIT_CONTROL

--- a/test/packages/with-custom-agent/auditd_manager_independent_agent/manifest.yml
+++ b/test/packages/with-custom-agent/auditd_manager_independent_agent/manifest.yml
@@ -1,15 +1,17 @@
-format_version: 1.0.0
+format_version: 2.12.0
 name: auditd_manager_independent_agent
 title: "Auditd Manager"
 version: 999.999.999
-license: basic
 description: "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel."
 type: integration
 categories:
   - os_system
   - security
 conditions:
-  kibana.version: "^8.2.0"
+  elastic:
+    subscription: basic
+  kibana:
+    version: "^8.2.0"
 screenshots:
   - src: /img/sample-screenshot.png
     title: Sample screenshot
@@ -30,3 +32,7 @@ policy_templates:
         description: Collecting auditd events
 owner:
   github: elastic/security-external-integrations
+
+agent:
+  privileges:
+    root: true


### PR DESCRIPTION
When using independent agents, if the package defines in its manifest that it requries root as:
```
agent:
  privileges:
    root: true
```

`elastic-package` will automatically set the user root in the docker-compose scenario for the agent.

Added this setting into the test package `auditid_manager_independent_agent`. It can be checked that these settings are set for that agent container along with the capabilities:

```
 $ docker inspect elastic-package-agent-auditd_manager_independent_agent-auditd-elastic-agent-1 | jq -r '.[] | .HostConfig.PidMode'
host

 $ docker inspect elastic-package-agent-auditd_manager_independent_agent-auditd-elastic-agent-1 | jq -r '.[] | .HostConfig.CapAdd'
[
  "AUDIT_CONTROL",
  "AUDIT_READ"
]

 $ docker inspect elastic-package-agent-auditd_manager_independent_agent-auditd-elastic-agent-1 | jq -r '.[] | .Config.User'
root

```