### PR TITLE
Tolerate errors dumping logs in pipeline tests

### DIFF
--- a/internal/stack/dump.go
+++ b/internal/stack/dump.go
@@ -71,7 +71,7 @@ func dumpStackLogs(ctx context.Context, options DumpOptions) ([]DumpResult, erro
 
 	for _, requestedService := range options.Services {
 		if !slices.Contains(services, requestedService) {
-			return nil, fmt.Errorf("local service %s does not exist", requestedService)
+			return nil, fmt.Errorf("%w: local service %s does not exist", ErrUnavailableStack, requestedService)
 		}
 	}
 

--- a/internal/testrunner/runners/pipeline/tester.go
+++ b/internal/testrunner/runners/pipeline/tester.go
@@ -235,6 +235,15 @@ func (r *tester) checkElasticsearchLogs(ctx context.Context, startTesting time.T
 
 	testingTime := startTesting.Truncate(time.Second)
 
+	statusOptions := stack.Options{
+		Profile: r.profile,
+	}
+	_, err := r.provider.Status(ctx, statusOptions)
+	if err != nil {
+		logger.Debugf("Not checking Elasticsearch logs: %s", err)
+		return nil, nil
+	}
+
 	dumpOptions := stack.DumpOptions{
 		Profile:  r.profile,
 		Services: []string{"elasticsearch"},
@@ -242,7 +251,7 @@ func (r *tester) checkElasticsearchLogs(ctx context.Context, startTesting time.T
 	}
 	dump, err := r.provider.Dump(ctx, dumpOptions)
 	var notImplementedErr *stack.ErrNotImplemented
-	if errors.As(err, &notImplementedErr) {
+	if errors.As(err, &notImplementedErr) || errors.Is(err, stack.ErrUnavailableStack) {
 		logger.Debugf("Not checking Elasticsearch logs: %s", err)
 		return nil, nil
 	}


### PR DESCRIPTION
Errors are ignored in two more cases now: when the status of the stack cannot be obtained, and when using the compose provider, when the elasticsearch service doesn't exist.

This should help on executions of pipeline tests against existing servers using only environment variables on default configuration, what is a common use case according to https://github.com/elastic/elastic-package/issues/2387. 

Fixes https://github.com/elastic/elastic-package/issues/2387.