### PR TITLE
[Buildkite] Update docker version to 26.1.2

### DIFF
--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -2,7 +2,7 @@ env:
   NOTIFY_TO: "ecosystem-team@elastic.co"
   SETUP_GVM_VERSION: 'v0.5.2' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
   DOCKER_COMPOSE_VERSION: "v2.24.1"
-  DOCKER_VERSION: "26.1.0"
+  DOCKER_VERSION: "26.1.2"
   KIND_VERSION: 'v0.20.0'
   K8S_VERSION: 'v1.29.0'
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,8 @@
 env:
-  SETUP_GVM_VERSION: 'v0.5.1' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
+  SETUP_GVM_VERSION: 'v0.5.2' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
   ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT: "true"
   DOCKER_COMPOSE_VERSION: "v2.24.1"
-  DOCKER_VERSION: "26.1.0"
+  DOCKER_VERSION: "26.1.2"
   KIND_VERSION: 'v0.20.0'
   K8S_VERSION: 'v1.29.0'
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"


### PR DESCRIPTION
This PR updates docker daemon to 26.1.2 version.
Release notes: https://docs.docker.com/engine/release-notes/26.1/#2612