### PR TITLE
Refactor mapping response given by the Elasticsearch client

### DIFF
--- a/internal/fields/dynamic_template.go
+++ b/internal/fields/dynamic_template.go
@@ -58,7 +58,6 @@ func (d *dynamicTemplate) Matches(currentPath string, definition map[string]any)
 	}
 
 	if len(d.pathMatch) > 0 {
-		// logger.Debugf("path_match -> Comparing %s to %q", strings.Join(d.pathMatch, ";"), currentPath)
 		matches, err := stringMatchesPatterns(d.pathMatch, currentPath, fullRegex)
 		if err != nil {
 			return false, fmt.Errorf("failed to parse dynamic template %s: %w", d.name, err)


### PR DESCRIPTION
Relates #2207 

This PR creates a new struct named `Mappings` to return both dynamic templates and properties for the corresponding methods in the Elasticsearch client.

This would help in case it is needed to add more fields from the Elasticsearch API response (runtime fields, settings, etc.)