### PR TITLE
Add error check for HTTPJSON template execution failure

### DIFF
--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -120,6 +120,15 @@ var (
 						regexp.MustCompile(`Component state changed .* \(HEALTHY->DEGRADED\): Degraded: pid .* missed .* check-in`),
 					},
 				},
+				{
+					// HTTPJSON template error.
+					includes: regexp.MustCompile(`^error processing response: template: :\d+:\d+: executing "" at <`),
+					excludes: []*regexp.Regexp{
+						// Unfortunate: https://github.com/elastic/beats/issues/34544
+						// See also https://github.com/elastic/beats/pull/39929.
+						regexp.MustCompile(`: map has no entry for key`),
+					},
+				},
 			},
 		},
 	}

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -127,6 +127,7 @@ var (
 						// Unfortunate: https://github.com/elastic/beats/issues/34544
 						// See also https://github.com/elastic/beats/pull/39929.
 						regexp.MustCompile(`: map has no entry for key`),
+						regexp.MustCompile(`: can't evaluate field (?:[^ ]+) in type interface`),
 					},
 				},
 			},


### PR DESCRIPTION
We don't know if this will result in failures in existing integrations, so running test integrations with a view to resolving them if they exist before this is merged.

Sadly, it needs to be relaxed, but it's better than nothing.

ref: https://github.com/elastic/integrations/pull/11361#discussion_r1792111556