### PR TITLE
Add flag to change directory before running the command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,6 +90,7 @@ func processPersistentFlags(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to change directory: %w", err)
 		}
+		logger.Debugf("Running command in directory \"%s\"", changeDirectory)
 	}
 
 	return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,8 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
 	"sort"
 
 	"github.com/spf13/cobra"
@@ -52,7 +54,8 @@ func RootCmd() *cobra.Command {
 			)
 		},
 	}
-	rootCmd.PersistentFlags().BoolP(cobraext.VerboseFlagName, "v", false, cobraext.VerboseFlagDescription)
+	rootCmd.PersistentFlags().BoolP(cobraext.VerboseFlagName, cobraext.VerboseFlagShorthand, false, cobraext.VerboseFlagDescription)
+	rootCmd.PersistentFlags().StringP(cobraext.ChangeDirectoryFlagName, cobraext.ChangeDirectoryFlagShorthand, "", cobraext.ChangeDirectoryFlagDescription)
 
 	for _, cmd := range commands {
 		rootCmd.AddCommand(cmd.Command)
@@ -74,10 +77,21 @@ func processPersistentFlags(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return cobraext.FlagParsingError(err, cobraext.VerboseFlagName)
 	}
-
 	if verbose {
 		logger.EnableDebugMode()
 	}
+
+	changeDirectory, err := cmd.Flags().GetString(cobraext.ChangeDirectoryFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.ChangeDirectoryFlagName)
+	}
+	if changeDirectory != "" {
+		err := os.Chdir(changeDirectory)
+		if err != nil {
+			return fmt.Errorf("failed to change directory: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/cobraext/flags.go
+++ b/internal/cobraext/flags.go
@@ -7,7 +7,12 @@ package cobraext
 // Global flags
 const (
 	VerboseFlagName        = "verbose"
+	VerboseFlagShorthand   = "v"
 	VerboseFlagDescription = "verbose mode"
+
+	ChangeDirectoryFlagName        = "change-directory"
+	ChangeDirectoryFlagShorthand   = "C"
+	ChangeDirectoryFlagDescription = "change to the specified directory before running the command"
 )
 
 // Primary flags reused by multiple commands

--- a/scripts/test-build-zip.sh
+++ b/scripts/test-build-zip.sh
@@ -13,10 +13,7 @@ cleanup() {
 
   # Clean used resources
   for d in test/packages/*/*/; do
-    (
-      cd "$d"
-      elastic-package clean -v
-    )
+    elastic-package clean -C "$d" -v
   done
 
   exit $r
@@ -43,12 +40,8 @@ for d in test/packages/*/*/; do
   if [ "$(testype $d)" == "false_positives" ]; then
     continue
   fi
-  (
-    cd $d
-    elastic-package build --zip --sign -v
-  )
+  elastic-package build -C "$d" --zip --sign -v
 done
-cd -
 
 # Remove unzipped built packages, leave .zip files
 rm -r build/packages/*/
@@ -62,9 +55,5 @@ for d in test/packages/*/*/; do
   if [ "$(testype $d)" == "false_positives" ]; then
     continue
   fi
-  (
-    cd $d
-    elastic-package install -v
-  )
-cd -
+  elastic-package install -C "$d" -v
 done

--- a/scripts/test-check-false-positives.sh
+++ b/scripts/test-check-false-positives.sh
@@ -13,10 +13,7 @@ function cleanup() {
 
   # Clean used resources
   for d in test/packages/${PACKAGE_TEST_TYPE:-false_positives}/${PACKAGE_UNDER_TEST:-*}/; do
-    (
-      cd "$d"
-      elastic-package clean -v
-    )
+    elastic-package clean -C "$d" -v
   done
 
   exit $r
@@ -36,10 +33,7 @@ function check_expected_errors() {
   fi
 
   rm -f ${result_tests}
-  (
-    cd "$package_root"
-    elastic-package test -v --report-format xUnit --report-output file --test-coverage --coverage-format=generic --defer-cleanup 1s || true
-  )
+  elastic-package test -C "$package_root" -v --report-format xUnit --report-output file --test-coverage --coverage-format=generic --defer-cleanup 1s || true
 
   cat ${result_tests} | tr -d '\n' > ${results_no_spaces}
 
@@ -69,18 +63,12 @@ function check_build_output() {
   local output_file="$PWD/build/elastic-package-output"
 
   if [ ! -f "${expected_build_output}" ]; then
-    (
-      cd "$package_root"
-      elastic-package build -v
-    )
+    elastic-package build -C "$package_root" -v
     return
   fi
 
-  (
-    cd "$package_root"
-    mkdir -p "$(dirname "$output_file")"
-    elastic-package build 2>&1 | tee "$output_file" || true # Ignore errors here
-  )
+  mkdir -p "$(dirname "$output_file")"
+  elastic-package build -C "$package_root" 2>&1 | tee "$output_file" || true # Ignore errors here
 
   diff -w -u "$expected_build_output" "$output_file" || (
     echo "Error: Build output has differences with expected output"

--- a/scripts/test-install-zip.sh
+++ b/scripts/test-install-zip.sh
@@ -17,10 +17,7 @@ cleanup() {
   elastic-package stack down -v
 
   for d in test/packages/*/*/; do
-    (
-      cd "$d"
-      elastic-package clean -v
-    )
+    elastic-package clean -C "$d" -v
   done
 
   exit $r
@@ -98,7 +95,6 @@ elastic-package stack up -d -v ${ARG_VERSION}
 
 ELASTIC_PACKAGE_LINKS_FILE_PATH="$(pwd)/scripts/links_table.yml"
 export ELASTIC_PACKAGE_LINKS_FILE_PATH
-OLDPWD=$PWD
 
 # Build packages
 for d in test/packages/*/*/; do
@@ -106,12 +102,8 @@ for d in test/packages/*/*/; do
   if [ "$(testype "$d")" == "false_positives" ]; then
     continue
   fi
-  (
-    cd "$d"
-    elastic-package build
-  )
+  elastic-package build -C "$d"
 done
-cd "$OLDPWD"
 
 # Remove unzipped built packages, leave .zip files
 rm -r build/packages/*/

--- a/scripts/test-system-test-flags.sh
+++ b/scripts/test-system-test-flags.sh
@@ -37,10 +37,7 @@ cleanup() {
 
     # Clean used resources
     for d in test/packages/*/*/; do
-        (
-        cd "$d"
-        elastic-package clean -v
-        )
+        elastic-package clean -C "$d" -v
     done
 
     exit $r


### PR DESCRIPTION
Add `-C`/`--change-directory` flag to change the directory before running any command. This allows to build, install or test packages without needing to move to the directory with the source of the package, in a similar fashion to similar flags other commands have.