### PR TITLE
Support Elastic Agent complete wolfi image

### DIFF
--- a/internal/install/application_configuration.go
+++ b/internal/install/application_configuration.go
@@ -163,27 +163,32 @@ func selectElasticAgentImageName(version, agentBaseImage string) string {
 		return elasticAgentWolfiImageName
 	}
 
+	shouldUseWolfiImage := shouldUseWolfiImages(v)
+
+	switch agentBaseImage {
+	case "systemd":
+		return selectElasticAgentSystemDImageName(v)
+	case "complete":
+		if shouldUseWolfiImage {
+			return elasticAgentCompleteWolfiImageName
+		}
+		return selectElasticAgentCompleteImageName(v)
+	default:
+		if shouldUseWolfiImage {
+			return elasticAgentWolfiImageName
+		}
+		return selectElasticAgentCompleteImageName(v)
+	}
+}
+
+func shouldUseWolfiImages(version *semver.Version) bool {
 	disableWolfiImages := false
 	valueEnv, ok := os.LookupEnv(disableElasticAgentWolfiEnvVar)
 	if ok && strings.ToLower(valueEnv) != "false" {
 		disableWolfiImages = true
 	}
 
-	shouldUseWolfiImages := !disableWolfiImages && !v.LessThan(elasticAgentWolfiVersion)
-	switch agentBaseImage {
-	case "systemd":
-		return selectElasticAgentSystemDImageName(v)
-	case "complete":
-		if shouldUseWolfiImages {
-			return elasticAgentCompleteWolfiImageName
-		}
-		return selectElasticAgentCompleteImageName(v)
-	default:
-		if shouldUseWolfiImages {
-			return elasticAgentWolfiImageName
-		}
-		return selectElasticAgentCompleteImageName(v)
-	}
+	return !disableWolfiImages && !version.LessThan(elasticAgentWolfiVersion)
 }
 
 func selectElasticAgentCompleteImageName(version *semver.Version) string {

--- a/internal/install/application_configuration.go
+++ b/internal/install/application_configuration.go
@@ -32,7 +32,7 @@ const (
 	elasticAgentImageName               = "docker.elastic.co/elastic-agent/elastic-agent"
 	elasticAgentCompleteLegacyImageName = "docker.elastic.co/beats/elastic-agent-complete"
 	elasticAgentCompleteImageName       = "docker.elastic.co/elastic-agent/elastic-agent-complete"
-	elasticAgentCompleteWolfiImageName  = "docker.elastic.co/elastic-agent/elastic-agent-wolfi-complete"
+	elasticAgentCompleteWolfiImageName  = "docker.elastic.co/elastic-agent/elastic-agent-complete-wolfi"
 	elasticAgentWolfiImageName          = "docker.elastic.co/elastic-agent/elastic-agent-wolfi"
 	elasticsearchImageName              = "docker.elastic.co/elasticsearch/elasticsearch"
 	kibanaImageName                     = "docker.elastic.co/kibana/kibana"

--- a/internal/install/application_configuration_test.go
+++ b/internal/install/application_configuration_test.go
@@ -76,10 +76,16 @@ func TestSelectElasticAgentImageName_EnableWolfiImageEnvVar(t *testing.T) {
 	assert.Equal(t, elasticAgentWolfiImageName, selected)
 }
 
-func TestSelectCompleteElasticAgentImageName_ForceCompleteImage(t *testing.T) {
-	version := stackVersion8160
+func TestSelectCompleteElasticAgentImageName_ForceCompleteImage_NonWolfi(t *testing.T) {
+	version := "8.15.0"
 	selected := selectElasticAgentImageName(version, "complete")
 	assert.Equal(t, elasticAgentCompleteImageName, selected)
+}
+
+func TestSelectCompleteElasticAgentImageName_ForceCompleteImage_Wolfi(t *testing.T) {
+	version := stackVersion8160
+	selected := selectElasticAgentImageName(version, "complete")
+	assert.Equal(t, elasticAgentCompleteWolfiImageName, selected)
 }
 
 func TestSelectCompleteElasticAgentImageName_ForceDefaultImage_DisabledEnvVar(t *testing.T) {


### PR DESCRIPTION
Update the Elastic Agent complete image used starting in Elastic stack versions 8.16.0-SNAPSHOT.

Follows https://github.com/elastic/elastic-package/pull/2038

With the logic in this PR:
- Starting with 8.16.0-SNAPSHOT, it will be used the `elastic-agent-wolfi` docker image: docker.elastic.co/elastic-agent/elastic-agent-wofi`
- If the test configuration specified `base_image: complete`:
    - Starting with 8.16.0-SNAPSHOT, it will use the complete wolfi image
    - elastic-package will use the same logic as before for older stack versions 
- If the test configuration specified `base_image: systemd`:
    - `elastic-package` will use `docker.elastic.co/elastic-agent/elastic-agent` docker images.
    - for older stack versions it will use `docker.elastic.co/beats/elastic-agent`