### PR TITLE
Skip .DS_Store folder and swp files (ViM) in the build command

### DIFF
--- a/internal/files/copy.go
+++ b/internal/files/copy.go
@@ -20,7 +20,7 @@ func CopyAll(sourcePath, destinationPath string) error {
 
 // CopyWithoutDev method copies files from the source to the destination, but skips _dev directories and empty folders.
 func CopyWithoutDev(sourcePath, destinationPath string) error {
-	return CopyWithSkipped(sourcePath, destinationPath, []string{"_dev", "build", ".git"}, []string{"\\.DS_Store", "\\..*\\.swp"})
+	return CopyWithSkipped(sourcePath, destinationPath, []string{"_dev", "build", ".git"}, []string{"^\\.DS_Store$", "^\\..*\\.swp$"})
 }
 
 // CopyWithSkipped method copies files from the source to the destination, but skips selected directories, empty folders and selected hidden files.

--- a/internal/files/copy.go
+++ b/internal/files/copy.go
@@ -55,11 +55,9 @@ func CopyWithSkipped(sourcePath, destinationPath string, skippedDirs, skippedFil
 			return nil // don't create empty directories inside packages, if the directory is empty, skip it.
 		}
 
-		if len(regexesFiles) > 0 {
-			for _, r := range regexesFiles {
-				if r.MatchString(filepath.Base(relativePath)) {
-					return nil
-				}
+		for _, r := range regexesFiles {
+			if r.MatchString(filepath.Base(relativePath)) {
+				return nil
 			}
 		}
 

--- a/internal/files/copy.go
+++ b/internal/files/copy.go
@@ -18,7 +18,7 @@ func CopyAll(sourcePath, destinationPath string) error {
 
 // CopyWithoutDev method copies files from the source to the destination, but skips _dev directories and empty folders.
 func CopyWithoutDev(sourcePath, destinationPath string) error {
-	return CopyWithSkipped(sourcePath, destinationPath, []string{"_dev", "build", ".git"})
+	return CopyWithSkipped(sourcePath, destinationPath, []string{"_dev", "build", ".git", ".DS_Store"})
 }
 
 // CopyWithSkipped method copies files from the source to the destination, but skips selected directories and empty folders.

--- a/internal/stack/boot.go
+++ b/internal/stack/boot.go
@@ -170,7 +170,7 @@ func copyUniquePackages(sourcePath, destinationPath string) error {
 		}
 		skippedDirs = append(skippedDirs, filepath.Join(name, version))
 	}
-	return files.CopyWithSkipped(sourcePath, destinationPath, skippedDirs)
+	return files.CopyWithSkipped(sourcePath, destinationPath, skippedDirs, []string{})
 }
 
 // stringsCut has been imported from Go source code.


### PR DESCRIPTION
Closes #2463

Add exceptions to skip some hidden files when running `elastic-package build`.
This PR skips the copy to the build directory (and zip file) the following files (using glob patterns):
- `.DS_Store` files created in macOS
- `.*.swp` files created by ViM


## How to test this PR locally

```shell
cd /path/to/repo/elastic-package

# Ensure that previous build files and folders are deleted
rm -rf build/packages/apache/
rm -rf build/packages/apache-999.999.999.zip

# Update some test package including the undesired hidden files
cd test/packages/parallel/apache

touch data_stream/access/.DS_Store
touch data_stream/access/.file.swp

# it should finish successfully the build process
elastic-package build -v

# those files or folders must be kept in the current package directory
ls -la data_stream/access

# the contents in the build directory must not have those files/folders
ls -la ../../../../build/packages/apache/999.999.999/data_stream/access
```