### PR TITLE
[docs] Reference Elastic Integrations Contribution docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ test and build your packages. Learn about each of these and other features in [_
 
 Currently, `elastic-package` only supports packages of type [Elastic Integrations](https://github.com/elastic/integrations).
 
+Please review the [Contributing Guide](https://github.com/elastic/integrations/blob/main/CONTRIBUTING.md) to learn how to build and develop packages, understand the release procedure and
+explore the builder tools.
+
 ## Getting started
 
 Download latest release from the [Releases](https://github.com/elastic/elastic-package/releases/latest) page.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ test and build your packages. Learn about each of these and other features in [_
 
 Currently, `elastic-package` only supports packages of type [Elastic Integrations](https://github.com/elastic/integrations).
 
-Please review the [Contributing Guide](https://github.com/elastic/integrations/blob/main/CONTRIBUTING.md) to learn how to build and develop packages, understand the release procedure and
+Please review the [integrations contributing guide](https://github.com/elastic/integrations/blob/main/CONTRIBUTING.md) to learn how to build and develop packages, understand the release procedure and
 explore the builder tools.
 
 ## Getting started

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -9,7 +9,7 @@ test and build your packages. Learn about each of these and other features in [_
 
 Currently, `elastic-package` only supports packages of type [Elastic Integrations](https://github.com/elastic/integrations).
 
-Please review the [integrations contributing cuide](https://github.com/elastic/integrations/blob/main/CONTRIBUTING.md) to learn how to build and develop packages, understand the release procedure and
+Please review the [integrations contributing guide](https://github.com/elastic/integrations/blob/main/CONTRIBUTING.md) to learn how to build and develop packages, understand the release procedure and
 explore the builder tools.
 
 ## Getting started

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -9,7 +9,7 @@ test and build your packages. Learn about each of these and other features in [_
 
 Currently, `elastic-package` only supports packages of type [Elastic Integrations](https://github.com/elastic/integrations).
 
-Please review the [Contributing Guide](https://github.com/elastic/integrations/blob/main/CONTRIBUTING.md) to learn how to build and develop packages, understand the release procedure and
+Please review the [integrations contributing cuide](https://github.com/elastic/integrations/blob/main/CONTRIBUTING.md) to learn how to build and develop packages, understand the release procedure and
 explore the builder tools.
 
 ## Getting started

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -9,6 +9,9 @@ test and build your packages. Learn about each of these and other features in [_
 
 Currently, `elastic-package` only supports packages of type [Elastic Integrations](https://github.com/elastic/integrations).
 
+Please review the [Contributing Guide](https://github.com/elastic/integrations/blob/main/CONTRIBUTING.md) to learn how to build and develop packages, understand the release procedure and
+explore the builder tools.
+
 ## Getting started
 
 Download latest release from the [Releases](https://github.com/elastic/elastic-package/releases/latest) page.


### PR DESCRIPTION
This adds the link to the contribution docs for Elastic Integrations.

![image](https://github.com/user-attachments/assets/da918717-db4d-47a9-b294-f3b1e653f932)

Closes: #1974