### PR TITLE
Add missing Test Run ID for service up command

### DIFF
--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -6,8 +6,14 @@ package common
 
 import (
 	"fmt"
+	"math/rand"
 	"slices"
 	"strings"
+)
+
+const (
+	testRunMaxID = 99999
+	testRunMinID = 10000
 )
 
 // TrimStringSlice removes whitespace from the beginning and end of the contents of a []string.
@@ -47,4 +53,8 @@ func ToStringSlice(val interface{}) ([]string, error) {
 		s = append(s, str)
 	}
 	return s, nil
+}
+
+func CreateTestRunID() string {
+	return fmt.Sprintf("%d", rand.Intn(testRunMaxID-testRunMinID)+testRunMinID)
 }

--- a/internal/service/boot.go
+++ b/internal/service/boot.go
@@ -8,11 +8,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/elastic/elastic-package/internal/common"
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/profile"
 
@@ -20,15 +20,6 @@ import (
 	"github.com/elastic/elastic-package/internal/servicedeployer"
 	"github.com/elastic/elastic-package/internal/testrunner/runners/system"
 )
-
-const (
-	testRunMaxID = 99999
-	testRunMinID = 10000
-)
-
-func createTestRunID() string {
-	return fmt.Sprintf("%d", rand.Intn(testRunMaxID-testRunMinID)+testRunMinID)
-}
 
 // Options define the details of the service which should be booted up.
 type Options struct {
@@ -74,7 +65,7 @@ func BootUp(ctx context.Context, options Options) error {
 	svcInfo.Name = options.ServiceName
 	svcInfo.Logs.Folder.Agent = system.ServiceLogsAgentDir
 	svcInfo.Logs.Folder.Local = locationManager.ServiceLogDir()
-	svcInfo.Test.RunID = createTestRunID()
+	svcInfo.Test.RunID = common.CreateTestRunID()
 	deployed, err := serviceDeployer.SetUp(ctx, svcInfo)
 	if err != nil {
 		return fmt.Errorf("can't set up the service deployer: %w", err)

--- a/internal/service/boot.go
+++ b/internal/service/boot.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"os"
 	"os/signal"
 	"syscall"
@@ -19,6 +20,15 @@ import (
 	"github.com/elastic/elastic-package/internal/servicedeployer"
 	"github.com/elastic/elastic-package/internal/testrunner/runners/system"
 )
+
+const (
+	testRunMaxID = 99999
+	testRunMinID = 10000
+)
+
+func createTestRunID() string {
+	return fmt.Sprintf("%d", rand.Intn(testRunMaxID-testRunMinID)+testRunMinID)
+}
 
 // Options define the details of the service which should be booted up.
 type Options struct {
@@ -64,6 +74,7 @@ func BootUp(ctx context.Context, options Options) error {
 	svcInfo.Name = options.ServiceName
 	svcInfo.Logs.Folder.Agent = system.ServiceLogsAgentDir
 	svcInfo.Logs.Folder.Local = locationManager.ServiceLogDir()
+	svcInfo.Test.RunID = createTestRunID()
 	deployed, err := serviceDeployer.SetUp(ctx, svcInfo)
 	if err != nil {
 		return fmt.Errorf("can't set up the service deployer: %w", err)

--- a/internal/servicedeployer/factory.go
+++ b/internal/servicedeployer/factory.go
@@ -31,9 +31,6 @@ type FactoryOptions struct {
 
 	PolicyName string
 
-	PackageName string
-	DataStream  string
-
 	Variant string
 
 	RunTearDown  bool

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -339,8 +339,6 @@ func (r *runner) createServiceOptions(variantName string) servicedeployer.Factor
 		Variant:                variantName,
 		Type:                   servicedeployer.TypeTest,
 		StackVersion:           r.stackVersion.Version(),
-		PackageName:            r.options.TestFolder.Package,
-		DataStream:             r.options.TestFolder.DataStream,
 		RunTearDown:            r.options.RunTearDown,
 		RunTestsOnly:           r.options.RunTestsOnly,
 		RunSetup:               r.options.RunSetup,

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -41,9 +40,6 @@ import (
 )
 
 const (
-	testRunMaxID = 99999
-	testRunMinID = 10000
-
 	checkFieldsBody = `{
 		"fields": ["*"],
 		"runtime_mappings": {
@@ -385,7 +381,7 @@ func (r *runner) createServiceInfo() (servicedeployer.ServiceInfo, error) {
 	svcInfo.Name = r.options.TestFolder.Package
 	svcInfo.Logs.Folder.Local = r.locationManager.ServiceLogDir()
 	svcInfo.Logs.Folder.Agent = ServiceLogsAgentDir
-	svcInfo.Test.RunID = createTestRunID()
+	svcInfo.Test.RunID = common.CreateTestRunID()
 
 	if r.options.RunTearDown || r.options.RunTestsOnly {
 		logger.Debug("Skip creating output directory")
@@ -644,10 +640,6 @@ func (r *runner) runTestPerVariant(ctx context.Context, result *testrunner.Resul
 		return partial, fmt.Errorf("failed to tear down runner: %w", tdErr)
 	}
 	return partial, nil
-}
-
-func createTestRunID() string {
-	return fmt.Sprintf("%d", rand.Intn(testRunMaxID-testRunMinID)+testRunMinID)
 }
 
 func (r *runner) isSyntheticsEnabled(ctx context.Context, dataStream, componentTemplatePackage string) (bool, error) {
@@ -1256,7 +1248,7 @@ func (r *runner) setupAgent(ctx context.Context, config *testConfig, state Servi
 	if !r.options.RunIndependentElasticAgent {
 		return nil, agentdeployer.AgentInfo{}, nil
 	}
-	agentRunID := createTestRunID()
+	agentRunID := common.CreateTestRunID()
 	if r.options.RunTearDown || r.options.RunTestsOnly {
 		agentRunID = state.AgentRunID
 	}


### PR DESCRIPTION
Follows #1850 

Add missing test run ID when creating the service using `elastic-package service up` command.

Take the chance to remove some unused fields from `servicedeployer.FactoryOptions`.