### PR TITLE
Add flag to enable logsdb mode in logs data streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,8 @@ The following settings are available per profile:
   an absolute path, out of the `.elastic-package` directory.
 * `stack.kibana_http2_enabled` can be used to control if HTTP/2 should be used in versions of
   kibana that support it. Defaults to true.
+* `stack.logsdb_enabled` can be set to true to activate the feature flag in Elasticsearch that
+  enables logs index mode in all data streams that support it. Defaults to false.
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.

--- a/internal/profile/_static/config.yml.example
+++ b/internal/profile/_static/config.yml.example
@@ -14,6 +14,10 @@
 # Flag to enable apm-server in elastic-package stack profile config
 # stack.apm_enabled: true
 
+## Logs DB
+# Flag to enable the logs index mode in logs data stream.
+# stack.logsdb_enabled: true
+
 ## Enable logstash for testing
 # Flag to enable logstash in elastic-package stack profile config
 # stack.logstash_enabled: true

--- a/internal/stack/_static/elasticsearch.yml.tmpl
+++ b/internal/stack/_static/elasticsearch.yml.tmpl
@@ -19,7 +19,6 @@ ingest.geoip.downloader.enabled: false
 cluster.logsdb.enabled: true
 {{- end -}}
 
-{{ $version := fact "elasticsearch_version" }}
 {{ if semverLessThan $version "8.0.0" }}
 script.max_compilations_rate: "use-context"
 script.context.template.max_compilations_rate: "unlimited"

--- a/internal/stack/_static/elasticsearch.yml.tmpl
+++ b/internal/stack/_static/elasticsearch.yml.tmpl
@@ -13,6 +13,12 @@ xpack.security.http.ssl.certificate: "certs/cert.pem"
 
 ingest.geoip.downloader.enabled: false
 
+{{- $version := fact "elasticsearch_version" -}}
+{{- $logsdb_enabled := fact "logsdb_enabled" -}}
+{{ if (and (eq $logsdb_enabled "true") (not (semverLessThan $version "8.15.0-SNAPSHOT"))) }}
+cluster.logsdb.enabled: true
+{{- end -}}
+
 {{ $version := fact "elasticsearch_version" }}
 {{ if semverLessThan $version "8.0.0" }}
 script.max_compilations_rate: "use-context"

--- a/internal/stack/resources.go
+++ b/internal/stack/resources.go
@@ -60,6 +60,7 @@ const (
 	configAPMEnabled         = "stack.apm_enabled"
 	configGeoIPDir           = "stack.geoip_dir"
 	configKibanaHTTP2Enabled = "stack.kibana_http2_enabled"
+	configLogsDBEnabled      = "stack.logsdb_enabled"
 	configLogstashEnabled    = "stack.logstash_enabled"
 	configSelfMonitorEnabled = "stack.self_monitor_enabled"
 )
@@ -158,12 +159,13 @@ func applyResources(profile *profile.Profile, stackVersion string) error {
 		"username": elasticsearchUsername,
 		"password": elasticsearchPassword,
 
+		"agent_publish_ports":  strings.Join(agentPorts, ","),
 		"apm_enabled":          profile.Config(configAPMEnabled, "false"),
 		"geoip_dir":            profile.Config(configGeoIPDir, "./ingest-geoip"),
+		"kibana_http2_enabled": profile.Config(configKibanaHTTP2Enabled, "true"),
+		"logsdb_enabled":       profile.Config(configLogsDBEnabled, "false"),
 		"logstash_enabled":     profile.Config(configLogstashEnabled, "false"),
 		"self_monitor_enabled": profile.Config(configSelfMonitorEnabled, "false"),
-		"agent_publish_ports":  strings.Join(agentPorts, ","),
-		"kibana_http2_enabled": profile.Config(configKibanaHTTP2Enabled, "true"),
 	})
 
 	if err := os.MkdirAll(stackDir, 0755); err != nil {

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -192,6 +192,8 @@ The following settings are available per profile:
   an absolute path, out of the `.elastic-package` directory.
 * `stack.kibana_http2_enabled` can be used to control if HTTP/2 should be used in versions of
   kibana that support it. Defaults to true.
+* `stack.logsdb_enabled` can be set to true to activate the feature flag in Elasticsearch that
+  enables logs index mode in all data streams that support it. Defaults to false.
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.


### PR DESCRIPTION
Add a new profile parameter, `stack.logsdb_enabled`, to enable the feature flag that enables the logs index mode in all logs data streams (https://github.com/elastic/elasticsearch/issues/108762), in stacks that support it.

This can be tested now with the 8.15 snapshots, for example:
```
elastic-package stack up -v -d -U stack.logsdb_enabled=true --version 8.15.0-SNAPSHOT
```

Closes https://github.com/elastic/elastic-package/issues/1842.