### PR TITLE
[CI] Use ephemeral token for git push commands

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -110,9 +110,6 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-package" && "$BUILDKITE_STEP_KEY" =
 fi
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-package-test-with-integrations" && "$BUILDKITE_STEP_KEY" == "pr-integrations" ]]; then
-    GITHUB_USERNAME_SECRET="elasticmachine"
-    export GITHUB_USERNAME_SECRET=$GITHUB_USERNAME_SECRET
-    export GITHUB_EMAIL_SECRET="elasticmachine@elastic.co"
     export GITHUB_TOKEN=$VAULT_GITHUB_TOKEN
 fi
 

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -110,6 +110,9 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-package" && "$BUILDKITE_STEP_KEY" =
 fi
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-package-test-with-integrations" && "$BUILDKITE_STEP_KEY" == "pr-integrations" ]]; then
+    GITHUB_USERNAME_SECRET="elasticmachine"
+    export GITHUB_USERNAME_SECRET=$GITHUB_USERNAME_SECRET
+    export GITHUB_EMAIL_SECRET="elasticmachine@elastic.co"
     export GITHUB_TOKEN=$VAULT_GITHUB_TOKEN
 fi
 

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -110,9 +110,11 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-package" && "$BUILDKITE_STEP_KEY" =
 fi
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-package-test-with-integrations" && "$BUILDKITE_STEP_KEY" == "pr-integrations" ]]; then
+    # required to set the git commit information
     GITHUB_USERNAME_SECRET="elasticmachine"
     export GITHUB_USERNAME_SECRET=$GITHUB_USERNAME_SECRET
     export GITHUB_EMAIL_SECRET="elasticmachine@elastic.co"
+    # required by `gh` commands
     export GITHUB_TOKEN=$VAULT_GITHUB_TOKEN
 fi
 

--- a/.buildkite/scripts/test-with-integrations.sh
+++ b/.buildkite/scripts/test-with-integrations.sh
@@ -38,6 +38,11 @@ get_source_commit_link() {
     echo "https://github.com/${GITHUB_PR_BASE_OWNER}/${GITHUB_PR_BASE_REPO}/commit/${GITHUB_PR_HEAD_SHA}"
 }
 
+set_git_config() {
+    git config user.name "${GITHUB_USERNAME_SECRET}"
+    git config user.email "${GITHUB_EMAIL_SECRET}"
+}
+
 git_push() {
     local branch="$1"
 
@@ -112,6 +117,8 @@ create_or_update_pull_request() {
     clone_repository "${repo_path}"
 
     pushd "${repo_path}" > /dev/null
+
+    set_git_config
 
     echo "Checking branch ${INTEGRATIONS_PR_BRANCH} in remote ${INTEGRATIONS_GITHUB_OWNER}/${INTEGRATIONS_GITHUB_REPO_NAME}"
     if ! exists_branch "${INTEGRATIONS_GITHUB_OWNER}" "${INTEGRATIONS_GITHUB_REPO_NAME}" "${INTEGRATIONS_PR_BRANCH}" ; then

--- a/.buildkite/scripts/test-with-integrations.sh
+++ b/.buildkite/scripts/test-with-integrations.sh
@@ -38,17 +38,10 @@ get_source_commit_link() {
     echo "https://github.com/${GITHUB_PR_BASE_OWNER}/${GITHUB_PR_BASE_REPO}/commit/${GITHUB_PR_HEAD_SHA}"
 }
 
-set_git_config() {
-    git config user.name "${GITHUB_USERNAME_SECRET}"
-    git config user.email "${GITHUB_EMAIL_SECRET}"
-}
+git_push() {
+    local branch="$1"
 
-git_push_with_auth() {
-    local owner="$1"
-    local repository="$2"
-    local branch="$3"
-
-    retry 3 git push https://${GITHUB_USERNAME_SECRET}:${GITHUB_TOKEN}@github.com/${owner}/${repository}.git "${branch}"
+    retry 3 git push origin "${branch}"
 }
 
 clone_repository() {
@@ -120,8 +113,6 @@ create_or_update_pull_request() {
 
     pushd "${repo_path}" > /dev/null
 
-    set_git_config
-
     echo "Checking branch ${INTEGRATIONS_PR_BRANCH} in remote ${INTEGRATIONS_GITHUB_OWNER}/${INTEGRATIONS_GITHUB_REPO_NAME}"
     if ! exists_branch "${INTEGRATIONS_GITHUB_OWNER}" "${INTEGRATIONS_GITHUB_REPO_NAME}" "${INTEGRATIONS_PR_BRANCH}" ; then
         checkout_options=" -b "
@@ -141,7 +132,7 @@ create_or_update_pull_request() {
     update_dependency
 
     echo "--- Pushing branch ${INTEGRATIONS_PR_BRANCH} to integrations repository..."
-    git_push_with_auth "${INTEGRATIONS_GITHUB_OWNER}" "${INTEGRATIONS_GITHUB_REPO_NAME}" "${INTEGRATIONS_PR_BRANCH}"
+    git_push "${INTEGRATIONS_PR_BRANCH}"
 
     if [ -z "${integrations_pr_number}" ]; then
         echo "--- Creating pull request :github:"


### PR DESCRIPTION
As ephemeral tokens can be used directly in `git` commands, this PR removes the requirement to set those for the `git push` command.

Tested: https://buildkite.com/elastic/elastic-package-test-with-integrations/builds/178
PR created: https://github.com/elastic/integrations/pull/10639

Follows: #1942 