### PR TITLE
Honor data_stream.dataset in input packages

### DIFF
--- a/test/packages/parallel/sql_input/_dev/test/system/test-default-config.yml
+++ b/test/packages/parallel/sql_input/_dev/test/system/test-default-config.yml
@@ -2,3 +2,4 @@ vars:
   hosts:
     - root:test@tcp({{Hostname}}:{{Port}})/
   sql_query: "SHOW GLOBAL STATUS LIKE 'Innodb_data%';"
+  data_stream.dataset: sql_input.test

--- a/test/packages/parallel/sql_input/agent/input/input.yml.hbs
+++ b/test/packages/parallel/sql_input/agent/input/input.yml.hbs
@@ -1,4 +1,6 @@
 metricsets: ["query"]
+data_stream:
+  dataset: {{data_stream.dataset}}
 period: {{period}}
 hosts:
 {{#each hosts}}


### PR DESCRIPTION
Input packages need to set `data_stream.dataset` in the agent configuration to actually send data to the configured dataset.

The configured dataset is set by the Fleet UI through a `data_stream.dataset` variable for input packages.

Following this, assume that system test configurations can include a `data_stream.dataset` variable, and use it in the places where a dataset is expected:
* In the data stream name.
* In the package component template.
* In the package policy.
* In the list of expected datasets.