### PR TITLE
internal/stack: improve semverLessThan error handling

### DIFF
--- a/internal/stack/resources.go
+++ b/internal/stack/resources.go
@@ -250,11 +250,11 @@ func addClientCertsToResources(resourceManager *resource.Manager, certResources 
 func semverLessThan(a, b string) (bool, error) {
 	sa, err := semver.NewVersion(a)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("%w: %q", err, a)
 	}
 	sb, err := semver.NewVersion(b)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("%w: %q", err, b)
 	}
 
 	return sa.LessThan(sb), nil


### PR DESCRIPTION
This makes errors like this actionable.

```
Error: booting up the stack failed: creating stack files failed: there were 4 errors: template: docker-compose-stack.yml.tmpl:8:7: executing "docker-compose-stack.yml.tmpl" at <semverLessThan $version "8.0.0">: error calling semverLessThan: Invalid Semantic Version, template: elasticsearch.yml.tmpl:22:6: executing "elasticsearch.yml.tmpl" at <semverLessThan $version "8.0.0">: error calling semverLessThan: Invalid Semantic Version, template: kibana.yml.tmpl:5:52: executing "kibana.yml.tmpl" at <semverLessThan $version "8.15.0-SNAPSHOT">: error calling semverLessThan: Invalid Semantic Version, template: elastic-agent.env.tmpl:8:11: executing "elastic-agent.env.tmpl" at <semverLessThan $version "8.0.0">: error calling semverLessThan: Invalid Semantic Version
```

ref elastic/integrations#11052