### PR TITLE
Store start time just before installing pipelines

### DIFF
--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -137,6 +137,7 @@ func (r *runner) run(ctx context.Context) ([]testrunner.TestResult, error) {
 		return nil, errors.New("data stream root not found")
 	}
 
+	startTime := time.Now()
 	var entryPipeline string
 	entryPipeline, r.pipelines, err = ingest.InstallDataStreamPipelines(r.options.API, dataStreamPath)
 	if err != nil {
@@ -176,7 +177,6 @@ func (r *runner) run(ctx context.Context) ([]testrunner.TestResult, error) {
 		expectedDatasets = []string{expectedDataset}
 	}
 
-	startTime := time.Now()
 	results := make([]testrunner.TestResult, 0)
 	for _, testCaseFile := range testCaseFiles {
 		validatorOptions := []fields.ValidatorOption{


### PR DESCRIPTION
Ensure that the start time for pipeline is stored just before installing the pipelines in case there are warnings in Elasticsearch during the pipeline installation itself.

To avoid errors like in this build: https://buildkite.com/elastic/elastic-package/builds/2892#018ef14c-bb78-4d02-9080-bc1daabc9503