### PR TITLE
Shorten docker container name

### DIFF
--- a/internal/agentdeployer/agent.go
+++ b/internal/agentdeployer/agent.go
@@ -24,7 +24,8 @@ import (
 )
 
 const (
-	dockerTestAgentNamePrefix    = "elastic-agent"
+	dockerTestAgentNamePrefix    = "agent"
+	dockerTestAgentServiceName   = "elastic-agent"
 	dockerTestAgentDockerCompose = "docker-agent-base.yml"
 	defaultAgentPolicyName       = "Elastic-Agent (elastic-package)"
 )
@@ -163,7 +164,7 @@ func (d *DockerComposeAgentDeployer) SetUp(ctx context.Context, agentInfo AgentI
 	}
 
 	// Service name defined in the docker-compose file
-	agentInfo.Name = dockerTestAgentNamePrefix
+	agentInfo.Name = dockerTestAgentServiceName
 	agentName := agentInfo.Name
 
 	opts := compose.CommandOptions{

--- a/internal/agentdeployer/agent.go
+++ b/internal/agentdeployer/agent.go
@@ -24,7 +24,6 @@ import (
 )
 
 const (
-	dockerTestAgentNamePrefix    = "agent"
 	dockerTestAgentServiceName   = "elastic-agent"
 	dockerTestAgentDockerCompose = "docker-agent-base.yml"
 	defaultAgentPolicyName       = "Elastic-Agent (elastic-package)"
@@ -224,7 +223,7 @@ func (d *DockerComposeAgentDeployer) SetUp(ctx context.Context, agentInfo AgentI
 }
 
 func (d *DockerComposeAgentDeployer) agentHostname() string {
-	return fmt.Sprintf("%s-%s-%s", dockerTestAgentNamePrefix, d.agentName(), d.agentRunID)
+	return fmt.Sprintf("%s-%s", dockerTestAgentServiceName, d.agentRunID)
 }
 
 func (d *DockerComposeAgentDeployer) agentName() string {


### PR DESCRIPTION
Relates #787
Relates https://github.com/elastic/integrations/pull/9660

Until now the elastic agent names created (`hostname`) are set as:
`elastic-agent-<package>-<data-stream>-<run_id>`

Using that pattern, it caused that for some packages the resulting name is longer than 64 characters causing an error in docker-compose.
```
 $ echo -n "elastic-agent-carbon_black_cloud-asset_vulnerability_summary-62403" |wc -c 
66
```

This PR changes the prefix to be just `agent`. For the example above it results in 58 characters:
```
 $ echo -n "agent-carbon_black_cloud-asset_vulnerability_summary-62403" |wc -c 
58
```


