### PR TITLE
Update capabilities for the docker custom agent

### DIFF
--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "8.17.1"
+	DefaultStackVersion = "8.17.0"
 )

--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "8.17.0"
+	DefaultStackVersion = "8.17.1"
 )

--- a/internal/servicedeployer/_static/docker-custom-agent-base.yml
+++ b/internal/servicedeployer/_static/docker-custom-agent-base.yml
@@ -6,6 +6,8 @@ services:
       retries: 180
       interval: 1s
     hostname: docker-custom-agent
+    cap_add:
+      - CAP_CHOWN
     cap_drop:
       - ALL
     environment:


### PR DESCRIPTION
Relates #2362 
Follows #2331

Add CAP_CHOWN capability to docker custom agent service deployer, as it was done for the `agentdeployer` in #2331. This type is currently deprecated, but it is still supported/running in `elastic-package`.

Testing with Elastic Stack version 8.17.1: https://buildkite.com/elastic/elastic-package/builds/4707
