### PR TITLE
Add missing context to api ingest pipelines

### DIFF
--- a/internal/benchrunner/runners/pipeline/runner.go
+++ b/internal/benchrunner/runners/pipeline/runner.go
@@ -48,7 +48,7 @@ func (r *runner) SetUp(ctx context.Context) error {
 		return errors.New("data stream root not found")
 	}
 
-	r.entryPipeline, r.pipelines, err = ingest.InstallDataStreamPipelines(r.options.API, dataStreamPath)
+	r.entryPipeline, r.pipelines, err = ingest.InstallDataStreamPipelines(ctx, r.options.API, dataStreamPath)
 	if err != nil {
 		return fmt.Errorf("installing ingest pipelines failed: %w", err)
 	}

--- a/internal/benchrunner/runners/rally/runner.go
+++ b/internal/benchrunner/runners/rally/runner.go
@@ -956,7 +956,7 @@ func (r *runner) reindexData(ctx context.Context) error {
 
 	logger.Debug("starting reindexing of data...")
 
-	logger.Debug("getting orignal mappings...")
+	logger.Debug("getting original mappings...")
 	// Get the mapping from the source data stream
 	mappingRes, err := r.options.ESAPI.Indices.GetMapping(
 		r.options.ESAPI.Indices.GetMapping.WithContext(ctx),

--- a/internal/benchrunner/runners/system/runner.go
+++ b/internal/benchrunner/runners/system/runner.go
@@ -748,7 +748,7 @@ func (r *runner) reindexData(ctx context.Context) error {
 
 	logger.Debug("starting reindexing of data...")
 
-	logger.Debug("getting orignal mappings...")
+	logger.Debug("getting original mappings...")
 	// Get the mapping from the source data stream
 	mappingRes, err := r.options.ESAPI.Indices.GetMapping(
 		r.options.ESAPI.Indices.GetMapping.WithContext(ctx),

--- a/internal/testrunner/runners/pipeline/tester.go
+++ b/internal/testrunner/runners/pipeline/tester.go
@@ -168,7 +168,7 @@ func (r *tester) run(ctx context.Context) ([]testrunner.TestResult, error) {
 
 	startTesting := time.Now()
 	var entryPipeline string
-	entryPipeline, r.pipelines, err = ingest.InstallDataStreamPipelines(r.esAPI, dataStreamPath)
+	entryPipeline, r.pipelines, err = ingest.InstallDataStreamPipelines(ctx, r.esAPI, dataStreamPath)
 	if err != nil {
 		return nil, fmt.Errorf("installing ingest pipelines failed: %w", err)
 	}
@@ -278,7 +278,6 @@ func (r *tester) checkElasticsearchLogs(ctx context.Context, startTesting time.T
 
 		return nil
 	})
-
 	if err != nil {
 		return nil, fmt.Errorf("error at parsing logs of elasticseach: %w", err)
 	}
@@ -297,7 +296,6 @@ func (r *tester) checkElasticsearchLogs(ctx context.Context, startTesting time.T
 	}
 
 	return []testrunner.TestResult{tr}, nil
-
 }
 
 func (r *tester) runTestCase(ctx context.Context, testCaseFile string, dsPath string, dsType string, pipeline string, validatorOptions []fields.ValidatorOption) ([]testrunner.TestResult, error) {


### PR DESCRIPTION
Add missing context variables to the ingest GetPipelines API queries.

References:
- https://github.com/elastic/go-elasticsearch/blob/7c663a64bd408a9ab89bed523a448201a8f26dbf/esapi/api.ingest.put_pipeline.go#L46C1-L46C112
```golang
type IngestPutPipeline func(id string, body io.Reader, o ...func(*IngestPutPipelineRequest)) (*Response, error)
```

- https://github.com/elastic/go-elasticsearch/blob/7c663a64bd408a9ab89bed523a448201a8f26dbf/esapi/api.ingest.get_pipeline.go#L45
```golang
type IngestGetPipeline func(o ...func(*IngestGetPipelineRequest)) (*Response, error)
```

## How to test locally

```shell
elastic-package stack up -v -d

# test some packages
cd test/packages/parallel/nginx
elastic-package test pipeline -v

cd ../aws
elastic-package test pipeline -v

elastic-package stack down -v
```

