### PR TITLE
Add support for working copies created with git worktree

### DIFF
--- a/internal/files/repository.go
+++ b/internal/files/repository.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/elastic/elastic-package/internal/logger"
 )
 
 func FindRepositoryRootDirectory() (string, error) {
@@ -18,7 +20,10 @@ func FindRepositoryRootDirectory() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("locating working directory failed: %w", err)
 	}
+	return findRepositoryRootDirectory(workDir)
+}
 
+func findRepositoryRootDirectory(workDir string) (string, error) {
 	// VolumeName() will return something like "C:" in Windows, and "" in other OSs
 	// rootDir will be something like "C:\" in Windows, and "/" everywhere else.
 	rootDir := filepath.VolumeName(workDir) + string(filepath.Separator)
@@ -30,6 +35,7 @@ func FindRepositoryRootDirectory() (string, error) {
 			return "", err
 		}
 		if gitRepo {
+			logger.Debugf("Found git repository directory: %q", dir)
 			return dir, nil
 		}
 		if dir == rootDir {
@@ -44,7 +50,7 @@ func FindRepositoryRootDirectory() (string, error) {
 func isGitRootDir(dir string) (bool, error) {
 	path := filepath.Join(dir, ".git")
 	fileInfo, err := os.Stat(path)
-	if err != nil && errors.Is(err, os.ErrNotExist) {
+	if errors.Is(err, os.ErrNotExist) {
 		return false, nil
 	}
 	if err != nil {

--- a/internal/files/repository.go
+++ b/internal/files/repository.go
@@ -5,10 +5,32 @@
 package files
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"gopkg.in/yaml.v3"
 )
+
+func isGitWorktree(path string) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", path, err)
+	}
+	type gitWorktree struct {
+		GitDir string `yaml:"gitdir"`
+	}
+	var worktree gitWorktree
+	dec := yaml.NewDecoder(bytes.NewBuffer(content))
+	dec.KnownFields(true)
+
+	if err := dec.Decode(&worktree); err != nil {
+		return fmt.Errorf("failed to decode %s: %w", path, err)
+	}
+
+	return nil
+}
 
 func FindRepositoryRootDirectory() (string, error) {
 	workDir, err := os.Getwd()
@@ -24,6 +46,14 @@ func FindRepositoryRootDirectory() (string, error) {
 	for dir != "." {
 		path := filepath.Join(dir, ".git")
 		fileInfo, err := os.Stat(path)
+		if err == nil && !fileInfo.IsDir() {
+			errWorktree := isGitWorktree(path)
+			if errWorktree != nil {
+				return "", errWorktree
+			}
+
+			return dir, nil
+		}
 		if err == nil && fileInfo.IsDir() {
 			return dir, nil
 		}

--- a/internal/files/repository_test.go
+++ b/internal/files/repository_test.go
@@ -1,0 +1,103 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package files
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepositoryDirectory(t *testing.T) {
+	tempDir := t.TempDir()
+
+	gitDir := filepath.Join(tempDir, ".git")
+	otherDir := filepath.Join(tempDir, "other")
+
+	err := os.MkdirAll(gitDir, 0o755)
+	require.NoError(t, err)
+	err = os.MkdirAll(otherDir, 0o755)
+	require.NoError(t, err)
+
+	err = os.Chdir(otherDir)
+	require.NoError(t, err)
+
+	dir, err := FindRepositoryRootDirectory()
+	require.NoError(t, err)
+	assert.Equal(t, tempDir, dir)
+
+	// test a non repository folder
+	nonGitDir := t.TempDir()
+
+	err = os.Chdir(nonGitDir)
+	require.NoError(t, err)
+
+	_, err = FindRepositoryRootDirectory()
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestRepositoryGitWorktree(t *testing.T) {
+	cases := []struct {
+		name          string
+		createGit     bool
+		contents      string
+		repoDir       string
+		expectedError string
+		valid         bool
+	}{
+		{
+			name:          "valid git worktree",
+			createGit:     true,
+			contents:      "gitdir: /path/to/repo/main",
+			repoDir:       t.TempDir(),
+			expectedError: "",
+			valid:         true,
+		},
+		{
+			name:          "invalid git worktree file",
+			createGit:     true,
+			contents:      "gitdir: /path/to/repo/main\nfoo: bar",
+			repoDir:       t.TempDir(),
+			expectedError: "yaml: unmarshal errors:\n  line 2: field foo not found in type files.gitWorktree",
+			valid:         false,
+		},
+		{
+			name:          "invalid git worktree file",
+			createGit:     false,
+			contents:      "",
+			repoDir:       t.TempDir(),
+			expectedError: "file does not exist",
+			valid:         false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gitWorktreeFile := filepath.Join(c.repoDir, ".git")
+			otherDir := filepath.Join(c.repoDir, "other")
+
+			if c.createGit {
+				err := os.WriteFile(gitWorktreeFile, []byte(c.contents), 0o644)
+				require.NoError(t, err)
+			}
+			err := os.MkdirAll(otherDir, 0o755)
+			require.NoError(t, err)
+
+			err = os.Chdir(otherDir)
+			require.NoError(t, err)
+
+			dir, err := FindRepositoryRootDirectory()
+			if c.valid {
+				require.NoError(t, err)
+				assert.Equal(t, c.repoDir, dir)
+			} else {
+				assert.ErrorContains(t, err, "yaml: unmarshal errors:\n  line 2: field foo not found in type files.gitWorktree")
+			}
+		})
+	}
+}

--- a/internal/files/repository_test.go
+++ b/internal/files/repository_test.go
@@ -49,10 +49,7 @@ func TestRepositoryGitDirectory(t *testing.T) {
 			err := os.MkdirAll(otherDir, 0o755)
 			require.NoError(t, err)
 
-			err = os.Chdir(otherDir)
-			require.NoError(t, err)
-
-			dir, err := FindRepositoryRootDirectory()
+			dir, err := findRepositoryRootDirectory(otherDir)
 			if c.valid {
 				require.NoError(t, err)
 				assert.Equal(t, c.repoDir, dir)
@@ -126,10 +123,7 @@ func TestRepositoryGitWorktree(t *testing.T) {
 			err := os.MkdirAll(otherDir, 0o755)
 			require.NoError(t, err)
 
-			err = os.Chdir(otherDir)
-			require.NoError(t, err)
-
-			dir, err := FindRepositoryRootDirectory()
+			dir, err := findRepositoryRootDirectory(otherDir)
 			if c.valid {
 				require.NoError(t, err)
 				assert.Equal(t, c.repoDir, dir)


### PR DESCRIPTION
Add support for working copies created with [`git worktree` command](https://git-scm.com/docs/git-worktree/2.30.0).

Working copies created with this command do not have a `.git` folder, instead those working copies have a `.git` file where it is indicated where the reference repository is. For isntance:

```
 $ cat .git
gitdir: /home/mariorodriguez/Coding/work/elastic-package/.git/worktrees/elastic-package-add-support-git-worktree
```

Currently, `elastic-package` fails since `.git` is not a folder with this error:
- In this example, `build` folder does not exist and `elastic-package` needs to create it
```
Error: error running package system tests: could not complete test run: can't install the package: there was an apply error: failed to build package: can't locate build directory: can't locate build packages root directory: can't create new build directory: package can be only built inside of a Git repository (.git folder is used as reference point)
```