### PR TITLE
Move installation package in policy and system tests

### DIFF
--- a/.buildkite/pipeline.trigger.integration.tests.sh
+++ b/.buildkite/pipeline.trigger.integration.tests.sh
@@ -96,10 +96,6 @@ for package in $(find . -maxdepth 1 -mindepth 1 -type d) ; do
         label_suffix=" (independent agent)"
     fi
     package_name=$(basename "${package}")
-    if [[ "${package_name}" == "gcp" ||  "${package_name}" == "aws" || "${package_name}" == "aws_logs" ]] ; then
-        echoerr "Skip package temporarily ${package_name}"
-        continue
-    fi
     if [[ "$independent_agent" == "false" && "$package_name" == "oracle" ]]; then
         echoerr "Package \"${package_name}\" skipped: not supported with Elastic Agent running in the stack (missing required software)."
         continue

--- a/.buildkite/pipeline.trigger.integration.tests.sh
+++ b/.buildkite/pipeline.trigger.integration.tests.sh
@@ -96,6 +96,10 @@ for package in $(find . -maxdepth 1 -mindepth 1 -type d) ; do
         label_suffix=" (independent agent)"
     fi
     package_name=$(basename "${package}")
+    if [[ "${package_name}" == "gcp" ||  "${package_name}" == "aws" || "${package_name}" == "aws_logs" ]] ; then
+        echoerr "Skip package temporarily ${package_name}"
+        continue
+    fi
     if [[ "$independent_agent" == "false" && "$package_name" == "oracle" ]]; then
         echoerr "Package \"${package_name}\" skipped: not supported with Elastic Agent running in the stack (missing required software)."
         continue

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -680,7 +680,7 @@ func testRunnerSystemCommandAction(cmd *cobra.Command, args []string) error {
 		cmd.Printf("Running tests per stages (technical preview)\n")
 	}
 
-	runner := system.NewSystemTester(system.SystemTesterOptions{
+	runner := system.NewSystemTestRunner(system.SystemTestRunnerOptions{
 		PackageRootPath: packageRootPath,
 		KibanaClient:    kibanaClient,
 		RunSetup:        runSetup,
@@ -689,7 +689,7 @@ func testRunnerSystemCommandAction(cmd *cobra.Command, args []string) error {
 	})
 
 	factory := func(folder testrunner.TestFolder) (testrunner.Tester, error) {
-		runner := system.NewSystemTestRunner(system.SystemTestRunnerOptions{
+		runner := system.NewSystemTester(system.SystemTesterOptions{
 			Profile:                    profile,
 			TestFolder:                 folder,
 			PackageRootPath:            packageRootPath,
@@ -844,13 +844,13 @@ func testRunnerPolicyCommandAction(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("can't create Kibana client: %w", err)
 	}
 
-	runner := policy.NewPolicyTester(policy.PolicyTesterOptions{
+	runner := policy.NewPolicyTestRunner(policy.PolicyTestRunnerOptions{
 		PackageRootPath: packageRootPath,
 		KibanaClient:    kibanaClient,
 	})
 
 	factory := func(folder testrunner.TestFolder) (testrunner.Tester, error) {
-		runner := policy.NewPolicyTestRunner(policy.PolicyTestRunnerOptions{
+		runner := policy.NewPolicyTester(policy.PolicyTesterOptions{
 			TestFolder:         folder,
 			PackageRootPath:    packageRootPath,
 			GenerateTestResult: generateTestResult,

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -289,7 +289,7 @@ func testRunnerStaticCommandAction(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.Enable(cmd.Context(), logger.Info)
 	defer stop()
 
-	factory := func(folder testrunner.TestFolder) (testrunner.TestRunner, error) {
+	factory := func(folder testrunner.TestFolder) (testrunner.Tester, error) {
 		runner := static.NewStaticRunner(static.StaticRunnerOptions{
 			TestFolder:      folder,
 			PackageRootPath: packageRootPath,
@@ -439,7 +439,7 @@ func testRunnerPipelineCommandAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	factory := func(folder testrunner.TestFolder) (testrunner.TestRunner, error) {
+	factory := func(folder testrunner.TestFolder) (testrunner.Tester, error) {
 		runner, err := pipeline.NewPipelineRunner(pipeline.PipelineRunnerOptions{
 			Profile:            profile,
 			TestFolder:         folder,
@@ -688,7 +688,7 @@ func testRunnerSystemCommandAction(cmd *cobra.Command, args []string) error {
 		RunTestsOnly:    runTestsOnly,
 	})
 
-	factory := func(folder testrunner.TestFolder) (testrunner.TestRunner, error) {
+	factory := func(folder testrunner.TestFolder) (testrunner.Tester, error) {
 		runner := system.NewSystemTestRunner(system.SystemTestRunnerOptions{
 			Profile:                    profile,
 			TestFolder:                 folder,
@@ -849,7 +849,7 @@ func testRunnerPolicyCommandAction(cmd *cobra.Command, args []string) error {
 		KibanaClient:    kibanaClient,
 	})
 
-	factory := func(folder testrunner.TestFolder) (testrunner.TestRunner, error) {
+	factory := func(folder testrunner.TestFolder) (testrunner.Tester, error) {
 		runner := policy.NewTestPolicyRunner(policy.PolicyTestRunnerOptions{
 			TestFolder:         folder,
 			PackageRootPath:    packageRootPath,

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -168,7 +168,7 @@ func testRunnerAssetCommandAction(cmd *cobra.Command, args []string) error {
 
 	_, pkg := filepath.Split(packageRootPath)
 
-	runner := asset.NewAssetRunner(asset.AssetRunnerOptions{
+	runner := asset.NewAssetTester(asset.AssetTesterOptions{
 		TestFolder:      testrunner.TestFolder{Package: pkg},
 		PackageRootPath: packageRootPath,
 		KibanaClient:    kibanaClient,
@@ -290,7 +290,7 @@ func testRunnerStaticCommandAction(cmd *cobra.Command, args []string) error {
 	defer stop()
 
 	factory := func(folder testrunner.TestFolder) (testrunner.Tester, error) {
-		runner := static.NewStaticRunner(static.StaticRunnerOptions{
+		runner := static.NewStaticTester(static.StaticTesterOptions{
 			TestFolder:      folder,
 			PackageRootPath: packageRootPath,
 		})
@@ -440,7 +440,7 @@ func testRunnerPipelineCommandAction(cmd *cobra.Command, args []string) error {
 	}
 
 	factory := func(folder testrunner.TestFolder) (testrunner.Tester, error) {
-		runner, err := pipeline.NewPipelineRunner(pipeline.PipelineRunnerOptions{
+		runner, err := pipeline.NewPipelineTester(pipeline.PipelineTesterOptions{
 			Profile:            profile,
 			TestFolder:         folder,
 			PackageRootPath:    packageRootPath,
@@ -680,7 +680,7 @@ func testRunnerSystemCommandAction(cmd *cobra.Command, args []string) error {
 		cmd.Printf("Running tests per stages (technical preview)\n")
 	}
 
-	runner := system.NewSystemRunner(system.SystemRunnerOptions{
+	runner := system.NewSystemTester(system.SystemTesterOptions{
 		PackageRootPath: packageRootPath,
 		KibanaClient:    kibanaClient,
 		RunSetup:        runSetup,
@@ -844,13 +844,13 @@ func testRunnerPolicyCommandAction(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("can't create Kibana client: %w", err)
 	}
 
-	runner := policy.NewPolicyRunner(policy.PolicyRunnerOptions{
+	runner := policy.NewPolicyTester(policy.PolicyTesterOptions{
 		PackageRootPath: packageRootPath,
 		KibanaClient:    kibanaClient,
 	})
 
 	factory := func(folder testrunner.TestFolder) (testrunner.Tester, error) {
-		runner := policy.NewTestPolicyRunner(policy.PolicyTestRunnerOptions{
+		runner := policy.NewPolicyTestRunner(policy.PolicyTestRunnerOptions{
 			TestFolder:         folder,
 			PackageRootPath:    packageRootPath,
 			GenerateTestResult: generateTestResult,

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -844,8 +844,13 @@ func testRunnerPolicyCommandAction(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("can't create Kibana client: %w", err)
 	}
 
+	runner := policy.NewPolicyRunner(policy.PolicyRunnerOptions{
+		PackageRootPath: packageRootPath,
+		KibanaClient:    kibanaClient,
+	})
+
 	factory := func(folder testrunner.TestFolder) (testrunner.TestRunner, error) {
-		runner := policy.NewPolicyRunner(policy.PolicyRunnerOptions{
+		runner := policy.NewTestPolicyRunner(policy.PolicyTestRunnerOptions{
 			TestFolder:         folder,
 			PackageRootPath:    packageRootPath,
 			GenerateTestResult: generateTestResult,
@@ -854,7 +859,7 @@ func testRunnerPolicyCommandAction(cmd *cobra.Command, args []string) error {
 		return runner, nil
 	}
 
-	results, err := testrunner.RunWithFactory(ctx, testFolders, factory)
+	results, err := testrunner.RunSuite(ctx, testFolders, runner, factory)
 	if err != nil {
 		return err
 	}

--- a/internal/testrunner/runners/asset/runner.go
+++ b/internal/testrunner/runners/asset/runner.go
@@ -29,13 +29,13 @@ type runner struct {
 	resourcesManager *resources.Manager
 }
 
-type AssetRunnerOptions struct {
+type AssetTesterOptions struct {
 	TestFolder      testrunner.TestFolder
 	PackageRootPath string
 	KibanaClient    *kibana.Client
 }
 
-func NewAssetRunner(options AssetRunnerOptions) *runner {
+func NewAssetTester(options AssetTesterOptions) *runner {
 	runner := runner{
 		testFolder:      options.TestFolder,
 		packageRootPath: options.PackageRootPath,

--- a/internal/testrunner/runners/asset/runner.go
+++ b/internal/testrunner/runners/asset/runner.go
@@ -49,8 +49,8 @@ func NewAssetRunner(options AssetRunnerOptions) *runner {
 	return &runner
 }
 
-// Ensures that runner implements testrunner.TestRunner interface
-var _ testrunner.TestRunner = new(runner)
+// Ensures that runner implements testrunner.Tester interface
+var _ testrunner.Tester = new(runner)
 
 // Type returns the type of test that can be run by this test runner.
 func (r *runner) Type() testrunner.TestType {

--- a/internal/testrunner/runners/pipeline/coverage.go
+++ b/internal/testrunner/runners/pipeline/coverage.go
@@ -18,7 +18,7 @@ import (
 )
 
 // getPipelineCoverage returns a coverage report for the provided set of ingest pipelines.
-func getPipelineCoverage(options PipelineRunnerOptions, pipelines []ingest.Pipeline) (testrunner.CoverageReport, error) {
+func getPipelineCoverage(options PipelineTesterOptions, pipelines []ingest.Pipeline) (testrunner.CoverageReport, error) {
 	dataStreamPath, found, err := packages.FindDataStreamRootForPath(options.TestFolder.Path)
 	if err != nil {
 		return nil, fmt.Errorf("locating data_stream root failed: %w", err)

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -58,7 +58,7 @@ type runner struct {
 	provider stack.Provider
 }
 
-type PipelineRunnerOptions struct {
+type PipelineTesterOptions struct {
 	Profile            *profile.Profile
 	DeferCleanup       time.Duration
 	API                *elasticsearch.API
@@ -69,7 +69,7 @@ type PipelineRunnerOptions struct {
 	CoverageType       string
 }
 
-func NewPipelineRunner(options PipelineRunnerOptions) (*runner, error) {
+func NewPipelineTester(options PipelineTesterOptions) (*runner, error) {
 	r := runner{
 		profile:            options.Profile,
 		deferCleanup:       options.DeferCleanup,
@@ -355,7 +355,7 @@ func (r *runner) runTestCase(ctx context.Context, testCaseFile string, dsPath st
 	}
 
 	if r.withCoverage {
-		tr.Coverage, err = getPipelineCoverage(PipelineRunnerOptions{
+		tr.Coverage, err = getPipelineCoverage(PipelineTesterOptions{
 			TestFolder:      r.testFolder,
 			API:             r.esAPI,
 			PackageRootPath: r.packageRootPath,

--- a/internal/testrunner/runners/pipeline/runner.go
+++ b/internal/testrunner/runners/pipeline/runner.go
@@ -110,8 +110,8 @@ type IngestPipelineReroute struct {
 	AdditionalFields map[string]interface{}               `yaml:",inline"`
 }
 
-// Ensures that runner implements testrunner.TestRunner interface
-var _ testrunner.TestRunner = new(runner)
+// Ensures that runner implements testrunner.Tester interface
+var _ testrunner.Tester = new(runner)
 
 // Type returns the type of test that can be run by this test runner.
 func (r *runner) Type() testrunner.TestType {

--- a/internal/testrunner/runners/policy/runner.go
+++ b/internal/testrunner/runners/policy/runner.go
@@ -38,7 +38,7 @@ var _ testrunner.Tester = new(runner)
 // Ensures that runner implements testrunner.TestRunner interface
 var _ testrunner.TestRunner = new(runner)
 
-type PolicyRunnerOptions struct {
+type PolicyTesterOptions struct {
 	KibanaClient    *kibana.Client
 	PackageRootPath string
 }
@@ -50,7 +50,7 @@ type PolicyTestRunnerOptions struct {
 	GenerateTestResult bool
 }
 
-func NewPolicyRunner(options PolicyRunnerOptions) *runner {
+func NewPolicyTester(options PolicyTesterOptions) *runner {
 	runner := runner{
 		kibanaClient:    options.KibanaClient,
 		packageRootPath: options.PackageRootPath,
@@ -61,7 +61,7 @@ func NewPolicyRunner(options PolicyRunnerOptions) *runner {
 	return &runner
 }
 
-func NewTestPolicyRunner(options PolicyTestRunnerOptions) *runner {
+func NewPolicyTestRunner(options PolicyTestRunnerOptions) *runner {
 	runner := runner{
 		kibanaClient:       options.KibanaClient,
 		testFolder:         options.TestFolder,

--- a/internal/testrunner/runners/policy/runner.go
+++ b/internal/testrunner/runners/policy/runner.go
@@ -32,6 +32,12 @@ type runner struct {
 	cleanup          func(context.Context) error
 }
 
+// Ensures that runner implements testrunner.Tester interface
+var _ testrunner.Tester = new(runner)
+
+// Ensures that runner implements testrunner.TestRunner interface
+var _ testrunner.TestRunner = new(runner)
+
 type PolicyRunnerOptions struct {
 	KibanaClient    *kibana.Client
 	PackageRootPath string

--- a/internal/testrunner/runners/policy/runner.go
+++ b/internal/testrunner/runners/policy/runner.go
@@ -38,19 +38,19 @@ var _ testrunner.Tester = new(runner)
 // Ensures that runner implements testrunner.TestRunner interface
 var _ testrunner.TestRunner = new(runner)
 
-type PolicyTesterOptions struct {
+type PolicyTestRunnerOptions struct {
 	KibanaClient    *kibana.Client
 	PackageRootPath string
 }
 
-type PolicyTestRunnerOptions struct {
+type PolicyTesterOptions struct {
 	TestFolder         testrunner.TestFolder
 	KibanaClient       *kibana.Client
 	PackageRootPath    string
 	GenerateTestResult bool
 }
 
-func NewPolicyTester(options PolicyTesterOptions) *runner {
+func NewPolicyTestRunner(options PolicyTestRunnerOptions) *runner {
 	runner := runner{
 		kibanaClient:    options.KibanaClient,
 		packageRootPath: options.PackageRootPath,
@@ -61,7 +61,7 @@ func NewPolicyTester(options PolicyTesterOptions) *runner {
 	return &runner
 }
 
-func NewPolicyTestRunner(options PolicyTestRunnerOptions) *runner {
+func NewPolicyTester(options PolicyTesterOptions) *runner {
 	runner := runner{
 		kibanaClient:       options.KibanaClient,
 		testFolder:         options.TestFolder,

--- a/internal/testrunner/runners/policy/runner.go
+++ b/internal/testrunner/runners/policy/runner.go
@@ -187,6 +187,7 @@ func (r *runner) setupSuite(ctx context.Context, manager *resources.Manager) (cl
 		return err
 	}
 
+	logger.Debugf("Installing package...")
 	_, err = manager.ApplyCtx(ctx, setupResources)
 	if err != nil {
 		if ctx.Err() == nil {

--- a/internal/testrunner/runners/static/runner.go
+++ b/internal/testrunner/runners/static/runner.go
@@ -39,8 +39,8 @@ func NewStaticRunner(options StaticRunnerOptions) *runner {
 	return &runner
 }
 
-// Ensures that runner implements testrunner.TestRunner interface
-var _ testrunner.TestRunner = new(runner)
+// Ensures that runner implements testrunner.Tester interface
+var _ testrunner.Tester = new(runner)
 
 const (
 	// TestType defining asset loading tests

--- a/internal/testrunner/runners/static/runner.go
+++ b/internal/testrunner/runners/static/runner.go
@@ -26,12 +26,12 @@ type runner struct {
 	packageRootPath string
 }
 
-type StaticRunnerOptions struct {
+type StaticTesterOptions struct {
 	TestFolder      testrunner.TestFolder
 	PackageRootPath string
 }
 
-func NewStaticRunner(options StaticRunnerOptions) *runner {
+func NewStaticTester(options StaticTesterOptions) *runner {
 	runner := runner{
 		testFolder:      options.TestFolder,
 		packageRootPath: options.PackageRootPath,

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -168,7 +168,7 @@ type runner struct {
 	shutdownAgentHandler      func(context.Context) error
 }
 
-type SystemRunnerOptions struct {
+type SystemTesterOptions struct {
 	PackageRootPath string
 	KibanaClient    *kibana.Client
 
@@ -198,7 +198,7 @@ type SystemTestRunnerOptions struct {
 	RunTestsOnly   bool
 }
 
-func NewSystemRunner(options SystemRunnerOptions) *runner {
+func NewSystemTester(options SystemTesterOptions) *runner {
 	r := runner{
 		packageRootPath: options.PackageRootPath,
 		kibanaClient:    options.KibanaClient,

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -275,11 +275,11 @@ func (r *runner) TearDownRunner(ctx context.Context) error {
 	return nil
 }
 
+// Ensures that runner implements testrunner.Tester interface
+var _ testrunner.Tester = new(runner)
+
 // Ensures that runner implements testrunner.TestRunner interface
 var _ testrunner.TestRunner = new(runner)
-
-// Ensures that runner implements testrunner.Runner interface
-var _ testrunner.Runner = new(runner)
 
 // Type returns the type of test that can be run by this test runner.
 func (r *runner) Type() testrunner.TestType {

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -168,7 +168,7 @@ type runner struct {
 	shutdownAgentHandler      func(context.Context) error
 }
 
-type SystemTesterOptions struct {
+type SystemTestRunnerOptions struct {
 	PackageRootPath string
 	KibanaClient    *kibana.Client
 
@@ -177,7 +177,7 @@ type SystemTesterOptions struct {
 	RunTestsOnly bool
 }
 
-type SystemTestRunnerOptions struct {
+type SystemTesterOptions struct {
 	Profile            *profile.Profile
 	TestFolder         testrunner.TestFolder
 	PackageRootPath    string
@@ -198,7 +198,7 @@ type SystemTestRunnerOptions struct {
 	RunTestsOnly   bool
 }
 
-func NewSystemTester(options SystemTesterOptions) *runner {
+func NewSystemTestRunner(options SystemTestRunnerOptions) *runner {
 	r := runner{
 		packageRootPath: options.PackageRootPath,
 		kibanaClient:    options.KibanaClient,
@@ -213,7 +213,7 @@ func NewSystemTester(options SystemTesterOptions) *runner {
 	return &r
 }
 
-func NewSystemTestRunner(options SystemTestRunnerOptions) *runner {
+func NewSystemTester(options SystemTesterOptions) *runner {
 	r := runner{
 		profile:                    options.Profile,
 		testFolder:                 options.TestFolder,

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -243,18 +243,19 @@ func NewSystemTester(options SystemTesterOptions) *runner {
 func (r *runner) SetupRunner(ctx context.Context) error {
 	if r.runTearDown {
 		logger.Debug("Skip installing package")
-	} else {
-		// Install the package before creating the policy, so we control exactly what is being
-		// installed.
-		logger.Debug("Installing package...")
-		resourcesOptions := resourcesOptions{
-			// Install it unless we are running the tear down only.
-			installedPackage: !r.runTearDown,
-		}
-		_, err := r.resourcesManager.ApplyCtx(ctx, r.resources(resourcesOptions))
-		if err != nil {
-			return fmt.Errorf("can't install the package: %w", err)
-		}
+		return nil
+	}
+
+	// Install the package before creating the policy, so we control exactly what is being
+	// installed.
+	logger.Debug("Installing package...")
+	resourcesOptions := resourcesOptions{
+		// Install it unless we are running the tear down only.
+		installedPackage: !r.runTearDown,
+	}
+	_, err := r.resourcesManager.ApplyCtx(ctx, r.resources(resourcesOptions))
+	if err != nil {
+		return fmt.Errorf("can't install the package: %w", err)
 	}
 
 	return nil

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -50,8 +50,8 @@ type TestOptions struct {
 	RunTestsOnly   bool
 }
 
-// TestRunner is the interface all test runners must implement.
-type TestRunner interface {
+// Tester is the interface all test runners must implement.
+type Tester interface {
 	// Type returns the test runner's type.
 	Type() TestType
 
@@ -66,10 +66,10 @@ type TestRunner interface {
 	TearDown(context.Context) error
 }
 
-type TestRunnerFactory func(TestFolder) (TestRunner, error)
+type TesterFactory func(TestFolder) (Tester, error)
 
-// Runner is the interface test runners that require a global initialization must implement.
-type Runner interface {
+// TestRunner is the interface test runners that require a global initialization must implement.
+type TestRunner interface {
 	// Type returns the test runner's type.
 	Type() TestType
 
@@ -291,7 +291,7 @@ func ExtractDataStreamFromPath(fullPath, packageRootPath string) string {
 	return dataStream
 }
 
-func RunSuite(ctx context.Context, tests []TestFolder, runner Runner, factory TestRunnerFactory) ([]TestResult, error) {
+func RunSuite(ctx context.Context, tests []TestFolder, runner TestRunner, factory TesterFactory) ([]TestResult, error) {
 	if len(tests) == 0 {
 		return nil, nil
 	}
@@ -313,16 +313,16 @@ func RunSuite(ctx context.Context, tests []TestFolder, runner Runner, factory Te
 }
 
 // RunWithFactory method delegates execution of tests to the runners generated through the factory function.
-func RunWithFactory(ctx context.Context, folders []TestFolder, factory TestRunnerFactory) ([]TestResult, error) {
+func RunWithFactory(ctx context.Context, folders []TestFolder, factory TesterFactory) ([]TestResult, error) {
 	var results []TestResult
 	for _, folder := range folders {
-		runner, err := factory(folder)
+		tester, err := factory(folder)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create runner: %w", err)
 		}
-		r, err := Run(ctx, runner)
+		r, err := Run(ctx, tester)
 		if err != nil {
-			return nil, fmt.Errorf("error running package %s tests: %w", runner.Type(), err)
+			return nil, fmt.Errorf("error running package %s tests: %w", tester.Type(), err)
 		}
 		results = append(results, r...)
 	}
@@ -330,9 +330,9 @@ func RunWithFactory(ctx context.Context, folders []TestFolder, factory TestRunne
 }
 
 // Run method delegates execution of tests to the given test runner.
-func Run(ctx context.Context, runner TestRunner) ([]TestResult, error) {
-	results, err := runner.Run(ctx)
-	tdErr := runner.TearDown(ctx)
+func Run(ctx context.Context, tester Tester) ([]TestResult, error) {
+	results, err := tester.Run(ctx)
+	tdErr := tester.TearDown(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not complete test run: %w", err)
 	}

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -66,6 +66,16 @@ type TestRunner interface {
 	TearDown(context.Context) error
 }
 
+// Runner is the interface test runners that require a global initialization must implement.
+type Runner interface {
+	// SetupRunner prepares global resources required by the test runner.
+	SetupRunner(context.Context) error
+
+	// TearDownRunner cleans up any global test runner resources. It must be called
+	// after the test runner has finished executing all its tests.
+	TearDownRunner(context.Context) error
+}
+
 // TestResult contains a single test's results
 type TestResult struct {
 	// Name of test result. Optional.

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -292,6 +292,9 @@ func ExtractDataStreamFromPath(fullPath, packageRootPath string) string {
 }
 
 func RunSuite(ctx context.Context, tests []TestFolder, runner Runner, factory TestRunnerFactory) ([]TestResult, error) {
+	if len(tests) == 0 {
+		return nil, nil
+	}
 	err := runner.SetupRunner(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup %s runner: %w", runner.Type(), err)


### PR DESCRIPTION
Part of #787 
Supersedes #1845 

Package installation process is repeated for every data stream and configuration file defined in every package (system and policy tests).

This process is just needed once:
- No need to install multiple times the same package.
- Every data stream and configuration file defines the required Package Policy.

This PR updates the runner to include two new methods in the interface (`SetupRunner` and `TearDownRunner`). These two methods are in charge of creating (or deleting) the global resources required to run all the tests for every data streams and configuration file defined in the package:
- For system and policy tests, installation (and uninstallation) of the package would be performed in these two new methods.

Depends on #1866