### PR TITLE
Update elastic-package test command to define each command separately

### DIFF
--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -155,12 +155,13 @@ func testRunnerAssetCommandAction(cmd *cobra.Command, args []string) error {
 	_, pkg := filepath.Split(packageRootPath)
 
 	results, err := testrunner.Run(ctx, testType, testrunner.TestOptions{
-		Profile:         profile,
-		TestFolder:      testrunner.TestFolder{Package: pkg},
-		PackageRootPath: packageRootPath,
-		WithCoverage:    testCoverage,
-		CoverageType:    testCoverageFormat,
-		KibanaClient:    kibanaClient,
+		Profile:                    profile,
+		TestFolder:                 testrunner.TestFolder{Package: pkg},
+		PackageRootPath:            packageRootPath,
+		WithCoverage:               testCoverage,
+		CoverageType:               testCoverageFormat,
+		KibanaClient:               kibanaClient,
+		RunIndependentElasticAgent: false,
 	})
 
 	if err != nil {
@@ -290,12 +291,13 @@ func testRunnerStaticCommandAction(cmd *cobra.Command, args []string) error {
 	var results []testrunner.TestResult
 	for _, folder := range testFolders {
 		r, err := testrunner.Run(ctx, testType, testrunner.TestOptions{
-			Profile:         profile,
-			TestFolder:      folder,
-			PackageRootPath: packageRootPath,
-			KibanaClient:    kibanaClient,
-			WithCoverage:    testCoverage,
-			CoverageType:    testCoverageFormat,
+			Profile:                    profile,
+			TestFolder:                 folder,
+			PackageRootPath:            packageRootPath,
+			KibanaClient:               kibanaClient,
+			WithCoverage:               testCoverage,
+			CoverageType:               testCoverageFormat,
+			RunIndependentElasticAgent: false,
 		})
 
 		// Results must be appended even if there is an error, since there could be
@@ -452,15 +454,16 @@ func testRunnerPipelineCommandAction(cmd *cobra.Command, args []string) error {
 	var results []testrunner.TestResult
 	for _, folder := range testFolders {
 		r, err := testrunner.Run(ctx, testType, testrunner.TestOptions{
-			Profile:            profile,
-			TestFolder:         folder,
-			PackageRootPath:    packageRootPath,
-			GenerateTestResult: generateTestResult,
-			API:                esClient.API,
-			KibanaClient:       kibanaClient,
-			WithCoverage:       testCoverage,
-			CoverageType:       testCoverageFormat,
-			DeferCleanup:       deferCleanup,
+			Profile:                    profile,
+			TestFolder:                 folder,
+			PackageRootPath:            packageRootPath,
+			GenerateTestResult:         generateTestResult,
+			API:                        esClient.API,
+			KibanaClient:               kibanaClient,
+			WithCoverage:               testCoverage,
+			CoverageType:               testCoverageFormat,
+			DeferCleanup:               deferCleanup,
+			RunIndependentElasticAgent: false,
 		})
 
 		// Results must be appended even if there is an error, since there could be
@@ -851,13 +854,14 @@ func testRunnerPolicyCommandAction(cmd *cobra.Command, args []string) error {
 	var results []testrunner.TestResult
 	for _, folder := range testFolders {
 		r, err := testrunner.Run(ctx, testType, testrunner.TestOptions{
-			Profile:            profile,
-			TestFolder:         folder,
-			PackageRootPath:    packageRootPath,
-			GenerateTestResult: generateTestResult,
-			KibanaClient:       kibanaClient,
-			WithCoverage:       testCoverage,
-			CoverageType:       testCoverageFormat,
+			Profile:                    profile,
+			TestFolder:                 folder,
+			PackageRootPath:            packageRootPath,
+			GenerateTestResult:         generateTestResult,
+			KibanaClient:               kibanaClient,
+			WithCoverage:               testCoverage,
+			CoverageType:               testCoverageFormat,
+			RunIndependentElasticAgent: false,
 		})
 
 		// Results must be appended even if there is an error, since there could be

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -60,26 +60,23 @@ func setupTestCommand() *cobraext.Command {
 		Use:   "test",
 		Short: "Run test suite for the package",
 		Long:  testLongDescription,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			err := cobraext.ComposeCommands(args,
-				getTestRunnerAssetCommand(),
-				getTestRunnerStaticCommand(),
-				getTestRunnerPipelineCommand(),
-				getTestRunnerSystemCommand(),
-				getTestRunnerPolicyCommand(),
-			)
-			if err != nil {
-				return fmt.Errorf("testing package failed: %w", err)
+		RunE: func(parent *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("unsupported test type: %s", args[0])
 			}
-			return nil
+			return cobraext.ComposeCommandsParentContext(parent, args, parent.Commands()...)
 		},
 	}
 
-	// cmd.PersistentFlags().StringP(cobraext.ReportFormatFlagName, "", string(formats.ReportFormatHuman), cobraext.ReportFormatFlagDescription)
-	// cmd.PersistentFlags().StringP(cobraext.ReportOutputFlagName, "", string(outputs.ReportOutputSTDOUT), cobraext.ReportOutputFlagDescription)
-	// cmd.PersistentFlags().BoolP(cobraext.TestCoverageFlagName, "", false, cobraext.TestCoverageFlagDescription)
-	// cmd.PersistentFlags().StringP(cobraext.TestCoverageFormatFlagName, "", "cobertura", fmt.Sprintf(cobraext.TestCoverageFormatFlagDescription, strings.Join(testrunner.CoverageFormatsList(), ",")))
-	// cmd.PersistentFlags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
+	cmd.PersistentFlags().StringP(cobraext.ReportFormatFlagName, "", string(formats.ReportFormatHuman), cobraext.ReportFormatFlagDescription)
+	cmd.PersistentFlags().StringP(cobraext.ReportOutputFlagName, "", string(outputs.ReportOutputSTDOUT), cobraext.ReportOutputFlagDescription)
+	cmd.PersistentFlags().BoolP(cobraext.TestCoverageFlagName, "", false, cobraext.TestCoverageFlagDescription)
+	cmd.PersistentFlags().StringP(cobraext.TestCoverageFormatFlagName, "", "cobertura", fmt.Sprintf(cobraext.TestCoverageFormatFlagDescription, strings.Join(testrunner.CoverageFormatsList(), ",")))
+	cmd.PersistentFlags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
+
+	// Just used in pipeline and system tests
+	// Keep it here for backwards compatbility
+	cmd.PersistentFlags().DurationP(cobraext.DeferCleanupFlagName, "", 0, cobraext.DeferCleanupFlagDescription)
 
 	assetCmd := getTestRunnerAssetCommand()
 	cmd.AddCommand(assetCmd.Command)
@@ -107,13 +104,6 @@ func getTestRunnerAssetCommand() *cobraext.Command {
 		Args:  cobra.NoArgs,
 		RunE:  testRunnerAssetCommandAction,
 	}
-
-	// Globals
-	cmd.Flags().StringP(cobraext.ReportFormatFlagName, "", string(formats.ReportFormatHuman), cobraext.ReportFormatFlagDescription)
-	cmd.Flags().StringP(cobraext.ReportOutputFlagName, "", string(outputs.ReportOutputSTDOUT), cobraext.ReportOutputFlagDescription)
-	cmd.Flags().BoolP(cobraext.TestCoverageFlagName, "", false, cobraext.TestCoverageFlagDescription)
-	cmd.Flags().StringP(cobraext.TestCoverageFormatFlagName, "", "cobertura", fmt.Sprintf(cobraext.TestCoverageFormatFlagDescription, strings.Join(testrunner.CoverageFormatsList(), ",")))
-	cmd.Flags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
 
 	return cobraext.NewCommand(cmd, cobraext.ContextPackage)
 }
@@ -199,13 +189,6 @@ func getTestRunnerStaticCommand() *cobraext.Command {
 		Args:  cobra.NoArgs,
 		RunE:  testRunnerStaticCommandAction,
 	}
-
-	// Globals
-	cmd.Flags().StringP(cobraext.ReportFormatFlagName, "", string(formats.ReportFormatHuman), cobraext.ReportFormatFlagDescription)
-	cmd.Flags().StringP(cobraext.ReportOutputFlagName, "", string(outputs.ReportOutputSTDOUT), cobraext.ReportOutputFlagDescription)
-	cmd.Flags().BoolP(cobraext.TestCoverageFlagName, "", false, cobraext.TestCoverageFlagDescription)
-	cmd.Flags().StringP(cobraext.TestCoverageFormatFlagName, "", "cobertura", fmt.Sprintf(cobraext.TestCoverageFormatFlagDescription, strings.Join(testrunner.CoverageFormatsList(), ",")))
-	cmd.Flags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
 
 	cmd.Flags().BoolP(cobraext.FailOnMissingFlagName, "m", false, cobraext.FailOnMissingFlagDescription)
 	cmd.Flags().StringSliceP(cobraext.DataStreamsFlagName, "d", nil, cobraext.DataStreamsFlagDescription)
@@ -348,16 +331,8 @@ func getTestRunnerPipelineCommand() *cobraext.Command {
 		RunE:  testRunnerPipelineCommandAction,
 	}
 
-	// Globals
-	cmd.Flags().StringP(cobraext.ReportFormatFlagName, "", string(formats.ReportFormatHuman), cobraext.ReportFormatFlagDescription)
-	cmd.Flags().StringP(cobraext.ReportOutputFlagName, "", string(outputs.ReportOutputSTDOUT), cobraext.ReportOutputFlagDescription)
-	cmd.Flags().BoolP(cobraext.TestCoverageFlagName, "", false, cobraext.TestCoverageFlagDescription)
-	cmd.Flags().StringP(cobraext.TestCoverageFormatFlagName, "", "cobertura", fmt.Sprintf(cobraext.TestCoverageFormatFlagDescription, strings.Join(testrunner.CoverageFormatsList(), ",")))
-	cmd.Flags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
-
 	cmd.Flags().BoolP(cobraext.FailOnMissingFlagName, "m", false, cobraext.FailOnMissingFlagDescription)
 	cmd.Flags().BoolP(cobraext.GenerateTestResultFlagName, "g", false, cobraext.GenerateTestResultFlagDescription)
-	cmd.Flags().DurationP(cobraext.DeferCleanupFlagName, "", 0, cobraext.DeferCleanupFlagDescription)
 	cmd.Flags().StringSliceP(cobraext.DataStreamsFlagName, "d", nil, cobraext.DataStreamsFlagDescription)
 
 	return cobraext.NewCommand(cmd, cobraext.ContextPackage)
@@ -521,16 +496,8 @@ func getTestRunnerSystemCommand() *cobraext.Command {
 		RunE:  testRunnerSystemCommandAction,
 	}
 
-	// Globals
-	cmd.Flags().StringP(cobraext.ReportFormatFlagName, "", string(formats.ReportFormatHuman), cobraext.ReportFormatFlagDescription)
-	cmd.Flags().StringP(cobraext.ReportOutputFlagName, "", string(outputs.ReportOutputSTDOUT), cobraext.ReportOutputFlagDescription)
-	cmd.Flags().BoolP(cobraext.TestCoverageFlagName, "", false, cobraext.TestCoverageFlagDescription)
-	cmd.Flags().StringP(cobraext.TestCoverageFormatFlagName, "", "cobertura", fmt.Sprintf(cobraext.TestCoverageFormatFlagDescription, strings.Join(testrunner.CoverageFormatsList(), ",")))
-	cmd.Flags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
-
 	cmd.Flags().BoolP(cobraext.FailOnMissingFlagName, "m", false, cobraext.FailOnMissingFlagDescription)
 	cmd.Flags().BoolP(cobraext.GenerateTestResultFlagName, "g", false, cobraext.GenerateTestResultFlagDescription)
-	cmd.Flags().DurationP(cobraext.DeferCleanupFlagName, "", 0, cobraext.DeferCleanupFlagDescription)
 	cmd.Flags().StringSliceP(cobraext.DataStreamsFlagName, "d", nil, cobraext.DataStreamsFlagDescription)
 	cmd.Flags().String(cobraext.VariantFlagName, "", cobraext.VariantFlagDescription)
 
@@ -776,13 +743,6 @@ func getTestRunnerPolicyCommand() *cobraext.Command {
 		Args:  cobra.NoArgs,
 		RunE:  testRunnerPolicyCommandAction,
 	}
-
-	// Globals
-	cmd.Flags().StringP(cobraext.ReportFormatFlagName, "", string(formats.ReportFormatHuman), cobraext.ReportFormatFlagDescription)
-	cmd.Flags().StringP(cobraext.ReportOutputFlagName, "", string(outputs.ReportOutputSTDOUT), cobraext.ReportOutputFlagDescription)
-	cmd.Flags().BoolP(cobraext.TestCoverageFlagName, "", false, cobraext.TestCoverageFlagDescription)
-	cmd.Flags().StringP(cobraext.TestCoverageFormatFlagName, "", "cobertura", fmt.Sprintf(cobraext.TestCoverageFormatFlagDescription, strings.Join(testrunner.CoverageFormatsList(), ",")))
-	cmd.Flags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
 
 	cmd.Flags().BoolP(cobraext.FailOnMissingFlagName, "m", false, cobraext.FailOnMissingFlagDescription)
 	cmd.Flags().StringSliceP(cobraext.DataStreamsFlagName, "d", nil, cobraext.DataStreamsFlagDescription)

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -17,9 +17,7 @@ import (
 
 	"github.com/elastic/elastic-package/internal/cobraext"
 	"github.com/elastic/elastic-package/internal/common"
-	"github.com/elastic/elastic-package/internal/elasticsearch"
 	"github.com/elastic/elastic-package/internal/install"
-	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/signal"
@@ -58,345 +56,848 @@ These tests allow you to test different configuration options and the policies t
 For details on how to configure and run policy tests, review the [HOWTO guide](https://github.com/elastic/elastic-package/blob/main/docs/howto/policy_testing.md).`
 
 func setupTestCommand() *cobraext.Command {
-	var testTypeCmdActions []cobraext.CommandAction
-
 	cmd := &cobra.Command{
 		Use:   "test",
 		Short: "Run test suite for the package",
 		Long:  testLongDescription,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.Println("Run test suite for the package")
-
-			if len(args) > 0 {
-				return fmt.Errorf("unsupported test type: %s", args[0])
-			}
-
-			return cobraext.ComposeCommandActions(cmd, args, testTypeCmdActions...)
-		},
 	}
 
-	cmd.PersistentFlags().BoolP(cobraext.FailOnMissingFlagName, "m", false, cobraext.FailOnMissingFlagDescription)
-	cmd.PersistentFlags().BoolP(cobraext.GenerateTestResultFlagName, "g", false, cobraext.GenerateTestResultFlagDescription)
 	cmd.PersistentFlags().StringP(cobraext.ReportFormatFlagName, "", string(formats.ReportFormatHuman), cobraext.ReportFormatFlagDescription)
 	cmd.PersistentFlags().StringP(cobraext.ReportOutputFlagName, "", string(outputs.ReportOutputSTDOUT), cobraext.ReportOutputFlagDescription)
 	cmd.PersistentFlags().BoolP(cobraext.TestCoverageFlagName, "", false, cobraext.TestCoverageFlagDescription)
 	cmd.PersistentFlags().StringP(cobraext.TestCoverageFormatFlagName, "", "cobertura", fmt.Sprintf(cobraext.TestCoverageFormatFlagDescription, strings.Join(testrunner.CoverageFormatsList(), ",")))
-	cmd.PersistentFlags().DurationP(cobraext.DeferCleanupFlagName, "", 0, cobraext.DeferCleanupFlagDescription)
-	cmd.PersistentFlags().String(cobraext.VariantFlagName, "", cobraext.VariantFlagDescription)
 	cmd.PersistentFlags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
 
-	for testType, runner := range testrunner.TestRunners() {
-		action := testTypeCommandActionFactory(runner)
-		testTypeCmdActions = append(testTypeCmdActions, action)
+	assetCmd := getTestRunnerAssetCommand()
+	cmd.AddCommand(assetCmd)
 
-		testTypeCmd := &cobra.Command{
-			Use:   string(testType),
-			Short: fmt.Sprintf("Run %s tests", runner.String()),
-			Long:  fmt.Sprintf("Run %s tests for the package.", runner.String()),
-			Args:  cobra.NoArgs,
-			RunE:  action,
-		}
-		if runner.CanRunPerDataStream() {
-			testTypeCmd.Flags().StringSliceP(cobraext.DataStreamsFlagName, "d", nil, cobraext.DataStreamsFlagDescription)
-		}
+	staticCmd := getTestRunnerStaticCommand()
+	cmd.AddCommand(staticCmd)
 
-		if runner.CanRunSetupTeardownIndependent() {
-			testTypeCmd.Flags().String(cobraext.ConfigFileFlagName, "", cobraext.ConfigFileFlagDescription)
-			testTypeCmd.Flags().Bool(cobraext.SetupFlagName, false, cobraext.SetupFlagDescription)
-			testTypeCmd.Flags().Bool(cobraext.TearDownFlagName, false, cobraext.TearDownFlagDescription)
-			testTypeCmd.Flags().Bool(cobraext.NoProvisionFlagName, false, cobraext.NoProvisionFlagDescription)
-			testTypeCmd.MarkFlagsMutuallyExclusive(cobraext.SetupFlagName, cobraext.TearDownFlagName, cobraext.NoProvisionFlagName)
-			testTypeCmd.MarkFlagsRequiredTogether(cobraext.ConfigFileFlagName, cobraext.SetupFlagName)
+	pipelineCmd := getTestRunnerPipelineCommand()
+	cmd.AddCommand(pipelineCmd)
 
-			// config file flag should not be used with tear-down or no-provision flags
-			testTypeCmd.MarkFlagsMutuallyExclusive(cobraext.ConfigFileFlagName, cobraext.TearDownFlagName)
-			testTypeCmd.MarkFlagsMutuallyExclusive(cobraext.ConfigFileFlagName, cobraext.NoProvisionFlagName)
+	systemCmd := getTestRunnerSystemCommand()
+	cmd.AddCommand(systemCmd)
 
-			// variant flag should not be used with tear-down and no-provision flags
-			// cannot be defined here using MarkFlagsMutuallyExclusive as in --config-file
-			// this restriction has been managed later in the code when processing the flags
-		}
-
-		if runner.CanRunPerDataStream() && runner.CanRunSetupTeardownIndependent() {
-			testTypeCmd.MarkFlagsMutuallyExclusive(cobraext.DataStreamsFlagName, cobraext.SetupFlagName)
-			testTypeCmd.MarkFlagsMutuallyExclusive(cobraext.DataStreamsFlagName, cobraext.TearDownFlagName)
-			testTypeCmd.MarkFlagsMutuallyExclusive(cobraext.DataStreamsFlagName, cobraext.NoProvisionFlagName)
-		}
-
-		cmd.AddCommand(testTypeCmd)
-	}
+	policyCmd := getTestRunnerPolicyCommand()
+	cmd.AddCommand(policyCmd)
 
 	return cobraext.NewCommand(cmd, cobraext.ContextPackage)
 }
 
-func testTypeCommandActionFactory(runner testrunner.TestRunner) cobraext.CommandAction {
-	testType := runner.Type()
-	return func(cmd *cobra.Command, args []string) error {
-		cmd.Printf("Run %s tests for the package\n", testType)
-
-		profile, err := cobraext.GetProfileFlag(cmd)
-		if err != nil {
-			return err
-		}
-
-		failOnMissing, err := cmd.Flags().GetBool(cobraext.FailOnMissingFlagName)
-		if err != nil {
-			return cobraext.FlagParsingError(err, cobraext.FailOnMissingFlagName)
-		}
-
-		generateTestResult, err := cmd.Flags().GetBool(cobraext.GenerateTestResultFlagName)
-		if err != nil {
-			return cobraext.FlagParsingError(err, cobraext.GenerateTestResultFlagName)
-		}
-
-		reportFormat, err := cmd.Flags().GetString(cobraext.ReportFormatFlagName)
-		if err != nil {
-			return cobraext.FlagParsingError(err, cobraext.ReportFormatFlagName)
-		}
-
-		reportOutput, err := cmd.Flags().GetString(cobraext.ReportOutputFlagName)
-		if err != nil {
-			return cobraext.FlagParsingError(err, cobraext.ReportOutputFlagName)
-		}
-
-		testCoverage, err := cmd.Flags().GetBool(cobraext.TestCoverageFlagName)
-		if err != nil {
-			return cobraext.FlagParsingError(err, cobraext.TestCoverageFlagName)
-		}
-
-		testCoverageFormat, err := cmd.Flags().GetString(cobraext.TestCoverageFormatFlagName)
-		if err != nil {
-			return cobraext.FlagParsingError(err, cobraext.TestCoverageFormatFlagName)
-		}
-
-		if !slices.Contains(testrunner.CoverageFormatsList(), testCoverageFormat) {
-			return cobraext.FlagParsingError(fmt.Errorf("coverage format not available: %s", testCoverageFormat), cobraext.TestCoverageFormatFlagName)
-		}
-
-		packageRootPath, found, err := packages.FindPackageRoot()
-		if !found {
-			return errors.New("package root not found")
-		}
-		if err != nil {
-			return fmt.Errorf("locating package root failed: %w", err)
-		}
-
-		manifest, err := packages.ReadPackageManifestFromPackageRoot(packageRootPath)
-		if err != nil {
-			return fmt.Errorf("reading package manifest failed (path: %s): %w", packageRootPath, err)
-		}
-
-		hasDataStreams, err := packageHasDataStreams(manifest)
-		if err != nil {
-			return fmt.Errorf("cannot determine if package has data streams: %w", err)
-		}
-
-		configFileFlag := ""
-		runSetup := false
-		runTearDown := false
-		runTestsOnly := false
-
-		if runner.CanRunSetupTeardownIndependent() && cmd.Flags().Lookup(cobraext.ConfigFileFlagName) != nil {
-			// not all test types define these flags
-			runSetup, err = cmd.Flags().GetBool(cobraext.SetupFlagName)
-			if err != nil {
-				return cobraext.FlagParsingError(err, cobraext.SetupFlagName)
-			}
-			runTearDown, err = cmd.Flags().GetBool(cobraext.TearDownFlagName)
-			if err != nil {
-				return cobraext.FlagParsingError(err, cobraext.TearDownFlagName)
-			}
-			runTestsOnly, err = cmd.Flags().GetBool(cobraext.NoProvisionFlagName)
-			if err != nil {
-				return cobraext.FlagParsingError(err, cobraext.NoProvisionFlagName)
-			}
-
-			configFileFlag, err = cmd.Flags().GetString(cobraext.ConfigFileFlagName)
-			if err != nil {
-				return cobraext.FlagParsingError(err, cobraext.ConfigFileFlagName)
-			}
-			if configFileFlag != "" {
-				absPath, err := filepath.Abs(configFileFlag)
-				if err != nil {
-					return fmt.Errorf("cannot obtain the absolute path for config file path: %s", configFileFlag)
-				}
-				if _, err := os.Stat(absPath); err != nil {
-					return fmt.Errorf("can't find config file %s: %w", configFileFlag, err)
-				}
-				configFileFlag = absPath
-			}
-		}
-
-		var testFolders []testrunner.TestFolder
-		if hasDataStreams && runner.CanRunPerDataStream() {
-			var dataStreams []string
-
-			if runner.CanRunSetupTeardownIndependent() && runSetup || runTearDown || runTestsOnly {
-				if runTearDown || runTestsOnly {
-					configFileFlag, err = readConfigFileFromState(profile.ProfilePath)
-					if err != nil {
-						return fmt.Errorf("failed to get config file from state: %w", err)
-					}
-				}
-				dataStream := testrunner.ExtractDataStreamFromPath(configFileFlag, packageRootPath)
-				dataStreams = append(dataStreams, dataStream)
-			} else if cmd.Flags().Lookup(cobraext.DataStreamsFlagName) != nil {
-				// We check for the existence of the data streams flag before trying to
-				// parse it because if the root test command is run instead of one of the
-				// subcommands of test, the data streams flag will not be defined.
-				dataStreams, err = cmd.Flags().GetStringSlice(cobraext.DataStreamsFlagName)
-				common.TrimStringSlice(dataStreams)
-				if err != nil {
-					return cobraext.FlagParsingError(err, cobraext.DataStreamsFlagName)
-				}
-
-				err = validateDataStreamsFlag(packageRootPath, dataStreams)
-				if err != nil {
-					return cobraext.FlagParsingError(err, cobraext.DataStreamsFlagName)
-				}
-			}
-
-			if runner.TestFolderRequired() {
-				testFolders, err = testrunner.FindTestFolders(packageRootPath, dataStreams, testType)
-				if err != nil {
-					return fmt.Errorf("unable to determine test folder paths: %w", err)
-				}
-			} else {
-				testFolders, err = testrunner.AssumeTestFolders(packageRootPath, dataStreams, testType)
-				if err != nil {
-					return fmt.Errorf("unable to assume test folder paths: %w", err)
-				}
-			}
-
-			if failOnMissing && len(testFolders) == 0 {
-				if len(dataStreams) > 0 {
-					return fmt.Errorf("no %s tests found for %s data stream(s)", testType, strings.Join(dataStreams, ","))
-				}
-				return fmt.Errorf("no %s tests found", testType)
-			}
-		} else {
-			_, pkg := filepath.Split(packageRootPath)
-
-			if runner.TestFolderRequired() {
-				testFolders, err = testrunner.FindTestFolders(packageRootPath, nil, testType)
-				if err != nil {
-					return fmt.Errorf("unable to determine test folder paths: %w", err)
-				}
-				if failOnMissing && len(testFolders) == 0 {
-					return fmt.Errorf("no %s tests found", testType)
-				}
-			} else {
-				testFolders = []testrunner.TestFolder{
-					{
-						Package: pkg,
-					},
-				}
-			}
-		}
-
-		deferCleanup, err := cmd.Flags().GetDuration(cobraext.DeferCleanupFlagName)
-		if err != nil {
-			return cobraext.FlagParsingError(err, cobraext.DeferCleanupFlagName)
-		}
-
-		variantFlag, _ := cmd.Flags().GetString(cobraext.VariantFlagName)
-
-		ctx, stop := signal.Enable(cmd.Context(), logger.Info)
-		defer stop()
-
-		var esAPI *elasticsearch.API
-		if testType != "static" {
-			// static tests do not need a running Elasticsearch
-			esClient, err := stack.NewElasticsearchClientFromProfile(profile)
-			if err != nil {
-				return fmt.Errorf("can't create Elasticsearch client: %w", err)
-			}
-			err = esClient.CheckHealth(ctx)
-			if err != nil {
-				return err
-			}
-			esAPI = esClient.API
-		}
-
-		var kibanaClient *kibana.Client
-		if testType == "system" || testType == "asset" || testType == "policy" {
-			// pipeline and static tests do not require a kibana client to perform their required operations
-			kibanaClient, err = stack.NewKibanaClientFromProfile(profile)
-			if err != nil {
-				return fmt.Errorf("can't create Kibana client: %w", err)
-			}
-		}
-
-		if runTearDown || runTestsOnly {
-			if variantFlag != "" {
-				return fmt.Errorf("variant flag cannot be set with --tear-down or --no-provision")
-			}
-		}
-
-		if runSetup || runTearDown || runTestsOnly {
-			// variant flag is not checked here since there are packages that do not have variants
-			if len(testFolders) != 1 {
-				return fmt.Errorf("wrong number of test folders (expected 1): %d", len(testFolders))
-			}
-
-			fmt.Printf("Running tests per stages (technical preview)\n")
-		}
-
-		var results []testrunner.TestResult
-		for _, folder := range testFolders {
-			r, err := testrunner.Run(ctx, testType, testrunner.TestOptions{
-				Profile:                    profile,
-				TestFolder:                 folder,
-				PackageRootPath:            packageRootPath,
-				GenerateTestResult:         generateTestResult,
-				API:                        esAPI,
-				KibanaClient:               kibanaClient,
-				DeferCleanup:               deferCleanup,
-				ServiceVariant:             variantFlag,
-				WithCoverage:               testCoverage,
-				CoverageType:               testCoverageFormat,
-				ConfigFilePath:             configFileFlag,
-				RunSetup:                   runSetup,
-				RunTearDown:                runTearDown,
-				RunTestsOnly:               runTestsOnly,
-				RunIndependentElasticAgent: false,
-			})
-
-			// Results must be appended even if there is an error, since there could be
-			// tests (e.g. system tests) that return both error and results.
-			results = append(results, r...)
-
-			if err != nil {
-				return fmt.Errorf("error running package %s tests: %w", testType, err)
-			}
-
-		}
-
-		format := testrunner.TestReportFormat(reportFormat)
-		report, err := testrunner.FormatReport(format, results)
-		if err != nil {
-			return fmt.Errorf("error formatting test report: %w", err)
-		}
-
-		if err := testrunner.WriteReport(manifest.Name, testrunner.TestReportOutput(reportOutput), report, format); err != nil {
-			return fmt.Errorf("error writing test report: %w", err)
-		}
-
-		if testCoverage {
-			err := testrunner.WriteCoverage(packageRootPath, manifest.Name, manifest.Type, runner.Type(), results, testCoverageFormat)
-			if err != nil {
-				return fmt.Errorf("error writing test coverage: %w", err)
-			}
-		}
-
-		// Check if there is any error or failure reported
-		for _, r := range results {
-			if r.ErrorMsg != "" || r.FailureMsg != "" {
-				return errors.New("one or more test cases failed")
-			}
-		}
-		return nil
+func getTestRunnerAssetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "asset",
+		Short: "Run asset tests",
+		Long:  "Run asset tests for the package",
+		Args:  cobra.NoArgs,
+		RunE:  testRunnerAssetCommandAction,
 	}
+
+	return cmd
+}
+
+func testRunnerAssetCommandAction(cmd *cobra.Command, args []string) error {
+	cmd.Printf("Run asset tests for the package\n")
+	testType := testrunner.TestType("asset")
+
+	profile, err := cobraext.GetProfileFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	reportFormat, err := cmd.Flags().GetString(cobraext.ReportFormatFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.ReportFormatFlagName)
+	}
+
+	reportOutput, err := cmd.Flags().GetString(cobraext.ReportOutputFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.ReportOutputFlagName)
+	}
+
+	testCoverage, err := cmd.Flags().GetBool(cobraext.TestCoverageFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.TestCoverageFlagName)
+	}
+
+	testCoverageFormat, err := cmd.Flags().GetString(cobraext.TestCoverageFormatFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.TestCoverageFormatFlagName)
+	}
+
+	if !slices.Contains(testrunner.CoverageFormatsList(), testCoverageFormat) {
+		return cobraext.FlagParsingError(fmt.Errorf("coverage format not available: %s", testCoverageFormat), cobraext.TestCoverageFormatFlagName)
+	}
+
+	packageRootPath, found, err := packages.FindPackageRoot()
+	if !found {
+		return errors.New("package root not found")
+	}
+	if err != nil {
+		return fmt.Errorf("locating package root failed: %w", err)
+	}
+
+	manifest, err := packages.ReadPackageManifestFromPackageRoot(packageRootPath)
+	if err != nil {
+		return fmt.Errorf("reading package manifest failed (path: %s): %w", packageRootPath, err)
+	}
+
+	ctx, stop := signal.Enable(cmd.Context(), logger.Info)
+	defer stop()
+
+	kibanaClient, err := stack.NewKibanaClientFromProfile(profile)
+	if err != nil {
+		return fmt.Errorf("can't create Kibana client: %w", err)
+	}
+
+	_, pkg := filepath.Split(packageRootPath)
+
+	results, err := testrunner.Run(ctx, testType, testrunner.TestOptions{
+		Profile:         profile,
+		TestFolder:      testrunner.TestFolder{Package: pkg},
+		PackageRootPath: packageRootPath,
+		WithCoverage:    testCoverage,
+		CoverageType:    testCoverageFormat,
+		KibanaClient:    kibanaClient,
+	})
+
+	if err != nil {
+		return fmt.Errorf("error running package %s tests: %w", testType, err)
+	}
+
+	return processResults(results, testType, reportFormat, reportOutput, packageRootPath, manifest.Name, manifest.Type, testCoverageFormat, testCoverage)
+}
+
+func getTestRunnerStaticCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "static",
+		Short: "Run static tests",
+		Long:  "Run static tests for the package",
+		Args:  cobra.NoArgs,
+		RunE:  testRunnerStaticCommandAction,
+	}
+
+	cmd.Flags().BoolP(cobraext.FailOnMissingFlagName, "m", false, cobraext.FailOnMissingFlagDescription)
+	cmd.Flags().StringSliceP(cobraext.DataStreamsFlagName, "d", nil, cobraext.DataStreamsFlagDescription)
+
+	return cmd
+}
+
+func testRunnerStaticCommandAction(cmd *cobra.Command, args []string) error {
+	cmd.Printf("Run static tests for the package\n")
+	testType := testrunner.TestType("static")
+
+	profile, err := cobraext.GetProfileFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	failOnMissing, err := cmd.Flags().GetBool(cobraext.FailOnMissingFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.FailOnMissingFlagName)
+	}
+
+	reportFormat, err := cmd.Flags().GetString(cobraext.ReportFormatFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.ReportFormatFlagName)
+	}
+
+	reportOutput, err := cmd.Flags().GetString(cobraext.ReportOutputFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.ReportOutputFlagName)
+	}
+
+	testCoverage, err := cmd.Flags().GetBool(cobraext.TestCoverageFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.TestCoverageFlagName)
+	}
+
+	testCoverageFormat, err := cmd.Flags().GetString(cobraext.TestCoverageFormatFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.TestCoverageFormatFlagName)
+	}
+
+	if !slices.Contains(testrunner.CoverageFormatsList(), testCoverageFormat) {
+		return cobraext.FlagParsingError(fmt.Errorf("coverage format not available: %s", testCoverageFormat), cobraext.TestCoverageFormatFlagName)
+	}
+
+	packageRootPath, found, err := packages.FindPackageRoot()
+	if !found {
+		return errors.New("package root not found")
+	}
+	if err != nil {
+		return fmt.Errorf("locating package root failed: %w", err)
+	}
+
+	manifest, err := packages.ReadPackageManifestFromPackageRoot(packageRootPath)
+	if err != nil {
+		return fmt.Errorf("reading package manifest failed (path: %s): %w", packageRootPath, err)
+	}
+
+	hasDataStreams, err := packageHasDataStreams(manifest)
+	if err != nil {
+		return fmt.Errorf("cannot determine if package has data streams: %w", err)
+	}
+	var testFolders []testrunner.TestFolder
+	if hasDataStreams {
+		var dataStreams []string
+		if cmd.Flags().Lookup(cobraext.DataStreamsFlagName) != nil {
+			// We check for the existence of the data streams flag before trying to
+			// parse it because if the root test command is run instead of one of the
+			// subcommands of test, the data streams flag will not be defined.
+			dataStreams, err = cmd.Flags().GetStringSlice(cobraext.DataStreamsFlagName)
+			common.TrimStringSlice(dataStreams)
+			if err != nil {
+				return cobraext.FlagParsingError(err, cobraext.DataStreamsFlagName)
+			}
+
+			err = validateDataStreamsFlag(packageRootPath, dataStreams)
+			if err != nil {
+				return cobraext.FlagParsingError(err, cobraext.DataStreamsFlagName)
+			}
+		}
+
+		testFolders, err = testrunner.AssumeTestFolders(packageRootPath, dataStreams, testType)
+		if err != nil {
+			return fmt.Errorf("unable to assume test folder paths: %w", err)
+		}
+
+		if failOnMissing && len(testFolders) == 0 {
+			if len(dataStreams) > 0 {
+				return fmt.Errorf("no %s tests found for %s data stream(s)", testType, strings.Join(dataStreams, ","))
+			}
+			return fmt.Errorf("no %s tests found", testType)
+		}
+	} else {
+		_, pkg := filepath.Split(packageRootPath)
+		testFolders = []testrunner.TestFolder{
+			{
+				Package: pkg,
+			},
+		}
+	}
+
+	ctx, stop := signal.Enable(cmd.Context(), logger.Info)
+	defer stop()
+
+	kibanaClient, err := stack.NewKibanaClientFromProfile(profile)
+	if err != nil {
+		return fmt.Errorf("can't create Kibana client: %w", err)
+	}
+
+	var results []testrunner.TestResult
+	for _, folder := range testFolders {
+		r, err := testrunner.Run(ctx, testType, testrunner.TestOptions{
+			Profile:         profile,
+			TestFolder:      folder,
+			PackageRootPath: packageRootPath,
+			KibanaClient:    kibanaClient,
+			WithCoverage:    testCoverage,
+			CoverageType:    testCoverageFormat,
+		})
+
+		// Results must be appended even if there is an error, since there could be
+		// tests (e.g. system tests) that return both error and results.
+		results = append(results, r...)
+
+		if err != nil {
+			return fmt.Errorf("error running package %s tests: %w", testType, err)
+		}
+	}
+
+	return processResults(results, testType, reportFormat, reportOutput, packageRootPath, manifest.Name, manifest.Type, testCoverageFormat, testCoverage)
+}
+
+func getTestRunnerPipelineCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pipeline",
+		Short: "Run pipeline tests",
+		Long:  "Run pipeline tests for the package",
+		Args:  cobra.NoArgs,
+		RunE:  testRunnerPipelineCommandAction,
+	}
+
+	cmd.Flags().BoolP(cobraext.FailOnMissingFlagName, "m", false, cobraext.FailOnMissingFlagDescription)
+	cmd.Flags().BoolP(cobraext.GenerateTestResultFlagName, "g", false, cobraext.GenerateTestResultFlagDescription)
+	cmd.Flags().DurationP(cobraext.DeferCleanupFlagName, "", 0, cobraext.DeferCleanupFlagDescription)
+	cmd.Flags().StringSliceP(cobraext.DataStreamsFlagName, "d", nil, cobraext.DataStreamsFlagDescription)
+
+	return cmd
+}
+
+func testRunnerPipelineCommandAction(cmd *cobra.Command, args []string) error {
+	cmd.Printf("Run pipeline tests for the package\n")
+	testType := testrunner.TestType("pipeline")
+
+	profile, err := cobraext.GetProfileFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	failOnMissing, err := cmd.Flags().GetBool(cobraext.FailOnMissingFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.FailOnMissingFlagName)
+	}
+
+	generateTestResult, err := cmd.Flags().GetBool(cobraext.GenerateTestResultFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.GenerateTestResultFlagName)
+	}
+
+	reportFormat, err := cmd.Flags().GetString(cobraext.ReportFormatFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.ReportFormatFlagName)
+	}
+
+	reportOutput, err := cmd.Flags().GetString(cobraext.ReportOutputFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.ReportOutputFlagName)
+	}
+
+	testCoverage, err := cmd.Flags().GetBool(cobraext.TestCoverageFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.TestCoverageFlagName)
+	}
+
+	testCoverageFormat, err := cmd.Flags().GetString(cobraext.TestCoverageFormatFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.TestCoverageFormatFlagName)
+	}
+
+	if !slices.Contains(testrunner.CoverageFormatsList(), testCoverageFormat) {
+		return cobraext.FlagParsingError(fmt.Errorf("coverage format not available: %s", testCoverageFormat), cobraext.TestCoverageFormatFlagName)
+	}
+
+	deferCleanup, err := cmd.Flags().GetDuration(cobraext.DeferCleanupFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.DeferCleanupFlagName)
+	}
+
+	packageRootPath, found, err := packages.FindPackageRoot()
+	if !found {
+		return errors.New("package root not found")
+	}
+	if err != nil {
+		return fmt.Errorf("locating package root failed: %w", err)
+	}
+
+	manifest, err := packages.ReadPackageManifestFromPackageRoot(packageRootPath)
+	if err != nil {
+		return fmt.Errorf("reading package manifest failed (path: %s): %w", packageRootPath, err)
+	}
+
+	hasDataStreams, err := packageHasDataStreams(manifest)
+	if err != nil {
+		return fmt.Errorf("cannot determine if package has data streams: %w", err)
+	}
+	var testFolders []testrunner.TestFolder
+	if hasDataStreams {
+		var dataStreams []string
+		if cmd.Flags().Lookup(cobraext.DataStreamsFlagName) != nil {
+			// We check for the existence of the data streams flag before trying to
+			// parse it because if the root test command is run instead of one of the
+			// subcommands of test, the data streams flag will not be defined.
+			dataStreams, err = cmd.Flags().GetStringSlice(cobraext.DataStreamsFlagName)
+			common.TrimStringSlice(dataStreams)
+			if err != nil {
+				return cobraext.FlagParsingError(err, cobraext.DataStreamsFlagName)
+			}
+
+			err = validateDataStreamsFlag(packageRootPath, dataStreams)
+			if err != nil {
+				return cobraext.FlagParsingError(err, cobraext.DataStreamsFlagName)
+			}
+		}
+
+		testFolders, err = testrunner.FindTestFolders(packageRootPath, dataStreams, testType)
+		if err != nil {
+			return fmt.Errorf("unable to determine test folder paths: %w", err)
+		}
+
+		if failOnMissing && len(testFolders) == 0 {
+			if len(dataStreams) > 0 {
+				return fmt.Errorf("no %s tests found for %s data stream(s)", testType, strings.Join(dataStreams, ","))
+			}
+			return fmt.Errorf("no %s tests found", testType)
+		}
+	} else {
+		testFolders, err = testrunner.FindTestFolders(packageRootPath, nil, testType)
+		if err != nil {
+			return fmt.Errorf("unable to determine test folder paths: %w", err)
+		}
+		if failOnMissing && len(testFolders) == 0 {
+			return fmt.Errorf("no %s tests found", testType)
+		}
+	}
+
+	ctx, stop := signal.Enable(cmd.Context(), logger.Info)
+	defer stop()
+
+	kibanaClient, err := stack.NewKibanaClientFromProfile(profile)
+	if err != nil {
+		return fmt.Errorf("can't create Kibana client: %w", err)
+	}
+
+	esClient, err := stack.NewElasticsearchClientFromProfile(profile)
+	if err != nil {
+		return fmt.Errorf("can't create Elasticsearch client: %w", err)
+	}
+	err = esClient.CheckHealth(ctx)
+	if err != nil {
+		return err
+	}
+
+	var results []testrunner.TestResult
+	for _, folder := range testFolders {
+		r, err := testrunner.Run(ctx, testType, testrunner.TestOptions{
+			Profile:            profile,
+			TestFolder:         folder,
+			PackageRootPath:    packageRootPath,
+			GenerateTestResult: generateTestResult,
+			API:                esClient.API,
+			KibanaClient:       kibanaClient,
+			WithCoverage:       testCoverage,
+			CoverageType:       testCoverageFormat,
+			DeferCleanup:       deferCleanup,
+		})
+
+		// Results must be appended even if there is an error, since there could be
+		// tests (e.g. system tests) that return both error and results.
+		results = append(results, r...)
+
+		if err != nil {
+			return fmt.Errorf("error running package %s tests: %w", testType, err)
+		}
+	}
+
+	return processResults(results, testType, reportFormat, reportOutput, packageRootPath, manifest.Name, manifest.Type, testCoverageFormat, testCoverage)
+}
+
+func getTestRunnerSystemCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "system",
+		Short: "Run system tests",
+		Long:  "Run system tests for the package",
+		Args:  cobra.NoArgs,
+		RunE:  testRunnerSystemCommandAction,
+	}
+
+	cmd.Flags().BoolP(cobraext.FailOnMissingFlagName, "m", false, cobraext.FailOnMissingFlagDescription)
+	cmd.Flags().BoolP(cobraext.GenerateTestResultFlagName, "g", false, cobraext.GenerateTestResultFlagDescription)
+	cmd.Flags().DurationP(cobraext.DeferCleanupFlagName, "", 0, cobraext.DeferCleanupFlagDescription)
+	cmd.Flags().StringSliceP(cobraext.DataStreamsFlagName, "d", nil, cobraext.DataStreamsFlagDescription)
+	cmd.Flags().String(cobraext.VariantFlagName, "", cobraext.VariantFlagDescription)
+
+	cmd.Flags().String(cobraext.ConfigFileFlagName, "", cobraext.ConfigFileFlagDescription)
+	cmd.Flags().Bool(cobraext.SetupFlagName, false, cobraext.SetupFlagDescription)
+	cmd.Flags().Bool(cobraext.TearDownFlagName, false, cobraext.TearDownFlagDescription)
+	cmd.Flags().Bool(cobraext.NoProvisionFlagName, false, cobraext.NoProvisionFlagDescription)
+
+	cmd.MarkFlagsMutuallyExclusive(cobraext.SetupFlagName, cobraext.TearDownFlagName, cobraext.NoProvisionFlagName)
+	cmd.MarkFlagsRequiredTogether(cobraext.ConfigFileFlagName, cobraext.SetupFlagName)
+
+	// config file flag should not be used with tear-down or no-provision flags
+	cmd.MarkFlagsMutuallyExclusive(cobraext.ConfigFileFlagName, cobraext.TearDownFlagName)
+	cmd.MarkFlagsMutuallyExclusive(cobraext.ConfigFileFlagName, cobraext.NoProvisionFlagName)
+
+	// variant flag should not be used with tear-down and no-provision flags
+	// cannot be defined here using MarkFlagsMutuallyExclusive as in --config-file
+	// this restriction has been managed later in the code when processing the flags
+	cmd.MarkFlagsMutuallyExclusive(cobraext.DataStreamsFlagName, cobraext.SetupFlagName)
+	cmd.MarkFlagsMutuallyExclusive(cobraext.DataStreamsFlagName, cobraext.TearDownFlagName)
+	cmd.MarkFlagsMutuallyExclusive(cobraext.DataStreamsFlagName, cobraext.NoProvisionFlagName)
+
+	return cmd
+}
+
+func testRunnerSystemCommandAction(cmd *cobra.Command, args []string) error {
+	cmd.Printf("Run system tests for the package\n")
+	testType := testrunner.TestType("system")
+
+	profile, err := cobraext.GetProfileFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	failOnMissing, err := cmd.Flags().GetBool(cobraext.FailOnMissingFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.FailOnMissingFlagName)
+	}
+
+	generateTestResult, err := cmd.Flags().GetBool(cobraext.GenerateTestResultFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.GenerateTestResultFlagName)
+	}
+
+	reportFormat, err := cmd.Flags().GetString(cobraext.ReportFormatFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.ReportFormatFlagName)
+	}
+
+	reportOutput, err := cmd.Flags().GetString(cobraext.ReportOutputFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.ReportOutputFlagName)
+	}
+
+	testCoverage, err := cmd.Flags().GetBool(cobraext.TestCoverageFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.TestCoverageFlagName)
+	}
+
+	testCoverageFormat, err := cmd.Flags().GetString(cobraext.TestCoverageFormatFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.TestCoverageFormatFlagName)
+	}
+
+	if !slices.Contains(testrunner.CoverageFormatsList(), testCoverageFormat) {
+		return cobraext.FlagParsingError(fmt.Errorf("coverage format not available: %s", testCoverageFormat), cobraext.TestCoverageFormatFlagName)
+	}
+
+	deferCleanup, err := cmd.Flags().GetDuration(cobraext.DeferCleanupFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.DeferCleanupFlagName)
+	}
+
+	variantFlag, err := cmd.Flags().GetString(cobraext.VariantFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.VariantFlagName)
+	}
+
+	packageRootPath, found, err := packages.FindPackageRoot()
+	if !found {
+		return errors.New("package root not found")
+	}
+	if err != nil {
+		return fmt.Errorf("locating package root failed: %w", err)
+	}
+
+	manifest, err := packages.ReadPackageManifestFromPackageRoot(packageRootPath)
+	if err != nil {
+		return fmt.Errorf("reading package manifest failed (path: %s): %w", packageRootPath, err)
+	}
+
+	hasDataStreams, err := packageHasDataStreams(manifest)
+	if err != nil {
+		return fmt.Errorf("cannot determine if package has data streams: %w", err)
+	}
+
+	runSetup, err := cmd.Flags().GetBool(cobraext.SetupFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.SetupFlagName)
+	}
+	runTearDown, err := cmd.Flags().GetBool(cobraext.TearDownFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.TearDownFlagName)
+	}
+	runTestsOnly, err := cmd.Flags().GetBool(cobraext.NoProvisionFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.NoProvisionFlagName)
+	}
+
+	configFileFlag, err := cmd.Flags().GetString(cobraext.ConfigFileFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.ConfigFileFlagName)
+	}
+	if configFileFlag != "" {
+		absPath, err := filepath.Abs(configFileFlag)
+		if err != nil {
+			return fmt.Errorf("cannot obtain the absolute path for config file path: %s", configFileFlag)
+		}
+		if _, err := os.Stat(absPath); err != nil {
+			return fmt.Errorf("can't find config file %s: %w", configFileFlag, err)
+		}
+		configFileFlag = absPath
+	}
+
+	var testFolders []testrunner.TestFolder
+	if hasDataStreams {
+		var dataStreams []string
+		if runSetup || runTearDown || runTestsOnly {
+			if runTearDown || runTestsOnly {
+				configFileFlag, err = readConfigFileFromState(profile.ProfilePath)
+				if err != nil {
+					return fmt.Errorf("failed to get config file from state: %w", err)
+				}
+			}
+			dataStream := testrunner.ExtractDataStreamFromPath(configFileFlag, packageRootPath)
+			dataStreams = append(dataStreams, dataStream)
+		} else if cmd.Flags().Lookup(cobraext.DataStreamsFlagName) != nil {
+			// We check for the existence of the data streams flag before trying to
+			// parse it because if the root test command is run instead of one of the
+			// subcommands of test, the data streams flag will not be defined.
+			dataStreams, err = cmd.Flags().GetStringSlice(cobraext.DataStreamsFlagName)
+			common.TrimStringSlice(dataStreams)
+			if err != nil {
+				return cobraext.FlagParsingError(err, cobraext.DataStreamsFlagName)
+			}
+
+			err = validateDataStreamsFlag(packageRootPath, dataStreams)
+			if err != nil {
+				return cobraext.FlagParsingError(err, cobraext.DataStreamsFlagName)
+			}
+		}
+
+		testFolders, err = testrunner.FindTestFolders(packageRootPath, dataStreams, testType)
+		if err != nil {
+			return fmt.Errorf("unable to determine test folder paths: %w", err)
+		}
+
+		if failOnMissing && len(testFolders) == 0 {
+			if len(dataStreams) > 0 {
+				return fmt.Errorf("no %s tests found for %s data stream(s)", testType, strings.Join(dataStreams, ","))
+			}
+			return fmt.Errorf("no %s tests found", testType)
+		}
+	} else {
+		testFolders, err = testrunner.FindTestFolders(packageRootPath, nil, testType)
+		if err != nil {
+			return fmt.Errorf("unable to determine test folder paths: %w", err)
+		}
+		if failOnMissing && len(testFolders) == 0 {
+			return fmt.Errorf("no %s tests found", testType)
+		}
+	}
+
+	ctx, stop := signal.Enable(cmd.Context(), logger.Info)
+	defer stop()
+
+	kibanaClient, err := stack.NewKibanaClientFromProfile(profile)
+	if err != nil {
+		return fmt.Errorf("can't create Kibana client: %w", err)
+	}
+
+	esClient, err := stack.NewElasticsearchClientFromProfile(profile)
+	if err != nil {
+		return fmt.Errorf("can't create Elasticsearch client: %w", err)
+	}
+	err = esClient.CheckHealth(ctx)
+	if err != nil {
+		return err
+	}
+
+	if runTearDown || runTestsOnly {
+		if variantFlag != "" {
+			return fmt.Errorf("variant flag cannot be set with --tear-down or --no-provision")
+		}
+	}
+
+	if runSetup || runTearDown || runTestsOnly {
+		// variant flag is not checked here since there are packages that do not have variants
+		if len(testFolders) != 1 {
+			return fmt.Errorf("wrong number of test folders (expected 1): %d", len(testFolders))
+		}
+
+		fmt.Printf("Running tests per stages (technical preview)\n")
+	}
+
+	var results []testrunner.TestResult
+	for _, folder := range testFolders {
+		r, err := testrunner.Run(ctx, testType, testrunner.TestOptions{
+			Profile:                    profile,
+			TestFolder:                 folder,
+			PackageRootPath:            packageRootPath,
+			ServiceVariant:             variantFlag,
+			GenerateTestResult:         generateTestResult,
+			API:                        esClient.API,
+			KibanaClient:               kibanaClient,
+			WithCoverage:               testCoverage,
+			CoverageType:               testCoverageFormat,
+			DeferCleanup:               deferCleanup,
+			ConfigFilePath:             configFileFlag,
+			RunSetup:                   runSetup,
+			RunTearDown:                runTearDown,
+			RunTestsOnly:               runTestsOnly,
+			RunIndependentElasticAgent: false,
+		})
+
+		// Results must be appended even if there is an error, since there could be
+		// tests (e.g. system tests) that return both error and results.
+		results = append(results, r...)
+
+		if err != nil {
+			return fmt.Errorf("error running package %s tests: %w", testType, err)
+		}
+	}
+
+	return processResults(results, testType, reportFormat, reportOutput, packageRootPath, manifest.Name, manifest.Type, testCoverageFormat, testCoverage)
+}
+
+func getTestRunnerPolicyCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "policy",
+		Short: "Run policy tests",
+		Long:  "Run policy tests for the package",
+		Args:  cobra.NoArgs,
+		RunE:  testRunnerPolicyCommandAction,
+	}
+
+	cmd.Flags().BoolP(cobraext.FailOnMissingFlagName, "m", false, cobraext.FailOnMissingFlagDescription)
+	cmd.Flags().StringSliceP(cobraext.DataStreamsFlagName, "d", nil, cobraext.DataStreamsFlagDescription)
+	cmd.Flags().BoolP(cobraext.GenerateTestResultFlagName, "g", false, cobraext.GenerateTestResultFlagDescription)
+	return cmd
+}
+
+func testRunnerPolicyCommandAction(cmd *cobra.Command, args []string) error {
+	cmd.Printf("Run policy tests for the package\n")
+	testType := testrunner.TestType("policy")
+
+	profile, err := cobraext.GetProfileFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	failOnMissing, err := cmd.Flags().GetBool(cobraext.FailOnMissingFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.FailOnMissingFlagName)
+	}
+
+	generateTestResult, err := cmd.Flags().GetBool(cobraext.GenerateTestResultFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.GenerateTestResultFlagName)
+	}
+
+	reportFormat, err := cmd.Flags().GetString(cobraext.ReportFormatFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.ReportFormatFlagName)
+	}
+
+	reportOutput, err := cmd.Flags().GetString(cobraext.ReportOutputFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.ReportOutputFlagName)
+	}
+
+	testCoverage, err := cmd.Flags().GetBool(cobraext.TestCoverageFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.TestCoverageFlagName)
+	}
+
+	testCoverageFormat, err := cmd.Flags().GetString(cobraext.TestCoverageFormatFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.TestCoverageFormatFlagName)
+	}
+
+	if !slices.Contains(testrunner.CoverageFormatsList(), testCoverageFormat) {
+		return cobraext.FlagParsingError(fmt.Errorf("coverage format not available: %s", testCoverageFormat), cobraext.TestCoverageFormatFlagName)
+	}
+
+	packageRootPath, found, err := packages.FindPackageRoot()
+	if !found {
+		return errors.New("package root not found")
+	}
+	if err != nil {
+		return fmt.Errorf("locating package root failed: %w", err)
+	}
+
+	manifest, err := packages.ReadPackageManifestFromPackageRoot(packageRootPath)
+	if err != nil {
+		return fmt.Errorf("reading package manifest failed (path: %s): %w", packageRootPath, err)
+	}
+
+	hasDataStreams, err := packageHasDataStreams(manifest)
+	if err != nil {
+		return fmt.Errorf("cannot determine if package has data streams: %w", err)
+	}
+
+	var testFolders []testrunner.TestFolder
+	if hasDataStreams {
+		var dataStreams []string
+		if cmd.Flags().Lookup(cobraext.DataStreamsFlagName) != nil {
+			// We check for the existence of the data streams flag before trying to
+			// parse it because if the root test command is run instead of one of the
+			// subcommands of test, the data streams flag will not be defined.
+			dataStreams, err = cmd.Flags().GetStringSlice(cobraext.DataStreamsFlagName)
+			common.TrimStringSlice(dataStreams)
+			if err != nil {
+				return cobraext.FlagParsingError(err, cobraext.DataStreamsFlagName)
+			}
+
+			err = validateDataStreamsFlag(packageRootPath, dataStreams)
+			if err != nil {
+				return cobraext.FlagParsingError(err, cobraext.DataStreamsFlagName)
+			}
+		}
+
+		testFolders, err = testrunner.FindTestFolders(packageRootPath, dataStreams, testType)
+		if err != nil {
+			return fmt.Errorf("unable to determine test folder paths: %w", err)
+		}
+
+		if failOnMissing && len(testFolders) == 0 {
+			if len(dataStreams) > 0 {
+				return fmt.Errorf("no %s tests found for %s data stream(s)", testType, strings.Join(dataStreams, ","))
+			}
+			return fmt.Errorf("no %s tests found", testType)
+		}
+	} else {
+		testFolders, err = testrunner.FindTestFolders(packageRootPath, nil, testType)
+		if err != nil {
+			return fmt.Errorf("unable to determine test folder paths: %w", err)
+		}
+		if failOnMissing && len(testFolders) == 0 {
+			return fmt.Errorf("no %s tests found", testType)
+		}
+	}
+
+	ctx, stop := signal.Enable(cmd.Context(), logger.Info)
+	defer stop()
+
+	kibanaClient, err := stack.NewKibanaClientFromProfile(profile)
+	if err != nil {
+		return fmt.Errorf("can't create Kibana client: %w", err)
+	}
+
+	var results []testrunner.TestResult
+	for _, folder := range testFolders {
+		r, err := testrunner.Run(ctx, testType, testrunner.TestOptions{
+			Profile:            profile,
+			TestFolder:         folder,
+			PackageRootPath:    packageRootPath,
+			GenerateTestResult: generateTestResult,
+			KibanaClient:       kibanaClient,
+			WithCoverage:       testCoverage,
+			CoverageType:       testCoverageFormat,
+		})
+
+		// Results must be appended even if there is an error, since there could be
+		// tests (e.g. system tests) that return both error and results.
+		results = append(results, r...)
+
+		if err != nil {
+			return fmt.Errorf("error running package %s tests: %w", testType, err)
+		}
+	}
+
+	return processResults(results, testType, reportFormat, reportOutput, packageRootPath, manifest.Name, manifest.Type, testCoverageFormat, testCoverage)
+}
+
+func processResults(results []testrunner.TestResult, testType testrunner.TestType, reportFormat, reportOutput, packageRootPath, packageName, packageType, testCoverageFormat string, testCoverage bool) error {
+	format := testrunner.TestReportFormat(reportFormat)
+	report, err := testrunner.FormatReport(format, results)
+	if err != nil {
+		return fmt.Errorf("error formatting test report: %w", err)
+	}
+
+	if err := testrunner.WriteReport(packageName, testrunner.TestReportOutput(reportOutput), report, format); err != nil {
+		return fmt.Errorf("error writing test report: %w", err)
+	}
+
+	if testCoverage {
+		err := testrunner.WriteCoverage(packageRootPath, packageName, packageType, testType, results, testCoverageFormat)
+		if err != nil {
+			return fmt.Errorf("error writing test coverage: %w", err)
+		}
+	}
+
+	// Check if there is any error or failure reported
+	for _, r := range results {
+		if r.ErrorMsg != "" || r.FailureMsg != "" {
+			return errors.New("one or more test cases failed")
+		}
+	}
+	return nil
+
 }
 
 func readConfigFileFromState(profilePath string) (string, error) {

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -90,7 +90,7 @@ func getTestRunnerAssetCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "asset",
 		Short: "Run asset tests",
-		Long:  "Run asset tests for the package",
+		Long:  "Run asset loading tests for the package",
 		Args:  cobra.NoArgs,
 		RunE:  testRunnerAssetCommandAction,
 	}
@@ -174,7 +174,7 @@ func getTestRunnerStaticCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "static",
 		Short: "Run static tests",
-		Long:  "Run static tests for the package",
+		Long:  "Run static files tests for the package",
 		Args:  cobra.NoArgs,
 		RunE:  testRunnerStaticCommandAction,
 	}

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -60,33 +60,46 @@ func setupTestCommand() *cobraext.Command {
 		Use:   "test",
 		Short: "Run test suite for the package",
 		Long:  testLongDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := cobraext.ComposeCommands(args,
+				getTestRunnerAssetCommand(),
+				getTestRunnerStaticCommand(),
+				getTestRunnerPipelineCommand(),
+				getTestRunnerSystemCommand(),
+				getTestRunnerPolicyCommand(),
+			)
+			if err != nil {
+				return fmt.Errorf("testing package failed: %w", err)
+			}
+			return nil
+		},
 	}
 
-	cmd.PersistentFlags().StringP(cobraext.ReportFormatFlagName, "", string(formats.ReportFormatHuman), cobraext.ReportFormatFlagDescription)
-	cmd.PersistentFlags().StringP(cobraext.ReportOutputFlagName, "", string(outputs.ReportOutputSTDOUT), cobraext.ReportOutputFlagDescription)
-	cmd.PersistentFlags().BoolP(cobraext.TestCoverageFlagName, "", false, cobraext.TestCoverageFlagDescription)
-	cmd.PersistentFlags().StringP(cobraext.TestCoverageFormatFlagName, "", "cobertura", fmt.Sprintf(cobraext.TestCoverageFormatFlagDescription, strings.Join(testrunner.CoverageFormatsList(), ",")))
-	cmd.PersistentFlags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
+	// cmd.PersistentFlags().StringP(cobraext.ReportFormatFlagName, "", string(formats.ReportFormatHuman), cobraext.ReportFormatFlagDescription)
+	// cmd.PersistentFlags().StringP(cobraext.ReportOutputFlagName, "", string(outputs.ReportOutputSTDOUT), cobraext.ReportOutputFlagDescription)
+	// cmd.PersistentFlags().BoolP(cobraext.TestCoverageFlagName, "", false, cobraext.TestCoverageFlagDescription)
+	// cmd.PersistentFlags().StringP(cobraext.TestCoverageFormatFlagName, "", "cobertura", fmt.Sprintf(cobraext.TestCoverageFormatFlagDescription, strings.Join(testrunner.CoverageFormatsList(), ",")))
+	// cmd.PersistentFlags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
 
 	assetCmd := getTestRunnerAssetCommand()
-	cmd.AddCommand(assetCmd)
+	cmd.AddCommand(assetCmd.Command)
 
 	staticCmd := getTestRunnerStaticCommand()
-	cmd.AddCommand(staticCmd)
+	cmd.AddCommand(staticCmd.Command)
 
 	pipelineCmd := getTestRunnerPipelineCommand()
-	cmd.AddCommand(pipelineCmd)
+	cmd.AddCommand(pipelineCmd.Command)
 
 	systemCmd := getTestRunnerSystemCommand()
-	cmd.AddCommand(systemCmd)
+	cmd.AddCommand(systemCmd.Command)
 
 	policyCmd := getTestRunnerPolicyCommand()
-	cmd.AddCommand(policyCmd)
+	cmd.AddCommand(policyCmd.Command)
 
 	return cobraext.NewCommand(cmd, cobraext.ContextPackage)
 }
 
-func getTestRunnerAssetCommand() *cobra.Command {
+func getTestRunnerAssetCommand() *cobraext.Command {
 	cmd := &cobra.Command{
 		Use:   "asset",
 		Short: "Run asset tests",
@@ -95,7 +108,14 @@ func getTestRunnerAssetCommand() *cobra.Command {
 		RunE:  testRunnerAssetCommandAction,
 	}
 
-	return cmd
+	// Globals
+	cmd.Flags().StringP(cobraext.ReportFormatFlagName, "", string(formats.ReportFormatHuman), cobraext.ReportFormatFlagDescription)
+	cmd.Flags().StringP(cobraext.ReportOutputFlagName, "", string(outputs.ReportOutputSTDOUT), cobraext.ReportOutputFlagDescription)
+	cmd.Flags().BoolP(cobraext.TestCoverageFlagName, "", false, cobraext.TestCoverageFlagDescription)
+	cmd.Flags().StringP(cobraext.TestCoverageFormatFlagName, "", "cobertura", fmt.Sprintf(cobraext.TestCoverageFormatFlagDescription, strings.Join(testrunner.CoverageFormatsList(), ",")))
+	cmd.Flags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
+
+	return cobraext.NewCommand(cmd, cobraext.ContextPackage)
 }
 
 func testRunnerAssetCommandAction(cmd *cobra.Command, args []string) error {
@@ -171,7 +191,7 @@ func testRunnerAssetCommandAction(cmd *cobra.Command, args []string) error {
 	return processResults(results, testType, reportFormat, reportOutput, packageRootPath, manifest.Name, manifest.Type, testCoverageFormat, testCoverage)
 }
 
-func getTestRunnerStaticCommand() *cobra.Command {
+func getTestRunnerStaticCommand() *cobraext.Command {
 	cmd := &cobra.Command{
 		Use:   "static",
 		Short: "Run static tests",
@@ -180,10 +200,17 @@ func getTestRunnerStaticCommand() *cobra.Command {
 		RunE:  testRunnerStaticCommandAction,
 	}
 
+	// Globals
+	cmd.Flags().StringP(cobraext.ReportFormatFlagName, "", string(formats.ReportFormatHuman), cobraext.ReportFormatFlagDescription)
+	cmd.Flags().StringP(cobraext.ReportOutputFlagName, "", string(outputs.ReportOutputSTDOUT), cobraext.ReportOutputFlagDescription)
+	cmd.Flags().BoolP(cobraext.TestCoverageFlagName, "", false, cobraext.TestCoverageFlagDescription)
+	cmd.Flags().StringP(cobraext.TestCoverageFormatFlagName, "", "cobertura", fmt.Sprintf(cobraext.TestCoverageFormatFlagDescription, strings.Join(testrunner.CoverageFormatsList(), ",")))
+	cmd.Flags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
+
 	cmd.Flags().BoolP(cobraext.FailOnMissingFlagName, "m", false, cobraext.FailOnMissingFlagDescription)
 	cmd.Flags().StringSliceP(cobraext.DataStreamsFlagName, "d", nil, cobraext.DataStreamsFlagDescription)
 
-	return cmd
+	return cobraext.NewCommand(cmd, cobraext.ContextPackage)
 }
 
 func testRunnerStaticCommandAction(cmd *cobra.Command, args []string) error {
@@ -312,7 +339,7 @@ func testRunnerStaticCommandAction(cmd *cobra.Command, args []string) error {
 	return processResults(results, testType, reportFormat, reportOutput, packageRootPath, manifest.Name, manifest.Type, testCoverageFormat, testCoverage)
 }
 
-func getTestRunnerPipelineCommand() *cobra.Command {
+func getTestRunnerPipelineCommand() *cobraext.Command {
 	cmd := &cobra.Command{
 		Use:   "pipeline",
 		Short: "Run pipeline tests",
@@ -321,12 +348,19 @@ func getTestRunnerPipelineCommand() *cobra.Command {
 		RunE:  testRunnerPipelineCommandAction,
 	}
 
+	// Globals
+	cmd.Flags().StringP(cobraext.ReportFormatFlagName, "", string(formats.ReportFormatHuman), cobraext.ReportFormatFlagDescription)
+	cmd.Flags().StringP(cobraext.ReportOutputFlagName, "", string(outputs.ReportOutputSTDOUT), cobraext.ReportOutputFlagDescription)
+	cmd.Flags().BoolP(cobraext.TestCoverageFlagName, "", false, cobraext.TestCoverageFlagDescription)
+	cmd.Flags().StringP(cobraext.TestCoverageFormatFlagName, "", "cobertura", fmt.Sprintf(cobraext.TestCoverageFormatFlagDescription, strings.Join(testrunner.CoverageFormatsList(), ",")))
+	cmd.Flags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
+
 	cmd.Flags().BoolP(cobraext.FailOnMissingFlagName, "m", false, cobraext.FailOnMissingFlagDescription)
 	cmd.Flags().BoolP(cobraext.GenerateTestResultFlagName, "g", false, cobraext.GenerateTestResultFlagDescription)
 	cmd.Flags().DurationP(cobraext.DeferCleanupFlagName, "", 0, cobraext.DeferCleanupFlagDescription)
 	cmd.Flags().StringSliceP(cobraext.DataStreamsFlagName, "d", nil, cobraext.DataStreamsFlagDescription)
 
-	return cmd
+	return cobraext.NewCommand(cmd, cobraext.ContextPackage)
 }
 
 func testRunnerPipelineCommandAction(cmd *cobra.Command, args []string) error {
@@ -478,7 +512,7 @@ func testRunnerPipelineCommandAction(cmd *cobra.Command, args []string) error {
 	return processResults(results, testType, reportFormat, reportOutput, packageRootPath, manifest.Name, manifest.Type, testCoverageFormat, testCoverage)
 }
 
-func getTestRunnerSystemCommand() *cobra.Command {
+func getTestRunnerSystemCommand() *cobraext.Command {
 	cmd := &cobra.Command{
 		Use:   "system",
 		Short: "Run system tests",
@@ -486,6 +520,13 @@ func getTestRunnerSystemCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE:  testRunnerSystemCommandAction,
 	}
+
+	// Globals
+	cmd.Flags().StringP(cobraext.ReportFormatFlagName, "", string(formats.ReportFormatHuman), cobraext.ReportFormatFlagDescription)
+	cmd.Flags().StringP(cobraext.ReportOutputFlagName, "", string(outputs.ReportOutputSTDOUT), cobraext.ReportOutputFlagDescription)
+	cmd.Flags().BoolP(cobraext.TestCoverageFlagName, "", false, cobraext.TestCoverageFlagDescription)
+	cmd.Flags().StringP(cobraext.TestCoverageFormatFlagName, "", "cobertura", fmt.Sprintf(cobraext.TestCoverageFormatFlagDescription, strings.Join(testrunner.CoverageFormatsList(), ",")))
+	cmd.Flags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
 
 	cmd.Flags().BoolP(cobraext.FailOnMissingFlagName, "m", false, cobraext.FailOnMissingFlagDescription)
 	cmd.Flags().BoolP(cobraext.GenerateTestResultFlagName, "g", false, cobraext.GenerateTestResultFlagDescription)
@@ -512,7 +553,7 @@ func getTestRunnerSystemCommand() *cobra.Command {
 	cmd.MarkFlagsMutuallyExclusive(cobraext.DataStreamsFlagName, cobraext.TearDownFlagName)
 	cmd.MarkFlagsMutuallyExclusive(cobraext.DataStreamsFlagName, cobraext.NoProvisionFlagName)
 
-	return cmd
+	return cobraext.NewCommand(cmd, cobraext.ContextPackage)
 }
 
 func testRunnerSystemCommandAction(cmd *cobra.Command, args []string) error {
@@ -727,7 +768,7 @@ func testRunnerSystemCommandAction(cmd *cobra.Command, args []string) error {
 	return processResults(results, testType, reportFormat, reportOutput, packageRootPath, manifest.Name, manifest.Type, testCoverageFormat, testCoverage)
 }
 
-func getTestRunnerPolicyCommand() *cobra.Command {
+func getTestRunnerPolicyCommand() *cobraext.Command {
 	cmd := &cobra.Command{
 		Use:   "policy",
 		Short: "Run policy tests",
@@ -736,10 +777,17 @@ func getTestRunnerPolicyCommand() *cobra.Command {
 		RunE:  testRunnerPolicyCommandAction,
 	}
 
+	// Globals
+	cmd.Flags().StringP(cobraext.ReportFormatFlagName, "", string(formats.ReportFormatHuman), cobraext.ReportFormatFlagDescription)
+	cmd.Flags().StringP(cobraext.ReportOutputFlagName, "", string(outputs.ReportOutputSTDOUT), cobraext.ReportOutputFlagDescription)
+	cmd.Flags().BoolP(cobraext.TestCoverageFlagName, "", false, cobraext.TestCoverageFlagDescription)
+	cmd.Flags().StringP(cobraext.TestCoverageFormatFlagName, "", "cobertura", fmt.Sprintf(cobraext.TestCoverageFormatFlagDescription, strings.Join(testrunner.CoverageFormatsList(), ",")))
+	cmd.Flags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
+
 	cmd.Flags().BoolP(cobraext.FailOnMissingFlagName, "m", false, cobraext.FailOnMissingFlagDescription)
 	cmd.Flags().StringSliceP(cobraext.DataStreamsFlagName, "d", nil, cobraext.DataStreamsFlagDescription)
 	cmd.Flags().BoolP(cobraext.GenerateTestResultFlagName, "g", false, cobraext.GenerateTestResultFlagDescription)
-	return cmd
+	return cobraext.NewCommand(cmd, cobraext.ContextPackage)
 }
 
 func testRunnerPolicyCommandAction(cmd *cobra.Command, args []string) error {

--- a/internal/cobraext/action.go
+++ b/internal/cobraext/action.go
@@ -32,3 +32,15 @@ func ComposeCommands(args []string, composed ...*Command) error {
 	}
 	return nil
 }
+
+func ComposeCommandsParentContext(parent *cobra.Command, args []string, composed ...*cobra.Command) error {
+	for _, cmd := range composed {
+		cmd.ParseFlags(args)
+		cmd.SetContext(parent.Context())
+		err := cmd.RunE(cmd, args)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/testrunner/runners/asset/runner.go
+++ b/internal/testrunner/runners/asset/runner.go
@@ -46,18 +46,6 @@ func (r runner) String() string {
 	return "asset loading"
 }
 
-// CanRunPerDataStream returns whether this test runner can run on individual
-// data streams within the package.
-func (r runner) CanRunPerDataStream() bool {
-	return false
-}
-
-// CanRunSetupTeardownIndependent returns whether this test runner can run setup or
-// teardown process independent.
-func (r *runner) CanRunSetupTeardownIndependent() bool {
-	return false
-}
-
 // Run runs the asset loading tests
 func (r *runner) Run(ctx context.Context, options testrunner.TestOptions) ([]testrunner.TestResult, error) {
 	r.testFolder = options.TestFolder
@@ -167,10 +155,6 @@ func (r *runner) TearDown(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func (r *runner) TestFolderRequired() bool {
-	return false
 }
 
 func findActualAsset(actualAssets []packages.Asset, expectedAsset packages.Asset) bool {

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -57,10 +57,6 @@ type IngestPipelineReroute struct {
 // Ensures that runner implements testrunner.TestRunner interface
 var _ testrunner.TestRunner = new(runner)
 
-func (r *runner) TestFolderRequired() bool {
-	return true
-}
-
 // Type returns the type of test that can be run by this test runner.
 func (r *runner) Type() testrunner.TestType {
 	return TestType
@@ -113,18 +109,6 @@ func (r *runner) TearDown(ctx context.Context) error {
 		return fmt.Errorf("uninstalling ingest pipelines failed: %w", err)
 	}
 	return nil
-}
-
-// CanRunPerDataStream returns whether this test runner can run on individual
-// data streams within the package.
-func (r *runner) CanRunPerDataStream() bool {
-	return true
-}
-
-// CanRunSetupTeardownIndependent returns whether this test runner can run setup or
-// teardown process independent.
-func (r *runner) CanRunSetupTeardownIndependent() bool {
-	return false
 }
 
 func (r *runner) run(ctx context.Context) ([]testrunner.TestResult, error) {

--- a/internal/testrunner/runners/policy/runner.go
+++ b/internal/testrunner/runners/policy/runner.go
@@ -161,15 +161,3 @@ func (r *runner) setupSuite(ctx context.Context, manager *resources.Manager, opt
 func (r *runner) TearDown(ctx context.Context) error {
 	return nil
 }
-
-func (r *runner) CanRunPerDataStream() bool {
-	return true
-}
-
-func (r *runner) TestFolderRequired() bool {
-	return true
-}
-
-func (r *runner) CanRunSetupTeardownIndependent() bool {
-	return false
-}

--- a/internal/testrunner/runners/static/runner.go
+++ b/internal/testrunner/runners/static/runner.go
@@ -203,17 +203,3 @@ func (r runner) getExpectedDatasets(pkgManifest *packages.PackageManifest) ([]st
 func (r runner) TearDown(ctx context.Context) error {
 	return nil // it's a static test runner, no state is stored
 }
-
-func (r runner) CanRunPerDataStream() bool {
-	return true
-}
-
-func (r *runner) TestFolderRequired() bool {
-	return false
-}
-
-// CanRunSetupTeardownIndependent returns whether this test runner can run setup or
-// teardown process independent.
-func (r *runner) CanRunSetupTeardownIndependent() bool {
-	return false
-}

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -166,22 +166,6 @@ func (r *runner) String() string {
 	return "system"
 }
 
-// CanRunPerDataStream returns whether this test runner can run on individual
-// data streams within the package.
-func (r *runner) CanRunPerDataStream() bool {
-	return true
-}
-
-func (r *runner) TestFolderRequired() bool {
-	return true
-}
-
-// CanRunSetupTeardownIndependent returns whether this test runner can run setup or
-// teardown process independent.
-func (r *runner) CanRunSetupTeardownIndependent() bool {
-	return true
-}
-
 // Run runs the system tests defined under the given folder
 func (r *runner) Run(ctx context.Context, options testrunner.TestOptions) ([]testrunner.TestResult, error) {
 	r.options = options

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -64,12 +64,6 @@ type TestRunner interface {
 	// TearDown cleans up any test runner resources. It must be called
 	// after the test runner has finished executing.
 	TearDown(context.Context) error
-
-	CanRunPerDataStream() bool
-
-	TestFolderRequired() bool
-
-	CanRunSetupTeardownIndependent() bool
 }
 
 var runners = map[TestType]TestRunner{}


### PR DESCRIPTION
This PR defines each subcommand under `elastic-package test` in its own function.

This allows us to remove functions from the TestRunner interface: TestFolderRequired, CanRunPerDataStream, CanRunSetupTeardownIndependent