### PR TITLE
[Buildkite] Enable delete redshift clusters with dry_run false

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -7,7 +7,8 @@ GO_VERSION=$(cat .go-version)
 export GO_VERSION
 
 export SERVERLESS=${SERVERLESS:-"false"}
-export WORKSPACE=$(pwd)
+WORKSPACE=$(pwd)
+export WORKSPACE
 
 
 GCP_SERVICE_ACCOUNT_SECRET_PATH=secret/ci/elastic-elastic-package/gcp-service-account

--- a/.buildkite/pipeline.cloud-cleanup.yml
+++ b/.buildkite/pipeline.cloud-cleanup.yml
@@ -30,7 +30,7 @@ steps:
     command: ".buildkite/scripts/cloud-cleanup.sh"
     env:
       RESOURCE_RETENTION_PERIOD: "24 hours"
-      DRY_RUN: "true"
+      DRY_RUN: "${DRY_RUN:-true}"
     agents:
       provider: "gcp" # this step requires docker
 

--- a/.buildkite/pipeline.cloud-cleanup.yml
+++ b/.buildkite/pipeline.cloud-cleanup.yml
@@ -29,7 +29,7 @@ steps:
     key: "cloud-cleanup"
     command: ".buildkite/scripts/cloud-cleanup.sh"
     env:
-      RESOURCE_RETENTION_PERIOD: "12 hours"
+      RESOURCE_RETENTION_PERIOD: "24 hours"
       DRY_RUN: "${DRY_RUN:-true}"
     agents:
       provider: "gcp" # this step requires docker

--- a/.buildkite/pipeline.cloud-cleanup.yml
+++ b/.buildkite/pipeline.cloud-cleanup.yml
@@ -29,7 +29,7 @@ steps:
     key: "cloud-cleanup"
     command: ".buildkite/scripts/cloud-cleanup.sh"
     env:
-      RESOURCE_RETENTION_PERIOD: "24 hours"
+      RESOURCE_RETENTION_PERIOD: "12 hours"
       DRY_RUN: "${DRY_RUN:-true}"
     agents:
       provider: "gcp" # this step requires docker

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,7 +14,7 @@ steps:
     trigger: elastic-package-cloud-cleanup
     build:
       env:
-        DRY_RUN: false 
+        DRY_RUN: false
         BUILDKITE_REFSPEC: "refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
         BUILDKITE_COMMIT: "${BUILDKITE_COMMIT}"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,84 +10,76 @@ env:
   IMAGE_UBUNTU_X86_64: "family/core-ubuntu-2204"
 
 steps:
-  - label: "Check cloud cleanup"
-    trigger: elastic-package-cloud-cleanup
-    build:
-      env:
-        DRY_RUN: false
-        BUILDKITE_REFSPEC: "refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
-        BUILDKITE_COMMIT: "${BUILDKITE_COMMIT}"
+  - label: ":go: Run check-static"
+    key: check-static
+    command: "make check-static"
+    agents:
+      image: "${LINUX_AGENT_IMAGE}"
+      cpu: "8"
+      memory: "4G"
 
-  # - label: ":go: Run check-static"
-  #   key: check-static
-  #   command: "make check-static"
-  #   agents:
-  #     image: "${LINUX_AGENT_IMAGE}"
-  #     cpu: "8"
-  #     memory: "4G"
+  - label: ":go: :linux: Run unit tests"
+    key: unit-tests-linux
+    command: "make test-go-ci"
+    artifact_paths:
+      - "build/test-results/*.xml"
+      - "build/test-coverage/*.xml"
+    agents:
+      image: "${LINUX_AGENT_IMAGE}"
+      cpu: "8"
+      memory: "4G"
 
-  # - label: ":go: :linux: Run unit tests"
-  #   key: unit-tests-linux
-  #   command: "make test-go-ci"
-  #   artifact_paths:
-  #     - "build/test-results/*.xml"
-  #     - "build/test-coverage/*.xml"
-  #   agents:
-  #     image: "${LINUX_AGENT_IMAGE}"
-  #     cpu: "8"
-  #     memory: "4G"
+  - label: ":go: :windows: Run unit tests"
+    key: unit-tests-windows
+    command: ".buildkite/scripts/unit_tests_windows.ps1"
+    agents:
+      provider: "gcp"
+      image: "${WINDOWS_AGENT_IMAGE}"
+    artifact_paths:
+      - "TEST-unit-windows.xml"
 
-  # - label: ":go: :windows: Run unit tests"
-  #   key: unit-tests-windows
-  #   command: ".buildkite/scripts/unit_tests_windows.ps1"
-  #   agents:
-  #     provider: "gcp"
-  #     image: "${WINDOWS_AGENT_IMAGE}"
-  #   artifact_paths:
-  #     - "TEST-unit-windows.xml"
+  - wait: ~
+    continue_on_failure: true
 
-  # - wait: ~
-  #   continue_on_failure: true
+  - label: ":pipeline: Trigger Integration tests"
+    command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
+    depends_on:
+      - step: check-static
+        allow_failure: false
+      - step: unit-tests-linux
+        allow_failure: false
+      - step: unit-tests-windows
+        allow_failure: false
 
-  # - label: ":pipeline: Trigger Integration tests"
-  #   command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
-  #   depends_on:
-  #     - step: check-static
-  #       allow_failure: false
-  #     - step: unit-tests-linux
-  #       allow_failure: false
-  #     - step: unit-tests-windows
-  #       allow_failure: false
+  - wait: ~
+    continue_on_failure: true
 
-  # - wait: ~
-  #   continue_on_failure: true
+  - label: ":junit: Transform windows paths to linux for Junit plugin"
+    commands:
+      - buildkite-agent artifact download "*-windows.xml" . --step unit-tests-windows
+      - mkdir -p build/test-results
+      - for file in $(ls *-windows.xml); do mv $$file build/test-results/; done
+    agents:
+      image: "${LINUX_AGENT_IMAGE}"
+      cpu: "8"
+      memory: "4G"
+    artifact_paths:
+      - "build/test-results/*.xml"
 
-  # - label: ":junit: Transform windows paths to linux for Junit plugin"
-  #   commands:
-  #     - buildkite-agent artifact download "*-windows.xml" . --step unit-tests-windows
-  #     - mkdir -p build/test-results
-  #     - for file in $(ls *-windows.xml); do mv $$file build/test-results/; done
-  #   agents:
-  #     image: "${LINUX_AGENT_IMAGE}"
-  #     cpu: "8"
-  #     memory: "4G"
-  #   artifact_paths:
-  #     - "build/test-results/*.xml"
+  - wait: ~
+    continue_on_failure: true
 
-  # - wait: ~
-  #   continue_on_failure: true
+  - label: ":junit: Junit annotate"
+    plugins:
+      - junit-annotate#v2.4.1:
+          artifacts: "build/test-results/*.xml"
+    agents:
+      provider: "gcp"  # junit plugin requires docker
 
-  # - label: ":junit: Junit annotate"
-  #   plugins:
-  #     - junit-annotate#v2.4.1:
-  #         artifacts: "build/test-results/*.xml"
-  #   agents:
-  #     provider: "gcp"  # junit plugin requires docker
-
-  # - label: ":github: Release"
-  #   key: "release"
-  #   if: |
-  #     build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
-  #   command: ".buildkite/scripts/release.sh"
-  #   agents:
-  #     provider: "gcp"
+  - label: ":github: Release"
+    key: "release"
+    if: |
+      build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
+    command: ".buildkite/scripts/release.sh"
+    agents:
+      provider: "gcp"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,7 +14,7 @@ steps:
     trigger: elastic-package-cloud-cleanup
     build:
       env:
-        DRY_RUN: true
+        DRY_RUN: false 
         BUILDKITE_REFSPEC: "refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
         BUILDKITE_COMMIT: "${BUILDKITE_COMMIT}"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,7 +14,7 @@ steps:
     trigger: elastic-package-cloud-cleanup
     build:
       env:
-        DRY_RUN: false
+        DRY_RUN: true
         BUILDKITE_REFSPEC: "refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
         BUILDKITE_COMMIT: "${BUILDKITE_COMMIT}"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,76 +10,84 @@ env:
   IMAGE_UBUNTU_X86_64: "family/core-ubuntu-2204"
 
 steps:
-  - label: ":go: Run check-static"
-    key: check-static
-    command: "make check-static"
-    agents:
-      image: "${LINUX_AGENT_IMAGE}"
-      cpu: "8"
-      memory: "4G"
+  - label: "Check cloud cleanup"
+    trigger: elastic-package-cloud-cleanup
+    build:
+      env:
+        DRY_RUN: true
+        BUILDKITE_REFSPEC: "refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
+        BUILDKITE_COMMIT: "${BUILDKITE_COMMIT}"
 
-  - label: ":go: :linux: Run unit tests"
-    key: unit-tests-linux
-    command: "make test-go-ci"
-    artifact_paths:
-      - "build/test-results/*.xml"
-      - "build/test-coverage/*.xml"
-    agents:
-      image: "${LINUX_AGENT_IMAGE}"
-      cpu: "8"
-      memory: "4G"
+  # - label: ":go: Run check-static"
+  #   key: check-static
+  #   command: "make check-static"
+  #   agents:
+  #     image: "${LINUX_AGENT_IMAGE}"
+  #     cpu: "8"
+  #     memory: "4G"
 
-  - label: ":go: :windows: Run unit tests"
-    key: unit-tests-windows
-    command: ".buildkite/scripts/unit_tests_windows.ps1"
-    agents:
-      provider: "gcp"
-      image: "${WINDOWS_AGENT_IMAGE}"
-    artifact_paths:
-      - "TEST-unit-windows.xml"
+  # - label: ":go: :linux: Run unit tests"
+  #   key: unit-tests-linux
+  #   command: "make test-go-ci"
+  #   artifact_paths:
+  #     - "build/test-results/*.xml"
+  #     - "build/test-coverage/*.xml"
+  #   agents:
+  #     image: "${LINUX_AGENT_IMAGE}"
+  #     cpu: "8"
+  #     memory: "4G"
 
-  - wait: ~
-    continue_on_failure: true
+  # - label: ":go: :windows: Run unit tests"
+  #   key: unit-tests-windows
+  #   command: ".buildkite/scripts/unit_tests_windows.ps1"
+  #   agents:
+  #     provider: "gcp"
+  #     image: "${WINDOWS_AGENT_IMAGE}"
+  #   artifact_paths:
+  #     - "TEST-unit-windows.xml"
 
-  - label: ":pipeline: Trigger Integration tests"
-    command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
-    depends_on:
-      - step: check-static
-        allow_failure: false
-      - step: unit-tests-linux
-        allow_failure: false
-      - step: unit-tests-windows
-        allow_failure: false
+  # - wait: ~
+  #   continue_on_failure: true
 
-  - wait: ~
-    continue_on_failure: true
+  # - label: ":pipeline: Trigger Integration tests"
+  #   command: ".buildkite/pipeline.trigger.integration.tests.sh | buildkite-agent pipeline upload"
+  #   depends_on:
+  #     - step: check-static
+  #       allow_failure: false
+  #     - step: unit-tests-linux
+  #       allow_failure: false
+  #     - step: unit-tests-windows
+  #       allow_failure: false
 
-  - label: ":junit: Transform windows paths to linux for Junit plugin"
-    commands:
-      - buildkite-agent artifact download "*-windows.xml" . --step unit-tests-windows
-      - mkdir -p build/test-results
-      - for file in $(ls *-windows.xml); do mv $$file build/test-results/; done
-    agents:
-      image: "${LINUX_AGENT_IMAGE}"
-      cpu: "8"
-      memory: "4G"
-    artifact_paths:
-      - "build/test-results/*.xml"
+  # - wait: ~
+  #   continue_on_failure: true
 
-  - wait: ~
-    continue_on_failure: true
+  # - label: ":junit: Transform windows paths to linux for Junit plugin"
+  #   commands:
+  #     - buildkite-agent artifact download "*-windows.xml" . --step unit-tests-windows
+  #     - mkdir -p build/test-results
+  #     - for file in $(ls *-windows.xml); do mv $$file build/test-results/; done
+  #   agents:
+  #     image: "${LINUX_AGENT_IMAGE}"
+  #     cpu: "8"
+  #     memory: "4G"
+  #   artifact_paths:
+  #     - "build/test-results/*.xml"
 
-  - label: ":junit: Junit annotate"
-    plugins:
-      - junit-annotate#v2.4.1:
-          artifacts: "build/test-results/*.xml"
-    agents:
-      provider: "gcp"  # junit plugin requires docker
+  # - wait: ~
+  #   continue_on_failure: true
 
-  - label: ":github: Release"
-    key: "release"
-    if: |
-      build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
-    command: ".buildkite/scripts/release.sh"
-    agents:
-      provider: "gcp"
+  # - label: ":junit: Junit annotate"
+  #   plugins:
+  #     - junit-annotate#v2.4.1:
+  #         artifacts: "build/test-results/*.xml"
+  #   agents:
+  #     provider: "gcp"  # junit plugin requires docker
+
+  # - label: ":github: Release"
+  #   key: "release"
+  #   if: |
+  #     build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
+  #   command: ".buildkite/scripts/release.sh"
+  #   agents:
+  #     provider: "gcp"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,7 +14,7 @@ steps:
     trigger: elastic-package-cloud-cleanup
     build:
       env:
-        DRY_RUN: true
+        DRY_RUN: false
         BUILDKITE_REFSPEC: "refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
         BUILDKITE_COMMIT: "${BUILDKITE_COMMIT}"
 

--- a/.buildkite/scripts/cloud-cleanup.sh
+++ b/.buildkite/scripts/cloud-cleanup.sh
@@ -168,6 +168,12 @@ while read -r i ; do
           --cluster-identifier "${identifier}" \
           --skip-final-cluster-snapshot
         echo "Done."
+        buildkite-agent annotate \
+            "Deleted redshift cluster: ${identifier}" \
+            --context "ctx-aws-readshift-deleted-${identifier}" \
+            --style "success"
+
+        resources_to_delete=0
     fi
 done <<< "$(jq -c '.Clusters[]' redshift_clusters.json)"
 

--- a/.buildkite/scripts/cloud-cleanup.sh
+++ b/.buildkite/scripts/cloud-cleanup.sh
@@ -164,10 +164,9 @@ while read -r i ; do
     resources_to_delete=1
     if [ "${DRY_RUN}" == "false" ]; then
         echo "Deleting: $identifier. It was created > ${RESOURCE_RETENTION_PERIOD} ago"
-        # This command has not been tested
-        # aws redshift delete-cluster \
-        #   --cluster-identifier "${identifier}" \
-        #   --skip-final-cluster-snapshot
+        aws redshift delete-cluster \
+          --cluster-identifier "${identifier}" \
+          --skip-final-cluster-snapshot
         echo "Done."
     fi
 done <<< "$(jq -c '.Clusters[]' redshift_clusters.json)"

--- a/.buildkite/scripts/cloud-cleanup.sh
+++ b/.buildkite/scripts/cloud-cleanup.sh
@@ -120,6 +120,8 @@ with_aws_cli
 export AWS_ACCESS_KEY_ID="${ELASTIC_PACKAGE_AWS_ACCESS_KEY}"
 export AWS_SECRET_ACCESS_KEY="${ELASTIC_PACKAGE_AWS_SECRET_KEY}"
 export AWS_DEFAULT_REGION=us-east-1
+# Avoid to send the output of the CLI to a pager
+export AWS_PAGER=""
 
 echo "--- Checking if any Redshift cluster still created"
 aws redshift describe-clusters \

--- a/.buildkite/scripts/cloud-cleanup.sh
+++ b/.buildkite/scripts/cloud-cleanup.sh
@@ -190,7 +190,7 @@ while read -r i ; do
       --cluster-identifier "${identifier}" \
       --skip-final-cluster-snapshot \
       --output json \
-      --query "Clusters[*].{ClusterStatus:ClusterStatus,ClusterIdentifier:ClusterIdentifier}" ; then
+      --query "Cluster.{ClusterStatus:ClusterStatus,ClusterIdentifier:ClusterIdentifier}" ; then
 
         echo "Failed delete-cluster"
         buildkite-agent annotate \

--- a/.buildkite/scripts/release.sh
+++ b/.buildkite/scripts/release.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 cleanup_binaries() {
     rm -rf "${WORKSPACE}"
 }
-trap cleanup_binaries exit
+trap cleanup_binaries EXIT
 
 export WORKSPACE="/tmp/bin-buildkite/"
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -153,7 +153,7 @@ spec:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
-          access_level: BUILD_AND_READ
+          access_level: READ_ONLY 
 
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -153,7 +153,7 @@ spec:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
-          access_level: READ_ONLY 
+          access_level: READ_ONLY
 
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json


### PR DESCRIPTION
Enable in cloud cleanup pipeline the action to delete Redshift Clusters when DRY_RUN is set to false.

Currently, keep DRY_RUN=true by default when it is triggered the pipeline automatically, since it has not been tested for the other resources.