### PR TITLE
Fix validation of subfields of flattened objects

### DIFF
--- a/internal/fields/testdata/flattened.json
+++ b/internal/fields/testdata/flattened.json
@@ -6,6 +6,7 @@
         "userName": "Bob",
         "groupName": "admin"
       }
-    }
+    },
+    "flattened.request_parameters.userID": 1000
   }
 }


### PR DESCRIPTION
When a document doesn't has subobjects, like when `subobjects: false` or synthetic mode is used, if an undocumented field is found, we need to check its ancestors to see if it is a member of a flattened object.

This is producing failures for `auditd_manager` package when LogsDB is enabled: https://buildkite.com/elastic/integrations/builds/15559
```
test case failed: one or more errors found in documents stored in logs-auditd_manager.auditd-20702 data stream: [0] field "auditd.data.a0" is undefined, could be a multifield
[1] field "auditd.data.a1" is undefined, could be a multifield
[2] field "auditd.data.a2" is undefined, could be a multifield
[3] field "auditd.data.a3" is undefined, could be a multifield
```