### PR TITLE
[CI] Update terraform_local package

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -10,14 +10,13 @@ export SERVERLESS=${SERVERLESS:-"false"}
 WORKSPACE=$(pwd)
 export WORKSPACE
 
-
 AWS_SERVICE_ACCOUNT_SECRET_PATH=kv/ci-shared/platform-ingest/aws_ingest_ci
 PRIVATE_CI_GCS_CREDENTIALS_PATH=kv/ci-shared/platform-ingest/gcp-platform-ingest-ci-service-account
 
 EC_TOKEN_PATH=kv/ci-shared/platform-ingest/platform-ingest-ec-qa
 EC_DATA_PATH=secret/ci/elastic-elastic-package/ec_data
 
-# variables required for terraform
+# variables required for Terraform
 export ENVIRONMENT="ci"
 REPO=$(repo_name "${BUILDKITE_REPO}")
 export REPO
@@ -44,8 +43,6 @@ export BRANCH_NAME_LOWER_CASE
 # This variable contains the build number https://buildkite.com/elastic/elastic-package/<number>
 export BUILD_ID="${BUILDKITE_BUILD_NUMBER}"
 # get current timestamp in milliseconds
-# From Jenkins
-# CREATED_DATE = "${new Date().getTime()}"
 CREATED_DATE=$(date +%s%3N)
 export CREATED_DATE
 
@@ -78,30 +75,6 @@ if is_step_required_to_upload_safe_logs; then
     PRIVATE_CI_GCS_CREDENTIALS_SECRET=$(retry 5 vault kv get -field plaintext -format=json ${PRIVATE_CI_GCS_CREDENTIALS_PATH} | jq -c)
     export PRIVATE_CI_GCS_CREDENTIALS_SECRET
     export JOB_GCS_BUCKET_INTERNAL="ingest-buildkite-ci"
-fi
-
-is_step_testing_aws () {
-    if [[ "$BUILDKITE_PIPELINE_SLUG" != "elastic-package" ]]; then
-        return 1
-    fi
-    if [[ "$BUILDKITE_STEP_KEY" == "integration-parallel-aws-agent-false" || "$BUILDKITE_STEP_KEY" == "integration-parallel-aws-agent-true" ]]; then
-        return 0
-    fi
-    if [[ "$BUILDKITE_STEP_KEY" == "integration-parallel-aws_logs-agent-false" || "$BUILDKITE_STEP_KEY" == "integration-parallel-aws_logs-agent-true" ]]; then
-        return 0
-    fi
-    return 1
-}
-
-if is_step_testing_aws; then
-    ELASTIC_PACKAGE_AWS_SECRET_KEY=$(retry 5 vault kv get -field secret_key ${AWS_SERVICE_ACCOUNT_SECRET_PATH})
-    export ELASTIC_PACKAGE_AWS_SECRET_KEY
-    ELASTIC_PACKAGE_AWS_ACCESS_KEY=$(retry 5 vault kv get -field access_key ${AWS_SERVICE_ACCOUNT_SECRET_PATH})
-    export ELASTIC_PACKAGE_AWS_ACCESS_KEY
-
-    # Environment variables required by the service deployer
-    export AWS_SECRET_ACCESS_KEY=${ELASTIC_PACKAGE_AWS_SECRET_KEY}
-    export AWS_ACCESS_KEY_ID=${ELASTIC_PACKAGE_AWS_ACCESS_KEY}
 fi
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-package" && "$BUILDKITE_STEP_KEY" == "release" ]]; then

--- a/test/packages/parallel/terraform_local/data_stream/local/_dev/deploy/tf/main.tf
+++ b/test/packages/parallel/terraform_local/data_stream/local/_dev/deploy/tf/main.tf
@@ -3,3 +3,19 @@ resource "local_file" "log" {
   filename        = "/tmp/service_logs/file.log"
   file_permission = "0777"
 }
+
+locals {
+  items ={
+    environment  = "${var.ENVIRONMENT}"
+    repo         = "${var.REPO}"
+    branch       = "${var.BRANCH}"
+    build        = "${var.BUILD_ID}"
+    created_date = "${var.CREATED_DATE}"
+  }
+}
+
+resource "local_file" "log_variables" {
+  content         = format("%s\n", jsonencode(local.items))
+  filename        = "/tmp/service_logs/file_vars.log"
+  file_permission = "0777"
+}

--- a/test/packages/parallel/terraform_local/data_stream/local/_dev/deploy/tf/variables.tf
+++ b/test/packages/parallel/terraform_local/data_stream/local/_dev/deploy/tf/variables.tf
@@ -1,0 +1,22 @@
+variable "BRANCH" {
+  description = "Branch name or pull request for tagging purposes"
+  default     = "unknown-branch"
+}
+
+variable "BUILD_ID" {
+  description = "Build ID in the CI for tagging purposes"
+  default     = "unknown-build"
+}
+
+variable "CREATED_DATE" {
+  description = "Creation date in epoch time for tagging purposes"
+  default     = "unknown-date"
+}
+
+variable "ENVIRONMENT" {
+  default = "unknown-environment"
+}
+
+variable "REPO" {
+  default = "unknown-repo-name"
+}

--- a/test/packages/parallel/terraform_local/data_stream/local/_dev/test/system/test-default-config.yml
+++ b/test/packages/parallel/terraform_local/data_stream/local/_dev/test/system/test-default-config.yml
@@ -1,2 +1,8 @@
 wait_for_data_timeout: 1m
-vars: ~
+data_stream:
+  vars:
+    paths:
+      - "{{ SERVICE_LOGS_DIR }}/file.log"
+      - "{{ SERVICE_LOGS_DIR }}/file_vars.log"
+assert:
+  hit_count: 2

--- a/test/packages/parallel/terraform_local/data_stream/local/fields/fields.yml
+++ b/test/packages/parallel/terraform_local/data_stream/local/fields/fields.yml
@@ -9,3 +9,13 @@
       type: text
     - name: file
       type: keyword
+    - name: branch
+      type: keyword
+    - name: build
+      type: keyword
+    - name: created_date 
+      type: keyword
+    - name: environment
+      type: keyword
+    - name: repo 
+      type: keyword

--- a/test/packages/parallel/terraform_local/data_stream/outputs/_dev/deploy/tf/variables.tf
+++ b/test/packages/parallel/terraform_local/data_stream/outputs/_dev/deploy/tf/variables.tf
@@ -1,0 +1,22 @@
+variable "BRANCH" {
+  description = "Branch name or pull request for tagging purposes"
+  default     = "unknown-branch"
+}
+
+variable "BUILD_ID" {
+  description = "Build ID in the CI for tagging purposes"
+  default     = "unknown-build"
+}
+
+variable "CREATED_DATE" {
+  description = "Creation date in epoch time for tagging purposes"
+  default     = "unknown-date"
+}
+
+variable "ENVIRONMENT" {
+  default = "unknown-environment"
+}
+
+variable "REPO" {
+  default = "unknown-repo-name"
+}


### PR DESCRIPTION
This PR updates the test package `terraform_local` to keep using the variables like `ENVIRONMENT`, `BUILD_ID`, `CREATED_DATE`, ... that are used to set tags in GCP or AWS resources.

In this test package, those variables are used to write a local file.

As part of this PR, `pre-hook` has been revisited to cleanup unused usages of credentials.