### PR TITLE
Don't run format on check

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -24,7 +24,6 @@ func setupCheckCommand() *cobraext.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := cobraext.ComposeCommands(args,
-				setupFormatCommand(),
 				setupLintCommand(),
 				setupBuildCommand(),
 			)


### PR DESCRIPTION
Running format on check modifies the working copy in an unexpected moment. This is problematic for example for coverage, as tests run check indirectly, so the resulting coverage may not fit the actual files.