### PR TITLE
Ignore empty namespaces when comparing policies

### DIFF
--- a/internal/testrunner/runners/policy/policy_test.go
+++ b/internal/testrunner/runners/policy/policy_test.go
@@ -59,6 +59,25 @@ id: "2e19c1c4-185b-11ef-a7fc-43855f39047f"
 			fail: true,
 		},
 		{
+			title: "clean namespaces if empty",
+			expected: `
+`,
+			found: `
+namespaces: []
+`,
+			equal: true,
+		},
+		{
+			title: "clean namespaces only if empty",
+			expected: `
+namespaces: []
+`,
+			found: `
+namespaces: [foo]
+`,
+			equal: false,
+		},
+		{
 			title: "clean expected",
 			expected: `
 inputs:
@@ -138,6 +157,7 @@ inputs:
           password: ${SECRET_0}
       type: sql/metrics
       use_output: default
+namespaces: []
 output_permissions:
     default:
         _elastic_agent_checks:


### PR DESCRIPTION
Fixes issues found in https://github.com/elastic/elastic-package/pull/2222.

`namespaces` is an array of strings (https://github.com/elastic/kibana/blob/05a9b26d3c8c9932aa344e53182296996e707dd3/x-pack/plugins/fleet/server/types/models/agent_policy.ts#L251).