### PR TITLE
Disable version check in 9.0 snapshots

### DIFF
--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -155,3 +155,7 @@ xpack.fleet.outputs:
         {{ indent $agent_key "        " }}
   {{ end }}
 {{ end }}
+
+{{- if eq $version "9.0.0-SNAPSHOT" }}
+xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
+{{- end }}


### PR DESCRIPTION
There are no packages published for 9.0 yet, and there won't be till we are closer to the release.