### PR TITLE
Force raising error in provisioning script if failure

### DIFF
--- a/internal/agentdeployer/_static/dockerfile.tmpl
+++ b/internal/agentdeployer/_static/dockerfile.tmpl
@@ -14,9 +14,10 @@ USER root
 
 {{ if ne $provisioning_script_contents "" }}
 COPY {{ $provisioning_script_filename }} .
-RUN chmod u+x {{ $provisioning_script_filename }} && \
+RUN set -eu ; \
+  chmod u+x {{ $provisioning_script_filename }} && \
   {{ $provisioning_script_language }} ./{{ $provisioning_script_filename }} && \
-  rm {{ $provisioning_script_filename }}
+  rm {{ $provisioning_script_filename }} || exit 1
 {{ end }}
 
 {{ if ne $pre_start_script_contents "" }}


### PR DESCRIPTION
Force to raise an error (interrupting docker build) if there is any failure in the provisioning script executed to build custom/independent Elastic Agents.


Relates https://github.com/elastic/integrations/pull/10943
Relates https://github.com/elastic/elastic-package/pull/2067