### PR TITLE
[system tests] Add support for systemd option in agent.base_image setting

### DIFF
--- a/internal/install/application_configuration_test.go
+++ b/internal/install/application_configuration_test.go
@@ -13,13 +13,13 @@ import (
 func TestSelectElasticAgentImageName_NoVersion(t *testing.T) {
 	var version string
 	selected := selectElasticAgentImageName(version, "")
-	assert.Equal(t, selected, elasticAgentImageName)
+	assert.Equal(t, selected, elasticAgentLegacyImageName)
 }
 
 func TestSelectElasticAgentImageName_OlderStack(t *testing.T) {
 	version := "7.14.99-SNAPSHOT"
 	selected := selectElasticAgentImageName(version, "")
-	assert.Equal(t, selected, elasticAgentImageName)
+	assert.Equal(t, selected, elasticAgentLegacyImageName)
 }
 
 func TestSelectElasticAgentImageName_FirstStackWithCompleteAgent(t *testing.T) {
@@ -53,31 +53,49 @@ func TestSelectElasticAgentImageName_NextStackInOwnNamespace(t *testing.T) {
 }
 
 func TestSelectElasticAgentImageName_WolfiImage(t *testing.T) {
-	version := "8.16.0-SNAPSHOT"
+	version := stackVersion8160
 	selected := selectElasticAgentImageName(version, "")
 	assert.Equal(t, selected, elasticAgentWolfiImageName)
 }
 
 func TestSelectElasticAgentImageName_DisableWolfiImageEnvVar(t *testing.T) {
-	version := "8.16.0-SNAPSHOT"
+	version := stackVersion8160
 	t.Setenv(disableElasticAgentWolfiEnvVar, "true")
 	selected := selectElasticAgentImageName(version, "")
 	assert.Equal(t, selected, elasticAgentCompleteImageName)
 }
 func TestSelectElasticAgentImageName_EnableWolfiImageEnvVar(t *testing.T) {
-	version := "8.16.0-SNAPSHOT"
+	version := stackVersion8160
 	t.Setenv(disableElasticAgentWolfiEnvVar, "false")
 	selected := selectElasticAgentImageName(version, "")
 	assert.Equal(t, selected, elasticAgentWolfiImageName)
 }
 
 func TestSelectCompleteElasticAgentImageName_ForceCompleteImage(t *testing.T) {
-	version := "8.16.0-SNAPSHOT"
+	version := stackVersion8160
 	selected := selectElasticAgentImageName(version, "complete")
 	assert.Equal(t, selected, elasticAgentCompleteImageName)
 }
 func TestSelectCompleteElasticAgentImageName_ForceDefaultImage(t *testing.T) {
-	version := "8.16.0-SNAPSHOT"
+	version := stackVersion8160
 	selected := selectElasticAgentImageName(version, "default")
 	assert.Equal(t, selected, elasticAgentWolfiImageName)
+}
+
+func TestSelectCompleteElasticAgentImageName_ForceDefaultImageOldStack(t *testing.T) {
+	version := "8.15.0-SNAPSHOT"
+	selected := selectElasticAgentImageName(version, "default")
+	assert.Equal(t, selected, elasticAgentCompleteImageName)
+}
+
+func TestSelectCompleteElasticAgentImageName_ForceSystemDImage(t *testing.T) {
+	version := stackVersion8160
+	selected := selectElasticAgentImageName(version, "systemd")
+	assert.Equal(t, selected, elasticAgentImageName)
+}
+
+func TestSelectCompleteElasticAgentImageName_ForceSystemDImageOldStack(t *testing.T) {
+	version := stackVersion715
+	selected := selectElasticAgentImageName(version, "systemd")
+	assert.Equal(t, selected, elasticAgentLegacyImageName)
 }

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -424,7 +424,7 @@ func (r *tester) createAgentInfo(policy *kibana.Policy, config *testConfig, runI
 	}
 
 	// This could be removed once package-spec adds this new field
-	if !slices.Contains([]string{"", "default", "complete"}, info.Agent.BaseImage) {
+	if !slices.Contains([]string{"", "default", "complete", "systemd"}, info.Agent.BaseImage) {
 		return agentdeployer.AgentInfo{}, fmt.Errorf("invalid value for agent.base_image: %q", info.Agent.BaseImage)
 	}
 


### PR DESCRIPTION
This PR adds support to run system tests using the regular Elastic Agent docker image (e.g. docker.elastic.co/elastic-agent/elastic-agent).

It will take into account the Elastic stack version to use `docker.elastic.co/beats/elastic-agent` docker image when it is required.

If there is no value defined for `agent.base_image` or it has the `default` value, the behaviour would be as it was up to now. It would use the complete image where it is supported.


Changed required in the spec: https://github.com/elastic/package-spec/pull/792