### PR TITLE
Add services name to containers logged while waiting for healthy

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -27,7 +27,11 @@ type NetworkDescription struct {
 type ContainerDescription struct {
 	Config struct {
 		Image  string
-		Labels map[string]string
+		Labels struct {
+			ComposeProject string `json:"com.docker.compose.project"`
+			ComposeService string `json:"com.docker.compose.service"`
+			ComposeVersion string `json:"com.docker.compose.version"`
+		}
 	}
 	ID    string
 	State struct {

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -27,11 +27,7 @@ type NetworkDescription struct {
 type ContainerDescription struct {
 	Config struct {
 		Image  string
-		Labels struct {
-			ComposeProject string `json:"com.docker.compose.project"`
-			ComposeService string `json:"com.docker.compose.service"`
-			ComposeVersion string `json:"com.docker.compose.version"`
-		}
+		Labels ConfigLabels
 	}
 	ID    string
 	State struct {
@@ -46,6 +42,13 @@ type ContainerDescription struct {
 			}
 		}
 	}
+}
+
+// ConfigLabels are the labels included in the config in container descriptions.
+type ConfigLabels struct {
+	ComposeProject string `json:"com.docker.compose.project"`
+	ComposeService string `json:"com.docker.compose.service"`
+	ComposeVersion string `json:"com.docker.compose.version"`
 }
 
 // String function dumps string representation of the container description.

--- a/internal/stack/compose.go
+++ b/internal/stack/compose.go
@@ -213,7 +213,7 @@ func dockerComposeStatus(ctx context.Context, options Options) ([]ServiceStatus,
 
 func newServiceStatus(description *docker.ContainerDescription) (*ServiceStatus, error) {
 	service := ServiceStatus{
-		Name:    description.Config.Labels[serviceLabelDockerCompose],
+		Name:    description.Config.Labels.ComposeService,
 		Status:  description.State.Status,
 		Version: getVersionFromDockerImage(description.Config.Image),
 	}

--- a/internal/stack/compose.go
+++ b/internal/stack/compose.go
@@ -23,8 +23,6 @@ type ServiceStatus struct {
 const readyServicesSuffix = "is_ready"
 
 const (
-	// serviceLabelDockerCompose is the label with the service name created by docker-compose
-	serviceLabelDockerCompose = "com.docker.compose.service"
 	// projectLabelDockerCompose is the label with the project name created by docker-compose
 	projectLabelDockerCompose = "com.docker.compose.project"
 )

--- a/internal/stack/compose_test.go
+++ b/internal/stack/compose_test.go
@@ -42,10 +42,10 @@ func TestNewServiceStatus(t *testing.T) {
 			description: docker.ContainerDescription{
 				Config: struct {
 					Image  string
-					Labels map[string]string
+					Labels docker.ConfigLabels
 				}{
 					Image:  "docker.test:1.42.0",
-					Labels: map[string]string{"com.docker.compose.service": "myservice", "foo": "bar"},
+					Labels: docker.ConfigLabels{ComposeService: "myservice"},
 				},
 				ID: "123456789ab",
 				State: struct {
@@ -85,10 +85,10 @@ func TestNewServiceStatus(t *testing.T) {
 			description: docker.ContainerDescription{
 				Config: struct {
 					Image  string
-					Labels map[string]string
+					Labels docker.ConfigLabels
 				}{
 					Image:  "docker.test:1.42.0",
-					Labels: map[string]string{"com.docker.compose.service": "myservice", "foo": "bar"},
+					Labels: docker.ConfigLabels{ComposeService: "myservice"},
 				},
 				ID: "123456789ab",
 				State: struct {
@@ -119,10 +119,10 @@ func TestNewServiceStatus(t *testing.T) {
 			description: docker.ContainerDescription{
 				Config: struct {
 					Image  string
-					Labels map[string]string
+					Labels docker.ConfigLabels
 				}{
 					Image:  "docker.test:1.42.0",
-					Labels: map[string]string{"com.docker.compose.service": "myservice", "foo": "bar"},
+					Labels: docker.ConfigLabels{ComposeService: "myservice"},
 				},
 				ID: "123456789ab",
 				State: struct {

--- a/internal/stack/serverless.go
+++ b/internal/stack/serverless.go
@@ -489,7 +489,7 @@ func (sp *serverlessProvider) localAgentStatus() ([]ServiceStatus, error) {
 func localServiceNames(project string) ([]string, error) {
 	services := []string{}
 	serviceFunc := func(description docker.ContainerDescription) error {
-		services = append(services, description.Config.Labels[serviceLabelDockerCompose])
+		services = append(services, description.Config.Labels.ComposeService)
 		return nil
 	}
 
@@ -518,7 +518,7 @@ func runOnLocalServices(project string, serviceFunc func(docker.ContainerDescrip
 	}
 
 	for _, containerDescription := range containerDescriptions {
-		serviceName := containerDescription.Config.Labels[serviceLabelDockerCompose]
+		serviceName := containerDescription.Config.Labels.ComposeService
 		if strings.HasSuffix(serviceName, readyServicesSuffix) {
 			continue
 		}


### PR DESCRIPTION
While investigating issues in the sql_input package I missed being able to see
what was the service that was failing to start, in the previous version the logs
only included the ID, what cannot be correlated with the service when running
in CI.

Take also the opportunity to refactor labels to use a struct instead of a map
for known labels.