### PR TITLE
Fix deprecated Kibana APIs

### DIFF
--- a/internal/agentdeployer/kubernetes.go
+++ b/internal/agentdeployer/kubernetes.go
@@ -221,11 +221,12 @@ func readCACertBase64(profile *profile.Profile) (string, error) {
 	return base64.StdEncoding.EncodeToString(d), nil
 }
 
-// getTokenPolicyName function returns the policy name for the 8.x Elastic stack. The agent's policy
-// is predefined in the Kibana configuration file. The logic is not present in older stacks.
+// getTokenPolicyName function returns the policy name for the >= 8.x Elastic stacks. The agent's policy
+// is predefined in the Kibana configuration file. The logic is not present in older stacks and it uses
+// the default policy in Kibana (empty string).
 func getTokenPolicyName(stackVersion, policyName string) string {
-	if strings.HasPrefix(stackVersion, "8.") {
-		return policyName
+	if strings.HasPrefix(stackVersion, "7.") {
+		return ""
 	}
-	return ""
+	return policyName
 }


### PR DESCRIPTION
Follows #2233 

This PR solves these two issues related to `9.0.0-SNAPSHOT`:
- Fixed API to get the list of Elastic Agents available and the API to reassign one policy to an Elastic Agent.
- Fixed Agent Policy name to be used in Elastic Agents when testing with Kubernetes (kind).

It has been kept the backwards compatibility to use the previous calls or fields in older stacks (`<9.x`).

Related PRs:
- https://github.com/elastic/kibana/pull/198313

## Author's checklist
- [x] Ensure `elastic-package stack up` runs successfully.
- [x] Run locally `elastic-package test system -v` with a local Elastic stack `9.0.0-SNAPSHOT`
- [x] Install package and try to edit and export dashboards
- [x] Test packages in the integrations repository with a local Elastic stack `9.0.0-SNAPSHOT`
    - This build could be taken as a reference: https://buildkite.com/elastic/integrations/builds/17827
- [x] Test packages in the integrations repository, each package with the required Elastic stack version.
    - https://github.com/elastic/integrations/pull/11790
- [x] Test packages with a Elastic Serverless project.
    - https://buildkite.com/elastic/elastic-package-test-serverless/builds/213