### PR TITLE
[system tests] [transforms] Support commas in the source indices definition

### DIFF
--- a/docs/howto/system_testing.md
+++ b/docs/howto/system_testing.md
@@ -429,6 +429,7 @@ for system tests.
 | skip.link | URL |  | URL linking to an issue about why the test is skipped. |
 | skip.reason | string |  | Reason to skip the test. If specified the test will not execute. |
 | skip_ignored_fields | array string |  | List of fields to be skipped when performing validation of fields ignored during ingestion. |
+| skip_transform_validation | boolean |  | Disable or enable the transforms validation performed in system tests. |
 | vars | dictionary |  | Package level variables to set (i.e. declared in `$package_root/manifest.yml`). If not specified the defaults from the manifest are used. |
 | wait_for_data_timeout | duration |  | Amount of time to wait for data to be present in Elasticsearch. Defaults to 10m. |
 

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/elastic/go-ucfg"
 	"github.com/elastic/go-ucfg/yaml"
@@ -207,14 +208,19 @@ type TransformDefinition struct {
 // HasSource checks if a given index or data stream name maches the transform sources
 func (t *Transform) HasSource(name string) (bool, error) {
 	for _, indexPattern := range t.Definition.Source.Index {
-		// Using filepath.Match to match index patterns because the syntax
-		// is basically the same.
-		found, err := filepath.Match(indexPattern, name)
-		if err != nil {
-			return false, fmt.Errorf("maching pattern %q with %q: %w", indexPattern, name, err)
-		}
-		if found {
-			return true, nil
+		// Split the pattern by commas in case the source indexes are provided with a
+		// comma-separated index strings
+		patterns := strings.Split(indexPattern, ",")
+		for _, pattern := range patterns {
+			// Using filepath.Match to match index patterns because the syntax
+			// is basically the same.
+			found, err := filepath.Match(pattern, name)
+			if err != nil {
+				return false, fmt.Errorf("maching pattern %q with %q: %w", pattern, name, err)
+			}
+			if found {
+				return true, nil
+			}
 		}
 	}
 	return false, nil

--- a/internal/testrunner/runners/system/test_config.go
+++ b/internal/testrunner/runners/system/test_config.go
@@ -42,6 +42,8 @@ type testConfig struct {
 		Vars common.MapStr `config:"vars"`
 	} `config:"data_stream"`
 
+	SkipTransformValidation bool `config:"skip_transform_validation"`
+
 	Assert struct {
 		// Expected number of hits for a given test
 		HitCount int `config:"hit_count"`

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -2080,7 +2080,10 @@ func (r *tester) checkTransforms(ctx context.Context, config *testConfig, pkgMan
 		// IDs format is: "<type>-<package>.<transform>-<namespace>-<version>"
 		// For instance: "logs-ti_anomali.latest_ioc-default-0.1.0"
 		transformPattern := fmt.Sprintf("%s-%s.%s-*-%s",
-			ds.Inputs[0].Streams[0].DataStream.Type,
+			// It cannot be used "ds.Inputs[0].Streams[0].DataStream.Type" since Fleet
+			// always create the transform with the prefix "logs-"
+			// https://github.com/elastic/kibana/blob/eed02b930ad332ad7261a0a4dff521e36021fb31/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/transform/install.ts#L855
+			"logs",
 			pkgManifest.Name,
 			transform.Name,
 			transform.Definition.Meta.FleetTransformVersion,

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -2057,6 +2057,10 @@ func selectPolicyTemplateByName(policies []packages.PolicyTemplate, name string)
 }
 
 func (r *tester) checkTransforms(ctx context.Context, config *testConfig, pkgManifest *packages.PackageManifest, ds kibana.PackageDataStream, dataStream string, syntheticEnabled bool) error {
+	if config.SkipTransformValidation {
+		return nil
+	}
+
 	transforms, err := packages.ReadTransformsFromPackageRoot(r.packageRootPath)
 	if err != nil {
 		return fmt.Errorf("loading transforms for package failed (root: %s): %w", r.packageRootPath, err)


### PR DESCRIPTION
Relates #2341 

Support to check transforms which source indices definition contains a list of comma-separated strings.

For instance ([link](https://github.com/elastic/integrations/blob/7801e00866ec0b5d4f4e4215f6b1107851083c87/packages/elasticsearch/elasticsearch/transform/index_pivot/transform.yml#L2))
```yaml
source:
  index: "metrics-elasticsearch.stack_monitoring.index*,.monitoring-es-8*,metricbeat-*"
```

`elastic-package` needs to check each source index defined in the transform independently to validate whether or not it matches with the data stream tested.


Notes:
- Discovered that Fleet creates the transforms with `logs-` prefix
- Added a configuration to skip the validation of transforms (required for `elasticsearch` package).
    - In 8.10.1, the destination index is not created:
       - Even, if the destination index is created beforehand, it fails with the same error.
       - Probably related to the aggregations ? [link](https://github.com/elastic/elasticsearch/blob/f77201fb128cbbe2c1c8920662631c54fa451b8a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/common/AbstractCompositeAggFunction.java#L90)
       - Error: `"Source indices have been deleted or closed."`
    - It looks like that the filters are too restrictive for the documents ingested in system test.
      Error: `"must specify at least one document in [docs]"`
