### PR TITLE
Replace deprecated apm settings

### DIFF
--- a/internal/stack/_static/elasticsearch.yml.tmpl
+++ b/internal/stack/_static/elasticsearch.yml.tmpl
@@ -29,7 +29,13 @@ script.context.template.cache_max_size: 2000
 
 {{ $apm_enabled := fact "apm_enabled" }}
 {{ if eq $apm_enabled "true" }}
+{{ if semverLessThan $version "8.14.0" }}
 tracing.apm.enabled: true
 tracing.apm.agent.server_url: "http://fleet-server:8200"
 tracing.apm.agent.environment: "dev"
+{{- else -}}
+telemetry.tracing.enabled: true
+telemetry.agent.server_url: "http://fleet-server:8200"
+telemetry.agent.environment: "dev"
+{{- end -}}
 {{- end -}}

--- a/internal/stack/_static/elasticsearch.yml.tmpl
+++ b/internal/stack/_static/elasticsearch.yml.tmpl
@@ -28,7 +28,7 @@ script.context.template.cache_max_size: 2000
 {{- end -}}
 
 {{ $apm_enabled := fact "apm_enabled" }}
-{{ if eq $apm_enabled "true" }}
+{{ if (and (eq $apm_enabled "true") (not (semverLessThan $version "8.5.0"))) }}
 {{ if semverLessThan $version "8.14.0" }}
 tracing.apm.enabled: true
 tracing.apm.agent.server_url: "http://fleet-server:8200"

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -96,6 +96,7 @@ xpack.fleet.agentPolicies:
         package:
           name: fleet_server
       {{ if eq $apm_enabled "true" }}
+      {{ if not (semverLessThan $version "8.5.0") }}
         inputs:
           - type: fleet-server
             vars:
@@ -106,6 +107,7 @@ xpack.fleet.agentPolicies:
                       enabled: true
                       hosts: ["http://fleet-server:8200"]
                       environment: "dev"
+      {{ end }}
       - name: apm-1
         package:
           name: apm

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -96,18 +96,18 @@ xpack.fleet.agentPolicies:
         package:
           name: fleet_server
       {{ if eq $apm_enabled "true" }}
-      {{ if not (semverLessThan $version "8.5.0") }}
         inputs:
           - type: fleet-server
             vars:
               - name: custom
                 value: |
+      {{ if not (semverLessThan $version "8.8.0") }}
                   server:
+      {{ end }}
                     instrumentation:
                       enabled: true
                       hosts: ["http://fleet-server:8200"]
                       environment: "dev"
-      {{ end }}
       - name: apm-1
         package:
           name: apm


### PR DESCRIPTION
`tracing.apm.*` settings were deprecated in 8.14.0 in favor of the new `telemetry.*` settings. Use the new settings starting with 8.14.0.

Old settings will be removed in 9.0.

See https://github.com/elastic/elasticsearch/pull/104908.