### PR TITLE
Enable http2 in kibana

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,6 +648,8 @@ The following settings are available per profile:
 * `stack.geoip_dir` defines a directory with GeoIP databases that can be used by
   Elasticsearch in stacks managed by elastic-package. It is recommended to use
   an absolute path, out of the `.elastic-package` directory.
+* `stack.kibana_http2_enabled` can be used to control if HTTP/2 should be used in versions of
+  kibana that support it. Defaults to true.
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -1,6 +1,10 @@
 {{ $version := fact "kibana_version" }}
 server.name: kibana
 server.host: "0.0.0.0"
+{{ if not (semverLessThan $version "8.15.0") }}
+server.protocol: http2
+{{ end }}
+
 server.ssl.enabled: true
 server.ssl.certificate: "/usr/share/kibana/config/certs/cert.pem"
 server.ssl.key: "/usr/share/kibana/config/certs/key.pem"

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -1,10 +1,9 @@
-{{ $version := fact "kibana_version" }}
+{{- $version := fact "kibana_version" }}
 server.name: kibana
 server.host: "0.0.0.0"
-{{ if not (semverLessThan $version "8.15.0") }}
+{{- if not (semverLessThan $version "8.15.0-SNAPSHOT") }}
 server.protocol: http2
-{{ end }}
-
+{{ end -}}
 server.ssl.enabled: true
 server.ssl.certificate: "/usr/share/kibana/config/certs/cert.pem"
 server.ssl.key: "/usr/share/kibana/config/certs/key.pem"

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -1,7 +1,8 @@
 {{- $version := fact "kibana_version" }}
 server.name: kibana
 server.host: "0.0.0.0"
-{{- if not (semverLessThan $version "8.15.0-SNAPSHOT") }}
+{{- $kibana_http2_enabled := fact "kibana_http2_enabled" -}}
+{{- if (and (eq $kibana_http2_enabled "true") (not (semverLessThan $version "8.15.0-SNAPSHOT"))) }}
 server.protocol: http2
 {{ end -}}
 server.ssl.enabled: true

--- a/internal/stack/resources.go
+++ b/internal/stack/resources.go
@@ -62,6 +62,7 @@ const (
 
 	configAPMEnabled         = "stack.apm_enabled"
 	configGeoIPDir           = "stack.geoip_dir"
+	configKibanaHTTP2Enabled = "stack.kibana_http2_enabled"
 	configLogstashEnabled    = "stack.logstash_enabled"
 	configSelfMonitorEnabled = "stack.self_monitor_enabled"
 )
@@ -165,6 +166,7 @@ func applyResources(profile *profile.Profile, stackVersion string) error {
 		"logstash_enabled":     profile.Config(configLogstashEnabled, "false"),
 		"self_monitor_enabled": profile.Config(configSelfMonitorEnabled, "false"),
 		"agent_publish_ports":  strings.Join(agentPorts, ","),
+		"kibana_http2_enabled": profile.Config(configKibanaHTTP2Enabled, "true"),
 	})
 
 	if err := os.MkdirAll(stackDir, 0755); err != nil {

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -190,6 +190,8 @@ The following settings are available per profile:
 * `stack.geoip_dir` defines a directory with GeoIP databases that can be used by
   Elasticsearch in stacks managed by elastic-package. It is recommended to use
   an absolute path, out of the `.elastic-package` directory.
+* `stack.kibana_http2_enabled` can be used to control if HTTP/2 should be used in versions of
+  kibana that support it. Defaults to true.
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.


### PR DESCRIPTION
Kibana 8.15.0 will have support for HTTP2 (after https://github.com/elastic/kibana/pull/183465). Let's use it in local stacks managed by `elastic-package`.

Or should we wait till this is closer to GA?