### PR TITLE
Enable skipped tests in annotations

### DIFF
--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -51,8 +51,9 @@ steps:
 
   - label: ":junit: Junit annotate"
     plugins:
-      - junit-annotate#v2.4.1:
+      - junit-annotate#v2.5.0:
           artifacts: "build/test-results/*.xml"
+          report-skipped: true
     agents:
       provider: "gcp"  # junit plugin requires docker
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -85,8 +85,9 @@ steps:
 
   - label: ":junit: Junit annotate"
     plugins:
-      - junit-annotate#v2.4.1:
+      - junit-annotate#v2.5.0:
           artifacts: "build/test-results/*.xml"
+          report-skipped: true
     agents:
       provider: "gcp"  # junit plugin requires docker
 


### PR DESCRIPTION
Update junit buildkite plugin and enable reporting the skipped tests in the corresponding annotations.

Skipped tests just are shown if there is any test failing.

Screenshots of skipped tests can be checked in https://github.com/elastic/integrations/pull/10735