### PR TITLE
Use SNAPSHOT image without build tag for 7.x

### DIFF
--- a/.github/workflows/updatecli.d/bump-latest-7x-version.yml
+++ b/.github/workflows/updatecli.d/bump-latest-7x-version.yml
@@ -25,11 +25,11 @@ scms:
 
 sources:
   latest7xSnapshot:
-    name: Get latest 7.x snapshot build
+    name: Get latest 7.x snapshot
     kind: json
     spec:
       file: https://storage.googleapis.com/artifacts-api/snapshots/7.17.json
-      key: .build_id
+      key: .version
 
 targets:
   update-7x-version:
@@ -40,4 +40,4 @@ targets:
     spec:
       file: Makefile
       matchpattern: '(./scripts/test-stack-command.sh) 7\.17\.[^\s]*'
-      replacepattern: '$1 {{ source "latest7xSnapshot" }}-SNAPSHOT'
+      replacepattern: '$1 {{ source "latest7xSnapshot" }}'


### PR DESCRIPTION
It looks like the image with the build id is not available for the complete image. Go back to use just the SNAPSHOT image.