### PR TITLE
[CI] Update path stack agent steps

### DIFF
--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -110,7 +110,7 @@ if [[ "${TARGET}" == "${PARALLEL_TARGET}" ]] || [[ "${TARGET}" == "${FALSE_POSIT
 
     if [[ "${UPLOAD_SAFE_LOGS}" -eq 1 ]] ; then
         package_folder="${PACKAGE}"
-        if [[ "${ELASTIC_PACKAGE_TEST_ENABLE_INDEPENDENT_AGENT:-"false"}" == "false" ]]; then
+        if [[ "${ELASTIC_PACKAGE_TEST_ENABLE_INDEPENDENT_AGENT:-""}" == "false" ]]; then
             package_folder="${package_folder}-stack_agent"
         fi
 

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -110,8 +110,8 @@ if [[ "${TARGET}" == "${PARALLEL_TARGET}" ]] || [[ "${TARGET}" == "${FALSE_POSIT
 
     if [[ "${UPLOAD_SAFE_LOGS}" -eq 1 ]] ; then
         package_folder="${PACKAGE}"
-        if [[ "${ELASTIC_PACKAGE_TEST_ENABLE_INDEPENDENT_AGENT:-"false"}" == "true" ]]; then
-            package_folder="${package_folder}-independent_agent"
+        if [[ "${ELASTIC_PACKAGE_TEST_ENABLE_INDEPENDENT_AGENT:-"false"}" == "false" ]]; then
+            package_folder="${package_folder}-stack_agent"
         fi
 
         if [[ "${retry_count}" -ne 0 ]]; then


### PR DESCRIPTION
Follows #1959 

As it has been changed to use independent Elastic Agents, it is also required to update the folder names used when uploading logs. Now the environment value has the value `false`.

With this change:
- packages testing with independent Elastic Agents (default now) won't have a suffix in the folder name (e.g. aws).
- packages testing with the Elastic Agent from the stack, it will be added a `-stack_agent` suffix (e.g. aws-stack_agent).