### PR TITLE
Add suffix to compose project names

### DIFF
--- a/internal/servicedeployer/custom_agent.go
+++ b/internal/servicedeployer/custom_agent.go
@@ -106,7 +106,7 @@ func (d *CustomAgentDeployer) SetUp(ctx context.Context, svcInfo ServiceInfo) (D
 
 	service := dockerComposeDeployedService{
 		ymlPaths: ymlPaths,
-		project:  "elastic-package-service",
+		project:  fmt.Sprintf("elastic-package-service-%s", svcInfo.Test.RunID),
 		variant: ServiceVariant{
 			Name: dockerCustomAgentName,
 			Env:  env,

--- a/internal/servicedeployer/terraform.go
+++ b/internal/servicedeployer/terraform.go
@@ -113,7 +113,7 @@ func (tsd TerraformServiceDeployer) SetUp(ctx context.Context, svcInfo ServiceIn
 
 	service := dockerComposeDeployedService{
 		ymlPaths:        ymlPaths,
-		project:         "elastic-package-service",
+		project:         fmt.Sprintf("elastic-package-service-%s", svcInfo.Test.RunID),
 		env:             tfEnvironment,
 		shutdownTimeout: 300 * time.Second,
 	}

--- a/scripts/test-system-test-flags.sh
+++ b/scripts/test-system-test-flags.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-DEFAULT_AGENT_CONTAINER_NAME="elastic-package-service-docker-custom-agent"
+DEFAULT_AGENT_CONTAINER_NAME="elastic-package-service-[0-9]{5}-docker-custom-agent"
 
 cleanup() {
     local r=$?


### PR DESCRIPTION
Follows #1838

Add suffix (run ID string) to compose project created by terraform and custom agent service deployers.