### PR TITLE
Update Elastic Agent test image used in system tests

### DIFF
--- a/internal/agentdeployer/_static/docker-agent-base.yml.tmpl
+++ b/internal/agentdeployer/_static/docker-agent-base.yml.tmpl
@@ -9,7 +9,7 @@ services:
   elastic-agent:
     hostname: ${AGENT_HOSTNAME}
     {{ if ne $dockerfile_hash "" }}
-    image: "elastic-package-test-elastic-agent-complete:{{ $stack_version }}-{{ $dockerfile_hash }}"
+    image: "elastic-package-test-elastic-agent:{{ $stack_version }}-{{ $dockerfile_hash }}"
     build:
       context: .
       args:


### PR DESCRIPTION
To avoid some misleading images, now all the test images created (if some provisioning script is required) would not have the `-complete` suffix, just `elastic-package-test-elastic-agent`.

Docker images names now would be `elastic-package-test-elastic-agent`. Example:

```
 $ docker images |grep elastic-package-test
elastic-package-test-elastic-agent                       8.16.0-SNAPSHOT-2459e61e8ebaf237cffe70dc5ad649cb   64c7b5e57aa7   4 seconds ago    1.67GB
elastic-package-test-elastic-agent-complete              8.16.0-SNAPSHOT-6ed1b4ccb43f7b566cbec820f45a3234   745e405a52d9   24 hours ago     3.6GB
elastic-package-test-elastic-agent-complete              8.16.0-SNAPSHOT-2f7e750349ac630f8be657e906a453ac   0180a6add844   24 hours ago     3.61GB
```

* The difference between the size is related to the based image used (elastic-agent-wolfi vs elastic-agent-complete)-