### PR TITLE
Correctly pass the Logstash monitoring env vars.

### DIFF
--- a/internal/stack/_static/Dockerfile.logstash
+++ b/internal/stack/_static/Dockerfile.logstash
@@ -1,6 +1,8 @@
 ARG IMAGE
 FROM ${IMAGE}
 
+ENV XPACK_MONITORING_ENABLED=$XPACK_MONITORING_ENABLED
+
 RUN if [ ! "$(bin/logstash-plugin list)" = *logstash-filter-elastic_integration* ]; then \
         echo "Missing plugin logstash-filter-elastic_integration, installing now."; \
         bin/logstash-plugin install logstash-filter-elastic_integration; \


### PR DESCRIPTION
When building Logstash with docker, it needs to pass the env vars to correctly reflect, which Logstash uses env2yaml tool to standardize it to internal settings.