### PR TITLE
Review tear down test system handlers

### DIFF
--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -1133,7 +1133,8 @@ func (r *tester) prepareScenario(ctx context.Context, config *testConfig, svcInf
 
 		// RunTestOnly step (--no-provision) should also reassign back the previous (original) policy
 		// even with with independent Elastic Agents, since this step creates a new test policy each execution
-		if r.runIndependentElasticAgent && !r.runTestsOnly {
+		// Moreover, ensure there is no agent service deployer (deprecated) being used
+		if scenario.agent != nil && r.runIndependentElasticAgent && !r.runTestsOnly {
 			return nil
 		}
 
@@ -1164,7 +1165,8 @@ func (r *tester) prepareScenario(ctx context.Context, config *testConfig, svcInf
 
 		// No need to reset agent log level when running independent Elastic Agents
 		// since the Elastic Agent is going to be removed/uninstalled
-		if r.runIndependentElasticAgent {
+		// Morevoer, ensure there is no agent service deployer (deprecated) being used
+		if scenario.agent != nil && r.runIndependentElasticAgent {
 			return nil
 		}
 
@@ -1316,7 +1318,7 @@ func (r *tester) setupService(ctx context.Context, config *testConfig, serviceOp
 		svcInfo.AgentNetworkName = agentInfo.NetworkName
 	}
 
-	// Set the right folder for logs execpt for custom agents that are still deployed using "servicedeployer"
+	// Set the right folder for logs except for custom agents that are still deployed using "servicedeployer"
 	if r.runIndependentElasticAgent && agentDeployed != nil {
 		svcInfo.Logs.Folder.Local = agentInfo.Logs.Folder.Local
 	}

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -1130,6 +1130,13 @@ func (r *tester) prepareScenario(ctx context.Context, config *testConfig, svcInf
 			// triggered with the flags for running spolicyToAssignDatastreamTestsetup stage (--setup)
 			return nil
 		}
+
+		// RunTestOnly step (--no-provision) should also reassign back the previous (original) policy
+		// even with with independent Elastic Agents, since this step creates a new test policy each execution
+		if r.runIndependentElasticAgent && !r.runTestsOnly {
+			return nil
+		}
+
 		logger.Debug("reassigning original policy back to agent...")
 		if err := r.kibanaClient.AssignPolicyToAgent(ctx, agent, origPolicy); err != nil {
 			return fmt.Errorf("error reassigning original policy to agent: %w", err)

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -1158,9 +1158,16 @@ func (r *tester) prepareScenario(ctx context.Context, config *testConfig, svcInf
 		}
 	}
 	r.resetAgentLogLevelHandler = func(ctx context.Context) error {
-		if r.runTestsOnly {
+		if r.runTestsOnly || r.runSetup {
 			return nil
 		}
+
+		// No need to reset agent log level when running independent Elastic Agents
+		// since the Elastic Agent is going to be removed/uninstalled
+		if r.runIndependentElasticAgent {
+			return nil
+		}
+
 		logger.Debugf("reassigning original log level %q back to agent...", origLogLevel)
 
 		if err := r.kibanaClient.SetAgentLogLevel(ctx, agent.ID, origLogLevel); err != nil {


### PR DESCRIPTION
This PR revisits the handlers run in the Tear Down test process for the system tests.

When using independent Elastic Agents for each test scenario, the following handlers can be skipped:
- Reassign policy back to the Elastic Agent
- Reset the log level to the Elastic Agent

When using independent Elastic Agents, those agents are going to be removed/uninstalled at the end of the test, so there is no need to run those two handlers. There is a special case where it needs to be kept the reassignment of the policy when using the `--no-provision` flag in system tests.