### PR TITLE
Added support for data stream overrides for specific integrations based on a defined list

### DIFF
--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -122,6 +122,9 @@ var (
 			},
 		},
 	}
+	dataStreamOverrides = map[string]bool{
+		"amazon_security_lake": true,
+	}
 	enableIndependentAgents = environment.WithElasticPackagePrefix("TEST_ENABLE_INDEPENDENT_AGENT")
 )
 
@@ -937,7 +940,7 @@ func (r *tester) prepareScenario(ctx context.Context, config *testConfig, svcInf
 
 	// Input packages can set `data_stream.dataset` by convention to customize the dataset.
 	dataStreamDataset := ds.Inputs[0].Streams[0].DataStream.Dataset
-	if scenario.pkgManifest.Type == "input" {
+	if scenario.pkgManifest.Type == "input" || dataStreamOverrides[scenario.pkgManifest.Name] {
 		v, _ := config.Vars.GetValue("data_stream.dataset")
 		if dataset, ok := v.(string); ok && dataset != "" {
 			dataStreamDataset = dataset
@@ -1290,7 +1293,7 @@ func (r *tester) validateTestScenario(ctx context.Context, result *testrunner.Re
 		}
 		expectedDatasets = []string{expectedDataset}
 	}
-	if scenario.pkgManifest.Type == "input" {
+	if scenario.pkgManifest.Type == "input" || dataStreamOverrides[scenario.pkgManifest.Name] {
 		v, _ := config.Vars.GetValue("data_stream.dataset")
 		if dataset, ok := v.(string); ok && dataset != "" {
 			expectedDatasets = append(expectedDatasets, dataset)


### PR DESCRIPTION
Some integrations like **amazon security lake** use routing rules to route results to a different data stream from a central data stream. Having such a mechanism the standard system tests fail since it always searches for hits in the central data stream. We need a way to dynamically instruct elastic-package to look for hits in a specific data stream during system tests. 
A similar functionally was recently added with a recent PR [here](https://github.com/elastic/elastic-package/pull/1851). This is just a small iteration on top of that change to allow elastic-package to honour dynamically defined data streams for select integration packages. 

NOTE: I have tested the functionally locally.