### PR TITLE
feat: allow pipeline test case to define the expected output based on service versions constraints

### DIFF
--- a/internal/testrunner/errors.go
+++ b/internal/testrunner/errors.go
@@ -25,5 +25,5 @@ type ErrTestCaseConstraintsSkip struct {
 
 // Error returns the message detailing the test case failure.
 func (e ErrTestCaseConstraintsSkip) Error() string {
-	return fmt.Sprintf("test case skipped validation against expected output due to non matching constraints")
+	return "test case skipped validation against expected output due to non matching constraints"
 }

--- a/internal/testrunner/errors.go
+++ b/internal/testrunner/errors.go
@@ -18,3 +18,12 @@ type ErrTestCaseFailed struct {
 func (e ErrTestCaseFailed) Error() string {
 	return fmt.Sprintf("test case failed: %s", e.Reason)
 }
+
+// ErrTestCaseConstraintsSkip represents a test case skipped due to version constraints specified in the config
+type ErrTestCaseConstraintsSkip struct {
+}
+
+// Error returns the message detailing the test case failure.
+func (e ErrTestCaseConstraintsSkip) Error() string {
+	return fmt.Sprintf("test case skipped validation against expected output due to non matching constraints")
+}

--- a/internal/testrunner/errors.go
+++ b/internal/testrunner/errors.go
@@ -18,12 +18,3 @@ type ErrTestCaseFailed struct {
 func (e ErrTestCaseFailed) Error() string {
 	return fmt.Sprintf("test case failed: %s", e.Reason)
 }
-
-// ErrTestCaseConstraintsSkip represents a test case skipped due to version constraints specified in the config
-type ErrTestCaseConstraintsSkip struct {
-}
-
-// Error returns the message detailing the test case failure.
-func (e ErrTestCaseConstraintsSkip) Error() string {
-	return "test case skipped validation against expected output due to non matching constraints"
-}

--- a/internal/testrunner/runners/pipeline/testconfig.go
+++ b/internal/testrunner/runners/pipeline/testconfig.go
@@ -82,8 +82,10 @@ func readConfigForTestCase(testCasePath string) (*testConfig, error) {
 		return nil, fmt.Errorf("can't load test configuration: %s: %w", configPath, err)
 	}
 
-	if err := cfg.Unpack(&c); err != nil {
-		return nil, fmt.Errorf("can't unpack test configuration: %s: %w", commonConfigPath, err)
+	if cfg != nil {
+		if err := cfg.Unpack(&c); err != nil {
+			return nil, fmt.Errorf("can't unpack test configuration: %s: %w", commonConfigPath, err)
+		}
 	}
 	return &c, nil
 }

--- a/internal/testrunner/runners/pipeline/testconfig.go
+++ b/internal/testrunner/runners/pipeline/testconfig.go
@@ -71,8 +71,12 @@ func readConfigForTestCase(testCasePath string) (*testConfig, error) {
 	configPath := filepath.Join(testCaseDir, expectedTestConfigFile(testCaseFile, configTestSuffixYAML))
 	cfgTestCase, err := yaml.NewConfigWithFile(configPath)
 	if err == nil {
-		if err := cfg.Merge(cfgTestCase); err != nil {
-			return nil, fmt.Errorf("can't merge common configuration %s with test case configuration %s: %w", commonConfigPath, configPath, err)
+		if cfg == nil {
+			cfg = cfgTestCase
+		} else {
+			if err := cfg.Merge(cfgTestCase); err != nil {
+				return nil, fmt.Errorf("can't merge common configuration %s with test case configuration %s: %w", commonConfigPath, configPath, err)
+			}
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return nil, fmt.Errorf("can't load test configuration: %s: %w", configPath, err)

--- a/internal/testrunner/runners/pipeline/tester.go
+++ b/internal/testrunner/runners/pipeline/tester.go
@@ -348,12 +348,6 @@ func (r *tester) runTestCase(ctx context.Context, testCaseFile string, dsPath st
 
 	err = r.verifyResults(testCaseFile, tc.config, result, fieldsValidator)
 	if err != nil {
-		if _, ok := err.(*testrunner.ErrTestCaseConstraintsSkip); ok {
-			results, _ := rc.WithSkip(&testrunner.SkipConfig{
-				Reason: err.Error(),
-			})
-			return results, nil
-		}
 		results, _ := rc.WithErrorf("verifying test result failed: %w", err)
 		return results, nil
 	}
@@ -431,7 +425,7 @@ func (r *tester) verifyResults(testCaseFile string, config *testConfig, result *
 
 	expectedResultFile, err := r.extractExpectedResultFile(testCaseFile, config)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to extract expected result file: %w", err)
 	}
 
 	if r.generateTestResult {
@@ -505,7 +499,7 @@ func (r *tester) extractExpectedResultFile(testCaseFile string, config *testConf
 		}
 	}
 
-	return "", &testrunner.ErrTestCaseConstraintsSkip{}
+	return expectedTestResultFile(testCasePath), nil
 }
 
 // stripEmptyTestResults function removes events which are nils. These nils can represent

--- a/internal/testrunner/runners/pipeline/testresult.go
+++ b/internal/testrunner/runners/pipeline/testresult.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-cmp/cmp"
@@ -30,15 +29,12 @@ type testResultDefinition struct {
 	Expected []json.RawMessage `json:"expected"`
 }
 
-func writeTestResult(testCasePath string, result *testResult, specVersion semver.Version) error {
-	testCaseDir := filepath.Dir(testCasePath)
-	testCaseFile := filepath.Base(testCasePath)
-
+func writeTestResult(expectedTestResultFile string, result *testResult, specVersion semver.Version) error {
 	data, err := marshalTestResultDefinition(result, specVersion)
 	if err != nil {
 		return fmt.Errorf("marshalling test result failed: %w", err)
 	}
-	err = os.WriteFile(filepath.Join(testCaseDir, expectedTestResultFile(testCaseFile)), data, 0644)
+	err = os.WriteFile(expectedTestResultFile, data, 0644)
 	if err != nil {
 		return fmt.Errorf("writing test result failed: %w", err)
 	}
@@ -137,12 +133,8 @@ func diffJson(want, got []byte, specVersion semver.Version) (string, error) {
 	return buf.String(), err
 }
 
-func readExpectedTestResult(testCasePath string, config *testConfig) (*testResult, error) {
-	testCaseDir := filepath.Dir(testCasePath)
-	testCaseFile := filepath.Base(testCasePath)
-
-	path := filepath.Join(testCaseDir, expectedTestResultFile(testCaseFile))
-	data, err := os.ReadFile(path)
+func readExpectedTestResult(expectedTestResultFile string, config *testConfig) (*testResult, error) {
+	data, err := os.ReadFile(expectedTestResultFile)
 	if err != nil {
 		return nil, fmt.Errorf("reading test result file failed: %w", err)
 	}

--- a/internal/testrunner/test_config.go
+++ b/internal/testrunner/test_config.go
@@ -35,7 +35,7 @@ func (s SkipConfig) String() string {
 	if s.Link.URL != nil {
 		return fmt.Sprintf("%s [%s]", s.Reason, s.Link)
 	} else {
-		return fmt.Sprintf("%s", s.Reason)
+		return s.Reason
 	}
 }
 

--- a/internal/testrunner/test_config.go
+++ b/internal/testrunner/test_config.go
@@ -32,7 +32,11 @@ func (u *packedURL) Unpack(s string) error {
 }
 
 func (s SkipConfig) String() string {
-	return fmt.Sprintf("%s [%s]", s.Reason, s.Link)
+	if s.Link.URL != nil {
+		return fmt.Sprintf("%s [%s]", s.Reason, s.Link)
+	} else {
+		return fmt.Sprintf("%s", s.Reason)
+	}
 }
 
 // SkippableConfig is a test configuration that allows skipping. This


### PR DESCRIPTION
This PR essentially allows to specify a different expected output for a given pipeline test case based on given version constraints of running stack services. Such a feature is required to handle gracefully cases as the one captured [here](https://github.com/elastic/integrations/pull/11067) where the normal CI tests are passing as the stack version is defined by the minimum one required by the package manifest. However, testing it with a higher version of the stack, although not required to be the minimum supported, it results in different expected outputs

An example of an integration package that this PR could be used with can be found [here](https://github.com/pkoutsovasilis/integrations/commit/1f8141e709aed4b08d2c5d5026381285249d9f67). Here we define different expected outputs for `test-cisco-ios.log` and `test-asr920.log` depending on the elasticsearch version of the running stack

