### PR TITLE
Revert "Chore(deps): bump updatecli/updatecli-action from 2.62.0 to 2.65.0 (#2004)"

### DIFF
--- a/.github/workflows/bump-elastic-stack-version.yml
+++ b/.github/workflows/bump-elastic-stack-version.yml
@@ -35,7 +35,7 @@ jobs:
           echo "UPDATECLI_ACTION=apply" >> $GITHUB_ENV
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@v2.65.0
+        uses: updatecli/updatecli-action@v2.62.0
 
       - name: Update default stack version
         # --experimental needed for commitusingapi option.


### PR DESCRIPTION
This reverts commit 3c040bcfb3a957e4dcc6a4de69b6cf03a10477ec.

Latest updatecli version seems to be still problematic, reverting last update.