### PR TITLE
Rename logs index mode to logsdb

### DIFF
--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -646,7 +646,8 @@ func isSyntheticSourceModeEnabled(ctx context.Context, api *elasticsearch.API, d
 	// It seems that some index modes enable synthetic source mode even when it is not explicitly mentioned
 	// in the mappings. So assume that when these index modes are used, the synthetic mode is also used.
 	var syntheticsIndexModes = []string{
-		"logs",
+		"logs", // Replaced in 8.15.0 with "logsdb", see https://github.com/elastic/elasticsearch/pull/111054
+		"logsdb",
 		"time_series",
 	}
 	if slices.Contains(syntheticsIndexModes, results.Template.Settings.Index.Mode) {


### PR DESCRIPTION
Update index mode detection according to https://github.com/elastic/elasticsearch/pull/111054.