### PR TITLE
Drop all capabilities by default in Elastic Agent containers

### DIFF
--- a/internal/agentdeployer/_static/docker-agent-base.yml.tmpl
+++ b/internal/agentdeployer/_static/docker-agent-base.yml.tmpl
@@ -18,6 +18,8 @@ services:
       - {{ . }}
     {{- end }}
     {{ end }}
+    cap_drop:
+      - ALL
     environment:
       - FLEET_ENROLL=1
       - FLEET_URL=https://fleet-server:8220

--- a/internal/servicedeployer/_static/docker-custom-agent-base.yml
+++ b/internal/servicedeployer/_static/docker-custom-agent-base.yml
@@ -6,6 +6,8 @@ services:
       retries: 180
       interval: 1s
     hostname: docker-custom-agent
+    cap_drop:
+      - ALL
     environment:
       - FLEET_ENROLL=1
       - FLEET_URL=https://fleet-server:8220

--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -139,6 +139,8 @@ services:
       interval: 5s
     hostname: docker-fleet-agent
     env_file: "./elastic-agent.env"
+    cap_drop:
+    - ALL
     volumes:
     - "../certs/ca-cert.pem:/etc/ssl/certs/elastic-package.pem"
     - type: bind

--- a/internal/stack/_static/serverless-docker-compose.yml.tmpl
+++ b/internal/stack/_static/serverless-docker-compose.yml.tmpl
@@ -9,6 +9,8 @@ services:
       interval: 5s
     hostname: docker-fleet-agent
     env_file: "./elastic-agent.env"
+    cap_drop:
+    - ALL
     volumes:
     - type: bind
       source: ../../../tmp/service_logs/


### PR DESCRIPTION
Part of #787 

In docker/docker-compose there are some capabilities that are added by default to every container (https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).
This PR ensures that agents are started with the minimum required capabilities, dropping by default all of them.

If `ALL` it is defined in `cap_drop` field, then it just adds the Linux capabilities for the container defined in `cap_add`:
https://github.com/moby/moby/blob/82d8f8d6e6dbc88ed437b8bf6c38399b46ba7d93/oci/caps/utils.go#L112-L114