### PR TITLE
Return error when profile cannot be loaded

### DIFF
--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -239,7 +239,7 @@ func LoadProfile(profileName string) (*Profile, error) {
 
 	profile, err := loadProfile(loc.ProfileDir(), profileName)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	err = profile.migrate(currentVersion)


### PR DESCRIPTION
Using a non existing profile can panic because an error is being ignored.