### PR TITLE
Add options for API key in clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ The output of this command is intended to be evaluated by the current shell. For
 
 Relevant environment variables are:
 
+- ELASTIC_PACKAGE_ELASTICSEARCH_API_KEY
 - ELASTIC_PACKAGE_ELASTICSEARCH_HOST
 - ELASTIC_PACKAGE_ELASTICSEARCH_USERNAME
 - ELASTIC_PACKAGE_ELASTICSEARCH_PASSWORD
@@ -690,13 +691,15 @@ There are available some environment variables that could be used to change some
 
 - To configure the Elastic stack to be used by `elastic-package`:
     - `ELASTIC_PACKAGE_ELASTICSEARCH_HOST`: Host of the elasticsearch (e.g. https://127.0.0.1:9200)
-    - `ELASTIC_PACKAGE_ELASTICSEARCH_USERNAME`: User name to connect to elasticsearch (e.g. elastic)
+    - `ELASTIC_PACKAGE_ELASTICSEARCH_API_KEY`: API key to connect to elasticsearch and kibana. When set it takes precedence over username and password.
+    - `ELASTIC_PACKAGE_ELASTICSEARCH_USERNAME`: User name to connect to elasticsearch and kibana (e.g. elastic)
     - `ELASTIC_PACKAGE_ELASTICSEARCH_PASSWORD`: Password of that user.
     - `ELASTIC_PACKAGE_ELASTICSEARCH_KIBANA_HOST`: Kibana URL (e.g. https://127.0.0.1:5601)
     - `ELASTIC_PACKAGE_ELASTICSEARCH_CA_CERT`: Path to the CA certificate to connect to the Elastic stack services.
 
 - To configure an external metricstore while running benchmarks (more info at [system benchmarking docs](https://github.com/elastic/elastic-package/blob/main/docs/howto/system_benchmarking.md#setting-up-an-external-metricstore) or [rally benchmarking docs](https://github.com/elastic/elastic-package/blob/main/docs/howto/rally_benchmarking.md#setting-up-an-external-metricstore)):
     - `ELASTIC_PACKAGE_ESMETRICSTORE_HOST`: Host of the elasticsearch (e.g. https://127.0.0.1:9200)
+    - `ELASTIC_PACKAGE_ESMETRICSTORE_API_KEY`: API key to connect to elasticsearch and kibana. When set it takes precedence over username and password.
     - `ELASTIC_PACKAGE_ESMETRICSTORE_USERNAME`: Username to connect to elasticsearch (e.g. elastic)
     - `ELASTIC_PACKAGE_ESMETRICSTORE_PASSWORD`: Password for the user.
     - `ELASTIC_PACKAGE_ESMETRICSTORE_CA_CERT`: Path to the CA certificate to connect to the Elastic stack services.

--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -655,16 +655,18 @@ func systemCommandAction(cmd *cobra.Command, args []string) error {
 
 func initializeESMetricsClient(ctx context.Context) (*elasticsearch.Client, error) {
 	address := os.Getenv(benchcommon.ESMetricstoreHostEnv)
+	apiKey := os.Getenv(benchcommon.ESMetricstoreAPIKeyEnv)
 	user := os.Getenv(benchcommon.ESMetricstoreUsernameEnv)
 	pass := os.Getenv(benchcommon.ESMetricstorePasswordEnv)
 	cacert := os.Getenv(benchcommon.ESMetricstoreCACertificateEnv)
-	if address == "" || user == "" || pass == "" {
+	if address == "" || ((user == "" || pass == "") && apiKey == "") {
 		logger.Debugf("can't initialize metricstore, missing environment configuration")
 		return nil, nil
 	}
 
 	esClient, err := stack.NewElasticsearchClient(
 		elasticsearch.OptionWithAddress(address),
+		elasticsearch.OptionWithAPIKey(apiKey),
 		elasticsearch.OptionWithUsername(user),
 		elasticsearch.OptionWithPassword(pass),
 		elasticsearch.OptionWithCertificateAuthority(cacert),

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -55,6 +55,7 @@ The output of this command is intended to be evaluated by the current shell. For
 
 Relevant environment variables are:
 
+- ELASTIC_PACKAGE_ELASTICSEARCH_API_KEY
 - ELASTIC_PACKAGE_ELASTICSEARCH_HOST
 - ELASTIC_PACKAGE_ELASTICSEARCH_USERNAME
 - ELASTIC_PACKAGE_ELASTICSEARCH_PASSWORD

--- a/internal/benchrunner/runners/common/env.go
+++ b/internal/benchrunner/runners/common/env.go
@@ -7,6 +7,7 @@ package common
 import "github.com/elastic/elastic-package/internal/environment"
 
 var (
+	ESMetricstoreAPIKeyEnv        = environment.WithElasticPackagePrefix("ESMETRICSTORE_API_KEY")
 	ESMetricstoreHostEnv          = environment.WithElasticPackagePrefix("ESMETRICSTORE_HOST")
 	ESMetricstoreUsernameEnv      = environment.WithElasticPackagePrefix("ESMETRICSTORE_USERNAME")
 	ESMetricstorePasswordEnv      = environment.WithElasticPackagePrefix("ESMETRICSTORE_PASSWORD")

--- a/internal/elasticsearch/client.go
+++ b/internal/elasticsearch/client.go
@@ -35,6 +35,7 @@ type ClusterStateRequest = esapi.ClusterStateRequest
 // clientOptions are used to configure a client.
 type clientOptions struct {
 	address  string
+	apiKey   string
 	username string
 	password string
 
@@ -46,6 +47,13 @@ type clientOptions struct {
 }
 
 type ClientOption func(*clientOptions)
+
+// OptionWithAPIKey sets the API key to be used by the client for authentication.
+func OptionWithAPIKey(apiKey string) ClientOption {
+	return func(opts *clientOptions) {
+		opts.apiKey = apiKey
+	}
+}
 
 // OptionWithAddress sets the address to be used by the client.
 func OptionWithAddress(address string) ClientOption {
@@ -109,6 +117,7 @@ func NewConfig(customOptions ...ClientOption) (elasticsearch.Config, error) {
 
 	config := elasticsearch.Config{
 		Addresses: []string{options.address},
+		APIKey:    options.apiKey,
 		Username:  options.username,
 		Password:  options.password,
 	}

--- a/internal/stack/config.go
+++ b/internal/stack/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Provider   string            `json:"provider,omitempty"`
 	Parameters map[string]string `json:"parameters,omitempty"`
 
+	ElasticsearchAPIKey   string `json:"elasticsearch_api_key,omitempty"`
 	ElasticsearchHost     string `json:"elasticsearch_host,omitempty"`
 	ElasticsearchUsername string `json:"elasticsearch_username,omitempty"`
 	ElasticsearchPassword string `json:"elasticsearch_password,omitempty"`

--- a/internal/stack/initconfig.go
+++ b/internal/stack/initconfig.go
@@ -9,6 +9,7 @@ import (
 )
 
 type InitConfig struct {
+	ElasticsearchAPIKey   string
 	ElasticsearchHostPort string
 	ElasticsearchUsername string
 	ElasticsearchPassword string
@@ -23,6 +24,7 @@ func StackInitConfig(profile *profile.Profile) (*InitConfig, error) {
 	}
 
 	return &InitConfig{
+		ElasticsearchAPIKey:   config.ElasticsearchAPIKey,
 		ElasticsearchHostPort: config.ElasticsearchHost,
 		ElasticsearchUsername: config.ElasticsearchUsername,
 		ElasticsearchPassword: config.ElasticsearchPassword,

--- a/internal/stack/shellinit_test.go
+++ b/internal/stack/shellinit_test.go
@@ -22,22 +22,47 @@ func TestCodeTemplate(t *testing.T) {
 		args args
 		want string
 	}{
-		{"bash code template", args{"bash"}, posixTemplate},
-		{"fish code template", args{"fish"}, fishTemplate},
-		{"sh code template", args{"sh"}, posixTemplate},
-		{"zsh code template", args{"zsh"}, posixTemplate},
+		{"bash code template", args{"bash"}, posixPattern},
+		{"fish code template", args{"fish"}, fishPattern},
+		{"sh code template", args{"sh"}, posixPattern},
+		{"zsh code template", args{"zsh"}, posixPattern},
+		{"pwsh code template", args{"pwsh"}, powershellPattern},
+		{"powershell code template", args{"powershell"}, powershellPattern},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, _ := initTemplate(tt.args.s); got != tt.want {
+			if got, _ := selectPattern(tt.args.s); got != tt.want {
 				t.Errorf("CodeTemplate() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
+func TestShellInit(t *testing.T) {
+	config := InitConfig{
+		ElasticsearchHostPort: "https://elastic.example.com:9200",
+		ElasticsearchUsername: "admin",
+		ElasticsearchPassword: "secret",
+		KibanaHostPort:        "https://kibana.example.com:5601",
+	}
+
+	expected := strings.TrimSpace(`
+export ELASTIC_PACKAGE_ELASTICSEARCH_API_KEY=
+export ELASTIC_PACKAGE_ELASTICSEARCH_HOST=https://elastic.example.com:9200
+export ELASTIC_PACKAGE_ELASTICSEARCH_USERNAME=admin
+export ELASTIC_PACKAGE_ELASTICSEARCH_PASSWORD=secret
+export ELASTIC_PACKAGE_KIBANA_HOST=https://kibana.example.com:5601
+export ELASTIC_PACKAGE_CA_CERT=
+`)
+
+	result, err := shellInitWithConfig(&config, "bash")
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, result)
+}
+
 func TestCodeTemplate_wrongInput(t *testing.T) {
-	_, err := initTemplate("invalid shell type")
+	_, err := selectPattern("invalid shell type")
 	assert.Error(t, err, "shell type is unknown, should be one of "+strings.Join(availableShellTypes, ", "))
 }
 

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -250,13 +250,15 @@ There are available some environment variables that could be used to change some
 
 - To configure the Elastic stack to be used by `elastic-package`:
     - `ELASTIC_PACKAGE_ELASTICSEARCH_HOST`: Host of the elasticsearch (e.g. https://127.0.0.1:9200)
-    - `ELASTIC_PACKAGE_ELASTICSEARCH_USERNAME`: User name to connect to elasticsearch (e.g. elastic)
+    - `ELASTIC_PACKAGE_ELASTICSEARCH_API_KEY`: API key to connect to elasticsearch and kibana. When set it takes precedence over username and password.
+    - `ELASTIC_PACKAGE_ELASTICSEARCH_USERNAME`: User name to connect to elasticsearch and kibana (e.g. elastic)
     - `ELASTIC_PACKAGE_ELASTICSEARCH_PASSWORD`: Password of that user.
     - `ELASTIC_PACKAGE_ELASTICSEARCH_KIBANA_HOST`: Kibana URL (e.g. https://127.0.0.1:5601)
     - `ELASTIC_PACKAGE_ELASTICSEARCH_CA_CERT`: Path to the CA certificate to connect to the Elastic stack services.
 
 - To configure an external metricstore while running benchmarks (more info at [system benchmarking docs](https://github.com/elastic/elastic-package/blob/main/docs/howto/system_benchmarking.md#setting-up-an-external-metricstore) or [rally benchmarking docs](https://github.com/elastic/elastic-package/blob/main/docs/howto/rally_benchmarking.md#setting-up-an-external-metricstore)):
     - `ELASTIC_PACKAGE_ESMETRICSTORE_HOST`: Host of the elasticsearch (e.g. https://127.0.0.1:9200)
+    - `ELASTIC_PACKAGE_ESMETRICSTORE_API_KEY`: API key to connect to elasticsearch and kibana. When set it takes precedence over username and password.
     - `ELASTIC_PACKAGE_ESMETRICSTORE_USERNAME`: Username to connect to elasticsearch (e.g. elastic)
     - `ELASTIC_PACKAGE_ESMETRICSTORE_PASSWORD`: Password for the user.
     - `ELASTIC_PACKAGE_ESMETRICSTORE_CA_CERT`: Path to the CA certificate to connect to the Elastic stack services.


### PR DESCRIPTION
Add support for API keys in clients and shellinit.

This is enough for some initial support of API keys (https://github.com/elastic/elastic-package/issues/1633), but many things can still fail, specially when running tests and so on. More about this in https://github.com/elastic/elastic-package/pull/2298.

Complementary to https://github.com/elastic/elastic-package/pull/2307 and https://github.com/elastic/elastic-package/pull/2309.