### PR TITLE
[Asset tests] Add `installationInfo` field to API response of get package

### DIFF
--- a/internal/kibana/packages.go
+++ b/internal/kibana/packages.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/packages"
 )
 
@@ -86,13 +85,11 @@ type FleetPackage struct {
 func (p *FleetPackage) Assets() []packages.Asset {
 	var assets []packages.Asset
 	if p.SavedObject != nil {
-		logger.Debugf("Adding from `savedObject`")
 		assets = append(assets, p.SavedObject.Attributes.InstalledElasticsearchAssets...)
 		assets = append(assets, p.SavedObject.Attributes.InstalledKibanaAssets...)
 		return assets
 	}
-	// starting in 9.0.0
-	logger.Debugf("Adding from `installationInfo`")
+	// starting in 9.0.0 "savedObject" fields does not exist in the API response
 	assets = append(assets, p.InstallationInfo.InstalledElasticsearchAssets...)
 	assets = append(assets, p.InstallationInfo.InstalledKibanaAssets...)
 	return assets
@@ -127,7 +124,6 @@ func (c *Client) GetPackage(ctx context.Context, name string) (*FleetPackage, er
 		// Response is here when new packages API is used (since 8.0)
 		Item *FleetPackage `json:"item"`
 	}
-	logger.Debugf(">>> Mario > Response:\n%s", string(respBody))
 	err = json.Unmarshal(respBody, &response)
 	switch {
 	case err != nil:


### PR DESCRIPTION
Asset tests are failing due to `savedObject` field is missing from the API response `GET /api/fleet/epm/packages/<package>/<version>`.

Probably related to this https://github.com/elastic/kibana/pull/198434/files#diff-466e258cb2e72645d2355d6d3bdb742b38059e03eb1830ee04afb79234520d1bR673

The same data that was present in `savedObject` is available in the `installationInfo` field from that API response. This PR updates the response in order to get the Kibana and Elasticsearch assets from the `installationInfo` field.

Example of builds where it is failing:
https://buildkite.com/elastic/elastic-package-test-serverless/builds/210
https://buildkite.com/elastic/integrations/builds/18433

## Author's Checklist
- [x] Test a package with a local Elastic stack running the latest 9.0.0-SNAPSHOT version.
- [x] Test packages with a Serverless project: https://buildkite.com/elastic/elastic-package-test-serverless/builds/211


## How to test this
```shell
elastic-package stack down -v
elastic-package stack update -v --version 9.0.0-SNAPSHOT
elastic-package stack up -v --version 9.0.0-SNAPSHOT

cd test/packages/parallel/apache
elastic-package test -v

# test other packages if required

elastic-package stack down -v
```