### PR TITLE
Fixes bump elastic stack workflow

### DIFF
--- a/.github/workflows/bump-elastic-stack-version.yml
+++ b/.github/workflows/bump-elastic-stack-version.yml
@@ -1,5 +1,5 @@
 ---
-name: bump-elastic-stack-version
+name: Update versions of Elastic Stack dependencies
 
 on:
   workflow_dispatch:
@@ -21,10 +21,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@9a37c7e35598d7b37d8e7568b40ed9538112be01 # v0.76.1
+        uses: updatecli/updatecli-action@v2.58.0 # v0.77.0
 
       - name: Run Updatecli in Apply mode
         # TODO: Change from diff to apply.
-        run: updatecli diff --config .github/workflows/updatecli.d/bump-elastic-stack-version.yml --values .github/workflows/updatecli.d/scm.yml
+        # --experimental needed for commitusingapi option.
+        run: updatecli --experimental diff --config .github/workflows/updatecli.d/bump-elastic-stack-version.yml --values .github/workflows/updatecli.d/scm.yml
         env:
           GITHUB_TOKEN: ${{ secrets.ECOSYSTEM_USER_TOKEN }}

--- a/.github/workflows/bump-elastic-stack-version.yml
+++ b/.github/workflows/bump-elastic-stack-version.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@v2.58.0 # v0.77.0
+        uses: updatecli/updatecli-action@v2.58.0 # updatecli v0.77.0
 
       - name: Update default stack version
         # --experimental needed for commitusingapi option.

--- a/.github/workflows/bump-elastic-stack-version.yml
+++ b/.github/workflows/bump-elastic-stack-version.yml
@@ -28,4 +28,4 @@ jobs:
         # --experimental needed for commitusingapi option.
         run: updatecli --experimental apply --config .github/workflows/updatecli.d/bump-elastic-stack-version.yml --values .github/workflows/updatecli.d/scm.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.ECOSYSTEM_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump-elastic-stack-version.yml
+++ b/.github/workflows/bump-elastic-stack-version.yml
@@ -26,6 +26,6 @@ jobs:
       - name: Run Updatecli in Apply mode
         # TODO: Change from diff to apply.
         # --experimental needed for commitusingapi option.
-        run: updatecli --experimental diff --config .github/workflows/updatecli.d/bump-elastic-stack-version.yml --values .github/workflows/updatecli.d/scm.yml
+        run: updatecli --experimental apply --config .github/workflows/updatecli.d/bump-elastic-stack-version.yml --values .github/workflows/updatecli.d/scm.yml
         env:
           GITHUB_TOKEN: ${{ secrets.ECOSYSTEM_USER_TOKEN }}

--- a/.github/workflows/bump-elastic-stack-version.yml
+++ b/.github/workflows/bump-elastic-stack-version.yml
@@ -4,7 +4,7 @@ name: Update versions of Elastic Stack dependencies
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 15 * * 1-5'
+    - cron: '0 1 * * 1-5'
 
 permissions:
   contents: read

--- a/.github/workflows/bump-elastic-stack-version.yml
+++ b/.github/workflows/bump-elastic-stack-version.yml
@@ -23,9 +23,26 @@ jobs:
       - name: Install Updatecli in the runner
         uses: updatecli/updatecli-action@v2.58.0 # v0.77.0
 
-      - name: Run Updatecli in Apply mode
-        # TODO: Change from diff to apply.
+      - name: Update default stack version
         # --experimental needed for commitusingapi option.
         run: updatecli --experimental apply --config .github/workflows/updatecli.d/bump-elastic-stack-version.yml --values .github/workflows/updatecli.d/scm.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update latest testing 7.x stack version
+        # --experimental needed for commitusingapi option.
+        run: updatecli --experimental apply --config .github/workflows/updatecli.d/bump-latest-7x-version.yml --values .github/workflows/updatecli.d/scm.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update latest testing stack version
+        # --experimental needed for commitusingapi option.
+        run: updatecli --experimental apply --config .github/workflows/updatecli.d/bump-latest-snapshot-version.yml --values .github/workflows/updatecli.d/scm.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Package Registry version
+        # --experimental needed for commitusingapi option.
+        run: updatecli --experimental apply --config .github/workflows/updatecli.d/bump-package-registry-version.yml --values .github/workflows/updatecli.d/scm.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/updatecli.d/bump-elastic-stack-version.yml
+++ b/.github/workflows/updatecli.d/bump-elastic-stack-version.yml
@@ -4,6 +4,7 @@ pipelineid: 'bump-elastic-stack-default-version'
 
 actions:
   default:
+    title: '[updatecli] Update default stack version to {{ source "latest8xVersion" }}'
     kind: github/pullrequest
     scmid: default
     spec:

--- a/.github/workflows/updatecli.d/bump-elastic-stack-version.yml
+++ b/.github/workflows/updatecli.d/bump-elastic-stack-version.yml
@@ -54,7 +54,7 @@ sources:
 
 targets:
   update-snapshot:
-    name: 'Update latest snapshot to {{ source "latestSnapshot" }}'
+    name: '[updatecli] Update latest snapshot to {{ source "latestSnapshot" }}'
     kind: file
     sourceid: latestSnapshot
     scmid: default
@@ -63,8 +63,7 @@ targets:
       matchpattern: '(./scripts/test-stack-command.sh) 8\.[^\s]+-SNAPSHOT'
       replacepattern: '$1 {{ source "latestSnapshot" }}-SNAPSHOT'
   update-7x-version:
-    name: "Update 7.x version"
-    title: '[updatecli] Update 7.x snapshot to {{ source "latest7xSnapshot" }}'
+    name: '[updatecli] Update 7.x snapshot to {{ source "latest7xSnapshot" }}'
     kind: file
     sourceid: latest7xSnapshot
     scmid: default
@@ -73,8 +72,7 @@ targets:
       matchpattern: '(./scripts/test-stack-command.sh) 7\.17\.[^\s]*'
       replacepattern: '$1 {{ source "latest7xSnapshot" }}-SNAPSHOT'
   update-default-version:
-    name: "Update default version"
-    title: '[updatecli] Update default stack version to {{ source "latest8xVersion" }}'
+    name: '[updatecli] Update default stack version to {{ source "latest8xVersion" }}'
     kind: file
     sourceid: latest8xVersion
     scmid: default
@@ -83,8 +81,7 @@ targets:
       matchpattern: '(DefaultStackVersion =) "[^"]+"'
       replacepattern: '$1 "{{ source "latest8xVersion" }}"'
   update-package-registry-base-image:
-    name: "Update Package Registry base image"
-    title: '[updatecli] Update Package Registry base image to {{ source "latestRegistryVersion" }}'
+    name: '[updatecli] Update Package Registry base image to {{ source "latestRegistryVersion" }}'
     kind: file
     sourceid: latestRegistryVersion
     scmid: default

--- a/.github/workflows/updatecli.d/bump-elastic-stack-version.yml
+++ b/.github/workflows/updatecli.d/bump-elastic-stack-version.yml
@@ -20,6 +20,7 @@ scms:
       user: '{{ requiredEnv "GITHUB_ACTOR" }}'
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       commitusingapi: true
+      branch: main
 
 sources:
   latestSnapshot:

--- a/.github/workflows/updatecli.d/bump-elastic-stack-version.yml
+++ b/.github/workflows/updatecli.d/bump-elastic-stack-version.yml
@@ -4,7 +4,6 @@ pipelineid: 'bump-elastic-stack-version'
 
 actions:
   default:
-    title: '[updatecli] update elastic stack version for testing {{ source "latestVersion" }}'
     kind: github/pullrequest
     scmid: default
     spec:
@@ -54,7 +53,7 @@ sources:
 
 targets:
   update-snapshot:
-    name: "Update snapshot"
+    name: 'Update latest snapshot to {{ source "latestSnapshot" }}'
     kind: file
     sourceid: latestSnapshot
     scmid: default
@@ -64,6 +63,7 @@ targets:
       replacepattern: '$1 {{ source "latestSnapshot" }}-SNAPSHOT'
   update-7x-version:
     name: "Update 7.x version"
+    title: '[updatecli] Update 7.x snapshot to {{ source "latest7xSnapshot" }}'
     kind: file
     sourceid: latest7xSnapshot
     scmid: default
@@ -73,6 +73,7 @@ targets:
       replacepattern: '$1 {{ source "latest7xSnapshot" }}-SNAPSHOT'
   update-default-version:
     name: "Update default version"
+    title: '[updatecli] Update default stack version to {{ source "latest8xVersion" }}'
     kind: file
     sourceid: latest8xVersion
     scmid: default
@@ -82,6 +83,7 @@ targets:
       replacepattern: '$1 "{{ source "latest8xVersion" }}"'
   update-package-registry-base-image:
     name: "Update Package Registry base image"
+    title: '[updatecli] Update Package Registry base image to {{ source "latestRegistryVersion" }}'
     kind: file
     sourceid: latestRegistryVersion
     scmid: default

--- a/.github/workflows/updatecli.d/bump-elastic-stack-version.yml
+++ b/.github/workflows/updatecli.d/bump-elastic-stack-version.yml
@@ -1,6 +1,6 @@
 ---
-name: Bump elastic-stack versions
-pipelineid: 'bump-elastic-stack-version'
+name: Bump elastic-stack default version
+pipelineid: 'bump-elastic-stack-default-version'
 
 actions:
   default:
@@ -23,18 +23,6 @@ scms:
       branch: main
 
 sources:
-  latestSnapshot:
-    name: Get latest snapshot build
-    kind: json
-    spec:
-      file: https://storage.googleapis.com/artifacts-api/snapshots/main.json
-      key: .build_id
-  latest7xSnapshot:
-    name: Get latest 7.x snapshot build
-    kind: json
-    spec:
-      file: https://storage.googleapis.com/artifacts-api/snapshots/7.17.json
-      key: .build_id
   latest8xVersion:
     name: Get latest 8.x version
     kind: file
@@ -45,32 +33,8 @@ sources:
           captureindex: 1
     spec:
       file: https://storage.googleapis.com/artifacts-api/releases/current/8
-  latestRegistryVersion:
-    name: Get latest Package Registry version
-    kind: json
-    spec:
-      file: https://api.github.com/repos/elastic/package-registry/releases/latest
-      key: .tag_name
 
 targets:
-  update-snapshot:
-    name: '[updatecli] Update latest snapshot to {{ source "latestSnapshot" }}'
-    kind: file
-    sourceid: latestSnapshot
-    scmid: default
-    spec:
-      file: Makefile
-      matchpattern: '(./scripts/test-stack-command.sh) 8\.[^\s]+-SNAPSHOT'
-      replacepattern: '$1 {{ source "latestSnapshot" }}-SNAPSHOT'
-  update-7x-version:
-    name: '[updatecli] Update 7.x snapshot to {{ source "latest7xSnapshot" }}'
-    kind: file
-    sourceid: latest7xSnapshot
-    scmid: default
-    spec:
-      file: Makefile
-      matchpattern: '(./scripts/test-stack-command.sh) 7\.17\.[^\s]*'
-      replacepattern: '$1 {{ source "latest7xSnapshot" }}-SNAPSHOT'
   update-default-version:
     name: '[updatecli] Update default stack version to {{ source "latest8xVersion" }}'
     kind: file
@@ -80,12 +44,3 @@ targets:
       file: internal/install/stack_version.go
       matchpattern: '(DefaultStackVersion =) "[^"]+"'
       replacepattern: '$1 "{{ source "latest8xVersion" }}"'
-  update-package-registry-base-image:
-    name: '[updatecli] Update Package Registry base image to {{ source "latestRegistryVersion" }}'
-    kind: file
-    sourceid: latestRegistryVersion
-    scmid: default
-    spec:
-      file: internal/stack/resources.go
-      matchpattern: '"(docker.elastic.co/package-registry/package-registry):v[0-9\.]+"'
-      replacepattern: '"$1:{{ source "latestRegistryVersion" }}"'

--- a/.github/workflows/updatecli.d/bump-latest-7x-version.yml
+++ b/.github/workflows/updatecli.d/bump-latest-7x-version.yml
@@ -4,6 +4,7 @@ pipelineid: 'bump-elastic-stack-7x-version'
 
 actions:
   default:
+    title: '[updatecli] Update 7.x snapshot to {{ source "latest7xSnapshot" }}'
     kind: github/pullrequest
     scmid: default
     spec:

--- a/.github/workflows/updatecli.d/bump-latest-7x-version.yml
+++ b/.github/workflows/updatecli.d/bump-latest-7x-version.yml
@@ -1,0 +1,42 @@
+---
+name: Bump 7.x test version
+pipelineid: 'bump-elastic-stack-7x-version'
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      labels:
+        - automation
+        - dependency
+
+scms:
+  default:
+    kind: github
+    spec:
+      owner: '{{ .scm.owner }}'
+      repository: '{{ .scm.repository }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      commitusingapi: true
+      branch: main
+
+sources:
+  latest7xSnapshot:
+    name: Get latest 7.x snapshot build
+    kind: json
+    spec:
+      file: https://storage.googleapis.com/artifacts-api/snapshots/7.17.json
+      key: .build_id
+
+targets:
+  update-7x-version:
+    name: '[updatecli] Update 7.x snapshot to {{ source "latest7xSnapshot" }}'
+    kind: file
+    sourceid: latest7xSnapshot
+    scmid: default
+    spec:
+      file: Makefile
+      matchpattern: '(./scripts/test-stack-command.sh) 7\.17\.[^\s]*'
+      replacepattern: '$1 {{ source "latest7xSnapshot" }}-SNAPSHOT'

--- a/.github/workflows/updatecli.d/bump-latest-snapshot-version.yml
+++ b/.github/workflows/updatecli.d/bump-latest-snapshot-version.yml
@@ -4,6 +4,7 @@ pipelineid: 'bump-latest-elastic-stack-version'
 
 actions:
   default:
+    title: '[updatecli] Update latest snapshot to {{ source "latestSnapshot" }}'
     kind: github/pullrequest
     scmid: default
     spec:

--- a/.github/workflows/updatecli.d/bump-latest-snapshot-version.yml
+++ b/.github/workflows/updatecli.d/bump-latest-snapshot-version.yml
@@ -1,0 +1,42 @@
+---
+name: Bump latest elastic-stack test version
+pipelineid: 'bump-latest-elastic-stack-version'
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      labels:
+        - automation
+        - dependency
+
+scms:
+  default:
+    kind: github
+    spec:
+      owner: '{{ .scm.owner }}'
+      repository: '{{ .scm.repository }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      commitusingapi: true
+      branch: main
+
+sources:
+  latestSnapshot:
+    name: Get latest snapshot build
+    kind: json
+    spec:
+      file: https://storage.googleapis.com/artifacts-api/snapshots/main.json
+      key: .build_id
+
+targets:
+  update-snapshot:
+    name: '[updatecli] Update latest snapshot to {{ source "latestSnapshot" }}'
+    kind: file
+    sourceid: latestSnapshot
+    scmid: default
+    spec:
+      file: Makefile
+      matchpattern: '(./scripts/test-stack-command.sh) 8\.[^\s]+-SNAPSHOT'
+      replacepattern: '$1 {{ source "latestSnapshot" }}-SNAPSHOT'

--- a/.github/workflows/updatecli.d/bump-package-registry-version.yml
+++ b/.github/workflows/updatecli.d/bump-package-registry-version.yml
@@ -4,6 +4,7 @@ pipelineid: 'bump-package-registry-version'
 
 actions:
   default:
+    title: '[updatecli] Update Package Registry base image to {{ source "latestRegistryVersion" }}'
     kind: github/pullrequest
     scmid: default
     spec:

--- a/.github/workflows/updatecli.d/bump-package-registry-version.yml
+++ b/.github/workflows/updatecli.d/bump-package-registry-version.yml
@@ -1,0 +1,42 @@
+---
+name: Bump Package Registry version
+pipelineid: 'bump-package-registry-version'
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      labels:
+        - automation
+        - dependency
+
+scms:
+  default:
+    kind: github
+    spec:
+      owner: '{{ .scm.owner }}'
+      repository: '{{ .scm.repository }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      commitusingapi: true
+      branch: main
+
+sources:
+  latestRegistryVersion:
+    name: Get latest Package Registry version
+    kind: json
+    spec:
+      file: https://api.github.com/repos/elastic/package-registry/releases/latest
+      key: .tag_name
+
+targets:
+  update-package-registry-base-image:
+    name: '[updatecli] Update Package Registry base image to {{ source "latestRegistryVersion" }}'
+    kind: file
+    sourceid: latestRegistryVersion
+    scmid: default
+    spec:
+      file: internal/stack/resources.go
+      matchpattern: '"(docker.elastic.co/package-registry/package-registry):v[0-9\.]+"'
+      replacepattern: '"$1:{{ source "latestRegistryVersion" }}"'


### PR DESCRIPTION
Follow-up of https://github.com/elastic/elastic-package/pull/1853.

It fixes some issues found after running the workflow:
- Enable execution by changing from `diff` to `apply`.
- Each target is executed in a different updatecli run, so they create different PRs with more meaningful titles.
- `--experimental` flag is required to use `commitusingapi` option.
- Updated `updatecli-action` to latest version.

Test execution can be found in https://github.com/elastic/elastic-package/actions/runs/9212610692, which has created the following PRs:
- https://github.com/elastic/elastic-package/pull/1860
- https://github.com/elastic/elastic-package/pull/1861
