### PR TITLE
Fix error handling when deleting data stream in system tests

### DIFF
--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -949,7 +949,7 @@ func (r *tester) prepareScenario(ctx context.Context, config *testConfig, svcInf
 
 	r.cleanTestScenarioHandler = func(ctx context.Context) error {
 		logger.Debugf("Deleting data stream for testing %s", scenario.dataStream)
-		r.deleteDataStream(ctx, scenario.dataStream)
+		err := r.deleteDataStream(ctx, scenario.dataStream)
 		if err != nil {
 			return fmt.Errorf("failed to delete data stream %s: %w", scenario.dataStream, err)
 		}


### PR DESCRIPTION
Error returning was being ignored, and error handled was a different one.