### PR TITLE
Fix race condition reading from PTTY

### DIFF
--- a/internal/compose/compose_other.go
+++ b/internal/compose/compose_other.go
@@ -55,9 +55,12 @@ func (p *Project) runDockerComposeCmd(ctx context.Context, opts dockerComposeOpt
 
 	logger.Debugf("running command: %s", cmd)
 	err = cmd.Run()
-	ptty.Close()
 	tty.Close()
 	wg.Wait()
+
+	// Don't close the PTTY before the goroutine with the Copy has finished.
+	ptty.Close()
+
 	if err != nil {
 		if msg := cleanComposeError(errBuffer.String()); len(msg) > 0 {
 			return fmt.Errorf("%w: %s", err, msg)


### PR DESCRIPTION
Execution of fast docker compose commands are getting stuck sometimes. One possible theory is that we are closing the pseudo-tty before the copy has finished, and it hangs there.

Close the pseudo-TTY after waiting for the finalization of the goroutine, so we avoid problems caused by closing it while it is being read.

Thanks @mrodm for reporting!