### PR TITLE
Exclude changelogs from base coverage reports

### DIFF
--- a/internal/testrunner/coverage.go
+++ b/internal/testrunner/coverage.go
@@ -38,6 +38,12 @@ func GenerateBasePackageCoverageReport(pkgName, rootPath, format string) (Covera
 			return nil
 		}
 
+		// Exclude changelog from coverage reports, as changelogs are frequently modified and not
+		// relevant to tests.
+		if d.Name() == "changelog.yml" && filepath.Dir(match) == filepath.Clean(rootPath) {
+			return nil
+		}
+
 		fileCoverage, err := generateBaseFileCoverageReport(repoPath, pkgName, match, format, false)
 		if err != nil {
 			return fmt.Errorf("failed to generate base coverage for \"%s\": %w", match, err)


### PR DESCRIPTION
These files are frequently modified and not usually relevant to tests. If in the future
they are used by some test, we can add the coverage there.