### PR TITLE
Update default disable wolfi image

### DIFF
--- a/.buildkite/pipeline.trigger.integration.tests.sh
+++ b/.buildkite/pipeline.trigger.integration.tests.sh
@@ -27,6 +27,8 @@ for test in "${STACK_COMMAND_TESTS[@]}"; do
     test_name=${test#"test-"}
     echo "      - label: \":go: Integration test: ${test_name}\""
     echo "        command: ./.buildkite/scripts/integration_tests.sh -t ${test}"
+    echo "        env:"
+    echo "          ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI: true"
     echo "        agents:"
     echo "          provider: \"gcp\""
     echo "          image: \"${UBUNTU_X86_64_AGENT_IMAGE}\""

--- a/.buildkite/pipeline.trigger.integration.tests.sh
+++ b/.buildkite/pipeline.trigger.integration.tests.sh
@@ -27,8 +27,6 @@ for test in "${STACK_COMMAND_TESTS[@]}"; do
     test_name=${test#"test-"}
     echo "      - label: \":go: Integration test: ${test_name}\""
     echo "        command: ./.buildkite/scripts/integration_tests.sh -t ${test}"
-    echo "        env:"
-    echo "          ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI: true"
     echo "        agents:"
     echo "          provider: \"gcp\""
     echo "          image: \"${UBUNTU_X86_64_AGENT_IMAGE}\""

--- a/README.md
+++ b/README.md
@@ -692,6 +692,9 @@ There are available some environment variables that could be used to change some
 
 - Related to tests:
     - `ELASTIC_PACKAGE_SERVERLESS_PIPELINE_TEST_DISABLE_COMPARE_RESULTS`: If set to `true`, the results from pipeline tests are not compared to avoid errors from GeoIP.
+    - `ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI`: If set to `true`, the Elastic Agent image used for running agents will be using the Ubuntu docker images
+      (e.g. `docker.elastic.co/elastic-agent/elastic-agent-complete`). If set to `false`, the Elastic Agent image used for the running agents will be based on the wolfi
+      images (e.g. `docker.elastic.co/elastic-agent/elastic-agent-wolfi`). Default: `true`.
 
 - To configure the Elastic stack to be used by `elastic-package`:
     - `ELASTIC_PACKAGE_ELASTICSEARCH_HOST`: Host of the elasticsearch (e.g. https://127.0.0.1:9200)

--- a/internal/install/application_configuration.go
+++ b/internal/install/application_configuration.go
@@ -21,12 +21,14 @@ import (
 )
 
 const (
-	stackVersion715 = "7.15.0-SNAPSHOT"
-	stackVersion820 = "8.2.0-SNAPSHOT"
+	stackVersion715  = "7.15.0-SNAPSHOT"
+	stackVersion820  = "8.2.0-SNAPSHOT"
+	stackVersion8160 = "8.16.0-SNAPSHOT"
 
 	elasticAgentImageName               = "docker.elastic.co/beats/elastic-agent"
 	elasticAgentCompleteLegacyImageName = "docker.elastic.co/beats/elastic-agent-complete"
 	elasticAgentCompleteImageName       = "docker.elastic.co/elastic-agent/elastic-agent-complete"
+	elasticAgentWolfiImageName          = "docker.elastic.co/elastic-agent/elastic-agent-wolfi"
 	elasticsearchImageName              = "docker.elastic.co/elasticsearch/elasticsearch"
 	kibanaImageName                     = "docker.elastic.co/kibana/kibana"
 	logstashImageName                   = "docker.elastic.co/logstash/logstash"
@@ -37,6 +39,7 @@ const (
 var (
 	elasticAgentCompleteFirstSupportedVersion = semver.MustParse(stackVersion715)
 	elasticAgentCompleteOwnNamespaceVersion   = semver.MustParse(stackVersion820)
+	elasticAgentWolfiVersion                  = semver.MustParse(stackVersion8160)
 
 	// ProfileNameEnvVar is the name of the environment variable to set the default profile
 	ProfileNameEnvVar = environment.WithElasticPackagePrefix("PROFILE")
@@ -149,6 +152,9 @@ func selectElasticAgentImageName(version string) string {
 	if err != nil {
 		logger.Errorf("stack version not in semver format (value: %s): %v", v, err)
 		return elasticAgentImageName
+	}
+	if !v.LessThan(elasticAgentWolfiVersion) {
+		return elasticAgentWolfiImageName
 	}
 	if !v.LessThan(elasticAgentCompleteOwnNamespaceVersion) {
 		return elasticAgentCompleteImageName

--- a/internal/install/application_configuration.go
+++ b/internal/install/application_configuration.go
@@ -159,11 +159,10 @@ func selectElasticAgentImageName(version string) string {
 		return elasticAgentImageName
 	}
 
-	// TODO: Set as default using wolfi images once they are available
-	disableWolfiImages := true
+	disableWolfiImages := false
 	valueEnv, ok := os.LookupEnv(disableElasticAgentWolfiEnvVar)
-	if ok && strings.ToLower(valueEnv) != "true" {
-		disableWolfiImages = false
+	if ok && strings.ToLower(valueEnv) != "false" {
+		disableWolfiImages = true
 	}
 	if !disableWolfiImages && !v.LessThan(elasticAgentWolfiVersion) {
 		return elasticAgentWolfiImageName

--- a/internal/install/application_configuration.go
+++ b/internal/install/application_configuration.go
@@ -159,10 +159,11 @@ func selectElasticAgentImageName(version string) string {
 		return elasticAgentImageName
 	}
 
-	disableWolfiImages := false
+	// TODO: Set as default using wolfi images once they are available
+	disableWolfiImages := true
 	valueEnv, ok := os.LookupEnv(disableElasticAgentWolfiEnvVar)
-	if ok && strings.ToLower(valueEnv) != "false" {
-		disableWolfiImages = true
+	if ok && strings.ToLower(valueEnv) != "true" {
+		disableWolfiImages = false
 	}
 	if !disableWolfiImages && !v.LessThan(elasticAgentWolfiVersion) {
 		return elasticAgentWolfiImageName

--- a/internal/install/application_configuration.go
+++ b/internal/install/application_configuration.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 
@@ -45,6 +46,8 @@ var (
 
 	// ProfileNameEnvVar is the name of the environment variable to set the default profile
 	ProfileNameEnvVar = environment.WithElasticPackagePrefix("PROFILE")
+
+	disableElasticAgentWolfiEnvVar = environment.WithElasticPackagePrefix("DISABLE_ELASTIC_AGENT_WOLFI")
 )
 
 func DefaultConfiguration() *ApplicationConfiguration {
@@ -155,7 +158,13 @@ func selectElasticAgentImageName(version string) string {
 		logger.Errorf("stack version not in semver format (value: %s): %v", v, err)
 		return elasticAgentImageName
 	}
-	if !v.LessThan(elasticAgentWolfiVersion) {
+
+	disableWolfiImages := false
+	valueEnv, ok := os.LookupEnv(disableElasticAgentWolfiEnvVar)
+	if ok && strings.ToLower(valueEnv) != "false" {
+		disableWolfiImages = true
+	}
+	if !disableWolfiImages && !v.LessThan(elasticAgentWolfiVersion) {
 		return elasticAgentWolfiImageName
 	}
 	if !v.LessThan(elasticAgentCompleteOwnNamespaceVersion) {

--- a/internal/install/application_configuration.go
+++ b/internal/install/application_configuration.go
@@ -23,7 +23,7 @@ import (
 const (
 	stackVersion715  = "7.15.0-SNAPSHOT"
 	stackVersion820  = "8.2.0-SNAPSHOT"
-	stackVersion8160 = "8.16.0-SNAPSHOT"
+	stackVersion8160 = "8.16.0-00000000-SNAPSHOT"
 
 	elasticAgentImageName               = "docker.elastic.co/beats/elastic-agent"
 	elasticAgentCompleteLegacyImageName = "docker.elastic.co/beats/elastic-agent-complete"

--- a/internal/install/application_configuration.go
+++ b/internal/install/application_configuration.go
@@ -21,8 +21,10 @@ import (
 )
 
 const (
-	stackVersion715  = "7.15.0-SNAPSHOT"
-	stackVersion820  = "8.2.0-SNAPSHOT"
+	stackVersion715 = "7.15.0-SNAPSHOT"
+	stackVersion820 = "8.2.0-SNAPSHOT"
+	// Not setting here 8.16.0-SNAPSHOT to take also into account prerelease versions
+	// like 8.16.0-21bba6f5-SNAPSHOT
 	stackVersion8160 = "8.16.0-00000000-SNAPSHOT"
 
 	elasticAgentImageName               = "docker.elastic.co/beats/elastic-agent"

--- a/internal/install/application_configuration_test.go
+++ b/internal/install/application_configuration_test.go
@@ -55,7 +55,8 @@ func TestSelectElasticAgentImageName_NextStackInOwnNamespace(t *testing.T) {
 func TestSelectElasticAgentImageName_WolfiImage(t *testing.T) {
 	version := "8.16.0-SNAPSHOT"
 	selected := selectElasticAgentImageName(version)
-	assert.Equal(t, selected, elasticAgentWolfiImageName)
+	// TODO: update once changed the default value
+	assert.Equal(t, selected, elasticAgentCompleteImageName)
 }
 
 func TestSelectElasticAgentImageName_DisableWolfiImageEnvVar(t *testing.T) {

--- a/internal/install/application_configuration_test.go
+++ b/internal/install/application_configuration_test.go
@@ -51,3 +51,22 @@ func TestSelectElasticAgentImageName_NextStackInOwnNamespace(t *testing.T) {
 	selected := selectElasticAgentImageName(version)
 	assert.Equal(t, selected, elasticAgentCompleteImageName)
 }
+
+func TestSelectElasticAgentImageName_WolfiImage(t *testing.T) {
+	version := "8.16.0-SNAPSHOT"
+	selected := selectElasticAgentImageName(version)
+	assert.Equal(t, selected, elasticAgentWolfiImageName)
+}
+
+func TestSelectElasticAgentImageName_DisableWolfiImageEnvVar(t *testing.T) {
+	version := "8.16.0-SNAPSHOT"
+	t.Setenv(disableElasticAgentWolfiEnvVar, "true")
+	selected := selectElasticAgentImageName(version)
+	assert.Equal(t, selected, elasticAgentCompleteImageName)
+}
+func TestSelectElasticAgentImageName_EnableWolfiImageEnvVar(t *testing.T) {
+	version := "8.16.0-SNAPSHOT"
+	t.Setenv(disableElasticAgentWolfiEnvVar, "false")
+	selected := selectElasticAgentImageName(version)
+	assert.Equal(t, selected, elasticAgentWolfiImageName)
+}

--- a/internal/install/application_configuration_test.go
+++ b/internal/install/application_configuration_test.go
@@ -55,8 +55,7 @@ func TestSelectElasticAgentImageName_NextStackInOwnNamespace(t *testing.T) {
 func TestSelectElasticAgentImageName_WolfiImage(t *testing.T) {
 	version := "8.16.0-SNAPSHOT"
 	selected := selectElasticAgentImageName(version)
-	// TODO: update once changed the default value
-	assert.Equal(t, selected, elasticAgentCompleteImageName)
+	assert.Equal(t, selected, elasticAgentWolfiImageName)
 }
 
 func TestSelectElasticAgentImageName_DisableWolfiImageEnvVar(t *testing.T) {

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -234,6 +234,9 @@ There are available some environment variables that could be used to change some
 
 - Related to tests:
     - `ELASTIC_PACKAGE_SERVERLESS_PIPELINE_TEST_DISABLE_COMPARE_RESULTS`: If set to `true`, the results from pipeline tests are not compared to avoid errors from GeoIP.
+    - `ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI`: If set to `true`, the Elastic Agent image used for running agents will be using the Ubuntu docker images
+      (e.g. `docker.elastic.co/elastic-agent/elastic-agent-complete`). If set to `false`, the Elastic Agent image used for the running agents will be based on the wolfi
+      images (e.g. `docker.elastic.co/elastic-agent/elastic-agent-wolfi`). Default: `true`.
 
 - To configure the Elastic stack to be used by `elastic-package`:
     - `ELASTIC_PACKAGE_ELASTICSEARCH_HOST`: Host of the elasticsearch (e.g. https://127.0.0.1:9200)


### PR DESCRIPTION
Follows #2038

Updates the default value for the ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI environment variable to be false. Therefore, from 8.16.0-SNAPSHOT stack versions it will be used wolfi docker images for Elastic Agent as part of the system testing.
