### PR TITLE
Update fleet-server healthcheck to be parameterizable

### DIFF
--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -1,6 +1,14 @@
-{{ $username := fact "username" }}
-{{ $password := fact "password" }}
-{{ $apm_enabled := fact "apm_enabled" }}
+{{- $username := fact "username" -}}
+{{- $password := fact "password" -}}
+{{- $apm_enabled := fact "apm_enabled" -}}
+{{- $version := fact "kibana_version" -}}
+
+{{- $fleet_healthcheck_success_checks := 3 -}}
+{{- $fleet_healthcheck_waiting_time := 1 -}}
+{{- if semverLessThan $version "8.0.0" -}}
+    {{- $fleet_healthcheck_success_checks = 10 -}}
+    {{- $fleet_healthcheck_waiting_time = 2 -}}
+{{- end -}}
 services:
   elasticsearch:
     image: "${ELASTICSEARCH_IMAGE_REF}"
@@ -94,7 +102,7 @@ services:
       kibana:
         condition: service_healthy
     healthcheck:
-      test: "bash /healthcheck.sh"
+      test: "bash /healthcheck.sh {{ $fleet_healthcheck_success_checks }} {{ $fleet_healthcheck_waiting_time }}"
       start_period: 60s
       interval: 5s
     hostname: docker-fleet-server

--- a/internal/stack/_static/fleet-server-healthcheck.sh
+++ b/internal/stack/_static/fleet-server-healthcheck.sh
@@ -2,16 +2,19 @@
 
 set -e -o pipefail
 
+NUMBER_SUCCESSES=$1
+WAITING_TIME=$2
+
 healthcheck() {
-    curl --cacert /etc/ssl/elastic-agent/ca-cert.pem -f https://localhost:8220/api/status | grep -i healthy 2>&1 >/dev/null
+    curl -s --cacert /etc/ssl/elastic-agent/ca-cert.pem -f https://localhost:8220/api/status | grep -i healthy 2>&1 >/dev/null
 }
 
 # Fleet Server can restart after announcing to be healthy, agents connecting during this restart will
 # fail to enroll. Expect 3 healthy healthchecks before considering it healthy.
-expected=3
-for i in $(seq $expected); do
+for i in $(seq "$NUMBER_SUCCESSES"); do
+	echo "Iter $i"
 	healthcheck
-	sleep 1
+	sleep "$WAITING_TIME"
 done
 
 exit 0

--- a/internal/stack/_static/fleet-server-healthcheck.sh
+++ b/internal/stack/_static/fleet-server-healthcheck.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-set -e -o pipefail
+set -e -u -o pipefail
 
-NUMBER_SUCCESSES=$1
-WAITING_TIME=$2
+NUMBER_SUCCESSES="$1"
+WAITING_TIME="$2"
 
 healthcheck() {
     curl -s --cacert /etc/ssl/elastic-agent/ca-cert.pem -f https://localhost:8220/api/status | grep -i healthy 2>&1 >/dev/null
@@ -12,7 +12,7 @@ healthcheck() {
 # Fleet Server can restart after announcing to be healthy, agents connecting during this restart will
 # fail to enroll. Expect 3 healthy healthchecks before considering it healthy.
 for i in $(seq "$NUMBER_SUCCESSES"); do
-	echo "Iter $i"
+	echo "Healthcheck run: $i"
 	healthcheck
 	sleep "$WAITING_TIME"
 done


### PR DESCRIPTION
This PR updates the Fleet Server healthcheck that is configured for the Elastic stack (docker-compose).

It allows to define different values for:
- number of success executions
- waiting time between iterations

This allows to set other values for Elastic stack versions <8.0.0. It has been observed that there are some issues in those packages running with Elastic tack 7.14.1 where the Elastic Agent of the stack could not be enrolled in Fleet.

Example of the Elastic Agent log:
- Elastic Agent cannot enroll in Fleet and it starts as managed locally
```
elastic-agent-1  | 2024-05-23T11:12:35.841Z	INFO	cmd/enroll_cmd.go:396	Starting enrollment to URL: https://fleet-server:8220/
elastic-agent-1  | Error: fail to enroll: fail to execute request to fleet-server: status code: 503, fleet-server returned an error: ServiceUnavailable, message: server is stopping
elastic-agent-1  | Error: enrollment failed: exit status 1
elastic-agent-1  | 2024-05-23T11:12:42.294Z	INFO	application/application.go:66	Detecting execution mode
elastic-agent-1  | 2024-05-23T11:12:42.295Z	INFO	application/application.go:75	Agent is managed locally
```

Errors shown in `elastic-package`:
- It didn't find any Elastic Agent with the required parameters
```
2024/05/23 11:13:25 DEBUG filter agents using criteria: NamePrefix=docker-fleet-agent
2024/05/23 11:13:25 DEBUG Number of available agents found (before filtering): 2
2024/05/23 11:13:25 DEBUG Found agent with policy revision 0: docker-fleet-agent
2024/05/23 11:13:25 DEBUG Found agent with NamePrefix (looking for docker-fleet-agent): docker-fleet-server
2024/05/23 11:13:25 DEBUG found 0 enrolled agent(s)
2024/05/23 11:13:26 DEBUG GET https://127.0.0.1:5601/api/fleet/agents
```

Build with failures:
https://buildkite.com/elastic/integrations/builds/11808#018fa520-0134-436c-a40b-c406f4803be6

Builds ran with these new parameters for healthcheck successfully:
- https://buildkite.com/elastic/integrations/builds/11884
- https://buildkite.com/elastic/integrations/builds/11886