### PR TITLE
Remove unused extra docker-compose files in default agent deployer

### DIFF
--- a/internal/agentdeployer/agent.go
+++ b/internal/agentdeployer/agent.go
@@ -43,9 +43,8 @@ var staticSource = resource.NewSourceFS(static)
 // CustomAgentDeployer knows how to deploy a custom elastic-agent defined via
 // a Docker Compose file.
 type DockerComposeAgentDeployer struct {
-	profile           *profile.Profile
-	dockerComposeFile string
-	stackVersion      string
+	profile      *profile.Profile
+	stackVersion string
 
 	policyName string
 
@@ -59,10 +58,9 @@ type DockerComposeAgentDeployer struct {
 }
 
 type DockerComposeAgentDeployerOptions struct {
-	Profile           *profile.Profile
-	DockerComposeFile string
-	StackVersion      string
-	PolicyName        string
+	Profile      *profile.Profile
+	StackVersion string
+	PolicyName   string
 
 	PackageName string
 	DataStream  string
@@ -86,14 +84,13 @@ var _ DeployedAgent = new(dockerComposeDeployedAgent)
 // NewCustomAgentDeployer returns a new instance of a deployedCustomAgent.
 func NewCustomAgentDeployer(options DockerComposeAgentDeployerOptions) (*DockerComposeAgentDeployer, error) {
 	return &DockerComposeAgentDeployer{
-		profile:           options.Profile,
-		dockerComposeFile: options.DockerComposeFile,
-		stackVersion:      options.StackVersion,
-		packageName:       options.PackageName,
-		dataStream:        options.DataStream,
-		policyName:        options.PolicyName,
-		runTearDown:       options.RunTearDown,
-		runTestsOnly:      options.RunTestsOnly,
+		profile:      options.Profile,
+		stackVersion: options.StackVersion,
+		packageName:  options.PackageName,
+		dataStream:   options.DataStream,
+		policyName:   options.PolicyName,
+		runTearDown:  options.RunTearDown,
+		runTestsOnly: options.RunTestsOnly,
 	}, nil
 }
 
@@ -125,20 +122,10 @@ func (d *DockerComposeAgentDeployer) SetUp(ctx context.Context, agentInfo AgentI
 		return nil, fmt.Errorf("could not create resources for custom agent: %w", err)
 	}
 
-	ymlPaths := []string{
-		filepath.Join(configDir, dockerTestAgentDockerCompose),
-	}
-	if d.dockerComposeFile != "" {
-		ymlPaths = []string{
-			d.dockerComposeFile,
-			filepath.Join(configDir, dockerTestAgentDockerCompose),
-		}
-	}
-
 	composeProjectName := fmt.Sprintf("elastic-package-agent-%s", d.agentName())
 
 	agent := dockerComposeDeployedAgent{
-		ymlPaths: ymlPaths,
+		ymlPaths: []string{filepath.Join(configDir, dockerTestAgentDockerCompose)},
 		project:  composeProjectName,
 		env:      env,
 	}

--- a/internal/agentdeployer/factory.go
+++ b/internal/agentdeployer/factory.go
@@ -52,14 +52,13 @@ func Factory(options FactoryOptions) (AgentDeployer, error) {
 			return nil, fmt.Errorf("agent deployer is not supported for type %s", options.Type)
 		}
 		opts := DockerComposeAgentDeployerOptions{
-			Profile:           options.Profile,
-			DockerComposeFile: "", // TODO: Allow other docker-compose files to apply overrides
-			StackVersion:      options.StackVersion,
-			PackageName:       options.PackageName,
-			PolicyName:        options.PolicyName,
-			DataStream:        options.DataStream,
-			RunTearDown:       options.RunTearDown,
-			RunTestsOnly:      options.RunTestsOnly,
+			Profile:      options.Profile,
+			StackVersion: options.StackVersion,
+			PackageName:  options.PackageName,
+			PolicyName:   options.PolicyName,
+			DataStream:   options.DataStream,
+			RunTearDown:  options.RunTearDown,
+			RunTestsOnly: options.RunTestsOnly,
 		}
 		return NewCustomAgentDeployer(opts)
 	case "agent":


### PR DESCRIPTION
Part of #787 

This PR removes the option to add extra docker-compose files to the default agent deployer.

This was added in case it would be needed to add a new docker-compse file to override the settings of the Elastic Agent. However, this has been changed in favor of a more generic approach of using provisioning (or pre-start) scripts. This approach could be used also in different environments too.

Related PRs:
- https://github.com/elastic/elastic-package/pull/1822
