### PR TITLE
Change separator in results file written

### DIFF
--- a/internal/testrunner/reporters/outputs/file.go
+++ b/internal/testrunner/reporters/outputs/file.go
@@ -43,7 +43,7 @@ func reportToFile(pkg, report string, testType testrunner.TestType, format testr
 		ext = "xml"
 	}
 
-	fileName := fmt.Sprintf("%s_%s_%d.%s", pkg, testType, time.Now().UnixNano(), ext)
+	fileName := fmt.Sprintf("%s-%s-%d.%s", pkg, testType, time.Now().UnixNano(), ext)
 	filePath := filepath.Join(dest, fileName)
 
 	if err := os.WriteFile(filePath, []byte(report+"\n"), 0644); err != nil {

--- a/scripts/test-check-false-positives.sh
+++ b/scripts/test-check-false-positives.sh
@@ -24,7 +24,7 @@ function check_expected_errors() {
   local package_name=""
   package_name=$(basename "$1")
   local expected_errors_file="${package_root%/}.expected_errors"
-  local result_tests="build/test-results/${package_name}_*.xml"
+  local result_tests="build/test-results/${package_name}-*.xml"
   local results_no_spaces="build/test-results-no-spaces.xml"
 
   if [ ! -f "${expected_errors_file}" ]; then


### PR DESCRIPTION
Relates https://github.com/elastic/integrations/issues/6071
Follows #1886 

In order to help distinguish what it is the package name and the type of test, this PR changes the separator used to write the file name.

It relies on the pattern for the name, that pattern does not allow to use dashes `-`:
https://github.com/elastic/package-spec/blob/d79da661a6c6f67414ca786abfa181e1264d05e5/spec/integration/manifest.spec.yml#L311

Example:
- Before: `nginx_ingress_controller_system_1719230208026443574.xml`
- After: `nginx_ingress_controller-system-1718962683763738623.xml`