### PR TITLE
Update default version of the stack to 8.13.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test-stack-command-oldest:
 	./scripts/test-stack-command.sh 7.14.2
 
 test-stack-command-7x:
-	./scripts/test-stack-command.sh 7.17.19
+	./scripts/test-stack-command.sh 7.17.21
 
 # Keeping a test for 8.6 because it has an specific configuration file.
 test-stack-command-86:

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test-stack-command-oldest:
 	./scripts/test-stack-command.sh 7.14.2
 
 test-stack-command-7x:
-	./scripts/test-stack-command.sh 7.17.21
+	./scripts/test-stack-command.sh 7.17.19
 
 # Keeping a test for 8.6 because it has an specific configuration file.
 test-stack-command-86:

--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "8.13.2"
+	DefaultStackVersion = "8.13.4"
 )


### PR DESCRIPTION
Update default version, ~and versions used in CI~.

Update:
Just updated default Elastic stack version to 8.13.4. Stack version 7.17 has been reverted due to a failure in the image