### PR TITLE
Run validation based on fields always, keep validation based on mapping optional

### DIFF
--- a/.buildkite/pipeline.trigger.integration.tests.sh
+++ b/.buildkite/pipeline.trigger.integration.tests.sh
@@ -113,7 +113,7 @@ echo "          - build/test-coverage/coverage-*.xml" # these files should not b
 # Add steps to test validation method mappings
 while IFS= read -r -d '' package ; do
     package_name=$(basename "${package}")
-    echo "      - label: \":go: Integration test: ${package_name} (just validate mappings)\""
+    echo "      - label: \":go: Integration test: ${package_name} (validate mappings)\""
     echo "        key: \"integration-parallel-${package_name}-agent-validate-mappings\""
     echo "        command: ./.buildkite/scripts/integration_tests.sh -t test-check-packages-parallel -p ${package_name}"
     echo "        env:"

--- a/internal/elasticsearch/client.go
+++ b/internal/elasticsearch/client.go
@@ -361,6 +361,16 @@ func (c *Client) SimulateIndexTemplate(ctx context.Context, indexTemplateName st
 		return nil, nil, fmt.Errorf("error unmarshaling mappings: %w", err)
 	}
 
+	// In case there are no dynamic templates, set an empty array
+	if string(preview.Template.Mappings.DynamicTemplates) == "" {
+		preview.Template.Mappings.DynamicTemplates = []byte("[]")
+	}
+
+	// In case there are no mappings defined, set an empty map
+	if string(preview.Template.Mappings.Properties) == "" {
+		preview.Template.Mappings.Properties = []byte("{}")
+	}
+
 	return preview.Template.Mappings.DynamicTemplates, preview.Template.Mappings.Properties, nil
 }
 
@@ -401,6 +411,16 @@ func (c *Client) DataStreamMappings(ctx context.Context, dataStreamName string) 
 	var mappingsDefinition mappings
 	for _, v := range mappingsRaw {
 		mappingsDefinition = v.Mappings
+	}
+
+	// In case there are no dynamic templates, set an empty array
+	if string(mappingsDefinition.DynamicTemplates) == "" {
+		mappingsDefinition.DynamicTemplates = []byte("[]")
+	}
+
+	// In case there are no mappings defined, set an empty map
+	if string(mappingsDefinition.Properties) == "" {
+		mappingsDefinition.Properties = []byte("{}")
 	}
 
 	return mappingsDefinition.DynamicTemplates, mappingsDefinition.Properties, nil

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -1648,7 +1648,7 @@ func (r *tester) validateTestScenario(ctx context.Context, result *testrunner.Re
 	}
 
 	if r.fieldValidationMethod == mappingsMethod {
-		logger.Warn("Validate mappings found (technical preview)")
+		logger.Warn("Validation based on mappings enabled (technical preview)")
 		exceptionFields := listExceptionFields(scenario.docs, fieldsValidator)
 
 		mappingsValidator, err := fields.CreateValidatorForMappings(r.esClient,

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -141,13 +141,11 @@ var (
 type fieldValidationMethod int
 
 const (
-	allMethods fieldValidationMethod = iota
-	fieldsMethod
+	fieldsMethod fieldValidationMethod = iota
 	mappingsMethod
 )
 
 var validationMethods = map[string]fieldValidationMethod{
-	"all":      allMethods,
 	"fields":   fieldsMethod,
 	"mappings": mappingsMethod,
 }
@@ -1632,13 +1630,11 @@ func (r *tester) validateTestScenario(ctx context.Context, result *testrunner.Re
 		return result.WithErrorf("creating fields validator for data stream failed (path: %s): %w", r.dataStreamPath, err)
 	}
 
-	if r.fieldValidationMethod == allMethods || r.fieldValidationMethod == fieldsMethod {
-		if errs := validateFields(scenario.docs, fieldsValidator); len(errs) > 0 {
-			return result.WithError(testrunner.ErrTestCaseFailed{
-				Reason:  fmt.Sprintf("one or more errors found in documents stored in %s data stream", scenario.dataStream),
-				Details: errs.Error(),
-			})
-		}
+	if errs := validateFields(scenario.docs, fieldsValidator); len(errs) > 0 {
+		return result.WithError(testrunner.ErrTestCaseFailed{
+			Reason:  fmt.Sprintf("one or more errors found in documents stored in %s data stream", scenario.dataStream),
+			Details: errs.Error(),
+		})
 	}
 
 	stackVersion, err := semver.NewVersion(r.stackVersion.Number)
@@ -1651,7 +1647,7 @@ func (r *tester) validateTestScenario(ctx context.Context, result *testrunner.Re
 		return result.WithError(err)
 	}
 
-	if r.fieldValidationMethod == allMethods || r.fieldValidationMethod == mappingsMethod {
+	if r.fieldValidationMethod == mappingsMethod {
 		logger.Warn("Validate mappings found (technical preview)")
 		exceptionFields := listExceptionFields(scenario.docs, fieldsValidator)
 


### PR DESCRIPTION
Relates #2341 
Relates #2207 

This PR follows #2285. It ensures that the validation based on fields is used for system tests always (as it is done nowadays). Validation based on mappings is kept optional and it can be enabled via environment variable.