### PR TITLE
feat(compose/agent): add stack.agent.ports option in config.yml to publish ports for agent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/magefile/mage v1.15.0
 	github.com/mholt/archiver/v3 v3.5.1
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/shirou/gopsutil/v3 v3.24.3
@@ -119,7 +120,6 @@ require (
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/moby/term v0.5.0 // indirect

--- a/internal/profile/_static/config.yml.example
+++ b/internal/profile/_static/config.yml.example
@@ -18,3 +18,8 @@
 # Flag to enable logstash in elastic-package stack profile config
 # stack.logstash_enabled: true
 
+## Specify agent ports to publish
+## port definition schema https://docs.docker.com/compose/compose-file/compose-file-v2/#ports
+# stack.agent.ports:
+# - 127.0.0.1:1514:1514/udp
+

--- a/internal/profile/_testdata/config.yml
+++ b/internal/profile/_testdata/config.yml
@@ -18,3 +18,8 @@ other.float: 0.12345
 
 # A bool. Will be parsed as string.
 other.bool: false
+
+other.array:
+  - "entry1"
+  - "entry2"
+  - "entry3"

--- a/internal/profile/config.go
+++ b/internal/profile/config.go
@@ -5,7 +5,6 @@
 package profile
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -13,6 +12,8 @@ import (
 	"github.com/elastic/go-ucfg/yaml"
 
 	"github.com/elastic/elastic-package/internal/common"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 type config struct {
@@ -50,7 +51,7 @@ func (c *config) get(name string) (string, bool) {
 	}
 }
 
-func (c *config) Unmarshal(name string, out any) error {
+func (c *config) Decode(name string, out any) error {
 	v, err := c.settings.GetValue(name)
 	if err != nil {
 		if errors.Is(err, common.ErrKeyNotFound) {
@@ -58,13 +59,7 @@ func (c *config) Unmarshal(name string, out any) error {
 		}
 		return err
 	}
-
-	data, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	if err := json.Unmarshal(data, out); err != nil {
+	if err := mapstructure.Decode(v, out); err != nil {
 		return err
 	}
 

--- a/internal/profile/config.go
+++ b/internal/profile/config.go
@@ -10,10 +10,9 @@ import (
 	"os"
 
 	"github.com/elastic/go-ucfg/yaml"
+	"github.com/mitchellh/mapstructure"
 
 	"github.com/elastic/elastic-package/internal/common"
-
-	"github.com/mitchellh/mapstructure"
 )
 
 type config struct {

--- a/internal/profile/config.go
+++ b/internal/profile/config.go
@@ -5,6 +5,7 @@
 package profile
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -47,4 +48,25 @@ func (c *config) get(name string) (string, bool) {
 	default:
 		return fmt.Sprintf("%v", v), true
 	}
+}
+
+func (c *config) Unmarshal(name string, out any) error {
+	v, err := c.settings.GetValue(name)
+	if err != nil {
+		if errors.Is(err, common.ErrKeyNotFound) {
+			return nil
+		}
+		return err
+	}
+
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(data, out); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/profile/config_test.go
+++ b/internal/profile/config_test.go
@@ -75,3 +75,30 @@ func TestLoadProfileConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigDecode(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected any
+		output   any
+		found    bool
+	}{
+		{
+			name:     "other.array",
+			expected: []string{"entry1", "entry2", "entry3"},
+			output:   []string{},
+			found:    true,
+		},
+	}
+
+	config, err := loadProfileConfig("_testdata/config.yml")
+	require.NoError(t, err)
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := config.Decode(c.name, &c.output)
+			require.NoError(t, err)
+			assert.Equal(t, c.expected, c.output)
+		})
+	}
+}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -141,13 +141,13 @@ type Profile struct {
 }
 
 // Path returns an absolute path to the given file
-func (profile Profile) Path(names ...string) string {
+func (profile *Profile) Path(names ...string) string {
 	elems := append([]string{profile.ProfilePath}, names...)
 	return filepath.Join(elems...)
 }
 
 // Config returns a configuration setting, or its default if setting not found
-func (profile Profile) Config(name string, def string) string {
+func (profile *Profile) Config(name string, def string) string {
 	v, found := profile.overrides[name]
 	if found {
 		return v
@@ -161,6 +161,10 @@ func (profile Profile) Config(name string, def string) string {
 	return def
 }
 
+func (profile *Profile) Unmarshal(name string, dst any) error {
+	return profile.config.Unmarshal(name, dst)
+}
+
 // RuntimeOverrides defines configuration overrides for the current session.
 func (profile *Profile) RuntimeOverrides(overrides map[string]string) {
 	profile.overrides = overrides
@@ -171,7 +175,7 @@ var ErrNotAProfile = errors.New("not a profile")
 
 // ComposeEnvVars returns a list of environment variables that can be passed
 // to docker-compose for the sake of filling out paths and names in the snapshot.yml file.
-func (profile Profile) ComposeEnvVars() []string {
+func (profile *Profile) ComposeEnvVars() []string {
 	return []string{
 		fmt.Sprintf("PROFILE_NAME=%s", profile.ProfileName),
 	}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -141,13 +141,13 @@ type Profile struct {
 }
 
 // Path returns an absolute path to the given file
-func (profile *Profile) Path(names ...string) string {
+func (profile Profile) Path(names ...string) string {
 	elems := append([]string{profile.ProfilePath}, names...)
 	return filepath.Join(elems...)
 }
 
 // Config returns a configuration setting, or its default if setting not found
-func (profile *Profile) Config(name string, def string) string {
+func (profile Profile) Config(name string, def string) string {
 	v, found := profile.overrides[name]
 	if found {
 		return v
@@ -175,7 +175,7 @@ var ErrNotAProfile = errors.New("not a profile")
 
 // ComposeEnvVars returns a list of environment variables that can be passed
 // to docker-compose for the sake of filling out paths and names in the snapshot.yml file.
-func (profile *Profile) ComposeEnvVars() []string {
+func (profile Profile) ComposeEnvVars() []string {
 	return []string{
 		fmt.Sprintf("PROFILE_NAME=%s", profile.ProfileName),
 	}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -161,8 +161,8 @@ func (profile *Profile) Config(name string, def string) string {
 	return def
 }
 
-func (profile *Profile) Unmarshal(name string, dst any) error {
-	return profile.config.Unmarshal(name, dst)
+func (profile *Profile) Decode(name string, dst any) error {
+	return profile.config.Decode(name, dst)
 }
 
 // RuntimeOverrides defines configuration overrides for the current session.

--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -139,6 +139,9 @@ services:
       interval: 5s
     hostname: docker-fleet-agent
     env_file: "./elastic-agent.env"
+    {{- if eq (fact "agent_has_publish_ports") "true" }}
+    ports: {{ fact "agent_publish_ports" }}
+    {{- end }}
     volumes:
     - "../certs/ca-cert.pem:/etc/ssl/certs/elastic-package.pem"
     - type: bind

--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -139,9 +139,7 @@ services:
       interval: 5s
     hostname: docker-fleet-agent
     env_file: "./elastic-agent.env"
-    {{- if eq (fact "agent_has_publish_ports") "true" }}
-    ports: {{ fact "agent_publish_ports" }}
-    {{- end }}
+    ports: [{{ fact "agent_publish_ports" }}]
     volumes:
     - "../certs/ca-cert.pem:/etc/ssl/certs/elastic-package.pem"
     - type: bind


### PR DESCRIPTION
This PR introduces support for defining inside `config.yml` of the profile ports for agent service to be published

- Relates to https://github.com/elastic/elastic-package/issues/1262
- Relates to https://github.com/elastic/elastic-package/issues/1355