### PR TITLE
feat: update capabilities to the minimum that agent requires

### DIFF
--- a/internal/profile/testdata/migration-home-legacy/profiles/default/stack/snapshot.yml
+++ b/internal/profile/testdata/migration-home-legacy/profiles/default/stack/snapshot.yml
@@ -136,6 +136,10 @@ services:
     env_file: "./elastic-agent.env"
     cap_drop:
     - ALL
+    cap_add:
+    - CHOWN
+    - SETPCAP
+    - SETFCAP
     ports: []
     volumes:
     - "../certs/ca-cert.pem:/etc/ssl/certs/elastic-package.pem"

--- a/internal/servicedeployer/_static/docker-custom-agent-base.yml
+++ b/internal/servicedeployer/_static/docker-custom-agent-base.yml
@@ -8,6 +8,10 @@ services:
     hostname: docker-custom-agent
     cap_drop:
       - ALL
+    cap_add:
+      - CHOWN
+      - SETPCAP
+      - SETFCAP
     environment:
       - FLEET_ENROLL=1
       - FLEET_URL=https://fleet-server:8220

--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -150,6 +150,10 @@ services:
     env_file: "./elastic-agent.env"
     cap_drop:
     - ALL
+    cap_add:
+    - CHOWN
+    - SETPCAP
+    - SETFCAP
     ports: [{{ fact "agent_publish_ports" }}]
     volumes:
     - "../certs/ca-cert.pem:/etc/ssl/certs/elastic-package.pem"

--- a/internal/stack/_static/serverless-docker-compose.yml.tmpl
+++ b/internal/stack/_static/serverless-docker-compose.yml.tmpl
@@ -11,6 +11,10 @@ services:
     env_file: "./elastic-agent.env"
     cap_drop:
     - ALL
+    cap_add:
+    - CHOWN
+    - SETPCAP
+    - SETFCAP
     volumes:
     - type: bind
       source: ../../../tmp/service_logs/

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -421,6 +421,9 @@ func (r *tester) createAgentInfo(policy *kibana.Policy, config *testConfig, runI
 		info.Agent.User = "root"
 	}
 
+	// Set linux capabilities to the minimum set required by the agent
+	info.Agent.LinuxCapabilities = []string{"CHOWN", "SETFCAP", "SETPCAP"}
+
 	return info, nil
 }
 


### PR DESCRIPTION
When [this PR](https://github.com/elastic/elastic-agent/pull/4925) gets merged the minimum capabilities required by elastic-agent, when running inside a container, will change. This PR prepares `elastic-package` for such a change