### PR TITLE
Show ignored fields error as xUnit error

### DIFF
--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -1909,7 +1909,7 @@ func validateIgnoredFields(stackVersionString string, scenario *scenarioTest, co
 		}
 
 		return testrunner.ErrTestCaseFailed{
-			Reason:  fmt.Sprintf("found ignored fields in data stream %s", scenario.dataStream),
+			Reason:  "found ignored fields in data stream",
 			Details: fmt.Sprintf("found ignored fields in data stream %s: %v. Affected documents: %s", scenario.dataStream, ignoredFields, degradedDocsJSON),
 		}
 	}

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -1908,7 +1908,10 @@ func validateIgnoredFields(stackVersionString string, scenario *scenarioTest, co
 			return fmt.Errorf("failed to marshal degraded docs to JSON: %w", err)
 		}
 
-		return fmt.Errorf("found ignored fields in data stream %s: %v. Affected documents: %s", scenario.dataStream, ignoredFields, degradedDocsJSON)
+		return testrunner.ErrTestCaseFailed{
+			Reason:  fmt.Sprintf("found ignored fields in data stream %s", scenario.dataStream),
+			Details: fmt.Sprintf("found ignored fields in data stream %s: %v. Affected documents: %s", scenario.dataStream, ignoredFields, degradedDocsJSON),
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR changes the error of the ignored fields to be shown as part of the xUnit files (XML).

Example for `zeronetworks` package from integrations repository:

```
FAILURE DETAILS:
zeronetworks/audit default:
found ignored fields in data stream logs-zeronetworks.audit-28964: [zeronetworks.audit.details.expiresAt zeronetworks.audit.details.protectionDate]. Affected documents: [
  {
    "_id": "WwOkI3UilYSxulaUzR+4QrFgAwQ=",
    "@timestamp": "2024-04-01T19:59:27.459Z",
    "ignored_field_values": {
      "zeronetworks.audit.details.protectionDate": [
        "01 May 24 20:00 UTC"
      ]
    }
  },
  {
    "_id": "miIZ4UaYlRX7GM5MhpGuC19AWF4=",
    "@timestamp": "2024-04-01T19:27:09.353Z",
    "ignored_field_values": {
      "zeronetworks.audit.details.expiresAt": [
        "01 Apr 24 19:48 UTC"
      ]
    }
  },
  {
    "_id": "HXfE07PTzjFSxG4kDTnrdup/7HU=",
    "@timestamp": "2024-04-01T18:43:10.675Z",
    "ignored_field_values": {
      "zeronetworks.audit.details.expiresAt": [
        "09 Apr 24 18:43 UTC"
      ]
    }
  },
  {
    "_id": "6Ltd0Ov89gBZD04zGDuWy7KV41g=",
    "@timestamp": "2024-04-01T16:06:50.678Z",
    "ignored_field_values": {
      "zeronetworks.audit.details.expiresAt": [
        "01 Apr 24 16:06 UTC"
      ]
    }
  },
  {
    "_id": "k/CKnSsz4WQ/1bH0+iOtLzHDRkE=",
    "@timestamp": "2024-04-01T15:23:44.397Z",
    "ignored_field_values": {
      "zeronetworks.audit.details.expiresAt": [
        "01 Apr 24 15:23 UTC"
      ]
    }
  }
]


╭──────────────┬─────────────┬───────────┬───────────┬───────────────────────────────────────────────────────────────────────────────────────────┬───────────────╮
│ PACKAGE      │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT                                                                                    │  TIME ELAPSED │
├──────────────┼─────────────┼───────────┼───────────┼───────────────────────────────────────────────────────────────────────────────────────────┼───────────────┤
│ zeronetworks │ audit       │ system    │ default   │ FAIL: test case failed: found ignored fields in data stream logs-zeronetworks.audit-28964 │ 40.114481494s │
╰──────────────┴─────────────┴───────────┴───────────┴───────────────────────────────────────────────────────────────────────────────────────────┴───────────────╯
```