### PR TITLE
Revert updatecli to a version known to work

### DIFF
--- a/.github/workflows/bump-elastic-stack-version.yml
+++ b/.github/workflows/bump-elastic-stack-version.yml
@@ -35,7 +35,7 @@ jobs:
           echo "UPDATECLI_ACTION=apply" >> $GITHUB_ENV
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@v2.63.0 # updatecli v0.77.0
+        uses: updatecli/updatecli-action@v2.62.0
 
       - name: Update default stack version
         # --experimental needed for commitusingapi option.


### PR DESCRIPTION
Latest version is failing, revert to the latest version known to work.