### PR TITLE
Update volumes to use bind type

### DIFF
--- a/internal/agentdeployer/_static/docker-agent-base.yml.tmpl
+++ b/internal/agentdeployer/_static/docker-agent-base.yml.tmpl
@@ -31,9 +31,9 @@ services:
       - type: bind
         source: ${SERVICE_LOGS_DIR}
         target: /tmp/service_logs/
-        read_write: true
+        read_only: false
       # Mount service_logs under /run too as a testing workaround for the journald input (see elastic-package#1235).
       - type: bind
         source: ${SERVICE_LOGS_DIR}
         target: /run/service_logs/
-        read_write: true
+        read_only: false

--- a/internal/agentdeployer/_static/docker-agent-base.yml.tmpl
+++ b/internal/agentdeployer/_static/docker-agent-base.yml.tmpl
@@ -24,11 +24,16 @@ services:
       - KIBANA_HOST=https://kibana:5601
       - FLEET_TOKEN_POLICY_NAME=${FLEET_TOKEN_POLICY_NAME}
     volumes:
-      - ${LOCAL_CA_CERT}:/etc/ssl/certs/elastic-package.pem
+      - type: bind
+        source: ${LOCAL_CA_CERT}
+        target: /etc/ssl/certs/elastic-package.pem
+        read_only: true
       - type: bind
         source: ${SERVICE_LOGS_DIR}
         target: /tmp/service_logs/
+        read_write: true
       # Mount service_logs under /run too as a testing workaround for the journald input (see elastic-package#1235).
       - type: bind
         source: ${SERVICE_LOGS_DIR}
         target: /run/service_logs/
+        read_write: true

--- a/internal/agentdeployer/_static/docker-agent-base.yml.tmpl
+++ b/internal/agentdeployer/_static/docker-agent-base.yml.tmpl
@@ -24,5 +24,11 @@ services:
       - KIBANA_HOST=https://kibana:5601
       - FLEET_TOKEN_POLICY_NAME=${FLEET_TOKEN_POLICY_NAME}
     volumes:
-      - ${SERVICE_LOGS_DIR}:/tmp/service_logs/
       - ${LOCAL_CA_CERT}:/etc/ssl/certs/elastic-package.pem
+      - type: bind
+        source: ${SERVICE_LOGS_DIR}
+        target: /tmp/service_logs/
+      # Mount service_logs under /run too as a testing workaround for the journald input (see elastic-package#1235).
+      - type: bind
+        source: ${SERVICE_LOGS_DIR}
+        target: /run/service_logs/


### PR DESCRIPTION
Use the same definitions for volumes as in the Elastic Agent defined in the stack:
https://github.com/elastic/elastic-package/blob/c2ff98b32e5cca207cb5858a973a91d1a3ffaf3f/internal/stack/_static/docker-compose-stack.yml.tmpl#L142-L150