### PR TITLE
Archive windows releases in zip format

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,3 +7,8 @@ builds:
       - darwin
       - linux
       - windows
+
+archives:
+  - format_overrides:
+      - goos: windows
+        format: zip


### PR DESCRIPTION
Zip is more convenient in Windows systems, that don't support tar.gz out of the box.