### PR TITLE
internal/{docs,testrunner/runners/system,internal/testrunner/runners/pipeline}: make json files end with newlines

### DIFF
--- a/internal/docs/sample_event.go
+++ b/internal/docs/sample_event.go
@@ -5,6 +5,7 @@
 package docs
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -54,7 +55,7 @@ func renderSampleEvent(packageRoot, dataStreamName string) (string, error) {
 			stripDataStreamFolderSuffix(dataStreamName)))
 	}
 	builder.WriteString("```json\n")
-	builder.Write(formatted)
+	builder.Write(bytes.TrimSpace(formatted))
 	builder.WriteString("\n```")
 	return builder.String(), nil
 }

--- a/internal/testrunner/runners/pipeline/testresult.go
+++ b/internal/testrunner/runners/pipeline/testresult.go
@@ -38,7 +38,7 @@ func writeTestResult(testCasePath string, result *testResult, specVersion semver
 	if err != nil {
 		return fmt.Errorf("marshalling test result failed: %w", err)
 	}
-	err = os.WriteFile(filepath.Join(testCaseDir, expectedTestResultFile(testCaseFile)), data, 0644)
+	err = os.WriteFile(filepath.Join(testCaseDir, expectedTestResultFile(testCaseFile)), append(data, '\n'), 0644)
 	if err != nil {
 		return fmt.Errorf("writing test result failed: %w", err)
 	}

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -2016,7 +2016,7 @@ func writeSampleEvent(path string, doc common.MapStr, specVersion semver.Version
 		return fmt.Errorf("marshalling sample event failed: %w", err)
 	}
 
-	err = os.WriteFile(filepath.Join(path, "sample_event.json"), body, 0644)
+	err = os.WriteFile(filepath.Join(path, "sample_event.json"), append(body, '\n'), 0644)
 	if err != nil {
 		return fmt.Errorf("writing sample event failed: %w", err)
 	}

--- a/test/packages/parallel/ti_anomali_logsdb/docs/README.md
+++ b/test/packages/parallel/ti_anomali_logsdb/docs/README.md
@@ -137,7 +137,6 @@ An example event for `threatstream` looks as following:
         }
     }
 }
-
 ```
 
 **Exported fields**


### PR DESCRIPTION
Currently test expectations and sample events are rendered to files without a
trailing space. This causes unnecessary diff noise as various people add or
remove the trailing character. In the case of sample events, it also results
in the addition of blank lines in the sample events rendered in to the
readme.

This change ensures that all test expectations and sample events are rendered
with a final new line and that sample events are white-space trimmed before
insertion into readme files.