### PR TITLE
[CI] Replace exit by continue in loop to check packages - serverless

### DIFF
--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -116,7 +116,8 @@ for d in test/packages/${PACKAGE_TEST_TYPE:-other}/${PACKAGE_UNDER_TEST:-*}/; do
         # FIXME: adding test-coverage for serverless results in errors like this:
         # Error: error running package pipeline tests: could not complete test run: error calculating pipeline coverage: error fetching pipeline stats for code coverage calculations: need exactly one ES node in stats response (got 4)
         elastic-package test pipeline -C "$d" -v --report-format xUnit --report-output file --defer-cleanup 1s
-        exit # as it is run in a subshell, it cannot be used "continue"
+
+        continue
     fi
     # Run all tests
     # defer-cleanup is set to a short period to verify that the option is available


### PR DESCRIPTION
Previously, that loop was based on sub-shells and it was required to use `exit` to continue to the next loop iterations.

With the latest changes, subshells are not used anymore and it can be used directly `continue`.