### PR TITLE
Add ecs@mappings multifields to all fields, not only external ones

### DIFF
--- a/internal/docs/exported_fields.go
+++ b/internal/docs/exported_fields.go
@@ -31,6 +31,10 @@ func renderExportedFields(fieldsParentDir string) (string, error) {
 		// SkipEmptyFields parameter when rendering fields. In other cases we want to
 		// keep them to accept them for validation.
 		SkipEmptyFields: true,
+
+		// Disable adding the additional multifields included in ecs@mappings, so they
+		// don't appear in the rendered configuration.
+		DisableAppendECSMultifields: true,
 	}
 	validator, err := fields.CreateValidatorForDirectory(fieldsParentDir, fields.WithInjectFieldsOptions(injectOptions))
 	if err != nil {

--- a/internal/fields/dependency_manager.go
+++ b/internal/fields/dependency_manager.go
@@ -162,6 +162,10 @@ type InjectFieldsOptions struct {
 	// fields that are only used for validation of documents, but are not needed on built packages.
 	IncludeValidationSettings bool
 
+	// DisableAppendECSMultifields can be set to disable the injection of the additional multifields
+	// included in ecs@mappings component teplate.
+	DisableAppendECSMultifields bool
+
 	root string
 }
 

--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -283,6 +283,12 @@ func createValidatorForDirectoryAndPackageRoot(fieldsParentDir string, finder pa
 	}
 
 	v.Schema = append(fields, v.Schema...)
+
+	// ecs@mappings adds additional multifields that are not defined anywhere.
+	// Adding them in all cases so packages can be tested in versions of the stack that
+	// add the ecs@mappings component template.
+	v.Schema = appendECSMappingMultifields(v.Schema, "")
+
 	return v, nil
 }
 
@@ -324,11 +330,6 @@ func initDependencyManagement(packageRoot string, specVersion semver.Version, im
 
 		schema = ecsSchema
 	}
-
-	// ecs@mappings adds additional multifields that are not defined anywhere.
-	// Adding them in all cases so packages can be tested in versions of the stack that
-	// add the ecs@mappings component template.
-	schema = appendECSMappingMultifields(schema, "")
 
 	return fdm, schema, nil
 }

--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -284,10 +284,12 @@ func createValidatorForDirectoryAndPackageRoot(fieldsParentDir string, finder pa
 
 	v.Schema = append(fields, v.Schema...)
 
-	// ecs@mappings adds additional multifields that are not defined anywhere.
-	// Adding them in all cases so packages can be tested in versions of the stack that
-	// add the ecs@mappings component template.
-	v.Schema = appendECSMappingMultifields(v.Schema, "")
+	if !v.injectFieldsOptions.DisableAppendECSMultifields {
+		// ecs@mappings adds additional multifields that are not defined anywhere.
+		// Adding them in all cases so packages can be tested in versions of the stack that
+		// add the ecs@mappings component template.
+		v.Schema = appendECSMappingMultifields(v.Schema, "")
+	}
 
 	return v, nil
 }


### PR DESCRIPTION
Multifields added by `ecs@mappings` are added to all fields, so we also need to add them to all fields
that match and not only to external ones.