### PR TITLE
Add skipped to the message for skipped tests in human reports

### DIFF
--- a/internal/testrunner/reporters/formats/human.go
+++ b/internal/testrunner/reporters/formats/human.go
@@ -57,7 +57,7 @@ func reportHumanFormat(results []testrunner.TestResult) (string, error) {
 		} else if r.FailureMsg != "" {
 			result = fmt.Sprintf("FAIL: %s", r.FailureMsg)
 		} else if r.Skipped != nil {
-			result = r.Skipped.String()
+			result = fmt.Sprintf("SKIPPED: %s", r.Skipped.String())
 		} else {
 			result = "PASS"
 		}


### PR DESCRIPTION
Currently, if there are skipped tests (e.g. system or pipeline tests), there is no reference in the output about that test is skipped:
```
--- Test results for package: elastic_package_registry - START ---
╭──────────────────────────┬─────────────┬───────────┬───────────┬─────────────────────────────────────────────────────────────┬──────────────╮
│ PACKAGE                  │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT                                                      │ TIME ELAPSED │
├──────────────────────────┼─────────────┼───────────┼───────────┼─────────────────────────────────────────────────────────────┼──────────────┤
│ elastic_package_registry │ metrics     │ system    │ default   │ test [https://github.com/elastic/integrations/issues/10904] │     30.268µs │
╰──────────────────────────┴─────────────┴───────────┴───────────┴─────────────────────────────────────────────────────────────┴──────────────╯
--- Test results for package: elastic_package_registry - END   ---
```

This PR adds `SKIPPED: ` to the message with the reason and link. Example:

```
--- Test results for package: elastic_package_registry - START ---
╭──────────────────────────┬─────────────┬───────────┬───────────┬──────────────────────────────────────────────────────────────────────┬──────────────╮
│ PACKAGE                  │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT                                                               │ TIME ELAPSED │
├──────────────────────────┼─────────────┼───────────┼───────────┼──────────────────────────────────────────────────────────────────────┼──────────────┤
│ elastic_package_registry │ metrics     │ system    │ default   │ SKIPPED: test [https://github.com/elastic/integrations/issues/10904] │     13.583µs │
╰──────────────────────────┴─────────────┴───────────┴───────────┴──────────────────────────────────────────────────────────────────────┴──────────────╯
--- Test results for package: elastic_package_registry - END   ---

```

This does not change the XML output (xUnit):
```
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite name="system" tests="1" skipped="1">
    <!--test suite for system tests-->
    <testcase name="system test: default" classname="elastic_package_registry.metrics" time="1.708e-05">
      <skipped message="test [https://github.com/elastic/integrations/issues/10904]"></skipped>
    </testcase>
  </testsuite>
</testsuites>
```