### PR TITLE
Deprecate agent service deployer

### DIFF
--- a/docs/howto/system_testing.md
+++ b/docs/howto/system_testing.md
@@ -110,7 +110,7 @@ volumes:
 
 ### Agent service deployer
 
-**NOTE**: To be deprecated soon in favor of creating new Elastic Agents in each test (technical preview yet). These
+**NOTE**: To be deprecated soon in favor of creating new Elastic Agents in each test. These
 Elastic Agents can be customized through the test configuration files adding the required settings. The settings
 available are detailed in [this section](#test-case-definition).
 
@@ -516,7 +516,7 @@ inserts the value of `response_split` from the test configuration into the integ
 
 Returning to `test-expected-hit-count-config.yml`, when `assert.hit_count` is defined and `> 0` the test will assert that the number of hits in the array matches that value and fail when this is not true.
 
-(Technical Preview) As an example to add settings to create a new Elastic Agent in a given test,
+As an example to add settings to create a new Elastic Agent in a given test,
 the`auditd_manager/audtid` data stream's `test-default-config.yml` is shown below:
 
 ```yaml
@@ -534,8 +534,10 @@ agent:
 ```
 
 With this test configuration file, the Elastic Agent is running in a docker environment,
-turned on sharing between container and the host operating system the PID address space and
-those two Linux Capabilities have been enabled for that Elastic Agent.
+turned on sharing between container and the host operating system the PID address space as well as
+the Linux Capabilities `AUDIT_CONTROL` and `AUDIT_READ` have been enabled for that Elastic Agent.
+In [this section](#running-a-system-test), there is also another example to customize the scripts
+to install new software or define new environment variables in the Elastic Agents.
 
 #### Placeholders
 

--- a/docs/howto/system_testing.md
+++ b/docs/howto/system_testing.md
@@ -110,7 +110,7 @@ volumes:
 
 ### Agent service deployer
 
-**NOTE**: To be deprecated soon in favor of creating new Elastic Agents in each test. These
+**NOTE**: Deprecated in favor of creating [new Elastic Agents in each test](#running-a-system-test). These
 Elastic Agents can be customized through the test configuration files adding the required settings. The settings
 available are detailed in [this section](#test-case-definition).
 

--- a/internal/servicedeployer/custom_agent.go
+++ b/internal/servicedeployer/custom_agent.go
@@ -70,7 +70,7 @@ func NewCustomAgentDeployer(options CustomAgentDeployerOptions) (*CustomAgentDep
 
 // SetUp sets up the service and returns any relevant information.
 func (d *CustomAgentDeployer) SetUp(ctx context.Context, svcInfo ServiceInfo) (DeployedService, error) {
-	logger.Debug("DEPRECATED - setting up service using Docker Compose service deployer")
+	logger.Warn("DEPRECATED - setting up service using Docker Compose service deployer")
 
 	appConfig, err := install.Configuration()
 	if err != nil {

--- a/internal/servicedeployer/custom_agent.go
+++ b/internal/servicedeployer/custom_agent.go
@@ -70,7 +70,7 @@ func NewCustomAgentDeployer(options CustomAgentDeployerOptions) (*CustomAgentDep
 
 // SetUp sets up the service and returns any relevant information.
 func (d *CustomAgentDeployer) SetUp(ctx context.Context, svcInfo ServiceInfo) (DeployedService, error) {
-	logger.Debug("setting up service using Docker Compose service deployer")
+	logger.Debug("DEPRECATED - setting up service using Docker Compose service deployer")
 
 	appConfig, err := install.Configuration()
 	if err != nil {


### PR DESCRIPTION
Deprecate Agent service deployer in favor of independent Elastic Agents.

This PR also updates the documentation about system testing to remove references about the technical preview of independent Elastic Agents.