### PR TITLE
Add github action to bump stack versions

### DIFF
--- a/.github/workflows/bump-elastic-stack-version.yml
+++ b/.github/workflows/bump-elastic-stack-version.yml
@@ -15,7 +15,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    needs: [filter]
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/bump-elastic-stack-version.yml
+++ b/.github/workflows/bump-elastic-stack-version.yml
@@ -1,0 +1,30 @@
+---
+name: bump-elastic-stack-version
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 15 * * 1-5'
+
+permissions:
+  contents: read
+
+jobs:
+  bump-elastic-stack:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    needs: [filter]
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@9a37c7e35598d7b37d8e7568b40ed9538112be01 # v0.76.1
+
+      - name: Run Updatecli in Apply mode
+        run: updatecli --experimental apply --config .github/workflows/updatecli.d/bump-elastic-stack-version.yml --values .github/workflows/updatecli.d/scm.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.ECOSYSTEM_USER_TOKEN }}

--- a/.github/workflows/bump-elastic-stack-version.yml
+++ b/.github/workflows/bump-elastic-stack-version.yml
@@ -24,6 +24,7 @@ jobs:
         uses: updatecli/updatecli-action@9a37c7e35598d7b37d8e7568b40ed9538112be01 # v0.76.1
 
       - name: Run Updatecli in Apply mode
-        run: updatecli --experimental apply --config .github/workflows/updatecli.d/bump-elastic-stack-version.yml --values .github/workflows/updatecli.d/scm.yml
+        # TODO: Change from diff to apply.
+        run: updatecli diff --config .github/workflows/updatecli.d/bump-elastic-stack-version.yml --values .github/workflows/updatecli.d/scm.yml
         env:
           GITHUB_TOKEN: ${{ secrets.ECOSYSTEM_USER_TOKEN }}

--- a/.github/workflows/updatecli.d/bump-elastic-stack-version.yml
+++ b/.github/workflows/updatecli.d/bump-elastic-stack-version.yml
@@ -1,0 +1,94 @@
+---
+name: Bump elastic-stack versions
+pipelineid: 'bump-elastic-stack-version'
+
+actions:
+  default:
+    title: '[updatecli] update elastic stack version for testing {{ source "latestVersion" }}'
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      labels:
+        - automation
+        - dependency
+        - backport-skip
+        - build-monitoring
+        - Team:Beats-On-Call
+
+scms:
+  default:
+    kind: github
+    spec:
+      owner: '{{ .scm.owner }}'
+      repository: '{{ .scm.repository }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      commitusingapi: true
+
+sources:
+  latestSnapshot:
+    name: Get latest snapshot build
+    kind: json
+    spec:
+      file: https://storage.googleapis.com/artifacts-api/snapshots/main.json
+      key: .build_id
+  latest7xSnapshot:
+    name: Get latest 7.x snapshot build
+    kind: json
+    spec:
+      file: https://storage.googleapis.com/artifacts-api/snapshots/7.17.json
+      key: .build_id
+  latest8xVersion:
+    name: Get latest 8.x version
+    kind: file
+    transformers:
+      # Get only the version to avoid spaces and newlines.
+      - findsubmatch:
+          pattern: '([0-9\.]+)'
+          captureindex: 1
+    spec:
+      file: https://storage.googleapis.com/artifacts-api/releases/current/8
+  latestRegistryVersion:
+    name: Get latest Package Registry version
+    kind: json
+    spec:
+      file: https://api.github.com/repos/elastic/package-registry/releases/latest
+      key: .tag_name
+
+targets:
+  update-snapshot:
+    name: "Update snapshot"
+    kind: file
+    sourceid: latestSnapshot
+    scmid: default
+    spec:
+      file: Makefile
+      matchpattern: '(./scripts/test-stack-command.sh) 8\.[^\s]+-SNAPSHOT'
+      replacepattern: '$1 {{ source "latestSnapshot" }}-SNAPSHOT'
+  update-7x-version:
+    name: "Update 7.x version"
+    kind: file
+    sourceid: latest7xSnapshot
+    scmid: default
+    spec:
+      file: Makefile
+      matchpattern: '(./scripts/test-stack-command.sh) 7\.17\.[^\s]*'
+      replacepattern: '$1 {{ source "latest7xSnapshot" }}-SNAPSHOT'
+  update-default-version:
+    name: "Update default version"
+    kind: file
+    sourceid: latest8xVersion
+    scmid: default
+    spec:
+      file: internal/install/stack_version.go
+      matchpattern: '(DefaultStackVersion =) "[^"]+"'
+      replacepattern: '$1 "{{ source "latest8xVersion" }}"'
+  update-package-registry-base-image:
+    name: "Update Package Registry base image"
+    kind: file
+    sourceid: latestRegistryVersion
+    scmid: default
+    spec:
+      file: internal/stack/resources.go
+      matchpattern: '"(docker.elastic.co/package-registry/package-registry):v[0-9\.]+"'
+      replacepattern: '"$1:{{ source "latestRegistryVersion" }}"'

--- a/.github/workflows/updatecli.d/bump-elastic-stack-version.yml
+++ b/.github/workflows/updatecli.d/bump-elastic-stack-version.yml
@@ -11,9 +11,6 @@ actions:
       labels:
         - automation
         - dependency
-        - backport-skip
-        - build-monitoring
-        - Team:Beats-On-Call
 
 scms:
   default:

--- a/.github/workflows/updatecli.d/scm.yml
+++ b/.github/workflows/updatecli.d/scm.yml
@@ -1,0 +1,4 @@
+---
+scm:
+  owner: elastic
+  repository: elastic-package


### PR DESCRIPTION
Add github action to automate bump of stack versions.

It bumps:
- Latest snapshot build for 8.x.
- Latest snapshot build for 7.17.x.
- Stack default version.
- Package Registry version.