### PR TITLE
[Buildkite] Add pipeline to test with Elastic serverless daily

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -60,13 +60,17 @@ is_step_required_to_upload_safe_logs() {
     if [[ "$BUILDKITE_PIPELINE_SLUG" != "elastic-package" && "$BUILDKITE_PIPELINE_SLUG" != "elastic-package-test-serverless" ]]; then
         return 1
     fi
-    # steps from elastic-package
-    if [[ "$BUILDKITE_STEP_KEY" =~ ^integration-parallel || "$BUILDKITE_STEP_KEY" =~ ^integration-false_positives ]]; then
-        return 0
+
+    if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-package" ]]; then
+        if [[ "$BUILDKITE_STEP_KEY" =~ ^integration-parallel || "$BUILDKITE_STEP_KEY" =~ ^integration-false_positives ]]; then
+            return 0
+        fi
     fi
-    # steps from elastic-package-test-serverless
-    if [[ "$BUILDKITE_STEP_KEY" == "test-serverless" ]]; then
-        return 0
+
+    if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-package-test-serverless" ]]; then
+        if [[ "$BUILDKITE_STEP_KEY" == "test-serverless" ]]; then
+            return 0
+        fi
     fi
     return 1
 }
@@ -155,9 +159,7 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-package-cloud-cleanup" && "$BUILDKI
 fi
 
 
-# TODO: Replace if condition
-# if [[ "${BUILDKITE_PIPELINE_SLUG}" == "elastic-package-test-serverless" ]]; then
-if [[ "${BUILDKITE_PIPELINE_SLUG}" == "elastic-package" ]]; then
+if [[ "${BUILDKITE_PIPELINE_SLUG}" == "elastic-package-test-serverless" ]]; then
     if [[ "${BUILDKITE_STEP_KEY}" == "test-serverless" ]]; then
         EC_API_KEY_SECRET=$(retry 5 vault kv get -field apiKey "${EC_TOKEN_PATH}")
         export EC_API_KEY_SECRET

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -6,10 +6,17 @@ set -euo pipefail
 GO_VERSION=$(cat .go-version)
 export GO_VERSION
 
+export SERVERLESS=${SERVERLESS:-"false"}
+export WORKSPACE=$(pwd)
+
+
 GCP_SERVICE_ACCOUNT_SECRET_PATH=secret/ci/elastic-elastic-package/gcp-service-account
 AWS_SERVICE_ACCOUNT_SECRET_PATH=kv/ci-shared/platform-ingest/aws_account_auth
 GITHUB_TOKEN_VAULT_PATH=kv/ci-shared/platform-ingest/github_token
 PRIVATE_CI_GCS_CREDENTIALS_PATH=kv/ci-shared/platform-ingest/gcp-platform-ingest-ci-service-account
+
+EC_TOKEN_PATH=kv/ci-shared/platform-ingest/platform-ingest-ec-qa
+EC_DATA_PATH=secret/ci/elastic-elastic-package/ec_data
 
 # variables required for terraform
 export ENVIRONMENT="ci"
@@ -46,11 +53,19 @@ export CREATED_DATE
 # Secrets must be redacted
 # https://buildkite.com/docs/pipelines/managing-log-output#redacted-environment-variables
 
+export TMP_FOLDER_TEMPLATE_BASE="tmp.${REPO}"
+export TMP_FOLDER_TEMPLATE="${TMP_FOLDER_TEMPLATE_BASE}.XXXXXXXXX"
+
 is_step_required_to_upload_safe_logs() {
-    if [[ "$BUILDKITE_PIPELINE_SLUG" != "elastic-package" ]]; then
+    if [[ "$BUILDKITE_PIPELINE_SLUG" != "elastic-package" && "$BUILDKITE_PIPELINE_SLUG" != "elastic-package-test-serverless" ]]; then
         return 1
     fi
+    # steps from elastic-package
     if [[ "$BUILDKITE_STEP_KEY" =~ ^integration-parallel || "$BUILDKITE_STEP_KEY" =~ ^integration-false_positives ]]; then
+        return 0
+    fi
+    # steps from elastic-package-test-serverless
+    if [[ "$BUILDKITE_STEP_KEY" == "test-serverless" ]]; then
         return 0
     fi
     return 1
@@ -139,3 +154,16 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-package-cloud-cleanup" && "$BUILDKI
     export ELASTIC_PACKAGE_GCP_EMAIL_SECRET
 fi
 
+
+# TODO: Replace if condition
+# if [[ "${BUILDKITE_PIPELINE_SLUG}" == "elastic-package-test-serverless" ]]; then
+if [[ "${BUILDKITE_PIPELINE_SLUG}" == "elastic-package" ]]; then
+    if [[ "${BUILDKITE_STEP_KEY}" == "test-serverless" ]]; then
+        EC_API_KEY_SECRET=$(retry 5 vault kv get -field apiKey "${EC_TOKEN_PATH}")
+        export EC_API_KEY_SECRET
+        EC_HOST_SECRET=$(retry 5 vault kv get -field url "${EC_TOKEN_PATH}")
+        export EC_HOST_SECRET
+        EC_REGION_SECRET=$(retry 5 vault read -field region_qa "${EC_DATA_PATH}")
+        export EC_REGION_SECRET
+    fi
+fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -165,5 +165,8 @@ if [[ "${BUILDKITE_PIPELINE_SLUG}" == "elastic-package" ]]; then
         export EC_HOST_SECRET
         EC_REGION_SECRET=$(retry 5 vault read -field region_qa "${EC_DATA_PATH}")
         export EC_REGION_SECRET
+
+        GITHUB_TOKEN=$(retry 5 vault kv get -field token ${GITHUB_TOKEN_VAULT_PATH})
+        export GITHUB_TOKEN
     fi
 fi

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -4,6 +4,15 @@ source .buildkite/scripts/tooling.sh
 
 set -euo pipefail
 
+# TODO: change pipeline slug
+if [[ "${BUILDKITE_PIPELINE_SLUG}" == "elastic-package" && "${BUILDKITE_STEP_KEY}" == "test-serverless" ]]; then
+    echo "--- Take down the Elastic stack"
+    # BUILDKITE resets PATH contents in pre-exit hook, but elastic-package
+    # is already installed in the test_serverless pipeline step, accessing
+    # directly to the binary
+    EC_API_KEY="${EC_API_KEY_SECRET}" EC_HOST="${EC_HOST_SECRET}" "${HOME}"/go/bin/elastic-package down -v
+fi
+
 unset_secrets
 
 # integrations-parallel-gcp
@@ -15,4 +24,3 @@ unset ELASTIC_PACKAGE_AWS_ACCESS_KEY
 unset ELASTIC_PACKAGE_AWS_SECRET_KEY
 unset AWS_ACCESS_KEY_ID
 unset AWS_SECRET_ACCESS_KEY
-

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -10,7 +10,7 @@ if [[ "${BUILDKITE_PIPELINE_SLUG}" == "elastic-package" && "${BUILDKITE_STEP_KEY
     # BUILDKITE resets PATH contents in pre-exit hook, but elastic-package
     # is already installed in the test_serverless pipeline step, accessing
     # directly to the binary
-    EC_API_KEY="${EC_API_KEY_SECRET}" EC_HOST="${EC_HOST_SECRET}" "${HOME}"/go/bin/elastic-package down -v
+    EC_API_KEY="${EC_API_KEY_SECRET}" EC_HOST="${EC_HOST_SECRET}" "${HOME}"/go/bin/elastic-package stack down -v
 fi
 
 unset_secrets

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -13,6 +13,8 @@ if [[ "${BUILDKITE_PIPELINE_SLUG}" == "elastic-package" && "${BUILDKITE_STEP_KEY
     EC_API_KEY="${EC_API_KEY_SECRET}" EC_HOST="${EC_HOST_SECRET}" "${HOME}"/go/bin/elastic-package stack down -v
 fi
 
+cleanup
+google_cloud_logout_active_account
 unset_secrets
 
 # integrations-parallel-gcp

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -13,6 +13,7 @@ if [[ "${BUILDKITE_PIPELINE_SLUG}" == "elastic-package" && "${BUILDKITE_STEP_KEY
     EC_API_KEY="${EC_API_KEY_SECRET}" EC_HOST="${EC_HOST_SECRET}" "${HOME}"/go/bin/elastic-package stack down -v
 fi
 
+echo "--- Cleanup"
 cleanup
 google_cloud_logout_active_account
 unset_secrets

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -15,7 +15,6 @@ fi
 
 echo "--- Cleanup"
 cleanup
-google_cloud_logout_active_account
 unset_secrets
 
 # integrations-parallel-gcp

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -4,8 +4,7 @@ source .buildkite/scripts/tooling.sh
 
 set -euo pipefail
 
-# TODO: change pipeline slug
-if [[ "${BUILDKITE_PIPELINE_SLUG}" == "elastic-package" && "${BUILDKITE_STEP_KEY}" == "test-serverless" ]]; then
+if [[ "${BUILDKITE_PIPELINE_SLUG}" == "elastic-package-test-serverless" && "${BUILDKITE_STEP_KEY}" == "test-serverless" ]]; then
     echo "--- Take down the Elastic stack"
     # BUILDKITE resets PATH contents in pre-exit hook, but elastic-package
     # is already installed in the test_serverless pipeline step, accessing

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -55,7 +55,7 @@ steps:
   - wait: ~
     continue_on_failure: true
 
-  - label: ":pipeline: Test Serverless Integration tests"
+  - label: ":elastic: Serverless Integration tests"
     key: test-serverless
     command: ".buildkite/scripts/test_packages_with_serverless.sh"
     env:

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -43,17 +43,6 @@ steps:
       cpu: "8"
       memory: "4G"
 
-  - label: ":go: :linux: Run unit tests"
-    key: unit-tests-linux
-    command: "make test-go-ci"
-    artifact_paths:
-      - "build/test-results/*.xml"
-      - "build/test-coverage/*.xml"
-    agents:
-      image: "${LINUX_AGENT_IMAGE}"
-      cpu: "8"
-      memory: "4G"
-
   - wait: ~
     continue_on_failure: true
 
@@ -68,8 +57,6 @@ steps:
       - build/test-coverage/coverage-*.xml
     depends_on:
       - step: check-static
-        allow_failure: false
-      - step: unit-tests-linux
         allow_failure: false
 
   - wait: ~

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -1,0 +1,73 @@
+env:
+  SETUP_GVM_VERSION: 'v0.5.2' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
+  ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT: "true"
+  DOCKER_COMPOSE_VERSION: "v2.24.1"
+  DOCKER_VERSION: "26.1.0"
+  KIND_VERSION: 'v0.20.0'
+  K8S_VERSION: 'v1.29.0'
+  LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
+
+steps:
+  - input: "Input values for the variables"
+    key: "input-variables"
+    fields:
+    - select: "SERVERLESS_PROJECT"
+      key: "SERVERLESS_PROJECT"
+      options:
+        - label: "observability"
+          value: "observability"
+        - label: "security"
+          value: "security"
+      default: "observability"
+    if: "build.source == 'ui'"
+
+  - wait: ~
+    if: "build.source == 'ui'"
+    allow_dependency_failure: false
+
+  - label: ":go: Run check-static"
+    key: check-static
+    command: "make check-static"
+    agents:
+      image: "${LINUX_AGENT_IMAGE}"
+      cpu: "8"
+      memory: "4G"
+
+  - label: ":go: :linux: Run unit tests"
+    key: unit-tests-linux
+    command: "make test-go-ci"
+    artifact_paths:
+      - "build/test-results/*.xml"
+      - "build/test-coverage/*.xml"
+    agents:
+      image: "${LINUX_AGENT_IMAGE}"
+      cpu: "8"
+      memory: "4G"
+
+  - wait: ~
+    continue_on_failure: true
+
+  - label: ":pipeline: Test Serverless Integration tests"
+    key: test-serverless
+    command: ".buildkite/scripts/test_packages_with_serverless.sh"
+    env:
+      SERVERLESS_PROJECT: "${SERVERLESS_PROJECT:-observability}"
+      UPLOAD_SAFE_LOGS: 1
+    artifact_paths:
+      - build/test-results/*.xml
+      - build/test-coverage/coverage-*.xml
+    depends_on:
+      - step: check-static
+        allow_failure: false
+      - step: unit-tests-linux
+        allow_failure: false
+
+  - wait: ~
+    continue_on_failure: true
+
+  - label: ":junit: Junit annotate"
+    plugins:
+      - junit-annotate#v2.4.1:
+          artifacts: "build/test-results/*.xml"
+    agents:
+      provider: "gcp"  # junit plugin requires docker

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -35,17 +35,6 @@ steps:
     if: "build.source == 'ui'"
     allow_dependency_failure: false
 
-  - label: ":go: Run check-static"
-    key: check-static
-    command: "make check-static"
-    agents:
-      image: "${LINUX_AGENT_IMAGE}"
-      cpu: "8"
-      memory: "4G"
-
-  - wait: ~
-    continue_on_failure: true
-
   - label: ":elastic: Serverless Integration tests"
     key: test-serverless
     command: ".buildkite/scripts/test_packages_with_serverless.sh"
@@ -55,9 +44,6 @@ steps:
     artifact_paths:
       - build/test-results/*.xml
       - build/test-coverage/coverage-*.xml
-    depends_on:
-      - step: check-static
-        allow_failure: false
 
   - wait: ~
     continue_on_failure: true

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -1,11 +1,19 @@
 env:
   SETUP_GVM_VERSION: 'v0.5.2' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
-  ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT: "true"
   DOCKER_COMPOSE_VERSION: "v2.24.1"
   DOCKER_VERSION: "26.1.0"
   KIND_VERSION: 'v0.20.0'
   K8S_VERSION: 'v1.29.0'
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
+  # Elastic package settings
+  # Manage docker output/logs
+  ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT: "true"
+  # Default license to use by `elastic-package build`
+  ELASTIC_PACKAGE_REPOSITORY_LICENSE: "licenses/Elastic-2.0.txt"
+  # Link definitions path (full path to be set in the corresponding step)
+  ELASTIC_PACKAGE_LINKS_FILE_PATH: "links_table.yml"
+  # Disable comparison of results in pipeline tests to avoid errors related to GeoIP fields
+  ELASTIC_PACKAGE_SERVERLESS_PIPELINE_TEST_DISABLE_COMPARE_RESULTS: "true"
 
 steps:
   - input: "Input values for the variables"

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -5,6 +5,7 @@ env:
   KIND_VERSION: 'v0.20.0'
   K8S_VERSION: 'v1.29.0'
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
+  GH_CLI_VERSION: "2.29.0"
   # Elastic package settings
   # Manage docker output/logs
   ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT: "true"

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -1,4 +1,5 @@
 env:
+  NOTIFY_TO: "ecosystem-team@elastic.co"
   SETUP_GVM_VERSION: 'v0.5.2' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
   DOCKER_COMPOSE_VERSION: "v2.24.1"
   DOCKER_VERSION: "26.1.0"
@@ -80,3 +81,7 @@ steps:
           artifacts: "build/test-results/*.xml"
     agents:
       provider: "gcp"  # junit plugin requires docker
+
+notify:
+  - email: "$NOTIFY_TO"
+    if: "build.state == 'failed' && build.env('BUILDKITE_PULL_REQUEST') == 'false'"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -47,6 +47,7 @@ steps:
       provider: "gcp"
     env:
       SERVERLESS_PROJECT: observability
+      GH_CLI_VERSION: "2.29.0"
       UPLOAD_SAFE_LOGS: 1
     artifact_paths:
       - build/test-results/*.xml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,76 +9,88 @@ env:
   WINDOWS_AGENT_IMAGE: "family/ci-windows-2022"
 
 steps:
-  - label: ":go: Run check-static"
-    key: check-static
-    command: "make check-static"
-    agents:
-      image: "${LINUX_AGENT_IMAGE}"
-      cpu: "8"
-      memory: "4G"
+  # - label: ":go: Run check-static"
+  #   key: check-static
+  #   command: "make check-static"
+  #   agents:
+  #     image: "${LINUX_AGENT_IMAGE}"
+  #     cpu: "8"
+  #     memory: "4G"
 
-  - label: ":go: :linux: Run unit tests"
-    key: unit-tests-linux
-    command: "make test-go-ci"
-    artifact_paths:
-      - "build/test-results/*.xml"
-      - "build/test-coverage/*.xml"
-    agents:
-      image: "${LINUX_AGENT_IMAGE}"
-      cpu: "8"
-      memory: "4G"
+  # - label: ":go: :linux: Run unit tests"
+  #   key: unit-tests-linux
+  #   command: "make test-go-ci"
+  #   artifact_paths:
+  #     - "build/test-results/*.xml"
+  #     - "build/test-coverage/*.xml"
+  #   agents:
+  #     image: "${LINUX_AGENT_IMAGE}"
+  #     cpu: "8"
+  #     memory: "4G"
 
-  - label: ":go: :windows: Run unit tests"
-    key: unit-tests-windows
-    command: ".buildkite/scripts/unit_tests_windows.ps1"
-    agents:
-      provider: "gcp"
-      image: "${WINDOWS_AGENT_IMAGE}"
-    artifact_paths:
-      - "TEST-unit-windows.xml"
+  # - label: ":go: :windows: Run unit tests"
+  #   key: unit-tests-windows
+  #   command: ".buildkite/scripts/unit_tests_windows.ps1"
+  #   agents:
+  #     provider: "gcp"
+  #     image: "${WINDOWS_AGENT_IMAGE}"
+  #   artifact_paths:
+  #     - "TEST-unit-windows.xml"
 
-  - wait: ~
-    continue_on_failure: true
-
-  - label: ":pipeline: Trigger Integration tests"
-    command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
-    depends_on:
-      - step: check-static
-        allow_failure: false
-      - step: unit-tests-linux
-        allow_failure: false
-      - step: unit-tests-windows
-        allow_failure: false
-
-  - wait: ~
-    continue_on_failure: true
-
-  - label: ":junit: Transform windows paths to linux for Junit plugin"
-    commands:
-      - buildkite-agent artifact download "*-windows.xml" . --step unit-tests-windows
-      - mkdir -p build/test-results
-      - for file in $(ls *-windows.xml); do mv $$file build/test-results/; done
-    agents:
-      image: "${LINUX_AGENT_IMAGE}"
-      cpu: "8"
-      memory: "4G"
-    artifact_paths:
-      - "build/test-results/*.xml"
-
-  - wait: ~
-    continue_on_failure: true
-
-  - label: ":junit: Junit annotate"
-    plugins:
-      - junit-annotate#v2.4.1:
-          artifacts: "build/test-results/*.xml"
-    agents:
-      provider: "gcp"  # junit plugin requires docker
-
-  - label: ":github: Release"
-    key: "release"
-    if: |
-      build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
-    command: ".buildkite/scripts/release.sh"
+  - label: ":package: test serverless"
+    key: test-serverless
+    command: ".buildkite/scripts/test_packages_with_serverless.sh"
     agents:
       provider: "gcp"
+    env:
+      SERVERLESS_PROJECT: observability
+      UPLOAD_SAFE_LOGS: 1
+    artifact_paths:
+      - build/test-results/*.xml
+      - build/test-coverage/coverage-*.xml
+
+  # - wait: ~
+  #   continue_on_failure: true
+
+  # - label: ":pipeline: Trigger Integration tests"
+  #   command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
+  #   depends_on:
+  #     - step: check-static
+  #       allow_failure: false
+  #     - step: unit-tests-linux
+  #       allow_failure: false
+  #     - step: unit-tests-windows
+  #       allow_failure: false
+
+  # - wait: ~
+  #   continue_on_failure: true
+
+  # - label: ":junit: Transform windows paths to linux for Junit plugin"
+  #   commands:
+  #     - buildkite-agent artifact download "*-windows.xml" . --step unit-tests-windows
+  #     - mkdir -p build/test-results
+  #     - for file in $(ls *-windows.xml); do mv $$file build/test-results/; done
+  #   agents:
+  #     image: "${LINUX_AGENT_IMAGE}"
+  #     cpu: "8"
+  #     memory: "4G"
+  #   artifact_paths:
+  #     - "build/test-results/*.xml"
+
+  # - wait: ~
+  #   continue_on_failure: true
+
+  # - label: ":junit: Junit annotate"
+  #   plugins:
+  #     - junit-annotate#v2.4.1:
+  #         artifacts: "build/test-results/*.xml"
+  #   agents:
+  #     provider: "gcp"  # junit plugin requires docker
+
+  # - label: ":github: Release"
+  #   key: "release"
+  #   if: |
+  #     build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
+  #   command: ".buildkite/scripts/release.sh"
+  #   agents:
+  #     provider: "gcp"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,19 +40,6 @@ steps:
   - wait: ~
     continue_on_failure: true
 
-  - label: ":package: test serverless"
-    key: test-serverless
-    command: ".buildkite/scripts/test_packages_with_serverless.sh"
-    agents:
-      provider: "gcp"
-    env:
-      SERVERLESS_PROJECT: observability
-      GH_CLI_VERSION: "2.29.0"
-      UPLOAD_SAFE_LOGS: 1
-    artifact_paths:
-      - build/test-results/*.xml
-      - build/test-coverage/coverage-*.xml
-
   - label: ":pipeline: Trigger Integration tests"
     command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
     depends_on:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,33 +9,36 @@ env:
   WINDOWS_AGENT_IMAGE: "family/ci-windows-2022"
 
 steps:
-  # - label: ":go: Run check-static"
-  #   key: check-static
-  #   command: "make check-static"
-  #   agents:
-  #     image: "${LINUX_AGENT_IMAGE}"
-  #     cpu: "8"
-  #     memory: "4G"
+  - label: ":go: Run check-static"
+    key: check-static
+    command: "make check-static"
+    agents:
+      image: "${LINUX_AGENT_IMAGE}"
+      cpu: "8"
+      memory: "4G"
 
-  # - label: ":go: :linux: Run unit tests"
-  #   key: unit-tests-linux
-  #   command: "make test-go-ci"
-  #   artifact_paths:
-  #     - "build/test-results/*.xml"
-  #     - "build/test-coverage/*.xml"
-  #   agents:
-  #     image: "${LINUX_AGENT_IMAGE}"
-  #     cpu: "8"
-  #     memory: "4G"
+  - label: ":go: :linux: Run unit tests"
+    key: unit-tests-linux
+    command: "make test-go-ci"
+    artifact_paths:
+      - "build/test-results/*.xml"
+      - "build/test-coverage/*.xml"
+    agents:
+      image: "${LINUX_AGENT_IMAGE}"
+      cpu: "8"
+      memory: "4G"
 
-  # - label: ":go: :windows: Run unit tests"
-  #   key: unit-tests-windows
-  #   command: ".buildkite/scripts/unit_tests_windows.ps1"
-  #   agents:
-  #     provider: "gcp"
-  #     image: "${WINDOWS_AGENT_IMAGE}"
-  #   artifact_paths:
-  #     - "TEST-unit-windows.xml"
+  - label: ":go: :windows: Run unit tests"
+    key: unit-tests-windows
+    command: ".buildkite/scripts/unit_tests_windows.ps1"
+    agents:
+      provider: "gcp"
+      image: "${WINDOWS_AGENT_IMAGE}"
+    artifact_paths:
+      - "TEST-unit-windows.xml"
+
+  - wait: ~
+    continue_on_failure: true
 
   - label: ":package: test serverless"
     key: test-serverless
@@ -49,48 +52,45 @@ steps:
       - build/test-results/*.xml
       - build/test-coverage/coverage-*.xml
 
-  # - wait: ~
-  #   continue_on_failure: true
+  - label: ":pipeline: Trigger Integration tests"
+    command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
+    depends_on:
+      - step: check-static
+        allow_failure: false
+      - step: unit-tests-linux
+        allow_failure: false
+      - step: unit-tests-windows
+        allow_failure: false
 
-  # - label: ":pipeline: Trigger Integration tests"
-  #   command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
-  #   depends_on:
-  #     - step: check-static
-  #       allow_failure: false
-  #     - step: unit-tests-linux
-  #       allow_failure: false
-  #     - step: unit-tests-windows
-  #       allow_failure: false
+  - wait: ~
+    continue_on_failure: true
 
-  # - wait: ~
-  #   continue_on_failure: true
+  - label: ":junit: Transform windows paths to linux for Junit plugin"
+    commands:
+      - buildkite-agent artifact download "*-windows.xml" . --step unit-tests-windows
+      - mkdir -p build/test-results
+      - for file in $(ls *-windows.xml); do mv $$file build/test-results/; done
+    agents:
+      image: "${LINUX_AGENT_IMAGE}"
+      cpu: "8"
+      memory: "4G"
+    artifact_paths:
+      - "build/test-results/*.xml"
 
-  # - label: ":junit: Transform windows paths to linux for Junit plugin"
-  #   commands:
-  #     - buildkite-agent artifact download "*-windows.xml" . --step unit-tests-windows
-  #     - mkdir -p build/test-results
-  #     - for file in $(ls *-windows.xml); do mv $$file build/test-results/; done
-  #   agents:
-  #     image: "${LINUX_AGENT_IMAGE}"
-  #     cpu: "8"
-  #     memory: "4G"
-  #   artifact_paths:
-  #     - "build/test-results/*.xml"
+  - wait: ~
+    continue_on_failure: true
 
-  # - wait: ~
-  #   continue_on_failure: true
+  - label: ":junit: Junit annotate"
+    plugins:
+      - junit-annotate#v2.4.1:
+          artifacts: "build/test-results/*.xml"
+    agents:
+      provider: "gcp"  # junit plugin requires docker
 
-  # - label: ":junit: Junit annotate"
-  #   plugins:
-  #     - junit-annotate#v2.4.1:
-  #         artifacts: "build/test-results/*.xml"
-  #   agents:
-  #     provider: "gcp"  # junit plugin requires docker
-
-  # - label: ":github: Release"
-  #   key: "release"
-  #   if: |
-  #     build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
-  #   command: ".buildkite/scripts/release.sh"
-  #   agents:
-  #     provider: "gcp"
+  - label: ":github: Release"
+    key: "release"
+    if: |
+      build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
+    command: ".buildkite/scripts/release.sh"
+    agents:
+      provider: "gcp"

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -31,6 +31,22 @@
         "skip_target_branches": [ ],
         "skip_ci_on_only_changed": [ ],
         "always_require_ci_on_changed": [ ]
+     },
+     {
+        "enabled": true,
+        "pipelineSlug": "elastic-package-test-serverless",
+        "allow_org_users": true,
+        "allowed_repo_permissions": ["admin", "write"],
+        "allowed_list": [ ],
+        "set_commit_status": false,
+        "build_on_commit": false,
+        "build_on_comment": true,
+        "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:test)\\W+(?:serverless))$",
+        "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:test)\\W+(?:serverless))$",
+        "skip_ci_labels": [ ],
+        "skip_target_branches": [ ],
+        "skip_ci_on_only_changed": [ ],
+        "always_require_ci_on_changed": [ ]
      }
    ]
 }

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -81,9 +81,9 @@ fi
 
 label="${TARGET}"
 if [ -n "${PACKAGE}" ]; then
-    label="${LABEL} - ${PACKAGE}"
+    label="${label} - ${PACKAGE}"
 fi
-echo "--- Run integration test ${TARGET}"
+echo "--- Run integration test ${label}"
 if [[ "${TARGET}" == "${PARALLEL_TARGET}" ]] || [[ "${TARGET}" == "${FALSE_POSITIVES_TARGET}" ]]; then
     make install
 

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -5,25 +5,6 @@ source .buildkite/scripts/tooling.sh
 
 set -euo pipefail
 
-cleanup() {
-    local error_code=$?
-
-    if [ $error_code != 0 ] ; then
-        # if variable is defined run the logout
-        if [ -n "${GOOGLE_APPLICATION_CREDENTIALS+x}" ]; then
-             google_cloud_logout_active_account
-        fi
-    fi
-
-    echo "Deleting temporal files..."
-    cd "${WORKSPACE}"
-    rm -rf "${TMP_FOLDER_TEMPLATE_BASE}.*"
-    echo "Done."
-
-    exit $error_code
-}
-trap cleanup EXIT
-
 usage() {
     echo "$0 [-t <target>] [-h]"
     echo "Trigger integration tests related to a target in Makefile"

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -80,8 +80,8 @@ if [[ "${TARGET}" == "${KIND_TARGET}" || "${TARGET}" == "${SYSTEM_TEST_FLAGS_TAR
 fi
 
 label="${TARGET}"
-if [ -n "${PACKAGE_UNDER_TEST}" ]; then
-    label="${LABEL} - ${PACKAGE_UNDER_TEST}"
+if [ -n "${PACKAGE}" ]; then
+    label="${LABEL} - ${PACKAGE}"
 fi
 echo "--- Run integration test ${TARGET}"
 if [[ "${TARGET}" == "${PARALLEL_TARGET}" ]] || [[ "${TARGET}" == "${FALSE_POSITIVES_TARGET}" ]]; then

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -98,6 +98,10 @@ if [[ "${TARGET}" == "${KIND_TARGET}" || "${TARGET}" == "${SYSTEM_TEST_FLAGS_TAR
     with_kubernetes
 fi
 
+label="${TARGET}"
+if [ -n "${PACKAGE_UNDER_TEST}" ]; then
+    label="${LABEL} - ${PACKAGE_UNDER_TEST}"
+fi
 echo "--- Run integration test ${TARGET}"
 if [[ "${TARGET}" == "${PARALLEL_TARGET}" ]] || [[ "${TARGET}" == "${FALSE_POSITIVES_TARGET}" ]]; then
     make install
@@ -138,7 +142,7 @@ if [[ "${TARGET}" == "${PARALLEL_TARGET}" ]] || [[ "${TARGET}" == "${FALSE_POSIT
     fi
 
     if [ $testReturnCode != 0 ]; then
-        echo "make SERVERLESS=${SERVERLESS} PACKAGE_UDER_TEST=${PACKAGE} ${TARGET} failed with ${testReturnCode}"
+        echo "make SERVERLESS=${SERVERLESS} PACKAGE_UNDER_TEST=${PACKAGE} ${TARGET} failed with ${testReturnCode}"
         exit ${testReturnCode}
     fi
 

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -5,6 +5,20 @@ source .buildkite/scripts/tooling.sh
 
 set -euo pipefail
 
+ensure_logout() {
+    local error_code=$?
+
+    if [ $error_code != 0 ] ; then
+        # if variable is defined run the logout
+        if [ -n "${GOOGLE_APPLICATION_CREDENTIALS+x}" ]; then
+             google_cloud_logout_active_account
+        fi
+    fi
+
+    exit $error_code
+}
+trap ensure_logout EXIT
+
 usage() {
     echo "$0 [-t <target>] [-h]"
     echo "Trigger integration tests related to a target in Makefile"

--- a/.buildkite/scripts/release.sh
+++ b/.buildkite/scripts/release.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+source .buildkite/scripts/install_deps.sh
+source .buildkite/scripts/tooling.sh
+
 set -euo pipefail
 
 cleanup() {
@@ -7,11 +10,9 @@ cleanup() {
 }
 trap cleanup exit
 
-WORKSPACE="/tmp/bin-buildkite/"
+export WORKSPACE="/tmp/bin-buildkite/"
 
 VERSION=""
-source .buildkite/scripts/install_deps.sh
-source .buildkite/scripts/tooling.sh
 
 add_bin_path
 with_go

--- a/.buildkite/scripts/test-with-integrations.sh
+++ b/.buildkite/scripts/test-with-integrations.sh
@@ -3,15 +3,6 @@ source .buildkite/scripts/install_deps.sh
 
 set -euo pipefail
 
-cleanup() {
-    echo "Deleting temporal files..."
-    cd "${WORKSPACE}"
-    rm -rf "${TMP_FOLDER_TEMPLATE_BASE}.*"
-    echo "Done."
-}
-
-trap cleanup EXIT
-
 add_bin_path
 
 echo "--- install gh cli"

--- a/.buildkite/scripts/test-with-integrations.sh
+++ b/.buildkite/scripts/test-with-integrations.sh
@@ -165,10 +165,10 @@ add_pr_comment() {
     local source_pr_number="$1"
     local integrations_pr_link="$2"
 
-    retry 3 \
-        gh pr comment "${source_pr_number}" \
-        --body "Created or updated PR in integrations repository to test this version. Check ${integrations_pr_link}" \
-        --repo "${GITHUB_PR_BASE_OWNER}/${GITHUB_PR_BASE_REPO}"
+    add_github_comment \
+        "${GITHUB_PR_BASE_OWNER}/${GITHUB_PR_BASE_REPO}" \
+        "${source_pr_number}" \
+        "Created or updated PR in integrations repository to test this version. Check ${integrations_pr_link}"
 }
 
 

--- a/.buildkite/scripts/test-with-integrations.sh
+++ b/.buildkite/scripts/test-with-integrations.sh
@@ -3,11 +3,6 @@ source .buildkite/scripts/install_deps.sh
 
 set -euo pipefail
 
-WORKSPACE="$(pwd)"
-
-TMP_FOLDER_TEMPLATE_BASE="tmp.${GITHUB_PR_BASE_REPO}"
-TMP_FOLDER_TEMPLATE="${TMP_FOLDER_TEMPLATE_BASE}.XXXXXXXXX"
-
 cleanup() {
     echo "Deleting temporal files..."
     cd "${WORKSPACE}"

--- a/.buildkite/scripts/test_packages_with_serverless.sh
+++ b/.buildkite/scripts/test_packages_with_serverless.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+source .buildkite/scripts/tooling.sh
+source .buildkite/scripts/install_deps.sh
+
+set -euo pipefail
+
+UPLOAD_SAFE_LOGS=${UPLOAD_SAFE_LOGS:-"0"}
+
+SKIPPED_PACKAGES_FILE_PATH="${WORKSPACE}/skipped_packages.txt"
+FAILED_PACKAGES_FILE_PATH="${WORKSPACE}/failed_packages.txt"
+
+export SERVERLESS="true"
+SERVERLESS_PROJECT=${SERVERLESS_PROJECT:-"observability"}
+
+echo "Running packages on Serverles project type: ${SERVERLESS_PROJECT}"
+if running_on_buildkite; then
+    SERVERLESS_PROJECT="$(buildkite-agent meta-data get SERVERLESS_PROJECT --default ${SERVERLESS_PROJECT:-"observability"})"
+    buildkite-agent annotate "Serverless Project: ${SERVERLESS_PROJECT}" --context "ctx-info-${SERVERLESS_PROJECT}" --style "info"
+fi
+
+add_bin_path
+
+echo "--- install go"
+with_go
+
+echo "--- Install docker"
+with_docker
+echo "--- Install docker-compose"
+with_docker_compose_plugin
+
+echo "--- Install elastic-package"
+# Required to start the Serverless Elastic stack
+make install
+
+prepare_serverless_stack
+
+echo "Waiting time to avoid getaddrinfo ENOTFOUND errors..."
+sleep 120
+echo "Done."
+
+list_packages() {
+    find test/packages/parallel -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort
+}
+
+any_package_failing=0
+
+for package in $(list_packages); do
+    echo "--- Test package: ${package}"
+    if ! .buildkite/scripts/integration_tests.sh -t test-check-packages-parallel -p "${package}" -s ; then
+        echo "- ${package}" >> "${FAILED_PACKAGES_FILE_PATH}"
+        any_package_failing=1
+    fi
+done
+
+if running_on_buildkite ; then
+    if [ -f "${SKIPPED_PACKAGES_FILE_PATH}" ]; then
+        create_collapsed_annotation "Skipped packages in ${SERVERLESS_PROJECT}" "${SKIPPED_PACKAGES_FILE_PATH}" "info" "ctx-skipped-packages-${SERVERLESS_PROJECT}"
+    fi
+
+    if [ -f "${FAILED_PACKAGES_FILE_PATH}" ]; then
+        create_collapsed_annotation "Failed packages in ${SERVERLESS_PROJECT}" "${FAILED_PACKAGES_FILE_PATH}" "error" "ctx-failed-packages-${SERVERLESS_PROJECT}"
+    fi
+fi
+
+if [ $any_package_failing -eq 1 ] ; then
+    echo "These packages have failed:"
+    cat "${FAILED_PACKAGES_FILE_PATH}"
+    exit 1
+fi

--- a/.buildkite/scripts/test_packages_with_serverless.sh
+++ b/.buildkite/scripts/test_packages_with_serverless.sh
@@ -53,7 +53,7 @@ make install
 
 prepare_serverless_stack
 
-echo "Waiting time to avoid getaddrinfo ENOTFOUND errors..."
+echo "Waiting time to avoid getaddrinfo ENOTFOUND errors if any..."
 sleep 120
 echo "Done."
 

--- a/.buildkite/scripts/test_packages_with_serverless.sh
+++ b/.buildkite/scripts/test_packages_with_serverless.sh
@@ -46,7 +46,6 @@ list_packages() {
 any_package_failing=0
 
 for package in $(list_packages); do
-    echo "--- Test package: ${package}"
     if ! .buildkite/scripts/integration_tests.sh -t test-check-packages-parallel -p "${package}" -s ; then
         echo "- ${package}" >> "${FAILED_PACKAGES_FILE_PATH}"
         any_package_failing=1

--- a/.buildkite/scripts/tooling.sh
+++ b/.buildkite/scripts/tooling.sh
@@ -161,3 +161,20 @@ cleanup() {
   rm -rf ${WORKSPACE}/${TMP_FOLDER_TEMPLATE_BASE}.*
   echo "Done."
 }
+
+create_collapsed_annotation() {
+    local title="$1"
+    local file="$2"
+    local style="$3"
+    local context="$4"
+
+    local annotation_file="tmp.annotation.md"
+    echo "<details><summary>${title}</summary>" >> ${annotation_file}
+    echo -e "\n\n" >> ${annotation_file}
+    cat "${file}" >> ${annotation_file}
+    echo "</details>" >> ${annotation_file}
+
+    cat ${annotation_file} | buildkite-agent annotate --style "${style}" --context "${context}"
+
+    rm -f ${annotation_file}
+}

--- a/.buildkite/scripts/tooling.sh
+++ b/.buildkite/scripts/tooling.sh
@@ -89,15 +89,6 @@ create_elastic_package_profile() {
 
 prepare_serverless_stack() {
     echo "--- Prepare serverless stack"
-    local stack_version=${STACK_VERSION:-""}
-
-    local args="-v"
-    if [ -n "${stack_version}" ]; then
-        args="${args} --version ${stack_version}"
-    fi
-
-    # Currently, if STACK_VERSION is not defined, for serverless it will be
-    # used as Elastic stack version (for agents) the default version in elastic-package
 
     # Creating a new profile allow to set a specific name for the serverless project
     local profile_name="elastic-package-${BUILDKITE_PIPELINE_SLUG}-${BUILDKITE_BUILD_NUMBER}-${SERVERLESS_PROJECT}"
@@ -110,6 +101,14 @@ prepare_serverless_stack() {
     export EC_HOST=${EC_HOST_SECRET}
 
     echo "Boot up the Elastic stack"
+    # Currently, if STACK_VERSION is not defined, for serverless it will be
+    # used as Elastic stack version (for agents) the default version in elastic-package
+    local stack_version=${STACK_VERSION:-""}
+    local args="-v"
+    if [ -n "${stack_version}" ]; then
+        args="${args} --version ${stack_version}"
+    fi
+
     # grep command required to remove password from the output
     if ! elastic-package stack up \
         -d \

--- a/.buildkite/scripts/tooling.sh
+++ b/.buildkite/scripts/tooling.sh
@@ -178,3 +178,14 @@ create_collapsed_annotation() {
 
     rm -f ${annotation_file}
 }
+
+add_github_comment() {
+    local repository="$1"
+    local pr_id="$2"
+    local message="$3"
+
+    retry 3 \
+        gh pr comment "${pr_id}" \
+        --body "${message}" \
+        --repo "${repository}"
+}

--- a/README.md
+++ b/README.md
@@ -114,6 +114,26 @@ Usually, this process would require the following manual steps:
     - Creating this PR would automatically trigger a new Jenkins pipeline.
 
 
+### Testing with Elastic serverless
+
+While working on a branch, it might be interesting to test your changes using
+a project created in [Elastic serverless](https://docs.elastic.co/serverless), instead of spinning up a local
+Elastic stack. To do so, you can add a new comment while developing in your Pull request
+a comment like `test serverless`.
+
+Adding that comment in your Pull Request will create a new build of this
+[Buildkite pipeline](https://buildkite.com/elastic/elastic-package-test-serverless).
+This pipeline creates a new Serverless project and run some tests with the packages defined
+in the `test/packages/parallel` folder. Currently, there are some differences with respect to testing
+with a local Elastic stack:
+- System tests are not executed.
+- Disabled comparison of results in pipeline tests to avoid errors related to GeoIP fields
+- Pipeline tests cannot be executed with coverage flags.
+
+At the same time, this pipeline is going to be triggered daily to test the latest contents
+of the main branch with an Elastic serverless project.
+
+
 ## Commands
 
 `elastic-package` currently offers the commands listed below.

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -155,3 +155,54 @@ spec:
         everyone:
           access_level: BUILD_AND_READ
 
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elastic-package-test-serverless
+  description: Pipeline to test elastic-package with Serverless projects
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/elastic-package-test-serverless
+
+spec:
+  type: buildkite-pipeline
+  owner: group:ingest-fp
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: elastic-package-test-serverless
+      description: Pipeline to test elastic-package with Serverless projects
+    spec:
+      pipeline_file: ".buildkite/pipeline.serverless.yml"
+      provider_settings:
+        build_pull_request_forks: false
+        # Managed by buildkite-pr-bot
+        build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
+        publish_commit_status: false # do not update status of commits for this pipeline
+        build_tags: false
+        build_branches: false
+        filter_enabled: true
+        filter_condition: >-
+          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null && build.source == 'api')
+      cancel_intermediate_builds: true
+      cancel_intermediate_builds_branch_filter: '!main'
+      skip_intermediate_builds: true
+      skip_intermediate_builds_branch_filter: '!main'
+      repository: elastic/elastic-package
+      schedules:
+        Test Serverless Daily:
+          branch: main
+          cronline: "00 5 * * *"
+          message: Test Serverless Daily
+          env:
+            SERVERLESS_PROJECT: observability
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: BUILD_AND_READ
+

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -20,6 +20,10 @@ cleanup() {
     kind delete cluster || true
   fi
 
+  # In case it is tested with Elatic serverless, there should be just one Elastic stack
+  # started to test all packages. In our CI, this Elastic serverless stack is started 
+  # at the beginning of the pipeline and must be running for all packages without stopping it between
+  # packages.
   if [[ "$SERVERLESS" != "true" ]]; then
       # Take down the stack
       elastic-package stack down -v
@@ -71,6 +75,9 @@ if [ "${PACKAGE_TEST_TYPE:-other}" == "with-logstash" ]; then
   echo "stack.logstash_enabled: true" >> ~/.elastic-package/profiles/logstash/config.yml
 fi
 
+# In case it is tested with Elatic serverless, there should be just one Elastic stack
+# started to test all packages. In our CI, this Elastic serverless stack is started 
+# at the beginning of the pipeline and must be running for all packages.
 if [[ "${SERVERLESS}" != "true" ]]; then
   # Update the stack
   elastic-package stack update -v

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -123,7 +123,9 @@ for d in test/packages/${PACKAGE_TEST_TYPE:-other}/${PACKAGE_UNDER_TEST:-*}/; do
           # skip system tests
           elastic-package test asset -v --report-format xUnit --report-output file --defer-cleanup 1s  --test-coverage --coverage-format=generic
           elastic-package test static -v --report-format xUnit --report-output file --defer-cleanup 1s  --test-coverage --coverage-format=generic
-          elastic-package test pipeline -v --report-format xUnit --report-output file --defer-cleanup 1s  --test-coverage --coverage-format=generic
+          # FIXME: adding test-coverage for serverless results in errors like this:
+          # Error: error running package pipeline tests: could not complete test run: error calculating pipeline coverage: error fetching pipeline stats for code coverage calculations: need exactly one ES node in stats response (got 4)
+          elastic-package test pipeline -v --report-format xUnit --report-output file --defer-cleanup 1s
           exit # as it is run in a subshell, it cannot be used "continue"
       fi
       # Run all tests

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -114,6 +114,26 @@ Usually, this process would require the following manual steps:
     - Creating this PR would automatically trigger a new Jenkins pipeline.
 
 
+### Testing with Elastic serverless
+
+While working on a branch, it might be interesting to test your changes using
+a project created in [Elastic serverless](https://docs.elastic.co/serverless), instead of spinning up a local
+Elastic stack. To do so, you can add a new comment while developing in your Pull request
+a comment like `test serverless`.
+
+Adding that comment in your Pull Request will create a new build of this
+[Buildkite pipeline](https://buildkite.com/elastic/elastic-package-test-serverless).
+This pipeline creates a new Serverless project and run some tests with the packages defined
+in the `test/packages/parallel` folder. Currently, there are some differences with respect to testing
+with a local Elastic stack:
+- System tests are not executed.
+- Disabled comparison of results in pipeline tests to avoid errors related to GeoIP fields
+- Pipeline tests cannot be executed with coverage flags.
+
+At the same time, this pipeline is going to be triggered daily to test the latest contents
+of the main branch with an Elastic serverless project.
+
+
 ## Commands
 
 `elastic-package` currently offers the commands listed below.


### PR DESCRIPTION
Closes #1656

Add a new pipeline to test `elastic-package` using the Elastic tack from a Serverless project (by default observability project). For that:
- A new pipeline that is going to be executed daily for Observability project
- Currently, this will be tested with all the packages under `test/packages/parallel`
    - No system tests (as in the integrations repository)
    - No coverage for pipeline tests, there are errors like:
      ```
      Error: error running package pipeline tests: could not complete test run: error calculating pipeline coverage: error fetching pipeline stats for code coverage calculations: need exactly one ES node in stats response (got 4)
      ```
    - Set an option to trigger this new pipeline using a comment in the Pull Request: `test serverless`: to be validated once this PR is merged


Example of build running Serverless step:
- https://buildkite.com/elastic/elastic-package/builds/2988
- https://buildkite.com/elastic/elastic-package/builds/2999