### PR TITLE
Ensure CAP_CHOWN capability is included if root user is required

### DIFF
--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -436,7 +436,7 @@ func (r *tester) createServiceOptions(variantName string) servicedeployer.Factor
 	}
 }
 
-func (r *tester) createAgentInfo(policy *kibana.Policy, config *testConfig, runID string, agentManifest packages.Agent) (agentdeployer.AgentInfo, error) {
+func (r *tester) createAgentInfo(policy *kibana.Policy, config *testConfig, runID string) (agentdeployer.AgentInfo, error) {
 	var info agentdeployer.AgentInfo
 
 	info.Name = r.testFolder.Package
@@ -456,8 +456,8 @@ func (r *tester) createAgentInfo(policy *kibana.Policy, config *testConfig, runI
 	info.Agent.AgentSettings = config.Agent.AgentSettings
 
 	// If user is defined in the configuration file, it has preference
-	// and it should not be overwritten by the value in the manifest
-	if info.Agent.User == "" && agentManifest.Privileges.Root {
+	// and it should not be overwritten by the value in the package or DataStream manifest
+	if info.Agent.User == "" && (r.pkgManifest.Agent.Privileges.Root || r.dataStreamManifest.Agent.Privileges.Root) {
 		info.Agent.User = "root"
 	}
 
@@ -1060,7 +1060,7 @@ func (r *tester) prepareScenario(ctx context.Context, config *testConfig, svcInf
 		policy = policyCurrent
 	}
 
-	agentDeployed, agentInfo, err := r.setupAgent(ctx, config, serviceStateData, policy, r.pkgManifest.Agent)
+	agentDeployed, agentInfo, err := r.setupAgent(ctx, config, serviceStateData, policy)
 	if err != nil {
 		return nil, err
 	}
@@ -1399,7 +1399,7 @@ func (r *tester) setupService(ctx context.Context, config *testConfig, serviceOp
 	return service, service.Info(), nil
 }
 
-func (r *tester) setupAgent(ctx context.Context, config *testConfig, state ServiceState, policy *kibana.Policy, agentManifest packages.Agent) (agentdeployer.DeployedAgent, agentdeployer.AgentInfo, error) {
+func (r *tester) setupAgent(ctx context.Context, config *testConfig, state ServiceState, policy *kibana.Policy) (agentdeployer.DeployedAgent, agentdeployer.AgentInfo, error) {
 	if !r.runIndependentElasticAgent {
 		return nil, agentdeployer.AgentInfo{}, nil
 	}
@@ -1408,7 +1408,7 @@ func (r *tester) setupAgent(ctx context.Context, config *testConfig, state Servi
 		agentRunID = state.AgentRunID
 	}
 	logger.Debug("setting up independent Elastic Agent...")
-	agentInfo, err := r.createAgentInfo(policy, config, agentRunID, agentManifest)
+	agentInfo, err := r.createAgentInfo(policy, config, agentRunID)
 	if err != nil {
 		return nil, agentdeployer.AgentInfo{}, err
 	}

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -461,6 +461,13 @@ func (r *tester) createAgentInfo(policy *kibana.Policy, config *testConfig, runI
 		info.Agent.User = "root"
 	}
 
+	if info.Agent.User == "root" {
+		// Ensure that CAP_CHOWN is present if the user for testing is root
+		if !slices.Contains(info.Agent.LinuxCapabilities, "CAP_CHOWN") {
+			info.Agent.LinuxCapabilities = append(info.Agent.LinuxCapabilities, "CAP_CHOWN")
+		}
+	}
+
 	// This could be removed once package-spec adds this new field
 	if !slices.Contains([]string{"", "default", "complete", "systemd"}, info.Agent.BaseImage) {
 		return agentdeployer.AgentInfo{}, fmt.Errorf("invalid value for agent.base_image: %q", info.Agent.BaseImage)


### PR DESCRIPTION
Ensure that CAP_CHOWN capability is present in the docker-compose scenario for the Elastic Agent container when the package requires or sets root privileges.

Fixes #2330 

Additional:
- Take into account if a data stream manifest defines that it requires root privileges.
    - `system` package defines root privileges in the manifest of some of its data streams: [example data stream manifest link](https://github.com/elastic/integrations/blob/5468ed672708099ed7aabfbc95ccee36820dc091/packages/system/data_stream/auth/manifest.yml#L102-L104)

## Author's checklist
- [x] Test packages from integrations with 8.18.0-SNAPSHOT
    - https://buildkite.com/elastic/integrations/builds/20277
    - https://buildkite.com/elastic/integrations/builds/20287 (including root privileges defined in data stream manifests)
- [x] Test packages from integrations with their minimum Kibana version supported
    - https://buildkite.com/elastic/integrations/builds/20292