### PR TITLE
Instantiate runners directly on test commands

### DIFF
--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -28,6 +28,7 @@ import (
 	_ "github.com/elastic/elastic-package/internal/testrunner/runners" // register all test runners
 	"github.com/elastic/elastic-package/internal/testrunner/runners/asset"
 	"github.com/elastic/elastic-package/internal/testrunner/runners/pipeline"
+	"github.com/elastic/elastic-package/internal/testrunner/runners/policy"
 	"github.com/elastic/elastic-package/internal/testrunner/runners/static"
 	"github.com/elastic/elastic-package/internal/testrunner/runners/system"
 )
@@ -859,21 +860,24 @@ func testRunnerPolicyCommandAction(cmd *cobra.Command, args []string) error {
 
 	var results []testrunner.TestResult
 	for _, folder := range testFolders {
-		r, err := testrunner.Run(ctx, testType, testrunner.TestOptions{
-			Profile:                    profile,
-			TestFolder:                 folder,
-			PackageRootPath:            packageRootPath,
-			GenerateTestResult:         generateTestResult,
-			KibanaClient:               kibanaClient,
-			RunIndependentElasticAgent: false,
+		runner := policy.NewPolicyRunner(policy.PolicyRunnerOptions{
+			TestFolder:         folder,
+			PackageRootPath:    packageRootPath,
+			GenerateTestResult: generateTestResult,
+			KibanaClient:       kibanaClient,
 		})
+		r, err := runner.Run(ctx, testrunner.TestOptions{})
 
 		// Results must be appended even if there is an error, since there could be
 		// tests (e.g. system tests) that return both error and results.
 		results = append(results, r...)
 
+		tdErr := runner.TearDown(ctx)
 		if err != nil {
 			return fmt.Errorf("error running package %s tests: %w", testType, err)
+		}
+		if tdErr != nil {
+			return fmt.Errorf("could not teardown test runner: %w", tdErr)
 		}
 	}
 

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -175,13 +175,9 @@ func testRunnerAssetCommandAction(cmd *cobra.Command, args []string) error {
 		KibanaClient:    kibanaClient,
 	})
 
-	results, err := runner.Run(ctx, testrunner.TestOptions{})
-	tdErr := runner.TearDown(ctx)
+	results, err := testrunner.Run(ctx, runner)
 	if err != nil {
 		return fmt.Errorf("error running package %s tests: %w", testType, err)
-	}
-	if tdErr != nil {
-		return fmt.Errorf("could not teardown test runner: %w", tdErr)
 	}
 
 	return processResults(results, testType, reportFormat, reportOutput, packageRootPath, manifest.Name, manifest.Type, testCoverageFormat, testCoverage)
@@ -300,18 +296,11 @@ func testRunnerStaticCommandAction(cmd *cobra.Command, args []string) error {
 			TestFolder:      folder,
 			PackageRootPath: packageRootPath,
 		})
-		r, err := runner.Run(ctx, testrunner.TestOptions{})
-		// Results must be appended even if there is an error, since there could be
-		// tests (e.g. system tests) that return both error and results.
-		results = append(results, r...)
-
-		tdErr := runner.TearDown(ctx)
+		r, err := testrunner.Run(ctx, runner)
 		if err != nil {
 			return fmt.Errorf("error running package %s tests: %w", testType, err)
 		}
-		if tdErr != nil {
-			return fmt.Errorf("could not teardown test runner: %w", tdErr)
-		}
+		results = append(results, r...)
 	}
 
 	return processResults(results, testType, reportFormat, reportOutput, packageRootPath, manifest.Name, manifest.Type, testCoverageFormat, testCoverage)
@@ -466,18 +455,11 @@ func testRunnerPipelineCommandAction(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to create pipeline runner: %w", err)
 		}
 
-		r, err := runner.Run(ctx, testrunner.TestOptions{})
-		// Results must be appended even if there is an error, since there could be
-		// tests (e.g. system tests) that return both error and results.
-		results = append(results, r...)
-
-		tdErr := runner.TearDown(ctx)
+		r, err := testrunner.Run(ctx, runner)
 		if err != nil {
 			return fmt.Errorf("error running package %s tests: %w", testType, err)
 		}
-		if tdErr != nil {
-			return fmt.Errorf("could not teardown test runner: %w", tdErr)
-		}
+		results = append(results, r...)
 	}
 
 	return processResults(results, testType, reportFormat, reportOutput, packageRootPath, manifest.Name, manifest.Type, testCoverageFormat, testCoverage)
@@ -717,18 +699,11 @@ func testRunnerSystemCommandAction(cmd *cobra.Command, args []string) error {
 			RunIndependentElasticAgent: false,
 		})
 
-		r, err := runner.Run(ctx, testrunner.TestOptions{})
-		// Results must be appended even if there is an error, since there could be
-		// tests (e.g. system tests) that return both error and results.
-		results = append(results, r...)
-
-		tdErr := runner.TearDown(ctx)
+		r, err := testrunner.Run(ctx, runner)
 		if err != nil {
 			return fmt.Errorf("error running package %s tests: %w", testType, err)
 		}
-		if tdErr != nil {
-			return fmt.Errorf("could not teardown test runner: %w", tdErr)
-		}
+		results = append(results, r...)
 	}
 
 	return processResults(results, testType, reportFormat, reportOutput, packageRootPath, manifest.Name, manifest.Type, testCoverageFormat, testCoverage)
@@ -866,19 +841,11 @@ func testRunnerPolicyCommandAction(cmd *cobra.Command, args []string) error {
 			GenerateTestResult: generateTestResult,
 			KibanaClient:       kibanaClient,
 		})
-		r, err := runner.Run(ctx, testrunner.TestOptions{})
-
-		// Results must be appended even if there is an error, since there could be
-		// tests (e.g. system tests) that return both error and results.
-		results = append(results, r...)
-
-		tdErr := runner.TearDown(ctx)
+		r, err := testrunner.Run(ctx, runner)
 		if err != nil {
 			return fmt.Errorf("error running package %s tests: %w", testType, err)
 		}
-		if tdErr != nil {
-			return fmt.Errorf("could not teardown test runner: %w", tdErr)
-		}
+		results = append(results, r...)
 	}
 
 	return processResults(results, testType, reportFormat, reportOutput, packageRootPath, manifest.Name, manifest.Type, testCoverageFormat, testCoverage)

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -25,7 +25,6 @@ import (
 	"github.com/elastic/elastic-package/internal/testrunner"
 	"github.com/elastic/elastic-package/internal/testrunner/reporters/formats"
 	"github.com/elastic/elastic-package/internal/testrunner/reporters/outputs"
-	_ "github.com/elastic/elastic-package/internal/testrunner/runners" // register all test runners
 	"github.com/elastic/elastic-package/internal/testrunner/runners/asset"
 	"github.com/elastic/elastic-package/internal/testrunner/runners/pipeline"
 	"github.com/elastic/elastic-package/internal/testrunner/runners/policy"

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -27,6 +27,7 @@ import (
 	"github.com/elastic/elastic-package/internal/testrunner/reporters/outputs"
 	_ "github.com/elastic/elastic-package/internal/testrunner/runners" // register all test runners
 	"github.com/elastic/elastic-package/internal/testrunner/runners/asset"
+	"github.com/elastic/elastic-package/internal/testrunner/runners/static"
 )
 
 const testLongDescription = `Use this command to run tests on a package. Currently, the following types of tests are available:
@@ -174,14 +175,10 @@ func testRunnerAssetCommandAction(cmd *cobra.Command, args []string) error {
 	results, err := runner.Run(ctx, testrunner.TestOptions{})
 	tdErr := runner.TearDown(ctx)
 	if err != nil {
-		return fmt.Errorf("could not complete test run: %w", err)
+		return fmt.Errorf("error running package %s tests: %w", testType, err)
 	}
 	if tdErr != nil {
 		return fmt.Errorf("could not teardown test runner: %w", tdErr)
-	}
-
-	if err != nil {
-		return fmt.Errorf("error running package %s tests: %w", testType, err)
 	}
 
 	return processResults(results, testType, reportFormat, reportOutput, packageRootPath, manifest.Name, manifest.Type, testCoverageFormat, testCoverage)
@@ -205,11 +202,6 @@ func getTestRunnerStaticCommand() *cobra.Command {
 func testRunnerStaticCommandAction(cmd *cobra.Command, args []string) error {
 	cmd.Printf("Run static tests for the package\n")
 	testType := testrunner.TestType("static")
-
-	profile, err := cobraext.GetProfileFlag(cmd)
-	if err != nil {
-		return err
-	}
 
 	failOnMissing, err := cmd.Flags().GetBool(cobraext.FailOnMissingFlagName)
 	if err != nil {
@@ -301,19 +293,21 @@ func testRunnerStaticCommandAction(cmd *cobra.Command, args []string) error {
 
 	var results []testrunner.TestResult
 	for _, folder := range testFolders {
-		r, err := testrunner.Run(ctx, testType, testrunner.TestOptions{
-			Profile:                    profile,
-			TestFolder:                 folder,
-			PackageRootPath:            packageRootPath,
-			RunIndependentElasticAgent: false,
+		runner := static.NewStaticRunner(static.StaticRunnerOptions{
+			TestFolder:      folder,
+			PackageRootPath: packageRootPath,
 		})
-
+		r, err := runner.Run(ctx, testrunner.TestOptions{})
 		// Results must be appended even if there is an error, since there could be
 		// tests (e.g. system tests) that return both error and results.
 		results = append(results, r...)
 
+		tdErr := runner.TearDown(ctx)
 		if err != nil {
 			return fmt.Errorf("error running package %s tests: %w", testType, err)
+		}
+		if tdErr != nil {
+			return fmt.Errorf("could not teardown test runner: %w", tdErr)
 		}
 	}
 

--- a/internal/testrunner/runners/asset/runner.go
+++ b/internal/testrunner/runners/asset/runner.go
@@ -63,7 +63,7 @@ func (r runner) String() string {
 }
 
 // Run runs the asset loading tests
-func (r *runner) Run(ctx context.Context, options testrunner.TestOptions) ([]testrunner.TestResult, error) {
+func (r *runner) Run(ctx context.Context) ([]testrunner.TestResult, error) {
 	return r.run(ctx)
 }
 

--- a/internal/testrunner/runners/asset/runner.go
+++ b/internal/testrunner/runners/asset/runner.go
@@ -17,10 +17,6 @@ import (
 	"github.com/elastic/elastic-package/internal/testrunner"
 )
 
-func init() {
-	testrunner.RegisterRunner(&runner{})
-}
-
 const (
 	// TestType defining asset loading tests
 	TestType testrunner.TestType = "asset"

--- a/internal/testrunner/runners/asset/runner.go
+++ b/internal/testrunner/runners/asset/runner.go
@@ -33,6 +33,26 @@ type runner struct {
 	resourcesManager *resources.Manager
 }
 
+type AssetRunnerOptions struct {
+	TestFolder      testrunner.TestFolder
+	PackageRootPath string
+	KibanaClient    *kibana.Client
+}
+
+func NewAssetRunner(options AssetRunnerOptions) *runner {
+	runner := runner{
+		testFolder:      options.TestFolder,
+		packageRootPath: options.PackageRootPath,
+		kibanaClient:    options.KibanaClient,
+	}
+
+	manager := resources.NewManager()
+	manager.RegisterProvider(resources.DefaultKibanaProviderName, &resources.KibanaProvider{Client: options.KibanaClient})
+	runner.resourcesManager = manager
+
+	return &runner
+}
+
 // Ensures that runner implements testrunner.TestRunner interface
 var _ testrunner.TestRunner = new(runner)
 
@@ -48,14 +68,6 @@ func (r runner) String() string {
 
 // Run runs the asset loading tests
 func (r *runner) Run(ctx context.Context, options testrunner.TestOptions) ([]testrunner.TestResult, error) {
-	r.testFolder = options.TestFolder
-	r.packageRootPath = options.PackageRootPath
-	r.kibanaClient = options.KibanaClient
-
-	manager := resources.NewManager()
-	manager.RegisterProvider(resources.DefaultKibanaProviderName, &resources.KibanaProvider{Client: r.kibanaClient})
-	r.resourcesManager = manager
-
 	return r.run(ctx)
 }
 

--- a/internal/testrunner/runners/pipeline/coverage.go
+++ b/internal/testrunner/runners/pipeline/coverage.go
@@ -17,8 +17,8 @@ import (
 	"github.com/elastic/elastic-package/internal/testrunner"
 )
 
-// GetPipelineCoverage returns a coverage report for the provided set of ingest pipelines.
-func GetPipelineCoverage(options PipelineRunnerOptions, pipelines []ingest.Pipeline) (testrunner.CoverageReport, error) {
+// getPipelineCoverage returns a coverage report for the provided set of ingest pipelines.
+func getPipelineCoverage(options PipelineRunnerOptions, pipelines []ingest.Pipeline) (testrunner.CoverageReport, error) {
 	dataStreamPath, found, err := packages.FindDataStreamRootForPath(options.TestFolder.Path)
 	if err != nil {
 		return nil, fmt.Errorf("locating data_stream root failed: %w", err)

--- a/internal/testrunner/runners/pipeline/coverage.go
+++ b/internal/testrunner/runners/pipeline/coverage.go
@@ -18,7 +18,7 @@ import (
 )
 
 // GetPipelineCoverage returns a coverage report for the provided set of ingest pipelines.
-func GetPipelineCoverage(options testrunner.TestOptions, pipelines []ingest.Pipeline) (testrunner.CoverageReport, error) {
+func GetPipelineCoverage(options PipelineRunnerOptions, pipelines []ingest.Pipeline) (testrunner.CoverageReport, error) {
 	dataStreamPath, found, err := packages.FindDataStreamRootForPath(options.TestFolder.Path)
 	if err != nil {
 		return nil, fmt.Errorf("locating data_stream root failed: %w", err)

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -124,7 +124,7 @@ func (r *runner) String() string {
 }
 
 // Run runs the pipeline tests defined under the given folder
-func (r *runner) Run(ctx context.Context, options testrunner.TestOptions) ([]testrunner.TestResult, error) {
+func (r *runner) Run(ctx context.Context) ([]testrunner.TestResult, error) {
 	return r.run(ctx)
 }
 

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -355,7 +355,7 @@ func (r *runner) runTestCase(ctx context.Context, testCaseFile string, dsPath st
 	}
 
 	if r.withCoverage {
-		tr.Coverage, err = GetPipelineCoverage(PipelineRunnerOptions{
+		tr.Coverage, err = getPipelineCoverage(PipelineRunnerOptions{
 			TestFolder:      r.testFolder,
 			API:             r.esAPI,
 			PackageRootPath: r.packageRootPath,

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -586,7 +586,3 @@ func checkErrorMessage(event json.RawMessage) error {
 		return fmt.Errorf("unexpected pipeline error (unexpected error.message type %T): %[1]v", m)
 	}
 }
-
-func init() {
-	testrunner.RegisterRunner(&runner{})
-}

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/elastic-package/internal/common"
+	"github.com/elastic/elastic-package/internal/elasticsearch"
 	"github.com/elastic/elastic-package/internal/elasticsearch/ingest"
 	"github.com/elastic/elastic-package/internal/environment"
 	"github.com/elastic/elastic-package/internal/fields"
@@ -28,6 +29,7 @@ import (
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/multierror"
 	"github.com/elastic/elastic-package/internal/packages"
+	"github.com/elastic/elastic-package/internal/profile"
 	"github.com/elastic/elastic-package/internal/stack"
 	"github.com/elastic/elastic-package/internal/testrunner"
 )
@@ -40,12 +42,66 @@ const (
 var serverlessDisableCompareResults = environment.WithElasticPackagePrefix("SERVERLESS_PIPELINE_TEST_DISABLE_COMPARE_RESULTS")
 
 type runner struct {
-	options   testrunner.TestOptions
+	profile            *profile.Profile
+	deferCleanup       time.Duration
+	esAPI              *elasticsearch.API
+	packageRootPath    string
+	testFolder         testrunner.TestFolder
+	generateTestResult bool
+	withCoverage       bool
+	coverageType       string
+
 	pipelines []ingest.Pipeline
 
 	runCompareResults bool
 
 	provider stack.Provider
+}
+
+type PipelineRunnerOptions struct {
+	Profile            *profile.Profile
+	DeferCleanup       time.Duration
+	API                *elasticsearch.API
+	PackageRootPath    string
+	TestFolder         testrunner.TestFolder
+	GenerateTestResult bool
+	WithCoverage       bool
+	CoverageType       string
+}
+
+func NewPipelineRunner(options PipelineRunnerOptions) (*runner, error) {
+	r := runner{
+		profile:            options.Profile,
+		deferCleanup:       options.DeferCleanup,
+		esAPI:              options.API,
+		packageRootPath:    options.PackageRootPath,
+		testFolder:         options.TestFolder,
+		generateTestResult: options.GenerateTestResult,
+		withCoverage:       options.WithCoverage,
+		coverageType:       options.CoverageType,
+	}
+
+	stackConfig, err := stack.LoadConfig(r.profile)
+	if err != nil {
+		return nil, err
+	}
+
+	provider, err := stack.BuildProvider(stackConfig.Provider, r.profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build stack provider: %w", err)
+	}
+	r.provider = provider
+
+	r.runCompareResults = true
+	if stackConfig.Provider == stack.ProviderServerless {
+		r.runCompareResults = true
+
+		v, ok := os.LookupEnv(serverlessDisableCompareResults)
+		if ok && strings.ToLower(v) == "true" {
+			r.runCompareResults = false
+		}
+	}
+	return &r, nil
 }
 
 type IngestPipelineReroute struct {
@@ -69,43 +125,20 @@ func (r *runner) String() string {
 
 // Run runs the pipeline tests defined under the given folder
 func (r *runner) Run(ctx context.Context, options testrunner.TestOptions) ([]testrunner.TestResult, error) {
-	r.options = options
-
-	stackConfig, err := stack.LoadConfig(r.options.Profile)
-	if err != nil {
-		return nil, err
-	}
-
-	provider, err := stack.BuildProvider(stackConfig.Provider, r.options.Profile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build stack provider: %w", err)
-	}
-	r.provider = provider
-
-	r.runCompareResults = true
-	if stackConfig.Provider == stack.ProviderServerless {
-		r.runCompareResults = true
-
-		v, ok := os.LookupEnv(serverlessDisableCompareResults)
-		if ok && strings.ToLower(v) == "true" {
-			r.runCompareResults = false
-		}
-	}
-
 	return r.run(ctx)
 }
 
 // TearDown shuts down the pipeline test runner.
 func (r *runner) TearDown(ctx context.Context) error {
-	if r.options.DeferCleanup > 0 {
-		logger.Debugf("Waiting for %s before cleanup...", r.options.DeferCleanup)
+	if r.deferCleanup > 0 {
+		logger.Debugf("Waiting for %s before cleanup...", r.deferCleanup)
 		select {
-		case <-time.After(r.options.DeferCleanup):
+		case <-time.After(r.deferCleanup):
 		case <-ctx.Done():
 		}
 	}
 
-	if err := ingest.UninstallPipelines(ctx, r.options.API, r.pipelines); err != nil {
+	if err := ingest.UninstallPipelines(ctx, r.esAPI, r.pipelines); err != nil {
 		return fmt.Errorf("uninstalling ingest pipelines failed: %w", err)
 	}
 	return nil
@@ -117,11 +150,11 @@ func (r *runner) run(ctx context.Context) ([]testrunner.TestResult, error) {
 		return nil, fmt.Errorf("listing test case definitions failed: %w", err)
 	}
 
-	if r.options.API == nil {
+	if r.esAPI == nil {
 		return nil, errors.New("missing Elasticsearch client")
 	}
 
-	dataStreamPath, found, err := packages.FindDataStreamRootForPath(r.options.TestFolder.Path)
+	dataStreamPath, found, err := packages.FindDataStreamRootForPath(r.testFolder.Path)
 	if err != nil {
 		return nil, fmt.Errorf("locating data_stream root failed: %w", err)
 	}
@@ -131,17 +164,17 @@ func (r *runner) run(ctx context.Context) ([]testrunner.TestResult, error) {
 
 	startTime := time.Now()
 	var entryPipeline string
-	entryPipeline, r.pipelines, err = ingest.InstallDataStreamPipelines(r.options.API, dataStreamPath)
+	entryPipeline, r.pipelines, err = ingest.InstallDataStreamPipelines(r.esAPI, dataStreamPath)
 	if err != nil {
 		return nil, fmt.Errorf("installing ingest pipelines failed: %w", err)
 	}
 
-	pkgManifest, err := packages.ReadPackageManifestFromPackageRoot(r.options.PackageRootPath)
+	pkgManifest, err := packages.ReadPackageManifestFromPackageRoot(r.packageRootPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read manifest: %w", err)
 	}
 
-	dsManifest, err := packages.ReadDataStreamManifestFromPackageRoot(r.options.PackageRootPath, r.options.TestFolder.DataStream)
+	dsManifest, err := packages.ReadDataStreamManifestFromPackageRoot(r.packageRootPath, r.testFolder.DataStream)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read data stream manifest: %w", err)
 	}
@@ -164,7 +197,7 @@ func (r *runner) run(ctx context.Context) ([]testrunner.TestResult, error) {
 	if len(expectedDatasets) == 0 {
 		expectedDataset := dsManifest.Dataset
 		if expectedDataset == "" {
-			expectedDataset = pkgManifest.Name + "." + r.options.TestFolder.DataStream
+			expectedDataset = pkgManifest.Name + "." + r.testFolder.DataStream
 		}
 		expectedDatasets = []string{expectedDataset}
 	}
@@ -201,7 +234,7 @@ func (r *runner) checkElasticsearchLogs(ctx context.Context, startTesting time.T
 	testingTime := startTesting.Truncate(time.Second)
 
 	dumpOptions := stack.DumpOptions{
-		Profile:  r.options.Profile,
+		Profile:  r.profile,
 		Services: []string{"elasticsearch"},
 		Since:    testingTime,
 	}
@@ -251,8 +284,8 @@ func (r *runner) checkElasticsearchLogs(ctx context.Context, startTesting time.T
 	tr := testrunner.TestResult{
 		TestType:    TestType,
 		Name:        "(ingest pipeline warnings)",
-		Package:     r.options.TestFolder.Package,
-		DataStream:  r.options.TestFolder.DataStream,
+		Package:     r.testFolder.Package,
+		DataStream:  r.testFolder.DataStream,
 		TimeElapsed: time.Since(startTime),
 	}
 
@@ -268,12 +301,12 @@ func (r *runner) checkElasticsearchLogs(ctx context.Context, startTesting time.T
 func (r *runner) runTestCase(ctx context.Context, testCaseFile string, dsPath string, dsType string, pipeline string, validatorOptions []fields.ValidatorOption) (testrunner.TestResult, error) {
 	tr := testrunner.TestResult{
 		TestType:   TestType,
-		Package:    r.options.TestFolder.Package,
-		DataStream: r.options.TestFolder.DataStream,
+		Package:    r.testFolder.Package,
+		DataStream: r.testFolder.DataStream,
 	}
 	startTime := time.Now()
 
-	tc, err := loadTestCaseFile(r.options.TestFolder.Path, testCaseFile)
+	tc, err := loadTestCaseFile(r.testFolder.Path, testCaseFile)
 	if err != nil {
 		err := fmt.Errorf("loading test case failed: %w", err)
 		tr.ErrorMsg = err.Error()
@@ -283,15 +316,15 @@ func (r *runner) runTestCase(ctx context.Context, testCaseFile string, dsPath st
 
 	if tc.config.Skip != nil {
 		logger.Warnf("skipping %s test for %s/%s: %s (details: %s)",
-			TestType, r.options.TestFolder.Package, r.options.TestFolder.DataStream,
+			TestType, r.testFolder.Package, r.testFolder.DataStream,
 			tc.config.Skip.Reason, tc.config.Skip.Link.String())
 
 		tr.Skipped = tc.config.Skip
 		return tr, nil
 	}
 
-	simulateDataStream := dsType + "-" + r.options.TestFolder.Package + "." + r.options.TestFolder.DataStream + "-default"
-	processedEvents, err := ingest.SimulatePipeline(ctx, r.options.API, pipeline, tc.events, simulateDataStream)
+	simulateDataStream := dsType + "-" + r.testFolder.Package + "." + r.testFolder.DataStream + "-default"
+	processedEvents, err := ingest.SimulatePipeline(ctx, r.esAPI, pipeline, tc.events, simulateDataStream)
 	if err != nil {
 		err := fmt.Errorf("simulating pipeline processing failed: %w", err)
 		tr.ErrorMsg = err.Error()
@@ -321,8 +354,13 @@ func (r *runner) runTestCase(ctx context.Context, testCaseFile string, dsPath st
 		return tr, nil
 	}
 
-	if r.options.WithCoverage {
-		tr.Coverage, err = GetPipelineCoverage(r.options, r.pipelines)
+	if r.withCoverage {
+		tr.Coverage, err = GetPipelineCoverage(PipelineRunnerOptions{
+			TestFolder:      r.testFolder,
+			API:             r.esAPI,
+			PackageRootPath: r.packageRootPath,
+			CoverageType:    r.coverageType,
+		}, r.pipelines)
 		if err != nil {
 			return tr, fmt.Errorf("error calculating pipeline coverage: %w", err)
 		}
@@ -332,9 +370,9 @@ func (r *runner) runTestCase(ctx context.Context, testCaseFile string, dsPath st
 }
 
 func (r *runner) listTestCaseFiles() ([]string, error) {
-	fis, err := os.ReadDir(r.options.TestFolder.Path)
+	fis, err := os.ReadDir(r.testFolder.Path)
 	if err != nil {
-		return nil, fmt.Errorf("reading pipeline tests failed (path: %s): %w", r.options.TestFolder.Path, err)
+		return nil, fmt.Errorf("reading pipeline tests failed (path: %s): %w", r.testFolder.Path, err)
 	}
 
 	var files []string
@@ -393,9 +431,9 @@ func loadTestCaseFile(testFolderPath, testCaseFile string) (*testCase, error) {
 }
 
 func (r *runner) verifyResults(testCaseFile string, config *testConfig, result *testResult, fieldsValidator *fields.Validator) error {
-	testCasePath := filepath.Join(r.options.TestFolder.Path, testCaseFile)
+	testCasePath := filepath.Join(r.testFolder.Path, testCaseFile)
 
-	manifest, err := packages.ReadPackageManifestFromPackageRoot(r.options.PackageRootPath)
+	manifest, err := packages.ReadPackageManifestFromPackageRoot(r.packageRootPath)
 	if err != nil {
 		return fmt.Errorf("failed to read package manifest: %w", err)
 	}
@@ -404,7 +442,7 @@ func (r *runner) verifyResults(testCaseFile string, config *testConfig, result *
 		return fmt.Errorf("failed to parse package format version %q: %w", manifest.SpecVersion, err)
 	}
 
-	if r.options.GenerateTestResult {
+	if r.generateTestResult {
 		err := writeTestResult(testCasePath, result, *specVersion)
 		if err != nil {
 			return fmt.Errorf("writing test result failed: %w", err)

--- a/internal/testrunner/runners/policy/policy.go
+++ b/internal/testrunner/runners/policy/policy.go
@@ -18,11 +18,11 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/elastic-package/internal/common"
-	"github.com/elastic/elastic-package/internal/testrunner"
+	"github.com/elastic/elastic-package/internal/kibana"
 )
 
-func dumpExpectedAgentPolicy(ctx context.Context, options testrunner.TestOptions, testPath string, policyID string, expectedRevision int) error {
-	policy, err := options.KibanaClient.DownloadPolicy(ctx, policyID)
+func dumpExpectedAgentPolicy(ctx context.Context, kibanaClient *kibana.Client, testPath string, policyID string, expectedRevision int) error {
+	policy, err := kibanaClient.DownloadPolicy(ctx, policyID)
 	if err != nil {
 		return fmt.Errorf("failed to download policy %q: %w", policyID, err)
 	}
@@ -40,8 +40,8 @@ func dumpExpectedAgentPolicy(ctx context.Context, options testrunner.TestOptions
 	return nil
 }
 
-func assertExpectedAgentPolicy(ctx context.Context, options testrunner.TestOptions, testPath string, policyID string, expectedRevision int) error {
-	policy, err := options.KibanaClient.DownloadPolicy(ctx, policyID)
+func assertExpectedAgentPolicy(ctx context.Context, kibanaClient *kibana.Client, testPath string, policyID string, expectedRevision int) error {
+	policy, err := kibanaClient.DownloadPolicy(ctx, policyID)
 	if err != nil {
 		return fmt.Errorf("failed to download policy %q: %w", policyID, err)
 	}

--- a/internal/testrunner/runners/policy/policy.go
+++ b/internal/testrunner/runners/policy/policy.go
@@ -21,7 +21,7 @@ import (
 	"github.com/elastic/elastic-package/internal/kibana"
 )
 
-func dumpExpectedAgentPolicy(ctx context.Context, kibanaClient *kibana.Client, testPath string, policyID string, expectedRevision int) error {
+func dumpExpectedAgentPolicy(ctx context.Context, kibanaClient *kibana.Client, testPath string, policyID string) error {
 	policy, err := kibanaClient.DownloadPolicy(ctx, policyID)
 	if err != nil {
 		return fmt.Errorf("failed to download policy %q: %w", policyID, err)
@@ -40,7 +40,7 @@ func dumpExpectedAgentPolicy(ctx context.Context, kibanaClient *kibana.Client, t
 	return nil
 }
 
-func assertExpectedAgentPolicy(ctx context.Context, kibanaClient *kibana.Client, testPath string, policyID string, expectedRevision int) error {
+func assertExpectedAgentPolicy(ctx context.Context, kibanaClient *kibana.Client, testPath string, policyID string) error {
 	policy, err := kibanaClient.DownloadPolicy(ctx, policyID)
 	if err != nil {
 		return fmt.Errorf("failed to download policy %q: %w", policyID, err)

--- a/internal/testrunner/runners/policy/runner.go
+++ b/internal/testrunner/runners/policy/runner.go
@@ -53,7 +53,7 @@ func (r *runner) String() string {
 	return string(TestType)
 }
 
-func (r *runner) Run(ctx context.Context, _ testrunner.TestOptions) ([]testrunner.TestResult, error) {
+func (r *runner) Run(ctx context.Context) ([]testrunner.TestResult, error) {
 	manager := resources.NewManager()
 	manager.RegisterProvider(resources.DefaultKibanaProviderName, &resources.KibanaProvider{
 		Client: r.kibanaClient,

--- a/internal/testrunner/runners/policy/runner.go
+++ b/internal/testrunner/runners/policy/runner.go
@@ -22,10 +22,6 @@ const (
 	TestType testrunner.TestType = "policy"
 )
 
-func init() {
-	testrunner.RegisterRunner(&runner{})
-}
-
 type runner struct {
 	testFolder         testrunner.TestFolder
 	packageRootPath    string

--- a/internal/testrunner/runners/policy/runner.go
+++ b/internal/testrunner/runners/policy/runner.go
@@ -120,14 +120,10 @@ func (r *runner) runTest(ctx context.Context, manager *resources.Manager, testPa
 	resources := resource.Resources{&policy}
 	_, testErr := manager.ApplyCtx(ctx, resources)
 	if testErr == nil {
-		// Revision 1 on creation, plus one revision for each attached policy.
-		// In some cases the revision 2 with the agent policy disappears if there is some
-		// issue with the final policy.
-		expectedRevision := 1 + len(policy.PackagePolicies)
 		if r.generateTestResult {
-			testErr = dumpExpectedAgentPolicy(ctx, r.kibanaClient, testPath, policy.ID, expectedRevision)
+			testErr = dumpExpectedAgentPolicy(ctx, r.kibanaClient, testPath, policy.ID)
 		} else {
-			testErr = assertExpectedAgentPolicy(ctx, r.kibanaClient, testPath, policy.ID, expectedRevision)
+			testErr = assertExpectedAgentPolicy(ctx, r.kibanaClient, testPath, policy.ID)
 		}
 	}
 

--- a/internal/testrunner/runners/static/runner.go
+++ b/internal/testrunner/runners/static/runner.go
@@ -55,7 +55,7 @@ func (r runner) String() string {
 	return "static files"
 }
 
-func (r runner) Run(ctx context.Context, options testrunner.TestOptions) ([]testrunner.TestResult, error) {
+func (r runner) Run(ctx context.Context) ([]testrunner.TestResult, error) {
 	return r.run(ctx)
 }
 

--- a/internal/testrunner/runners/static/runner.go
+++ b/internal/testrunner/runners/static/runner.go
@@ -42,10 +42,6 @@ func NewStaticRunner(options StaticRunnerOptions) *runner {
 // Ensures that runner implements testrunner.TestRunner interface
 var _ testrunner.TestRunner = new(runner)
 
-func init() {
-	testrunner.RegisterRunner(&runner{})
-}
-
 const (
 	// TestType defining asset loading tests
 	TestType testrunner.TestType = "static"

--- a/internal/testrunner/runners/static/runner.go
+++ b/internal/testrunner/runners/static/runner.go
@@ -22,8 +22,8 @@ import (
 const sampleEventJSON = "sample_event.json"
 
 type runner struct {
-	TestFolder      testrunner.TestFolder
-	PackageRootPath string
+	testFolder      testrunner.TestFolder
+	packageRootPath string
 }
 
 type StaticRunnerOptions struct {
@@ -33,11 +33,10 @@ type StaticRunnerOptions struct {
 
 func NewStaticRunner(options StaticRunnerOptions) *runner {
 	runner := runner{
-		TestFolder:      options.TestFolder,
-		PackageRootPath: options.PackageRootPath,
+		testFolder:      options.TestFolder,
+		packageRootPath: options.PackageRootPath,
 	}
 	return &runner
-
 }
 
 // Ensures that runner implements testrunner.TestRunner interface
@@ -67,37 +66,37 @@ func (r runner) Run(ctx context.Context, options testrunner.TestOptions) ([]test
 func (r runner) run(ctx context.Context) ([]testrunner.TestResult, error) {
 	result := testrunner.NewResultComposer(testrunner.TestResult{
 		TestType:   TestType,
-		Package:    r.TestFolder.Package,
-		DataStream: r.TestFolder.DataStream,
+		Package:    r.testFolder.Package,
+		DataStream: r.testFolder.DataStream,
 	})
 
-	testConfig, err := newConfig(r.TestFolder.Path)
+	testConfig, err := newConfig(r.testFolder.Path)
 	if err != nil {
 		return result.WithError(fmt.Errorf("unable to load asset loading test config file: %w", err))
 	}
 
 	if testConfig != nil && testConfig.Skip != nil {
 		logger.Warnf("skipping %s test for %s: %s (details: %s)",
-			TestType, r.TestFolder.Package,
+			TestType, r.testFolder.Package,
 			testConfig.Skip.Reason, testConfig.Skip.Link.String())
 		return result.WithSkip(testConfig.Skip)
 	}
 
-	pkgManifest, err := packages.ReadPackageManifestFromPackageRoot(r.PackageRootPath)
+	pkgManifest, err := packages.ReadPackageManifestFromPackageRoot(r.packageRootPath)
 	if err != nil {
 		return result.WithError(fmt.Errorf("failed to read manifest: %w", err))
 	}
 
 	// join together results from verifyStreamConfig and verifySampleEvent
-	return append(r.verifyStreamConfig(ctx, r.PackageRootPath), r.verifySampleEvent(pkgManifest)...), nil
+	return append(r.verifyStreamConfig(ctx, r.packageRootPath), r.verifySampleEvent(pkgManifest)...), nil
 }
 
 func (r runner) verifyStreamConfig(ctx context.Context, packageRootPath string) []testrunner.TestResult {
 	resultComposer := testrunner.NewResultComposer(testrunner.TestResult{
 		Name:       "Verify benchmark config",
 		TestType:   TestType,
-		Package:    r.TestFolder.Package,
-		DataStream: r.TestFolder.DataStream,
+		Package:    r.testFolder.Package,
+		DataStream: r.testFolder.DataStream,
 	})
 
 	withOpts := []stream.OptionFunc{
@@ -107,7 +106,7 @@ func (r runner) verifyStreamConfig(ctx context.Context, packageRootPath string) 
 	ctx, stop := signal.Enable(ctx, logger.Info)
 	defer stop()
 
-	hasBenchmark, err := stream.StaticValidation(ctx, stream.NewOptions(withOpts...), r.TestFolder.DataStream)
+	hasBenchmark, err := stream.StaticValidation(ctx, stream.NewOptions(withOpts...), r.testFolder.DataStream)
 	if err != nil {
 		results, _ := resultComposer.WithError(err)
 		return results
@@ -125,8 +124,8 @@ func (r runner) verifySampleEvent(pkgManifest *packages.PackageManifest) []testr
 	resultComposer := testrunner.NewResultComposer(testrunner.TestResult{
 		Name:       "Verify " + sampleEventJSON,
 		TestType:   TestType,
-		Package:    r.TestFolder.Package,
-		DataStream: r.TestFolder.DataStream,
+		Package:    r.testFolder.Package,
+		DataStream: r.testFolder.DataStream,
 	})
 
 	sampleEventPath, found, err := r.getSampleEventPath()
@@ -176,14 +175,14 @@ func (r runner) verifySampleEvent(pkgManifest *packages.PackageManifest) []testr
 
 func (r runner) getSampleEventPath() (string, bool, error) {
 	var sampleEventPath string
-	if r.TestFolder.DataStream != "" {
+	if r.testFolder.DataStream != "" {
 		sampleEventPath = filepath.Join(
-			r.PackageRootPath,
+			r.packageRootPath,
 			"data_stream",
-			r.TestFolder.DataStream,
+			r.testFolder.DataStream,
 			sampleEventJSON)
 	} else {
-		sampleEventPath = filepath.Join(r.PackageRootPath, sampleEventJSON)
+		sampleEventPath = filepath.Join(r.packageRootPath, sampleEventJSON)
 	}
 	_, err := os.Stat(sampleEventPath)
 	if errors.Is(err, os.ErrNotExist) {
@@ -196,7 +195,7 @@ func (r runner) getSampleEventPath() (string, bool, error) {
 }
 
 func (r runner) getExpectedDatasets(pkgManifest *packages.PackageManifest) ([]string, error) {
-	dsName := r.TestFolder.DataStream
+	dsName := r.testFolder.DataStream
 	if dsName == "" {
 		// TODO: This should return the package name plus the policy name, but we don't know
 		// what policy created this event, so we cannot reliably know it here. Skip the check
@@ -204,7 +203,7 @@ func (r runner) getExpectedDatasets(pkgManifest *packages.PackageManifest) ([]st
 		return nil, nil
 	}
 
-	dataStreamManifest, err := packages.ReadDataStreamManifestFromPackageRoot(r.PackageRootPath, dsName)
+	dataStreamManifest, err := packages.ReadDataStreamManifestFromPackageRoot(r.packageRootPath, dsName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read data stream manifest: %w", err)
 	}

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -77,10 +77,6 @@ const (
 	DevDeployDir = "_dev/deploy"
 )
 
-func init() {
-	testrunner.RegisterRunner(&runner{})
-}
-
 const (
 	// TestType defining system tests
 	TestType testrunner.TestType = "system"

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -225,7 +225,7 @@ func (r *runner) String() string {
 }
 
 // Run runs the system tests defined under the given folder
-func (r *runner) Run(ctx context.Context, options testrunner.TestOptions) ([]testrunner.TestResult, error) {
+func (r *runner) Run(ctx context.Context) ([]testrunner.TestResult, error) {
 	if !r.runSetup && !r.runTearDown && !r.runTestsOnly {
 		return r.run(ctx)
 	}

--- a/internal/testrunner/runners/system/runner_test.go
+++ b/internal/testrunner/runners/system/runner_test.go
@@ -374,11 +374,9 @@ func TestCheckAgentLogs(t *testing.T) {
 			}
 
 			runner := runner{
-				options: testrunner.TestOptions{
-					TestFolder: testrunner.TestFolder{
-						Package:    "package",
-						DataStream: "datastream",
-					},
+				testFolder: testrunner.TestFolder{
+					Package:    "package",
+					DataStream: "datastream",
 				},
 			}
 			results, err := runner.checkAgentLogs(dump, startTime, tc.errorPatterns)

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -66,8 +66,6 @@ type TestRunner interface {
 	TearDown(context.Context) error
 }
 
-var runners = map[TestType]TestRunner{}
-
 // TestResult contains a single test's results
 type TestResult struct {
 	// Name of test result. Optional.
@@ -278,11 +276,6 @@ func ExtractDataStreamFromPath(fullPath, packageRootPath string) string {
 	return dataStream
 }
 
-// RegisterRunner method registers the test runner.
-func RegisterRunner(runner TestRunner) {
-	runners[runner.Type()] = runner
-}
-
 // Run method delegates execution to the registered test runner, based on the test type.
 func Run(ctx context.Context, runner TestRunner) ([]TestResult, error) {
 	results, err := runner.Run(ctx, TestOptions{})
@@ -294,11 +287,6 @@ func Run(ctx context.Context, runner TestRunner) ([]TestResult, error) {
 		return results, fmt.Errorf("could not teardown test runner: %w", tdErr)
 	}
 	return results, nil
-}
-
-// TestRunners returns registered test runners.
-func TestRunners() map[TestType]TestRunner {
-	return runners
 }
 
 // findDataStreamTestFoldersPaths can only be called for test runners that require tests to be defined

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -59,7 +59,7 @@ type TestRunner interface {
 	String() string
 
 	// Run executes the test runner.
-	Run(context.Context, TestOptions) ([]TestResult, error)
+	Run(context.Context) ([]TestResult, error)
 
 	// TearDown cleans up any test runner resources. It must be called
 	// after the test runner has finished executing.
@@ -278,7 +278,7 @@ func ExtractDataStreamFromPath(fullPath, packageRootPath string) string {
 
 // Run method delegates execution to the registered test runner, based on the test type.
 func Run(ctx context.Context, runner TestRunner) ([]TestResult, error) {
-	results, err := runner.Run(ctx, TestOptions{})
+	results, err := runner.Run(ctx)
 	tdErr := runner.TearDown(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not complete test run: %w", err)

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -284,13 +284,8 @@ func RegisterRunner(runner TestRunner) {
 }
 
 // Run method delegates execution to the registered test runner, based on the test type.
-func Run(ctx context.Context, testType TestType, options TestOptions) ([]TestResult, error) {
-	runner, defined := runners[testType]
-	if !defined {
-		return nil, fmt.Errorf("unregistered runner test: %s", testType)
-	}
-
-	results, err := runner.Run(ctx, options)
+func Run(ctx context.Context, runner TestRunner) ([]TestResult, error) {
+	results, err := runner.Run(ctx, TestOptions{})
 	tdErr := runner.TearDown(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not complete test run: %w", err)


### PR DESCRIPTION
Relates #787
Follows #1886 

This PR instantiates in each command the corresponding runner, for that new constructors have been added into each runner. This allows us to create independent Options structs for each runner with just the required options for each runner.

These changes allow to remove the registry of the runners.

For now, it is kept the TestRunner interface since that will force to define Run and TearDown methods so they can be used in `testrunner.Run()`