### PR TITLE
Workaround issue with SVE/seccomp in OSX

### DIFF
--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -19,6 +19,13 @@ services:
     environment:
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g {{ if not (semverLessThan $version "8.15.0-SNAPSHOT") -}}-Des.failure_store_feature_flag_enabled=true{{- end -}}"
       - "ELASTIC_PASSWORD={{ $password }}"
+{{- $host_os := fact "host_os" -}}
+{{- $host_arch := fact "host_arch" -}}
+{{- if (and (eq $host_os "darwin") (eq $host_arch "arm64")) -}}
+      # Workaround, see https://github.com/elastic/elasticsearch/issues/118583#issuecomment-2644523205
+      - "discovery.type=single-node"
+      - "_JAVA_OPTS=-XX:UseSVE=0"
+{{- end }}
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml"
       - "../certs/elasticsearch:/usr/share/elasticsearch/config/certs"

--- a/internal/stack/resources.go
+++ b/internal/stack/resources.go
@@ -11,6 +11,7 @@ import (
 	"html/template"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -168,6 +169,9 @@ func applyResources(profile *profile.Profile, stackVersion string) error {
 		"logsdb_enabled":       profile.Config(configLogsDBEnabled, "false"),
 		"logstash_enabled":     profile.Config(configLogstashEnabled, "false"),
 		"self_monitor_enabled": profile.Config(configSelfMonitorEnabled, "false"),
+
+		"host_os":   runtime.GOOS,
+		"host_arch": runtime.GOARCH,
 	})
 
 	if err := os.MkdirAll(stackDir, 0755); err != nil {


### PR DESCRIPTION
Fixes https://github.com/elastic/elastic-package/issues/2446, according to https://github.com/elastic/elasticsearch/issues/118583#issuecomment-2644523205.