### PR TITLE
Set latency preset in the default ES output

### DIFF
--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -125,6 +125,9 @@ xpack.fleet.outputs:
     ca_trusted_fingerprint: "${ELASTIC_PACKAGE_CA_TRUSTED_FINGERPRINT}"
     is_default: true
     is_default_monitoring: true
+    {{- if not (semverLessThan $version "8.12.0") }}
+    preset: latency
+    {{ end }}
 
   {{ $logstash_enabled := fact "logstash_enabled" }}
   {{ if eq $logstash_enabled "true" }}

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -125,7 +125,18 @@ xpack.fleet.outputs:
     ca_trusted_fingerprint: "${ELASTIC_PACKAGE_CA_TRUSTED_FINGERPRINT}"
     is_default: true
     is_default_monitoring: true
-    {{- if not (semverLessThan $version "8.12.0") }}
+    {{- if semverLessThan $version "8.12.0" }}
+    # performance tuning preset values optimized for latency
+    # values retrieved from https://www.elastic.co/guide/en/fleet/8.14/es-output-settings.html#es-output-settings-performance-tuning-settings
+    config:
+      bulk_max_size: 50
+      worker: 1
+      queue.mem.events: 4100
+      queue.mem.flush.min_events: 2050
+      queue.mem.flush.timeout: 1s
+      compression_level: 1
+      connection_idle_timeout: 60
+    {{ else }}
     preset: latency
     {{ end }}
 

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -65,7 +65,7 @@ if [ "${PACKAGE_TEST_TYPE:-other}" == "with-logstash" ]; then
   echo "stack.logstash_enabled: true" >> ~/.elastic-package/profiles/logstash/config.yml
 fi
 
-# In case it is tested with Elatic serverless, there should be just one Elastic stack
+# In case it is tested with Elastic serverless, there should be just one Elastic stack
 # started to test all packages. In our CI, this Elastic serverless stack is started 
 # at the beginning of the pipeline and must be running for all packages.
 if [[ "${SERVERLESS}" != "true" ]]; then


### PR DESCRIPTION
Fixes #1956 

Set for Elastic Stack versions `>=8.12` the Elasticsearch output preset `latency` as the default value.

For Elastic Stack versions `>=8.0 & < 8.12`, those settings that `latency` preset configures are added directly to the output via `config` key. 

An example of applying this change running system tests with `nginx` package (from elastic-package repo):
- `latency` preset set:
```
╭─────────┬─────────────┬───────────┬───────────────────────┬────────┬───────────────╮
│ PACKAGE │ DATA STREAM │ TEST TYPE │ TEST NAME             │ RESULT │  TIME ELAPSED │
├─────────┼─────────────┼───────────┼───────────────────────┼────────┼───────────────┤
│ nginx   │ access      │ system    │ default (variant: v1) │ PASS   │   31.4586152s │
│ nginx   │ error       │ system    │ default (variant: v1) │ PASS   │ 31.071471239s │
│ nginx   │ stubstatus  │ system    │ default (variant: v1) │ PASS   │ 32.145618723s │
╰─────────┴─────────────┴───────────┴───────────────────────┴────────┴───────────────╯
```
- default preset (`balanced`):
```
╭─────────┬─────────────┬───────────┬───────────────────────┬────────┬───────────────╮
│ PACKAGE │ DATA STREAM │ TEST TYPE │ TEST NAME             │ RESULT │  TIME ELAPSED │
├─────────┼─────────────┼───────────┼───────────────────────┼────────┼───────────────┤
│ nginx   │ access      │ system    │ default (variant: v1) │ PASS   │ 43.745287116s │
│ nginx   │ error       │ system    │ default (variant: v1) │ PASS   │ 42.650101001s │
│ nginx   │ stubstatus  │ system    │ default (variant: v1) │ PASS   │  40.52918326s │
╰─────────┴─────────────┴───────────┴───────────────────────┴────────┴───────────────╯

```