### PR TITLE
[CI] Set 7.17 28 in test-stack-command-7x step pipeline

### DIFF
--- a/.github/workflows/updatecli/updatecli.d/bump-latest-7x-version.yml
+++ b/.github/workflows/updatecli/updatecli.d/bump-latest-7x-version.yml
@@ -29,8 +29,7 @@ sources:
     name: Get latest 7.x snapshot
     kind: json
     spec:
-      file: https://storage.googleapis.com/artifacts-api/snapshots/7.17.json
-      key: .version
+      file: https://storage.googleapis.com/artifacts-api/releases/current/7.17
 
 targets:
   update-7x-version:

--- a/.github/workflows/updatecli/updatecli.d/bump-latest-7x-version.yml
+++ b/.github/workflows/updatecli/updatecli.d/bump-latest-7x-version.yml
@@ -27,9 +27,14 @@ scms:
 sources:
   latest7xSnapshot:
     name: Get latest 7.x snapshot
-    kind: json
+    kind: file
     spec:
       file: https://storage.googleapis.com/artifacts-api/releases/current/7.17
+    transformers:
+      # Get only the version to avoid spaces and newlines.
+      - findsubmatch:
+          pattern: '([0-9\.]+)'
+          captureindex: 1
 
 targets:
   update-7x-version:

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test-stack-command-oldest:
 	./scripts/test-stack-command.sh 7.14.2
 
 test-stack-command-7x:
-	./scripts/test-stack-command.sh 7.17.28-SNAPSHOT
+	./scripts/test-stack-command.sh 7.17.28
 
 # Keeping a test for 8.6 because it has an specific configuration file.
 test-stack-command-86:


### PR DESCRIPTION
Related errors:
- https://github.com/elastic/elastic-package/pull/2431

Set Elastic stack version 7.17.28 for pipeline step `test-stack-command-7x`

Example of the Github Action run:
https://github.com/elastic/elastic-package/actions/runs/13542034659/job/37845061343?pr=2433