### PR TITLE
[Buildkite] Fix cloud cleanup pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,84 +10,76 @@ env:
   IMAGE_UBUNTU_X86_64: "family/core-ubuntu-2204"
 
 steps:
-  - label: "Check cloud cleanup"
-    trigger: elastic-package-cloud-cleanup
-    build:
-      env:
-        DRY_RUN: true
-        BUILDKITE_REFSPEC: "refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
-        BUILDKITE_COMMIT: "${BUILDKITE_COMMIT}"
+  - label: ":go: Run check-static"
+    key: check-static
+    command: "make check-static"
+    agents:
+      image: "${LINUX_AGENT_IMAGE}"
+      cpu: "8"
+      memory: "4G"
 
-  # - label: ":go: Run check-static"
-  #   key: check-static
-  #   command: "make check-static"
-  #   agents:
-  #     image: "${LINUX_AGENT_IMAGE}"
-  #     cpu: "8"
-  #     memory: "4G"
+  - label: ":go: :linux: Run unit tests"
+    key: unit-tests-linux
+    command: "make test-go-ci"
+    artifact_paths:
+      - "build/test-results/*.xml"
+      - "build/test-coverage/*.xml"
+    agents:
+      image: "${LINUX_AGENT_IMAGE}"
+      cpu: "8"
+      memory: "4G"
 
-  # - label: ":go: :linux: Run unit tests"
-  #   key: unit-tests-linux
-  #   command: "make test-go-ci"
-  #   artifact_paths:
-  #     - "build/test-results/*.xml"
-  #     - "build/test-coverage/*.xml"
-  #   agents:
-  #     image: "${LINUX_AGENT_IMAGE}"
-  #     cpu: "8"
-  #     memory: "4G"
+  - label: ":go: :windows: Run unit tests"
+    key: unit-tests-windows
+    command: ".buildkite/scripts/unit_tests_windows.ps1"
+    agents:
+      provider: "gcp"
+      image: "${WINDOWS_AGENT_IMAGE}"
+    artifact_paths:
+      - "TEST-unit-windows.xml"
 
-  # - label: ":go: :windows: Run unit tests"
-  #   key: unit-tests-windows
-  #   command: ".buildkite/scripts/unit_tests_windows.ps1"
-  #   agents:
-  #     provider: "gcp"
-  #     image: "${WINDOWS_AGENT_IMAGE}"
-  #   artifact_paths:
-  #     - "TEST-unit-windows.xml"
+  - wait: ~
+    continue_on_failure: true
 
-  # - wait: ~
-  #   continue_on_failure: true
+  - label: ":pipeline: Trigger Integration tests"
+    command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
+    depends_on:
+      - step: check-static
+        allow_failure: false
+      - step: unit-tests-linux
+        allow_failure: false
+      - step: unit-tests-windows
+        allow_failure: false
 
-  # - label: ":pipeline: Trigger Integration tests"
-  #   command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
-  #   depends_on:
-  #     - step: check-static
-  #       allow_failure: false
-  #     - step: unit-tests-linux
-  #       allow_failure: false
-  #     - step: unit-tests-windows
-  #       allow_failure: false
+  - wait: ~
+    continue_on_failure: true
 
-  # - wait: ~
-  #   continue_on_failure: true
+  - label: ":junit: Transform windows paths to linux for Junit plugin"
+    commands:
+      - buildkite-agent artifact download "*-windows.xml" . --step unit-tests-windows
+      - mkdir -p build/test-results
+      - for file in $(ls *-windows.xml); do mv $$file build/test-results/; done
+    agents:
+      image: "${LINUX_AGENT_IMAGE}"
+      cpu: "8"
+      memory: "4G"
+    artifact_paths:
+      - "build/test-results/*.xml"
 
-  # - label: ":junit: Transform windows paths to linux for Junit plugin"
-  #   commands:
-  #     - buildkite-agent artifact download "*-windows.xml" . --step unit-tests-windows
-  #     - mkdir -p build/test-results
-  #     - for file in $(ls *-windows.xml); do mv $$file build/test-results/; done
-  #   agents:
-  #     image: "${LINUX_AGENT_IMAGE}"
-  #     cpu: "8"
-  #     memory: "4G"
-  #   artifact_paths:
-  #     - "build/test-results/*.xml"
+  - wait: ~
+    continue_on_failure: true
 
-  # - wait: ~
-  #   continue_on_failure: true
+  - label: ":junit: Junit annotate"
+    plugins:
+      - junit-annotate#v2.4.1:
+          artifacts: "build/test-results/*.xml"
+    agents:
+      provider: "gcp"  # junit plugin requires docker
 
-  # - label: ":junit: Junit annotate"
-  #   plugins:
-  #     - junit-annotate#v2.4.1:
-  #         artifacts: "build/test-results/*.xml"
-  #   agents:
-  #     provider: "gcp"  # junit plugin requires docker
-
-  # - label: ":github: Release"
-  #   key: "release"
-  #   if: |
-  #     build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
-  #   command: ".buildkite/scripts/release.sh"
-  #   agents:
-  #     provider: "gcp"
+  - label: ":github: Release"
+    key: "release"
+    if: |
+      build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
+    command: ".buildkite/scripts/release.sh"
+    agents:
+      provider: "gcp"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,76 +10,84 @@ env:
   IMAGE_UBUNTU_X86_64: "family/core-ubuntu-2204"
 
 steps:
-  - label: ":go: Run check-static"
-    key: check-static
-    command: "make check-static"
-    agents:
-      image: "${LINUX_AGENT_IMAGE}"
-      cpu: "8"
-      memory: "4G"
+  - label: "Check cloud cleanup"
+    trigger: elastic-package-cloud-cleanup
+    build:
+      env:
+        DRY_RUN: true
+        BUILDKITE_REFSPEC: "refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
+        BUILDKITE_COMMIT: "${BUILDKITE_COMMIT}"
 
-  - label: ":go: :linux: Run unit tests"
-    key: unit-tests-linux
-    command: "make test-go-ci"
-    artifact_paths:
-      - "build/test-results/*.xml"
-      - "build/test-coverage/*.xml"
-    agents:
-      image: "${LINUX_AGENT_IMAGE}"
-      cpu: "8"
-      memory: "4G"
+  # - label: ":go: Run check-static"
+  #   key: check-static
+  #   command: "make check-static"
+  #   agents:
+  #     image: "${LINUX_AGENT_IMAGE}"
+  #     cpu: "8"
+  #     memory: "4G"
 
-  - label: ":go: :windows: Run unit tests"
-    key: unit-tests-windows
-    command: ".buildkite/scripts/unit_tests_windows.ps1"
-    agents:
-      provider: "gcp"
-      image: "${WINDOWS_AGENT_IMAGE}"
-    artifact_paths:
-      - "TEST-unit-windows.xml"
+  # - label: ":go: :linux: Run unit tests"
+  #   key: unit-tests-linux
+  #   command: "make test-go-ci"
+  #   artifact_paths:
+  #     - "build/test-results/*.xml"
+  #     - "build/test-coverage/*.xml"
+  #   agents:
+  #     image: "${LINUX_AGENT_IMAGE}"
+  #     cpu: "8"
+  #     memory: "4G"
 
-  - wait: ~
-    continue_on_failure: true
+  # - label: ":go: :windows: Run unit tests"
+  #   key: unit-tests-windows
+  #   command: ".buildkite/scripts/unit_tests_windows.ps1"
+  #   agents:
+  #     provider: "gcp"
+  #     image: "${WINDOWS_AGENT_IMAGE}"
+  #   artifact_paths:
+  #     - "TEST-unit-windows.xml"
 
-  - label: ":pipeline: Trigger Integration tests"
-    command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
-    depends_on:
-      - step: check-static
-        allow_failure: false
-      - step: unit-tests-linux
-        allow_failure: false
-      - step: unit-tests-windows
-        allow_failure: false
+  # - wait: ~
+  #   continue_on_failure: true
 
-  - wait: ~
-    continue_on_failure: true
+  # - label: ":pipeline: Trigger Integration tests"
+  #   command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
+  #   depends_on:
+  #     - step: check-static
+  #       allow_failure: false
+  #     - step: unit-tests-linux
+  #       allow_failure: false
+  #     - step: unit-tests-windows
+  #       allow_failure: false
 
-  - label: ":junit: Transform windows paths to linux for Junit plugin"
-    commands:
-      - buildkite-agent artifact download "*-windows.xml" . --step unit-tests-windows
-      - mkdir -p build/test-results
-      - for file in $(ls *-windows.xml); do mv $$file build/test-results/; done
-    agents:
-      image: "${LINUX_AGENT_IMAGE}"
-      cpu: "8"
-      memory: "4G"
-    artifact_paths:
-      - "build/test-results/*.xml"
+  # - wait: ~
+  #   continue_on_failure: true
 
-  - wait: ~
-    continue_on_failure: true
+  # - label: ":junit: Transform windows paths to linux for Junit plugin"
+  #   commands:
+  #     - buildkite-agent artifact download "*-windows.xml" . --step unit-tests-windows
+  #     - mkdir -p build/test-results
+  #     - for file in $(ls *-windows.xml); do mv $$file build/test-results/; done
+  #   agents:
+  #     image: "${LINUX_AGENT_IMAGE}"
+  #     cpu: "8"
+  #     memory: "4G"
+  #   artifact_paths:
+  #     - "build/test-results/*.xml"
 
-  - label: ":junit: Junit annotate"
-    plugins:
-      - junit-annotate#v2.4.1:
-          artifacts: "build/test-results/*.xml"
-    agents:
-      provider: "gcp"  # junit plugin requires docker
+  # - wait: ~
+  #   continue_on_failure: true
 
-  - label: ":github: Release"
-    key: "release"
-    if: |
-      build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
-    command: ".buildkite/scripts/release.sh"
-    agents:
-      provider: "gcp"
+  # - label: ":junit: Junit annotate"
+  #   plugins:
+  #     - junit-annotate#v2.4.1:
+  #         artifacts: "build/test-results/*.xml"
+  #   agents:
+  #     provider: "gcp"  # junit plugin requires docker
+
+  # - label: ":github: Release"
+  #   key: "release"
+  #   if: |
+  #     build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
+  #   command: ".buildkite/scripts/release.sh"
+  #   agents:
+  #     provider: "gcp"

--- a/.buildkite/scripts/cloud-cleanup.sh
+++ b/.buildkite/scripts/cloud-cleanup.sh
@@ -101,6 +101,7 @@ if any_resources_to_delete "${AWS_RESOURCES_FILE}" ; then
     resources_to_delete=1
 fi
 
+echo "Resources to delete: ${resources_to_delete}"
 if [ "${resources_to_delete}" -eq 1 ]; then
     message="There are resources to be deleted"
     echo "${message}"
@@ -170,6 +171,7 @@ jq -c '.Clusters[]' redshift_clusters.json | while read i ; do
     fi
 done
 
+echo "Resources to delete: ${resources_to_delete}"
 if [ "${resources_to_delete}" -eq 1 ]; then
     message="There are redshift resources to be deleted"
     echo "${message}"

--- a/.buildkite/scripts/cloud-cleanup.sh
+++ b/.buildkite/scripts/cloud-cleanup.sh
@@ -8,11 +8,12 @@ AWS_RESOURCES_FILE="aws.resources.txt"
 GCP_RESOURCES_FILE="gcp.resources.txt"
 
 RESOURCE_RETENTION_PERIOD="${RESOURCE_RETENTION_PERIOD:-"24 hours"}"
-export DELETE_RESOURCES_BEFORE_DATE=$(date -Is -d "${RESOURCE_RETENTION_PERIOD} ago")
+DELETE_RESOURCES_BEFORE_DATE=$(date -Is -d "${RESOURCE_RETENTION_PERIOD} ago")
+export DELETE_RESOURCES_BEFORE_DATE
 
 CLOUD_REAPER_IMAGE="${DOCKER_REGISTRY}/observability-ci/cloud-reaper:0.3.0"
 
-DRY_RUN="$(buildkite-agent meta-data get DRY_RUN --default ${DRY_RUN:-"true"})"
+DRY_RUN="$(buildkite-agent meta-data get DRY_RUN --default "${DRY_RUN:-"true"}")"
 
 resources_to_delete=0
 
@@ -39,7 +40,7 @@ any_resources_to_delete() {
 
 cloud_reaper_aws() {
     echo "Validating configuration"
-    docker run --rm -v $(pwd)/.buildkite/configs/cleanup.aws.yml:/etc/cloud-reaper/config.yml \
+    docker run --rm -v "$(pwd)/.buildkite/configs/cleanup.aws.yml":/etc/cloud-reaper/config.yml \
       -e ACCOUNT_SECRET="${ELASTIC_PACKAGE_AWS_SECRET_KEY}" \
       -e ACCOUNT_KEY="${ELASTIC_PACKAGE_AWS_ACCESS_KEY}" \
       -e ACCOUNT_PROJECT="${ELASTIC_PACKAGE_AWS_USER_SECRET}" \
@@ -50,7 +51,7 @@ cloud_reaper_aws() {
           validate
 
     echo "Scanning resources"
-    docker run --rm -v $(pwd)/.buildkite/configs/cleanup.aws.yml:/etc/cloud-reaper/config.yml \
+    docker run --rm -v "$(pwd)/.buildkite/configs/cleanup.aws.yml":/etc/cloud-reaper/config.yml \
       -e ACCOUNT_SECRET="${ELASTIC_PACKAGE_AWS_SECRET_KEY}" \
       -e ACCOUNT_KEY="${ELASTIC_PACKAGE_AWS_ACCESS_KEY}" \
       -e ACCOUNT_PROJECT="${ELASTIC_PACKAGE_AWS_USER_SECRET}" \
@@ -63,7 +64,7 @@ cloud_reaper_aws() {
 
 cloud_reaper_gcp() {
     echo "Validating configuration"
-    docker run --rm -v $(pwd)/.buildkite/configs/cleanup.gcp.yml:/etc/cloud-reaper/config.yml \
+    docker run --rm -v "$(pwd)/.buildkite/configs/cleanup.gcp.yml":/etc/cloud-reaper/config.yml \
       -e ACCOUNT_SECRET="${ELASTIC_PACKAGE_GCP_KEY_SECRET}" \
       -e ACCOUNT_KEY="${ELASTIC_PACKAGE_GCP_EMAIL_SECRET}" \
       -e ACCOUNT_PROJECT="${ELASTIC_PACKAGE_GCP_PROJECT_SECRET}" \
@@ -74,7 +75,7 @@ cloud_reaper_gcp() {
           validate
 
     echo "Scanning resources"
-    docker run --rm -v $(pwd)/.buildkite/configs/cleanup.gcp.yml:/etc/cloud-reaper/config.yml \
+    docker run --rm -v "$(pwd)/.buildkite/configs/cleanup.gcp.yml":/etc/cloud-reaper/config.yml \
       -e ACCOUNT_SECRET="${ELASTIC_PACKAGE_GCP_KEY_SECRET}" \
       -e ACCOUNT_KEY="${ELASTIC_PACKAGE_GCP_EMAIL_SECRET}" \
       -e ACCOUNT_PROJECT="${ELASTIC_PACKAGE_GCP_PROJECT_SECRET}" \
@@ -130,7 +131,7 @@ clusters_num=$(jq -rc '.Clusters | length' redshift_clusters.json)
 
 echo "Number of clusters found: ${clusters_num}"
 
-jq -c '.Clusters[]' redshift_clusters.json | while read i ; do
+jq -c '.Clusters[]' redshift_clusters.json | while read -r i ; do
     identifier=$(echo "$i" | jq -rc ".ClusterIdentifier")
     # tags
     repo=$(echo "$i" | jq -rc '.Tags[] | select(.Key == "repo").Value')

--- a/.buildkite/scripts/cloud-cleanup.sh
+++ b/.buildkite/scripts/cloud-cleanup.sh
@@ -130,7 +130,7 @@ clusters_num=$(jq -rc '.Clusters | length' redshift_clusters.json)
 
 echo "Number of clusters found: ${clusters_num}"
 
-for i in $(jq -c '.Clusters[]' redshift_clusters.json); do
+while read -r i ; do
     identifier=$(echo "$i" | jq -rc ".ClusterIdentifier")
     # tags
     repo=$(echo "$i" | jq -rc '.Tags[] | select(.Key == "repo").Value')
@@ -170,7 +170,7 @@ for i in $(jq -c '.Clusters[]' redshift_clusters.json); do
         #   --skip-final-cluster-snapshot
         echo "Done."
     fi
-done
+done <<< "$(jq -c '.Clusters[]' redshift_clusters.json)"
 
 if [ "${resources_to_delete}" -eq 1 ]; then
     message="There are redshift resources to be deleted"

--- a/.buildkite/scripts/cloud-cleanup.sh
+++ b/.buildkite/scripts/cloud-cleanup.sh
@@ -130,7 +130,7 @@ clusters_num=$(jq -rc '.Clusters | length' redshift_clusters.json)
 
 echo "Number of clusters found: ${clusters_num}"
 
-while read -r i ; do
+for i in $(jq -c '.Clusters[]' redshift_clusters.json); do
     identifier=$(echo "$i" | jq -rc ".ClusterIdentifier")
     # tags
     repo=$(echo "$i" | jq -rc '.Tags[] | select(.Key == "repo").Value')
@@ -170,7 +170,7 @@ while read -r i ; do
         #   --skip-final-cluster-snapshot
         echo "Done."
     fi
-done <<< "$(jq -c '.Clusters[]' redshift_clusters.json)"
+done
 
 if [ "${resources_to_delete}" -eq 1 ]; then
     message="There are redshift resources to be deleted"

--- a/.buildkite/scripts/cloud-cleanup.sh
+++ b/.buildkite/scripts/cloud-cleanup.sh
@@ -163,6 +163,7 @@ jq -c '.Clusters[]' redshift_clusters.json | while read -r i ; do
 
     echo "To be deleted cluster: $identifier. It was created > ${RESOURCE_RETENTION_PERIOD} ago"
     resources_to_delete=1
+    echo "Resources to delete: ${resources_to_delete}"
     if [ "${DRY_RUN}" == "false" ]; then
         echo "Deleting: $identifier. It was created > ${RESOURCE_RETENTION_PERIOD} ago"
         # aws redshift delete-cluster \

--- a/.buildkite/scripts/cloud-cleanup.sh
+++ b/.buildkite/scripts/cloud-cleanup.sh
@@ -102,7 +102,6 @@ if any_resources_to_delete "${AWS_RESOURCES_FILE}" ; then
     resources_to_delete=1
 fi
 
-echo "Resources to delete: ${resources_to_delete}"
 if [ "${resources_to_delete}" -eq 1 ]; then
     message="There are resources to be deleted"
     echo "${message}"
@@ -131,7 +130,7 @@ clusters_num=$(jq -rc '.Clusters | length' redshift_clusters.json)
 
 echo "Number of clusters found: ${clusters_num}"
 
-jq -c '.Clusters[]' redshift_clusters.json | while read -r i ; do
+while read -r i ; do
     identifier=$(echo "$i" | jq -rc ".ClusterIdentifier")
     # tags
     repo=$(echo "$i" | jq -rc '.Tags[] | select(.Key == "repo").Value')
@@ -163,7 +162,6 @@ jq -c '.Clusters[]' redshift_clusters.json | while read -r i ; do
 
     echo "To be deleted cluster: $identifier. It was created > ${RESOURCE_RETENTION_PERIOD} ago"
     resources_to_delete=1
-    echo "Resources to delete: ${resources_to_delete}"
     if [ "${DRY_RUN}" == "false" ]; then
         echo "Deleting: $identifier. It was created > ${RESOURCE_RETENTION_PERIOD} ago"
         # aws redshift delete-cluster \
@@ -171,7 +169,7 @@ jq -c '.Clusters[]' redshift_clusters.json | while read -r i ; do
         #   --skip-final-cluster-snapshot
         echo "Done."
     fi
-done
+done <<< "$(jq -c '.Clusters[]' redshift_clusters.json)"
 
 echo "Resources to delete: ${resources_to_delete}"
 if [ "${resources_to_delete}" -eq 1 ]; then

--- a/.buildkite/scripts/cloud-cleanup.sh
+++ b/.buildkite/scripts/cloud-cleanup.sh
@@ -164,6 +164,7 @@ while read -r i ; do
     resources_to_delete=1
     if [ "${DRY_RUN}" == "false" ]; then
         echo "Deleting: $identifier. It was created > ${RESOURCE_RETENTION_PERIOD} ago"
+        # This command has not been tested
         # aws redshift delete-cluster \
         #   --cluster-identifier "${identifier}" \
         #   --skip-final-cluster-snapshot
@@ -171,7 +172,6 @@ while read -r i ; do
     fi
 done <<< "$(jq -c '.Clusters[]' redshift_clusters.json)"
 
-echo "Resources to delete: ${resources_to_delete}"
 if [ "${resources_to_delete}" -eq 1 ]; then
     message="There are redshift resources to be deleted"
     echo "${message}"


### PR DESCRIPTION
Ensure that the Buildkite pipeline in charge of checking for stale cloud resources fails if there is any resource to delete, so the team is notified.

Example of build with the expected failure:
https://buildkite.com/elastic/elastic-package-cloud-cleanup/builds/84