### PR TITLE
Update check command help after removal of formatting action

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ _Context: package_
 
 Use this command to verify if the package is correct in terms of formatting, validation and building.
 
-It will execute the format, lint, and build commands all at once, in that order.
+It will execute the lint and build commands all at once, in that order.
 
 ### `elastic-package clean`
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -14,7 +14,7 @@ import (
 
 const checkLongDescription = `Use this command to verify if the package is correct in terms of formatting, validation and building.
 
-It will execute the format, lint, and build commands all at once, in that order.`
+It will execute the lint and build commands all at once, in that order.`
 
 func setupCheckCommand() *cobraext.Command {
 	cmd := &cobra.Command{


### PR DESCRIPTION
After removing the formatting action from the check command in https://github.com/elastic/elastic-package/pull/1936 we didn't update the help text.

Closes https://github.com/elastic/elastic-package/issues/2024