### PR TITLE
Check stack subscription to use or not upload API to install packages - WIP

### DIFF
--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -166,6 +166,15 @@ func testRunnerAssetCommandAction(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("can't create Kibana client: %w", err)
 	}
 
+	esClient, err := stack.NewElasticsearchClientFromProfile(profile)
+	if err != nil {
+		return fmt.Errorf("can't create Elasticsearch client: %w", err)
+	}
+	err = esClient.CheckHealth(ctx)
+	if err != nil {
+		return err
+	}
+
 	globalTestConfig, err := testrunner.ReadGlobalTestConfig(packageRootPath)
 	if err != nil {
 		return fmt.Errorf("failed to read global config: %w", err)
@@ -174,6 +183,7 @@ func testRunnerAssetCommandAction(cmd *cobra.Command, args []string) error {
 	runner := asset.NewAssetTestRunner(asset.AssetTestRunnerOptions{
 		PackageRootPath:  packageRootPath,
 		KibanaClient:     kibanaClient,
+		ESClient:         esClient,
 		GlobalTestConfig: globalTestConfig.Asset,
 		WithCoverage:     testCoverage,
 		CoverageType:     testCoverageFormat,
@@ -564,7 +574,7 @@ func testRunnerSystemCommandAction(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to read global config: %w", err)
 	}
 
-	runner := system.NewSystemTestRunner(system.SystemTestRunnerOptions{
+	runner, err := system.NewSystemTestRunner(system.SystemTestRunnerOptions{
 		Profile:            profile,
 		PackageRootPath:    packageRootPath,
 		KibanaClient:       kibanaClient,
@@ -584,6 +594,9 @@ func testRunnerSystemCommandAction(cmd *cobra.Command, args []string) error {
 		CoverageType:       testCoverageFormat,
 		CheckFailureStore:  checkFailureStore,
 	})
+	if err != nil {
+		return fmt.Errorf("failed to create system test runner: %w", err)
+	}
 
 	logger.Debugf("Running suite...")
 	results, err := testrunner.RunSuite(ctx, runner)
@@ -677,6 +690,15 @@ func testRunnerPolicyCommandAction(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("can't create Kibana client: %w", err)
 	}
 
+	esClient, err := stack.NewElasticsearchClientFromProfile(profile)
+	if err != nil {
+		return fmt.Errorf("can't create Elasticsearch client: %w", err)
+	}
+	err = esClient.CheckHealth(ctx)
+	if err != nil {
+		return err
+	}
+
 	manifest, err := packages.ReadPackageManifestFromPackageRoot(packageRootPath)
 	if err != nil {
 		return fmt.Errorf("reading package manifest failed (path: %s): %w", packageRootPath, err)
@@ -687,9 +709,10 @@ func testRunnerPolicyCommandAction(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to read global config: %w", err)
 	}
 
-	runner := policy.NewPolicyTestRunner(policy.PolicyTestRunnerOptions{
+	runner, err := policy.NewPolicyTestRunner(policy.PolicyTestRunnerOptions{
 		PackageRootPath:    packageRootPath,
 		KibanaClient:       kibanaClient,
+		ESClient:           esClient,
 		DataStreams:        dataStreams,
 		FailOnMissingTests: failOnMissing,
 		GenerateTestResult: generateTestResult,
@@ -697,6 +720,9 @@ func testRunnerPolicyCommandAction(cmd *cobra.Command, args []string) error {
 		WithCoverage:       testCoverage,
 		CoverageType:       testCoverageFormat,
 	})
+	if err != nil {
+		return fmt.Errorf("failed to create policy test runner: %w", err)
+	}
 
 	results, err := testrunner.RunSuite(ctx, runner)
 	if err != nil {

--- a/internal/benchrunner/runners/common/elasticsearch.go
+++ b/internal/benchrunner/runners/common/elasticsearch.go
@@ -59,3 +59,30 @@ func CountDocsInDataStream(ctx context.Context, esapi *elasticsearch.API, dataSt
 
 	return numHits, nil
 }
+
+func StackSubscription(ctx context.Context, esapi *elasticsearch.API) (string, error) {
+	resp, err := esapi.License.Get(esapi.License.Get.WithContext(ctx))
+	if err != nil {
+		return "", fmt.Errorf("error getting subscription: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get subscription: %s", resp.String())
+	}
+
+	type licenseResponse struct {
+		License struct {
+			Type string `json:"Type"`
+		} `json:"license"`
+	}
+
+	var data licenseResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	if err != nil {
+		return "", fmt.Errorf("error decoding subscription: %w", err)
+	}
+
+	return data.License.Type, nil
+
+}

--- a/internal/benchrunner/runners/rally/runner.go
+++ b/internal/benchrunner/runners/rally/runner.go
@@ -484,11 +484,16 @@ func (r *runner) installPackageFromRegistry(ctx context.Context, packageName, pa
 }
 
 func (r *runner) installPackageFromPackageRoot(ctx context.Context) error {
+	subscription, err := common.StackSubscription(ctx, r.options.ESAPI)
+	if err != nil {
+		return fmt.Errorf("failed to get stack subscription: %w", err)
+	}
 	logger.Debug("Installing package...")
 	installer, err := installer.NewForPackage(installer.Options{
-		Kibana:         r.options.KibanaClient,
-		RootPath:       r.options.PackageRootPath,
-		SkipValidation: true,
+		Kibana:            r.options.KibanaClient,
+		RootPath:          r.options.PackageRootPath,
+		SkipValidation:    true,
+		StackSubscription: subscription,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize package installer: %w", err)

--- a/internal/benchrunner/runners/stream/runner.go
+++ b/internal/benchrunner/runners/stream/runner.go
@@ -251,11 +251,16 @@ func (r *runner) installPackage(ctx context.Context) error {
 }
 
 func (r *runner) installPackageFromPackageRoot(ctx context.Context) error {
+	subscription, err := common.StackSubscription(ctx, r.options.ESAPI)
+	if err != nil {
+		return fmt.Errorf("failed to get stack subscription: %w", err)
+	}
 	logger.Debug("Installing package...")
 	installer, err := installer.NewForPackage(installer.Options{
-		Kibana:         r.options.KibanaClient,
-		RootPath:       r.options.PackageRootPath,
-		SkipValidation: true,
+		Kibana:            r.options.KibanaClient,
+		RootPath:          r.options.PackageRootPath,
+		SkipValidation:    true,
+		StackSubscription: subscription,
 	})
 
 	if err != nil {

--- a/internal/elasticsearch/client.go
+++ b/internal/elasticsearch/client.go
@@ -196,7 +196,7 @@ type Info struct {
 	Version     struct {
 		Number      string `json:"number"`
 		BuildFlavor string `json:"build_flavor"`
-	} `json:"version`
+	} `json:"version"`
 }
 
 // Info gets cluster information and metadata.
@@ -218,6 +218,33 @@ func (client *Client) Info(ctx context.Context) (*Info, error) {
 	}
 
 	return &info, nil
+}
+
+// Subscription gets cluster subscription.
+func (client *Client) Subscription(ctx context.Context) (string, error) {
+	resp, err := client.Client.License.Get(client.Client.License.Get.WithContext(ctx))
+	if err != nil {
+		return "", fmt.Errorf("error getting subscription: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get subscription: %s", resp.String())
+	}
+
+	type licenseResponse struct {
+		License struct {
+			Type string `json:"Type"`
+		} `json:"license"`
+	}
+
+	var data licenseResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	if err != nil {
+		return "", fmt.Errorf("error decoding subscription: %w", err)
+	}
+
+	return data.License.Type, nil
 }
 
 // IsFailureStoreAvailable checks if the failure store is available.

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -32,6 +32,8 @@ const (
 	dataStreamTypeMetrics    = "metrics"
 	dataStreamTypeSynthetics = "synthetics"
 	dataStreamTypeTraces     = "traces"
+
+	defaultSubscription = "basic"
 )
 
 // VarValue represents a variable value as defined in a package or data stream
@@ -151,6 +153,17 @@ type PackageManifest struct {
 	Categories      []string         `config:"categories" json:"categories" yaml:"categories"`
 	Agent           Agent            `config:"agent" json:"agent" yaml:"agent"`
 	Elasticsearch   *Elasticsearch   `config:"elasticsearch" json:"elasticsearch" yaml:"elasticsearch"`
+}
+
+func (p PackageManifest) Subscription() string {
+	if p.Conditions.Elastic.Subscription != "" {
+		return p.Conditions.Elastic.Subscription
+	}
+	if p.License != "" {
+		return p.License
+	}
+
+	return defaultSubscription
 }
 
 type ManifestIndexTemplate struct {

--- a/internal/resources/fleetpackage.go
+++ b/internal/resources/fleetpackage.go
@@ -24,6 +24,9 @@ type FleetPackage struct {
 	// RootPath is the root of the package source to install.
 	RootPath string
 
+	// StackSubscription is the subscription used in the Elastic stack.
+	StackSubscription string
+
 	// Absent is set to true to indicate that the package should not be installed.
 	Absent bool
 
@@ -56,9 +59,10 @@ func (f *FleetPackage) installer(ctx resource.Context) (installer.Installer, err
 	}
 
 	return installer.NewForPackage(installer.Options{
-		Kibana:         provider.Client,
-		RootPath:       f.RootPath,
-		SkipValidation: true,
+		Kibana:            provider.Client,
+		RootPath:          f.RootPath,
+		SkipValidation:    true,
+		StackSubscription: f.StackSubscription,
 	})
 }
 

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -31,6 +31,8 @@ type runner struct {
 	esAPI           *elasticsearch.API
 	esClient        *elasticsearch.Client
 
+	stackSubscription string
+
 	dataStreams    []string
 	serviceVariant string
 
@@ -81,7 +83,7 @@ type SystemTestRunnerOptions struct {
 	CoverageType       string
 }
 
-func NewSystemTestRunner(options SystemTestRunnerOptions) *runner {
+func NewSystemTestRunner(options SystemTestRunnerOptions) (*runner, error) {
 	r := runner{
 		packageRootPath:    options.PackageRootPath,
 		kibanaClient:       options.KibanaClient,
@@ -107,7 +109,13 @@ func NewSystemTestRunner(options SystemTestRunnerOptions) *runner {
 	r.resourcesManager.RegisterProvider(resources.DefaultKibanaProviderName, &resources.KibanaProvider{Client: r.kibanaClient})
 
 	r.serviceStateFilePath = filepath.Join(stateFolderPath(r.profile.ProfilePath), serviceStateFileName)
-	return &r
+
+	stackSubscription, err := options.ESClient.Subscription(context.TODO())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get stack subscription: %w", err)
+	}
+	r.stackSubscription = stackSubscription
+	return &r, nil
 }
 
 // SetupRunner prepares global resources required by the test runner.
@@ -124,6 +132,7 @@ func (r *runner) SetupRunner(ctx context.Context) error {
 		// Install it unless we are running the tear down only.
 		installedPackage: !r.runTearDown,
 	}
+
 	_, err := r.resourcesManager.ApplyCtx(ctx, r.resources(resourcesOptions))
 	if err != nil {
 		return fmt.Errorf("can't install the package: %w", err)
@@ -316,9 +325,10 @@ func (r *runner) Type() testrunner.TestType {
 func (r *runner) resources(opts resourcesOptions) resources.Resources {
 	return resources.Resources{
 		&resources.FleetPackage{
-			RootPath: r.packageRootPath,
-			Absent:   !opts.installedPackage,
-			Force:    opts.installedPackage, // Force re-installation, in case there are code changes in the same package version.
+			RootPath:          r.packageRootPath,
+			StackSubscription: r.stackSubscription,
+			Absent:            !opts.installedPackage,
+			Force:             opts.installedPackage, // Force re-installation, in case there are code changes in the same package version.
 		},
 	}
 }


### PR DESCRIPTION
This PR checks whether or not the license of the Elastic stack is the required one to upload packages via API.
Until Elastic stack 8.8.2 the license required was `Enterprise`. In Elastic stack 8.8.2, the license required was `basic`.