### PR TITLE
Calculate exception fields just with mappings validation

### DIFF
--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -1524,10 +1524,10 @@ func (r *tester) validateTestScenario(ctx context.Context, result *testrunner.Re
 		return result.WithError(err)
 	}
 
-	exceptionFields := listExceptionFields(scenario.docs, fieldsValidator)
-
 	if r.fieldValidationMethod == allMethods || r.fieldValidationMethod == mappingsMethod {
 		logger.Warn("Validate mappings found (technical preview)")
+		exceptionFields := listExceptionFields(scenario.docs, fieldsValidator)
+
 		mappingsValidator, err := fields.CreateValidatorForMappings(r.dataStreamPath, r.esClient,
 			fields.WithMappingValidatorFallbackSchema(fieldsValidator.Schema),
 			fields.WithMappingValidatorIndexTemplate(scenario.indexTemplateName),


### PR DESCRIPTION
Follows #2214

Obtain the list of exception fields to be used with the new validation based on mappings when this method is selected (via environment variable).