### PR TITLE
ci(buildkite): exclude files/folders that are not tested in Buildkite

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -13,7 +13,12 @@
         "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$",
         "skip_ci_labels": [ ],
         "skip_target_branches": [ ],
-        "skip_ci_on_only_changed": [ ],
+        "skip_ci_on_only_changed": [
+          "^docs/",
+          "^.github/",
+          "^.mergify.yml",
+          "\\.md$"
+        ],
         "always_require_ci_on_changed": [ ]
      },
      {

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -16,8 +16,7 @@
         "skip_ci_on_only_changed": [
           "^docs/",
           "^.github/",
-          "^.mergify.yml",
-          "\\.md$"
+          "^.mergify.yml"
         ],
         "always_require_ci_on_changed": [ ]
      },


### PR DESCRIPTION
## What does this PR do?

Skip files that are not used in Buildkite

## Why is it important?

Run faster builds and avoid waste of CI cycles.

I decided to support the whole `.github` folder since some other files, such as CODEOWNERS or .dependabot.yml, and the rest are not used by Buildkite.

The same for the `docs`, IIUC, that's not tested in BK itself but a BK docs pipeline owned by the docs team