### PR TITLE
Update default value for env. var used for Wolfi images

### DIFF
--- a/internal/install/application_configuration.go
+++ b/internal/install/application_configuration.go
@@ -162,10 +162,10 @@ func selectElasticAgentImageName(version, agentBaseImage string) string {
 		return elasticAgentLegacyImageName
 	}
 
-	disableWolfiImages := true
+	disableWolfiImages := false
 	valueEnv, ok := os.LookupEnv(disableElasticAgentWolfiEnvVar)
-	if ok && strings.ToLower(valueEnv) != "true" {
-		disableWolfiImages = false
+	if ok && strings.ToLower(valueEnv) != "false" {
+		disableWolfiImages = true
 	}
 	switch {
 	case agentBaseImage == "complete":

--- a/internal/install/application_configuration_test.go
+++ b/internal/install/application_configuration_test.go
@@ -53,14 +53,14 @@ func TestSelectElasticAgentImageName_NextStackInOwnNamespace(t *testing.T) {
 	assert.Equal(t, selected, elasticAgentCompleteImageName)
 }
 
-func TestSelectElasticAgentImageName_DefaultImage816_WihtoutEnvVar(t *testing.T) {
+func TestSelectElasticAgentImageName_DefaultImage816_WithoutEnvVar(t *testing.T) {
 	version := stackVersion8160
 	// Try to keep the test agnostic from the environment variables defined in CI
 	t.Setenv(disableElasticAgentWolfiEnvVar, "")
 	os.Unsetenv(disableElasticAgentWolfiEnvVar)
 
 	selected := selectElasticAgentImageName(version, "")
-	assert.Equal(t, selected, elasticAgentCompleteImageName)
+	assert.Equal(t, selected, elasticAgentWolfiImageName)
 }
 
 func TestSelectElasticAgentImageName_DisableWolfiImageEnvVar(t *testing.T) {


### PR DESCRIPTION
This PR updates the default Elastic Agent image used for Elastic stack versions >= 8.16.0 to be the Elastic Agent images based on Wolfi.