### PR TITLE
[system test] Add remove agent handler just after setting up agent

### DIFF
--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -1179,7 +1179,7 @@ func (r *tester) prepareScenario(ctx context.Context, config *testConfig, stackC
 
 	scenario.agent = agentDeployed
 
-	if r.runIndependentElasticAgent {
+	if agentDeployed != nil {
 		// Ensure agent created by `r.setupAgent` is removed if service fails to start
 		// This function should also be called after setting the service, since custom agents or kubernetes deployer
 		// create new Elastic Agents too.

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -1180,9 +1180,11 @@ func (r *tester) prepareScenario(ctx context.Context, config *testConfig, stackC
 	scenario.agent = agentDeployed
 
 	if agentDeployed != nil {
-		// Ensure agent created by `r.setupAgent` is removed if service fails to start
-		// This function should also be called after setting the service, since custom agents or kubernetes deployer
-		// create new Elastic Agents too.
+		// The Elastic Agent created in `r.setupAgent` needs to be retrieved just after starting it, to ensure
+		// it can be removed and unenrolled if the service fails to start.
+		// This function must also be called after setting the service (r.setupService), since there are other
+		// deployers like custom agents or kubernetes deployer that create new Elastic Agents too that needs to
+		// be retrieved too.
 		_, err := r.checkEnrolledAgents(ctx, agentInfo, svcInfo)
 		if err != nil {
 			return nil, fmt.Errorf("can't check enrolled agents: %w", err)
@@ -1249,7 +1251,8 @@ func (r *tester) prepareScenario(ctx context.Context, config *testConfig, stackC
 	}
 
 	// While there could be created Elastic Agents within `setupService()` (custom agents and k8s agents),
-	// this "checkEnrolledAgents" call to must be located after creating the service.
+	// this "checkEnrolledAgents" call must be duplicated here after creating the service too. This will
+	// ensure to get the right Enrolled Elastic Agent too.
 	agent, err := r.checkEnrolledAgents(ctx, agentInfo, svcInfo)
 	if err != nil {
 		return nil, fmt.Errorf("can't check enrolled agents: %w", err)


### PR DESCRIPTION
Relates #2039
Follows #2409

Ensure Elastic Agent created when using Independent Agents (default method via `r.setupAgent`) is removed even if the service exists with error.

Example of Buildkite build where service containers fails (e.g. mysql) and the agent is not removed:
https://buildkite.com/elastic/integrations/builds/22965

One example of this scenario is when the service container cannot started (it exits with failure). In that case, the new Elastic Agent created was not removed in the tear down process and therefore the corresponding Agent policies were not able to be deleted.

This PR duplicates the call to `checkEnrolledAgents` just after setting up the Elastic Agent so even in the case `setupService` fails, the new Elastic Agent can be deleted in the tear down process.

It needs to be duplicated this call since `r.setupService` could create new agents in case of the kubernetes service deployer or the custom agents deployer (the latter is deprecated) if the Elastic Agent of the stack is used (disabled Independent Elastic Agents).

In this buildkite build (with the changes of this PR), `mysql` now reports the container exit as error in xUnit files:
https://buildkite.com/elastic/integrations/builds/22973
