### PR TITLE
Add detection of source.mode synthetics for 8.17.2 onwards

### DIFF
--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -681,7 +681,12 @@ func isSyntheticSourceModeEnabled(ctx context.Context, api *elasticsearch.API, d
 			} `json:"mappings"`
 			Settings struct {
 				Index struct {
-					Mode string `json:"mode"`
+					Mode    string `json:"mode"`
+					Mapping struct {
+						Source struct {
+							Mode string `json:"mode"`
+						} `json:"source"`
+					} `json:"mapping"`
 				} `json:"index"`
 			} `json:"settings"`
 		} `json:"template"`
@@ -691,7 +696,8 @@ func isSyntheticSourceModeEnabled(ctx context.Context, api *elasticsearch.API, d
 		return false, fmt.Errorf("could not decode index template simulation response: %w", err)
 	}
 
-	if results.Template.Mappings.Source.Mode == "synthetic" {
+	// in 8.17.2 source mode definition is now under settings object
+	if results.Template.Mappings.Source.Mode == "synthetic" || results.Template.Settings.Index.Mapping.Source.Mode == "synthetic" {
 		return true, nil
 	}
 


### PR DESCRIPTION
Relates https://github.com/elastic/elastic-package/pull/2397

This PR adds support to detect synthetic mode from 8.17.2 onwards.

It looks like that starting in this version this mode is declared under the `settings` object:
```json
{
  "template": {
    "settings": {
      "index": {
        "mapping": {
          "total_fields": {
            "limit": "1000",
            "ignore_dynamic_beyond_limit": "true"
          },
          "source": {
            "mode": "synthetic"
          }
        },
      }
    }
  }
}
```

Before this (in 8.17.1), there is also a warning message in the API response:
```json
#! Configuring source mode in mappings is deprecated and will be removed in future versions. Use [index.mapping.source.mode] index setting instead.
{
  "template": {
    "mappings": {
      "_source": {
        "mode": "synthetic"
      }
    }
  }
}
```

## How to test this PR locally

```
elastic-package stack up -v -d --version 8.17.2

cd test/packages/other/synthetic_mode

elastic-package test system -v

# Using DevTools query to check the API response to read the source mode
# POST /_index_template/_simulate_index/metrics-synthetic_mode.synthetic-25370-simulated

elastic-package stack down -v
```