### PR TITLE
Update cleanup to remove service logs from independent Elastic Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ _Context: package_
 
 Use this command to clean resources used for building the package.
 
-The command will remove built package files (in build/), files needed for managing the development stack (in ~/.elastic-package/stack/development) and stack service logs (in ~/.elastic-package/tmp/service_logs).
+The command will remove built package files (in build/), files needed for managing the development stack (in ~/.elastic-package/stack/development) and stack service logs (in ~/.elastic-package/tmp/service_logs and ~/.elastic-package/profiles/<profile>/service_logs/).
 
 ### `elastic-package create`
 

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -11,11 +11,12 @@ import (
 
 	"github.com/elastic/elastic-package/internal/cleanup"
 	"github.com/elastic/elastic-package/internal/cobraext"
+	"github.com/elastic/elastic-package/internal/install"
 )
 
 const cleanLongDescription = `Use this command to clean resources used for building the package.
 
-The command will remove built package files (in build/), files needed for managing the development stack (in ~/.elastic-package/stack/development) and stack service logs (in ~/.elastic-package/tmp/service_logs).`
+The command will remove built package files (in build/), files needed for managing the development stack (in ~/.elastic-package/stack/development) and stack service logs (in ~/.elastic-package/tmp/service_logs and ~/.elastic-package/profiles/<profile>/service_logs/).`
 
 func setupCleanCommand() *cobraext.Command {
 	cmd := &cobra.Command{
@@ -25,12 +26,18 @@ func setupCleanCommand() *cobraext.Command {
 		Args:  cobra.NoArgs,
 		RunE:  cleanCommandAction,
 	}
+	cmd.PersistentFlags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
 
 	return cobraext.NewCommand(cmd, cobraext.ContextPackage)
 }
 
 func cleanCommandAction(cmd *cobra.Command, args []string) error {
 	cmd.Println("Clean used resources")
+
+	profile, err := cobraext.GetProfileFlag(cmd)
+	if err != nil {
+		return err
+	}
 
 	target, err := cleanup.Build()
 	if err != nil {
@@ -55,6 +62,14 @@ func cleanCommandAction(cmd *cobra.Command, args []string) error {
 	}
 	if target != "" {
 		cmd.Printf("Temporary service logs removed: %s\n", target)
+	}
+
+	target, err = cleanup.ServiceLogsIndependentAgents(profile)
+	if err != nil {
+		return fmt.Errorf("can't clean temporary service logs: %w", err)
+	}
+	if target != "" {
+		cmd.Printf("Temporary service logs (independent Elastic Agents) removed: %s\n", target)
 	}
 
 	cmd.Println("Done")

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -79,7 +79,7 @@ func setupTestCommand() *cobraext.Command {
 	cmd.PersistentFlags().StringP(cobraext.ProfileFlagName, "p", "", fmt.Sprintf(cobraext.ProfileFlagDescription, install.ProfileNameEnvVar))
 
 	// Just used in pipeline and system tests
-	// Keep it here for backwards compatbility
+	// Keep it here for backwards compatibility
 	cmd.PersistentFlags().DurationP(cobraext.DeferCleanupFlagName, "", 0, cobraext.DeferCleanupFlagDescription)
 
 	assetCmd := getTestRunnerAssetCommand()
@@ -743,7 +743,6 @@ func processResults(results []testrunner.TestResult, testType testrunner.TestTyp
 		}
 	}
 	return nil
-
 }
 
 func validateDataStreamsFlag(packageRootPath string, dataStreams []string) error {

--- a/internal/agentdeployer/directories.go
+++ b/internal/agentdeployer/directories.go
@@ -21,8 +21,20 @@ func ServiceLogsDir(profile *profile.Profile) string {
 	return filepath.Join(profile.ProfilePath, serviceLogsDir)
 }
 
-func CreateServiceLogsDir(profile *profile.Profile, name string) (string, error) {
-	dirPath := filepath.Join(ServiceLogsDir(profile), name)
+func ServiceLogsDirGlobPackage(profile *profile.Profile, packageRootPath string) string {
+	packageFolderName := filepath.Base(packageRootPath)
+	return fmt.Sprintf("%s/agent-%s-*", ServiceLogsDir(profile), packageFolderName)
+}
+
+func CreateServiceLogsDir(profile *profile.Profile, packageRootpath, dataStream, runID string) (string, error) {
+	packageFolderName := filepath.Base(packageRootpath)
+	folderName := fmt.Sprintf("agent-%s", packageFolderName)
+	if dataStream != "" {
+		folderName = fmt.Sprintf("%s-%s", folderName, dataStream)
+	}
+	folderName = fmt.Sprintf("%s-%s", folderName, runID)
+
+	dirPath := filepath.Join(ServiceLogsDir(profile), folderName)
 	err := os.MkdirAll(dirPath, 0755)
 	if err != nil {
 		return "", fmt.Errorf("mkdir failed for service logs (path: %s): %w", dirPath, err)

--- a/internal/agentdeployer/directories.go
+++ b/internal/agentdeployer/directories.go
@@ -17,8 +17,12 @@ const (
 	deployerDir    = "deployer"
 )
 
+func ServiceLogsDir(profile *profile.Profile) string {
+	return filepath.Join(profile.ProfilePath, serviceLogsDir)
+}
+
 func CreateServiceLogsDir(profile *profile.Profile, name string) (string, error) {
-	dirPath := filepath.Join(profile.ProfilePath, serviceLogsDir, name)
+	dirPath := filepath.Join(ServiceLogsDir(profile), name)
 	err := os.MkdirAll(dirPath, 0755)
 	if err != nil {
 		return "", fmt.Errorf("mkdir failed for service logs (path: %s): %w", dirPath, err)

--- a/internal/cleanup/service_logs.go
+++ b/internal/cleanup/service_logs.go
@@ -44,11 +44,9 @@ func ServiceLogsIndependentAgents(profile *profile.Profile) (string, error) {
 		return "", fmt.Errorf("locating package root failed: %w", err)
 	}
 
-	packageFolder := filepath.Base(packageRootPath)
-	serviceLogsDir := agentdeployer.ServiceLogsDir(profile)
+	serviceLogDirGlob := agentdeployer.ServiceLogsDirGlobPackage(profile, packageRootPath)
 
-	folderGlob := fmt.Sprintf("%s/agent-%s-*", serviceLogsDir, packageFolder)
-	folders, err := filepath.Glob(folderGlob)
+	folders, err := filepath.Glob(serviceLogDirGlob)
 	if err != nil {
 		return "", fmt.Errorf("pattern malformed: %w", err)
 	}
@@ -59,5 +57,5 @@ func ServiceLogsIndependentAgents(profile *profile.Profile) (string, error) {
 		}
 	}
 
-	return folderGlob, nil
+	return serviceLogDirGlob, nil
 }

--- a/internal/cleanup/service_logs.go
+++ b/internal/cleanup/service_logs.go
@@ -6,6 +6,7 @@ package cleanup
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/elastic/elastic-package/internal/agentdeployer"
@@ -53,9 +54,9 @@ func ServiceLogsIndependentAgents(profile *profile.Profile) (string, error) {
 	}
 	for _, f := range folders {
 		logger.Debugf("Remove folder (path: %s)", f)
-		// if err := os.RemoveAll(f); err != nil {
-		// 	return "", fmt.Errorf("can't remove folder (path: %s): %w", f, err)
-		// }
+		if err := os.RemoveAll(f); err != nil {
+			return "", fmt.Errorf("can't remove folder (path: %s): %w", f, err)
+		}
 	}
 
 	return folderGlob, nil

--- a/internal/cleanup/service_logs.go
+++ b/internal/cleanup/service_logs.go
@@ -35,7 +35,7 @@ func ServiceLogs() (string, error) {
 	return locationManager.ServiceLogDir(), nil
 }
 
-// ServiceLogs function removes service logs from temporary directory in the `~/.elastic-package`.
+// ServiceLogsIndependentAgent function removes service logs from temporary directory for independent agents in `~/.elastic-package`.
 func ServiceLogsIndependentAgents(profile *profile.Profile) (string, error) {
 	logger.Debug("Clean all service logs from independent Elastic Agents")
 

--- a/internal/cleanup/service_logs.go
+++ b/internal/cleanup/service_logs.go
@@ -6,10 +6,14 @@ package cleanup
 
 import (
 	"fmt"
+	"path/filepath"
 
+	"github.com/elastic/elastic-package/internal/agentdeployer"
 	"github.com/elastic/elastic-package/internal/configuration/locations"
 	"github.com/elastic/elastic-package/internal/files"
 	"github.com/elastic/elastic-package/internal/logger"
+	"github.com/elastic/elastic-package/internal/packages"
+	"github.com/elastic/elastic-package/internal/profile"
 )
 
 // ServiceLogs function removes service logs from temporary directory in the `~/.elastic-package`.
@@ -26,5 +30,33 @@ func ServiceLogs() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("can't remove content (path: %s): %w", locationManager.ServiceLogDir(), err)
 	}
+
 	return locationManager.ServiceLogDir(), nil
+}
+
+// ServiceLogs function removes service logs from temporary directory in the `~/.elastic-package`.
+func ServiceLogsIndependentAgents(profile *profile.Profile) (string, error) {
+	logger.Debug("Clean all service logs from independent Elastic Agents")
+
+	packageRootPath, err := packages.MustFindPackageRoot()
+	if err != nil {
+		return "", fmt.Errorf("locating package root failed: %w", err)
+	}
+
+	packageFolder := filepath.Base(packageRootPath)
+	serviceLogsDir := agentdeployer.ServiceLogsDir(profile)
+
+	folderGlob := fmt.Sprintf("%s/agent-%s-*", serviceLogsDir, packageFolder)
+	folders, err := filepath.Glob(folderGlob)
+	if err != nil {
+		return "", fmt.Errorf("pattern malformed: %w", err)
+	}
+	for _, f := range folders {
+		logger.Debugf("Remove folder (path: %s)", f)
+		// if err := os.RemoveAll(f); err != nil {
+		// 	return "", fmt.Errorf("can't remove folder (path: %s): %w", f, err)
+		// }
+	}
+
+	return folderGlob, nil
 }

--- a/internal/stack/clients.go
+++ b/internal/stack/clients.go
@@ -111,7 +111,7 @@ func NewKibanaClientFromProfile(profile *profile.Profile, customOptions ...kiban
 
 	kibanaHost, found := os.LookupEnv(KibanaHostEnv)
 	if !found {
-		// Using backgound context on initial call to avoid context cancellation.
+		// Using background context on initial call to avoid context cancellation.
 		status, err := Status(context.Background(), Options{Profile: profile})
 		if err != nil {
 			return nil, fmt.Errorf("failed to check status of stack in current profile: %w", err)

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -404,13 +404,7 @@ func (r *tester) createAgentInfo(policy *kibana.Policy, config *testConfig, runI
 	info.Logs.Folder.Agent = ServiceLogsAgentDir
 	info.Test.RunID = runID
 
-	folderName := fmt.Sprintf("agent-%s", r.testFolder.Package)
-	if r.testFolder.DataStream != "" {
-		folderName = fmt.Sprintf("%s-%s", folderName, r.testFolder.DataStream)
-	}
-	folderName = fmt.Sprintf("%s-%s", folderName, runID)
-
-	dirPath, err := agentdeployer.CreateServiceLogsDir(r.profile, folderName)
+	dirPath, err := agentdeployer.CreateServiceLogsDir(r.profile, r.packageRootPath, r.testFolder.DataStream, runID)
 	if err != nil {
 		return agentdeployer.AgentInfo{}, fmt.Errorf("failed to create service logs dir: %w", err)
 	}


### PR DESCRIPTION
Update `elastic-package cleanup` to remove also service logs folders created for independent Elastic Agents.

Tested with `nginx` (from test package) and `sql_input` (from integrations repository).

## How to test locally

```shell
elastic-package stack up -v -d

cd test/packages/parallel/nginx

# run tests and press Ctrl-C once the process is waiting for elastic-agent containers to be healthy
elastic-package test system -v

# check that some folders have been created in the profile default folder:
ls -l ~/.elastic-package/profiles/default/service_logs

# for instance
# drwxr-xr-x 2 user user 4096 ago 28 12:40 agent-nginx-access-85847
# drwxr-xr-x 2 user user 4096 ago 28 12:40 agent-nginx-error-59191
# drwxr-xr-x 2 user user 4096 ago 28 12:40 agent-nginx-stubstatus-91770

# run cleanup command
elastic-package clean -v

# the previous folders in the service logs dir should be deleted
ls -l ~/.elastic-package/profiles/default/service_logs
```

