### PR TITLE
Add support to define expose ports for independent agents

### DIFF
--- a/internal/agentdeployer/_static/docker-agent-base.yml.tmpl
+++ b/internal/agentdeployer/_static/docker-agent-base.yml.tmpl
@@ -18,6 +18,12 @@ services:
       - {{ . }}
     {{- end }}
     {{ end }}
+    {{ if .exposePorts }}
+    ports:
+    {{- range .exposePorts }}
+      - "{{ . }}"
+    {{- end }}
+    {{ end }}
     environment:
       - FLEET_ENROLL=1
       - FLEET_URL=https://fleet-server:8220

--- a/internal/agentdeployer/_static/docker-agent-base.yml.tmpl
+++ b/internal/agentdeployer/_static/docker-agent-base.yml.tmpl
@@ -18,9 +18,9 @@ services:
       - {{ . }}
     {{- end }}
     {{ end }}
-    {{ if .exposePorts }}
+    {{ if .ports }}
     ports:
-    {{- range .exposePorts }}
+    {{- range .ports }}
       - "{{ . }}"
     {{- end }}
     {{ end }}

--- a/internal/agentdeployer/agent.go
+++ b/internal/agentdeployer/agent.go
@@ -256,6 +256,7 @@ func (d *DockerComposeAgentDeployer) installDockerfile(agentInfo AgentInfo) (str
 		"capabilities": agentInfo.Agent.LinuxCapabilities,
 		"runtime":      agentInfo.Agent.Runtime,
 		"pidMode":      agentInfo.Agent.PidMode,
+		"exposePorts":  agentInfo.Agent.ExposePorts,
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to create contents of the docker-compose file %q: %w", customAgentDockerfile, err)

--- a/internal/agentdeployer/agent.go
+++ b/internal/agentdeployer/agent.go
@@ -256,7 +256,7 @@ func (d *DockerComposeAgentDeployer) installDockerfile(agentInfo AgentInfo) (str
 		"capabilities": agentInfo.Agent.LinuxCapabilities,
 		"runtime":      agentInfo.Agent.Runtime,
 		"pidMode":      agentInfo.Agent.PidMode,
-		"exposePorts":  agentInfo.Agent.ExposePorts,
+		"ports":        agentInfo.Agent.Ports,
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to create contents of the docker-compose file %q: %w", customAgentDockerfile, err)

--- a/internal/agentdeployer/info.go
+++ b/internal/agentdeployer/info.go
@@ -82,6 +82,8 @@ type AgentInfo struct {
 		Runtime string
 		// LinuxCapabilities is a list of the capabilities needed to run the Elastic Agent process
 		LinuxCapabilities []string
+		// ExposePorts is a list of ports to make them available to communicate to the Elastic Agent process
+		ExposePorts []string
 	}
 
 	// CustomProperties store additional data used to boot up the service, e.g. AWS credentials.

--- a/internal/agentdeployer/info.go
+++ b/internal/agentdeployer/info.go
@@ -82,8 +82,8 @@ type AgentInfo struct {
 		Runtime string
 		// LinuxCapabilities is a list of the capabilities needed to run the Elastic Agent process
 		LinuxCapabilities []string
-		// ExposePorts is a list of ports to make them available to communicate to the Elastic Agent process
-		ExposePorts []string
+		// Ports is a list of ports to make them available to communicate to the Elastic Agent process
+		Ports []string
 	}
 
 	// CustomProperties store additional data used to boot up the service, e.g. AWS credentials.

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -338,6 +338,7 @@ func (r *runner) createAgentInfo(policy *kibana.Policy, config *testConfig, agen
 	info.Agent.LinuxCapabilities = config.Agent.LinuxCapabilities
 	info.Agent.Runtime = config.Agent.Runtime
 	info.Agent.PidMode = config.Agent.PidMode
+	info.Agent.ExposePorts = config.Agent.ExposePorts
 
 	// If user is defined in the configuration file, it has preference
 	// and it should not be overwritten by the value in the manifest

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -338,7 +338,7 @@ func (r *runner) createAgentInfo(policy *kibana.Policy, config *testConfig, agen
 	info.Agent.LinuxCapabilities = config.Agent.LinuxCapabilities
 	info.Agent.Runtime = config.Agent.Runtime
 	info.Agent.PidMode = config.Agent.PidMode
-	info.Agent.ExposePorts = config.Agent.ExposePorts
+	info.Agent.Ports = config.Agent.Ports
 
 	// If user is defined in the configuration file, it has preference
 	// and it should not be overwritten by the value in the manifest

--- a/internal/testrunner/runners/system/test_config.go
+++ b/internal/testrunner/runners/system/test_config.go
@@ -58,6 +58,7 @@ type testConfig struct {
 		PidMode           string   `config:"pid_mode"`
 		LinuxCapabilities []string `config:"linux_capabilities"`
 		Runtime           string   `config:"runtime"`
+		ExposePorts       []string `config:"expose_ports"`
 	} `config:"agent"`
 }
 

--- a/internal/testrunner/runners/system/test_config.go
+++ b/internal/testrunner/runners/system/test_config.go
@@ -58,7 +58,7 @@ type testConfig struct {
 		PidMode           string   `config:"pid_mode"`
 		LinuxCapabilities []string `config:"linux_capabilities"`
 		Runtime           string   `config:"runtime"`
-		ExposePorts       []string `config:"expose_ports"`
+		Ports             []string `config:"ports"`
 	} `config:"agent"`
 }
 


### PR DESCRIPTION
Part of #787
Relates #1262 #1355

This PR allows users to define which ports should be exposed from the Elastic Agent container.ç
This definition should be added to the system configuration file. Example:

```yaml
agent:
  ports:
    - "127.0.0.1:3000:3000"
```

This example is based on agents using docker as a runtime https://docs.docker.com/compose/compose-file/compose-file-v2/#ports