### PR TITLE
[system tests] Add exceptions for leaf of objects if required for mapping bases validation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,7 +52,7 @@ func RootCmd() *cobra.Command {
 			)
 		},
 	}
-	rootCmd.PersistentFlags().BoolP(cobraext.VerboseFlagName, cobraext.VerboseFlagShorthand, false, cobraext.VerboseFlagDescription)
+	rootCmd.PersistentFlags().CountP(cobraext.VerboseFlagName, cobraext.VerboseFlagShorthand, cobraext.VerboseFlagDescription)
 	rootCmd.PersistentFlags().StringP(cobraext.ChangeDirectoryFlagName, cobraext.ChangeDirectoryFlagShorthand, "", cobraext.ChangeDirectoryFlagDescription)
 
 	for _, cmd := range commands {
@@ -71,12 +71,14 @@ func Commands() []*cobraext.Command {
 }
 
 func processPersistentFlags(cmd *cobra.Command, args []string) error {
-	verbose, err := cmd.Flags().GetBool(cobraext.VerboseFlagName)
+	verbose, err := cmd.Flags().GetCount(cobraext.VerboseFlagName)
 	if err != nil {
 		return cobraext.FlagParsingError(err, cobraext.VerboseFlagName)
 	}
-	if verbose {
+	if verbose == 1 {
 		logger.EnableDebugMode()
+	} else if verbose > 1 {
+		logger.EnableTraceMode()
 	}
 
 	changeDirectory, err := cmd.Flags().GetString(cobraext.ChangeDirectoryFlagName)

--- a/internal/fields/exceptionfields.go
+++ b/internal/fields/exceptionfields.go
@@ -48,8 +48,8 @@ func (v *Validator) listExceptionFieldsMapElement(root string, elem common.MapSt
 			all = append(all, fields...)
 		}
 	}
-	all = slices.Compact(all)
 	slices.Sort(all)
+	all = slices.Compact(all)
 	return all
 }
 

--- a/internal/fields/exceptionfields.go
+++ b/internal/fields/exceptionfields.go
@@ -37,7 +37,7 @@ func (v *Validator) listExceptionFieldsMapElement(root string, elem common.MapSt
 			all = append(all, fields...)
 		default:
 			if skipLeafOfObject(root, name, v.specVersion, v.Schema) {
-				logger.Warnf("Skip validating leaf of object (key %q spec %q)", key, v.specVersion)
+				logger.Tracef("Skip validating leaf of object (key %q spec %q)", key, v.specVersion)
 				all = append(all, key)
 				// Till some versions we skip some validations on leaf of objects, check if it is the case.
 				break
@@ -88,7 +88,7 @@ func (v *Validator) parseExceptionField(key string, definition FieldDefinition, 
 	case "ip":
 	case "array":
 		if v.specVersion.LessThan(semver2_0_0) {
-			logger.Warnf("Skip validating field of type array with spec < 2.0.0 (key %q type %q spec %q)", key, definition.Type, v.specVersion)
+			logger.Tracef("Skip validating field of type array with spec < 2.0.0 (key %q type %q spec %q)", key, definition.Type, v.specVersion)
 			return []string{key}
 		}
 		return nil
@@ -99,7 +99,7 @@ func (v *Validator) parseExceptionField(key string, definition FieldDefinition, 
 			// This is probably an element from an array of objects,
 			// even if not recommended, it should be validated.
 			if v.specVersion.LessThan(semver3_0_1) {
-				logger.Warnf("Skip validating object (map[string]any) in package spec < 3.0.1 (key %q type %q spec %q)", key, definition.Type, v.specVersion)
+				logger.Tracef("Skip validating object (map[string]any) in package spec < 3.0.1 (key %q type %q spec %q)", key, definition.Type, v.specVersion)
 				return []string{key}
 			}
 			return nil
@@ -107,13 +107,13 @@ func (v *Validator) parseExceptionField(key string, definition FieldDefinition, 
 			// This can be an array of array of objects. Elasticsearh will probably
 			// flatten this. So even if this is quite unexpected, let's try to handle it.
 			if v.specVersion.LessThan(semver3_0_1) {
-				logger.Warnf("Skip validating object ([]any) because spec < 3.0.1 (key %q type %q spec %q)", key, definition.Type, v.specVersion)
+				logger.Tracef("Skip validating object ([]any) because spec < 3.0.1 (key %q type %q spec %q)", key, definition.Type, v.specVersion)
 				return []string{key}
 			}
 			return nil
 		case nil:
 			// The document contains a null, let's consider this like an empty array.
-			logger.Warnf("Skip validating object empty array because spec < 3.0.1 (key %q type %q spec %q)", key, definition.Type, v.specVersion)
+			logger.Tracef("Skip validating object empty array because spec < 3.0.1 (key %q type %q spec %q)", key, definition.Type, v.specVersion)
 			return []string{key}
 		default:
 			switch {
@@ -125,7 +125,7 @@ func (v *Validator) parseExceptionField(key string, definition FieldDefinition, 
 				return v.parseExceptionField(key, definition, val)
 			case definition.Type == "object" && definition.ObjectType == "":
 				// Legacy mapping, ambiguous definition not allowed by recent versions of the spec, ignore it.
-				logger.Warnf("Skip legacy mapping: object field without \"object_type\" parameter: %q", key)
+				logger.Tracef("Skip legacy mapping: object field without \"object_type\" parameter: %q", key)
 				return []string{key}
 			}
 

--- a/internal/fields/exceptionfields.go
+++ b/internal/fields/exceptionfields.go
@@ -38,6 +38,7 @@ func (v *Validator) listExceptionFieldsMapElement(root string, elem common.MapSt
 			all = append(all, fields...)
 		default:
 			if skipLeafOfObject(root, name, v.specVersion, v.Schema) {
+				logger.Tracef("Skip validating leaf of object (spec %q): %q", v.specVersion, key)
 				all = append(all, key)
 				// Till some versions we skip some validations on leaf of objects, check if it is the case.
 				break
@@ -49,7 +50,6 @@ func (v *Validator) listExceptionFieldsMapElement(root string, elem common.MapSt
 	}
 	all = slices.Compact(all)
 	slices.Sort(all)
-	logger.Tracef("Skip validating leafs of object %q (spec %q): %s", root, v.specVersion, strings.Join(all, ","))
 	return all
 }
 

--- a/internal/fields/exceptionfields.go
+++ b/internal/fields/exceptionfields.go
@@ -37,6 +37,8 @@ func (v *Validator) listExceptionFieldsMapElement(root string, elem common.MapSt
 			all = append(all, fields...)
 		default:
 			if skipLeafOfObject(root, name, v.specVersion, v.Schema) {
+				logger.Warnf("Skip validating leaf of object (key %q spec %q)", key, v.specVersion)
+				all = append(all, key)
 				// Till some versions we skip some validations on leaf of objects, check if it is the case.
 				break
 			}

--- a/internal/fields/exceptionfields.go
+++ b/internal/fields/exceptionfields.go
@@ -5,6 +5,7 @@
 package fields
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/elastic/elastic-package/internal/common"
@@ -37,7 +38,6 @@ func (v *Validator) listExceptionFieldsMapElement(root string, elem common.MapSt
 			all = append(all, fields...)
 		default:
 			if skipLeafOfObject(root, name, v.specVersion, v.Schema) {
-				logger.Tracef("Skip validating leaf of object (key %q spec %q)", key, v.specVersion)
 				all = append(all, key)
 				// Till some versions we skip some validations on leaf of objects, check if it is the case.
 				break
@@ -47,6 +47,9 @@ func (v *Validator) listExceptionFieldsMapElement(root string, elem common.MapSt
 			all = append(all, fields...)
 		}
 	}
+	all = slices.Compact(all)
+	slices.Sort(all)
+	logger.Tracef("Skip validating leafs of object %q (spec %q): %s", root, v.specVersion, strings.Join(all, ","))
 	return all
 }
 

--- a/internal/fields/exceptionfields_test.go
+++ b/internal/fields/exceptionfields_test.go
@@ -36,7 +36,7 @@ func TestFindExceptionElements(t *testing.T) {
 					Type: "array",
 				},
 			},
-			expected:    []string{"remote_ip_list", "remote_ip_list"},
+			expected:    []string{"remote_ip_list"},
 			specVersion: *semver.MustParse("1.5.0"),
 		},
 		{
@@ -68,7 +68,7 @@ func TestFindExceptionElements(t *testing.T) {
 					Type: "nested",
 				},
 			},
-			expected:    []string{"ip_port_info", "ip_port_info"},
+			expected:    []string{"ip_port_info"},
 			specVersion: *semver.MustParse("1.5.0"),
 		},
 		{
@@ -118,7 +118,7 @@ func TestFindExceptionElements(t *testing.T) {
 					Type: "group",
 				},
 			},
-			expected:    []string{"answers", "answers"},
+			expected:    []string{"answers"},
 			specVersion: *semver.MustParse("1.5.0"),
 		},
 		{

--- a/internal/fields/mappings.go
+++ b/internal/fields/mappings.go
@@ -437,7 +437,7 @@ func (v *MappingValidator) compareMappings(path string, couldBeParametersDefinit
 	}
 
 	if slices.Contains(v.exceptionFields, path) {
-		logger.Warnf("Found exception field, skip its validation: %q", path)
+		logger.Tracef("Found exception field, skip its validation: %q", path)
 		return nil
 	}
 
@@ -561,7 +561,7 @@ func (v *MappingValidator) validateMappingsNotInPreview(currentPath string, chil
 
 	for fieldPath, object := range flattenFields {
 		if slices.Contains(v.exceptionFields, fieldPath) {
-			logger.Warnf("Found exception field, skip its validation (not present in preview): %q", fieldPath)
+			logger.Tracef("Found exception field, skip its validation (not present in preview): %q", fieldPath)
 			return nil
 		}
 
@@ -572,7 +572,7 @@ func (v *MappingValidator) validateMappingsNotInPreview(currentPath string, chil
 		}
 
 		if isEmptyObject(def) {
-			logger.Debugf("Skip field which value is an empty object: %q", fieldPath)
+			logger.Tracef("Skip field which value is an empty object: %q", fieldPath)
 			continue
 		}
 

--- a/internal/fields/mappings.go
+++ b/internal/fields/mappings.go
@@ -457,7 +457,7 @@ func (v *MappingValidator) compareMappings(path string, couldBeParametersDefinit
 			}
 			return nil
 		} else if !isObject(preview) {
-			errs = append(errs, fmt.Errorf("not found properties in preview mappings for path: %q", path))
+			errs = append(errs, fmt.Errorf("undefined field mappings found in path: %q", path))
 			return errs.Unique()
 		}
 		previewProperties, err := getMappingDefinitionsField("properties", preview)

--- a/internal/fields/mappings_test.go
+++ b/internal/fields/mappings_test.go
@@ -749,7 +749,7 @@ func TestComparingMappings(t *testing.T) {
 			exceptionFields: []string{},
 			schema:          []FieldDefinition{},
 			expectedErrors: []string{
-				`not found properties in preview mappings for path: "foo"`,
+				`undefined field mappings found in path: "foo"`,
 			},
 		},
 		{

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -10,12 +10,21 @@ import (
 )
 
 var isDebugMode bool
+var isTraceMode bool
 
 // EnableDebugMode method enables verbose logging.
 func EnableDebugMode() {
 	isDebugMode = true
 
 	Debug("Enable verbose logging")
+}
+
+// EnableTraceMode method enables trace verbose logging.
+func EnableTraceMode() {
+	isDebugMode = true
+	isTraceMode = true
+
+	Debug("Enable trace verbose logging")
 }
 
 // Debug method logs message with "debug" level.
@@ -36,7 +45,28 @@ func Debugf(format string, a ...interface{}) {
 
 // IsDebugMode method checks if the debug mode is enabled.
 func IsDebugMode() bool {
-	return isDebugMode
+	return isDebugMode || isTraceMode
+}
+
+// Trace method logs message with "trace" level.
+func Trace(a ...interface{}) {
+	if !IsTraceMode() {
+		return
+	}
+	logMessage("TRACE", a...)
+}
+
+// Tracef method logs message with "trace" level and formats it.
+func Tracef(format string, a ...interface{}) {
+	if !IsTraceMode() {
+		return
+	}
+	logMessagef("TRACE", format, a...)
+}
+
+// IsTraceMode method checks if the trace mode is enabled.
+func IsTraceMode() bool {
+	return isTraceMode
 }
 
 // Info method logs message with "info" level.

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -2395,7 +2395,7 @@ func listExceptionFields(docs []common.MapStr, fieldsValidator *fields.Validator
 		}
 	}
 
-	logger.Debugf("Fields to be skipped validation: %s", strings.Join(allFields, ","))
+	logger.Tracef("Fields to be skipped validation: %s", strings.Join(allFields, ","))
 	return allFields
 }
 

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -2395,6 +2395,7 @@ func listExceptionFields(docs []common.MapStr, fieldsValidator *fields.Validator
 		}
 	}
 
+	logger.Debugf("Fields to be skipped validation: %s", strings.Join(allFields, ","))
 	return allFields
 }
 


### PR DESCRIPTION
This PR adds the same exception for leaf of objects that was set in place for validation based on fields found in documents:
https://github.com/elastic/elastic-package/blob/b64f3748e2b513f3ee8baa4474f21b209a937162/internal/fields/exceptionfields.go#L39


These validations are based on the spec version defined in the package.

Found issue in these builds for `gcp` and `network_traffic` where those missing definitions should be ignored since those packages define spec version 3.0.0

https://buildkite.com/elastic/integrations/builds/23010

Buildkite build testing this change with all packages: https://buildkite.com/elastic/integrations/builds/23032

Buildkite build testing with stack 9.1.0-SNAPSHOT with this change:
https://buildkite.com/elastic/integrations/builds/23034


## How to test locally this PR

```shell

cd path/to/integrations

elastic-package stack up -v -d --version 9.1.0-SNAPSHOT

cd packages/gcp 
elastic-package test system -v --data-streams firewall

cd ../packages/network_traffic
elastic-package test system -v --data-streams dns

elastic-package stack down -v
```