### PR TITLE
Enable independent agents if root privileges are required at both package or data stream level

### DIFF
--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -190,9 +190,6 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 		}
 
 		runIndependentElasticAgent := false
-
-		// If the environment variable is present, it always has preference over the root
-		// privileges value (if any) defined in the manifest file
 		v, ok := os.LookupEnv(enableIndependentAgents)
 		if ok {
 			runIndependentElasticAgent = strings.ToLower(v) == "true"

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -189,9 +189,7 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 			return fmt.Errorf("cannot determine if package has data streams: %w", err)
 		}
 
-		// Temporarily until independent Elastic Agents are enabled by default,
-		// enable independent Elastic Agents if package defines that requires root privileges
-		runIndependentElasticAgent := manifest.Agent.Privileges.Root
+		runIndependentElasticAgent := false
 
 		// If the environment variable is present, it always has preference over the root
 		// privileges value (if any) defined in the manifest file

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -18,7 +18,6 @@ import (
 	"github.com/elastic/elastic-package/internal/cobraext"
 	"github.com/elastic/elastic-package/internal/common"
 	"github.com/elastic/elastic-package/internal/elasticsearch"
-	"github.com/elastic/elastic-package/internal/environment"
 	"github.com/elastic/elastic-package/internal/install"
 	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/logger"
@@ -52,8 +51,6 @@ For details on how to run static tests for a package, see the [HOWTO guide](http
 These tests allow you to test a package's ability to ingest data end-to-end.
 
 For details on how to configure amd run system tests, review the [HOWTO guide](https://github.com/elastic/elastic-package/blob/main/docs/howto/system_testing.md).`
-
-var enableIndependentAgents = environment.WithElasticPackagePrefix("TEST_ENABLE_INDEPENDENT_AGENT")
 
 func setupTestCommand() *cobraext.Command {
 	var testTypeCmdActions []cobraext.CommandAction
@@ -187,12 +184,6 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 		hasDataStreams, err := packageHasDataStreams(manifest)
 		if err != nil {
 			return fmt.Errorf("cannot determine if package has data streams: %w", err)
-		}
-
-		runIndependentElasticAgent := false
-		v, ok := os.LookupEnv(enableIndependentAgents)
-		if ok {
-			runIndependentElasticAgent = strings.ToLower(v) == "true"
 		}
 
 		configFileFlag := ""
@@ -363,7 +354,7 @@ func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.Command
 				RunSetup:                   runSetup,
 				RunTearDown:                runTearDown,
 				RunTestsOnly:               runTestsOnly,
-				RunIndependentElasticAgent: runIndependentElasticAgent,
+				RunIndependentElasticAgent: false,
 			})
 
 			// Results must be appended even if there is an error, since there could be

--- a/internal/files/repository.go
+++ b/internal/files/repository.go
@@ -11,8 +11,6 @@ import (
 	"path/filepath"
 
 	"gopkg.in/yaml.v3"
-
-	"github.com/elastic/elastic-package/internal/logger"
 )
 
 func FindRepositoryRootDirectory() (string, error) {
@@ -35,7 +33,6 @@ func findRepositoryRootDirectory(workDir string) (string, error) {
 			return "", err
 		}
 		if gitRepo {
-			logger.Debugf("Found git repository directory: %q", dir)
 			return dir, nil
 		}
 		if dir == rootDir {

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -162,6 +162,7 @@ type DataStreamManifest struct {
 		Input string     `config:"input" json:"input" yaml:"input"`
 		Vars  []Variable `config:"vars" json:"vars" yaml:"vars"`
 	} `config:"streams" json:"streams" yaml:"streams"`
+	Agent Agent `config:"agent" json:"agent" yaml:"agent"`
 }
 
 // Transform contains information about a transform included in a package.

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -853,7 +853,7 @@ func (r *runner) prepareScenario(ctx context.Context, config *testConfig, svcInf
 
 	// Temporarily until independent Elastic Agents are enabled by default,
 	// enable independent Elastic Agents if package defines that requires root privileges
-	if scenario.pkgManifest.Agent.Privileges.Root == true || scenario.dataStreamManifest.Agent.Privileges.Root == true {
+	if scenario.pkgManifest.Agent.Privileges.Root || scenario.dataStreamManifest.Agent.Privileges.Root {
 		r.options.RunIndependentElasticAgent = true
 	}
 
@@ -1297,7 +1297,7 @@ func (r *runner) removeServiceStateFile() error {
 
 func (r *runner) createServiceStateDir() error {
 	dirPath := filepath.Dir(r.serviceStateFilePath)
-	err := os.MkdirAll(dirPath, 0755)
+	err := os.MkdirAll(dirPath, 0o755)
 	if err != nil {
 		return fmt.Errorf("mkdir failed (path: %s): %w", dirPath, err)
 	}
@@ -1357,7 +1357,7 @@ func (r *runner) writeScenarioState(opts scenarioStateOpts) error {
 		return fmt.Errorf("failed to marshall service setup data: %w", err)
 	}
 
-	err = os.WriteFile(r.serviceStateFilePath, dataBytes, 0644)
+	err = os.WriteFile(r.serviceStateFilePath, dataBytes, 0o644)
 	if err != nil {
 		return fmt.Errorf("failed to write service setup JSON: %w", err)
 	}
@@ -1976,7 +1976,7 @@ func writeSampleEvent(path string, doc common.MapStr, specVersion semver.Version
 		return fmt.Errorf("marshalling sample event failed: %w", err)
 	}
 
-	err = os.WriteFile(filepath.Join(path, "sample_event.json"), body, 0644)
+	err = os.WriteFile(filepath.Join(path, "sample_event.json"), body, 0o644)
 	if err != nil {
 		return fmt.Errorf("writing sample event failed: %w", err)
 	}

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -1297,7 +1297,7 @@ func (r *runner) removeServiceStateFile() error {
 
 func (r *runner) createServiceStateDir() error {
 	dirPath := filepath.Dir(r.serviceStateFilePath)
-	err := os.MkdirAll(dirPath, 0o755)
+	err := os.MkdirAll(dirPath, 0755)
 	if err != nil {
 		return fmt.Errorf("mkdir failed (path: %s): %w", dirPath, err)
 	}
@@ -1357,7 +1357,7 @@ func (r *runner) writeScenarioState(opts scenarioStateOpts) error {
 		return fmt.Errorf("failed to marshall service setup data: %w", err)
 	}
 
-	err = os.WriteFile(r.serviceStateFilePath, dataBytes, 0o644)
+	err = os.WriteFile(r.serviceStateFilePath, dataBytes, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to write service setup JSON: %w", err)
 	}
@@ -1976,7 +1976,7 @@ func writeSampleEvent(path string, doc common.MapStr, specVersion semver.Version
 		return fmt.Errorf("marshalling sample event failed: %w", err)
 	}
 
-	err = os.WriteFile(filepath.Join(path, "sample_event.json"), body, 0o644)
+	err = os.WriteFile(filepath.Join(path, "sample_event.json"), body, 0644)
 	if err != nil {
 		return fmt.Errorf("writing sample event failed: %w", err)
 	}

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -853,7 +853,7 @@ func (r *runner) prepareScenario(ctx context.Context, config *testConfig, svcInf
 
 	// Temporarily until independent Elastic Agents are enabled by default,
 	// enable independent Elastic Agents if package defines that requires root privileges
-	if scenario.pkgManifest.Agent.Privileges.Root || scenario.dataStreamManifest.Agent.Privileges.Root {
+	if pkg, ds := scenario.pkgManifest, scenario.dataStreamManifest; pkg.Agent.Privileges.Root || (ds != nil && ds.Agent.Privileges.Root) {
 		r.options.RunIndependentElasticAgent = true
 	}
 


### PR DESCRIPTION
Follows #1724 
Relates #1586

This PR also enables independent Elastic Agents in case root privileges are defined in the Data Stream manifest.

If any of the two files (package manifest or Data Stream manifest) defines that root privileges are required, it is enabled independent Elastic Agents.

As previously, if the environment variable `ELASTIC_PACKAGE_TEST_ENABLE_INDEPENENT_AGENT` is set, it has preference over the values defined in those manifests.