### PR TITLE
[Kubernetes] Update kubernetes version to 1.30

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ env:
   DOCKER_COMPOSE_VERSION: "v2.24.1"
   DOCKER_VERSION: "26.1.2"
   KIND_VERSION: 'v0.20.0'
-  K8S_VERSION: 'v1.29.0'
+  K8S_VERSION: 'v1.30.0'
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
   # Using this one instead of family/core-windows-2022 because of conflicts with the pre-installed docker.
   WINDOWS_AGENT_IMAGE: "family/platform-ingest-beats-windows-2022"


### PR DESCRIPTION
## What does this PR do

Updates the K8s version being used by elastic package.

## Related issues

Relates to https://github.com/elastic/observability-dev/issues/3068