### PR TITLE
Update package name used in test folders - Asset runner

### DIFF
--- a/internal/testrunner/runners/asset/runner.go
+++ b/internal/testrunner/runners/asset/runner.go
@@ -6,6 +6,7 @@ package asset
 
 import (
 	"context"
+	"path/filepath"
 
 	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/testrunner"
@@ -60,11 +61,12 @@ func (r *runner) TearDownRunner(ctx context.Context) error {
 }
 
 func (r *runner) GetTests(ctx context.Context) ([]testrunner.Tester, error) {
+	_, pkg := filepath.Split(r.packageRootPath)
 	testers := []testrunner.Tester{
 		NewAssetTester(AssetTesterOptions{
 			PackageRootPath:  r.packageRootPath,
 			KibanaClient:     r.kibanaClient,
-			TestFolder:       testrunner.TestFolder{Package: r.packageRootPath},
+			TestFolder:       testrunner.TestFolder{Package: pkg},
 			GlobalTestConfig: r.globalTestConfig,
 			WithCoverage:     r.withCoverage,
 			CoverageType:     r.coverageType,

--- a/internal/testrunner/runners/asset/tester.go
+++ b/internal/testrunner/runners/asset/tester.go
@@ -146,7 +146,7 @@ func (r *tester) run(ctx context.Context) ([]testrunner.TestResult, error) {
 	for _, e := range expectedAssets {
 		rc := testrunner.NewResultComposer(testrunner.TestResult{
 			Name:       fmt.Sprintf("%s %s is loaded", e.Type, e.ID),
-			Package:    installedPackage.Name,
+			Package:    r.testFolder.Package,
 			DataStream: e.DataStream,
 			TestType:   TestType,
 		})


### PR DESCRIPTION
This PR updates the package strings set for the TestFolders in the Asset Runner/Tester to be the same as in the other tests (policy, system, static and pipeline).

This mainly affects those packages whose folder name is different of the `name` specified in their `manfiest.yml`.
 

This package name is used in the xUnit reports and it can be seen the difference in those values for the asset tests `classname` attribute:

- Before
    - Asset
    ```xml
    <testsuites>
      <testsuite name="asset" tests="29">
      <!-- test suite for asset tests -->
        <testcase name="asset test: dashboard apache-Logs-Apache-Dashboard is loaded" classname="apache." time="1.979e-06"/>
        <testcase name="asset test: dashboard apache-Metrics-Apache-HTTPD-server-status is loaded" classname="apache." time="5.8e-07"/>
        ...
      </testsuite>
    </testsuites>
    ```
    - Static
    ```xml
    <testsuites>
      <testsuite name="static" tests="3">
      <!-- test suite for static tests -->
        <testcase name="static test: Verify sample_event.json" classname="apache_basic_license.access" time="0.115197493"/>
        <testcase name="static test: Verify sample_event.json" classname="apache_basic_license.error" time="0.100131448"/>
        <testcase name="static test: Verify sample_event.json" classname="apache_basic_license.status" time="0.079474684"/>
      </testsuite>
    </testsuites>
    ```
- After
    - Asset
      ```xml
      <testsuites>
        <testsuite name="pipeline" tests="18">
          <!--test suite for pipeline tests-->
          <testcase name="pipeline test: (ingest pipeline warnings test-access-basic.log)" classname="apache_basic_license.access" time="0.298683383"></testcase>
          <testcase name="pipeline test: (ingest pipeline warnings test-access-darwin.log)" classname="apache_basic_license.access" time="0.329030781"></testcase>
          ...
        </testsuite>
      </testsuites>
      ```
    - Static
      ```xml
      <testsuites>
        <testsuite name="static" tests="3">
          <!--test suite for static tests-->
          <testcase name="static test: Verify sample_event.json" classname="apache_basic_license.access" time="0.081731747"></testcase>
          <testcase name="static test: Verify sample_event.json" classname="apache_basic_license.error" time="0.059626114"></testcase>
          <testcase name="static test: Verify sample_event.json" classname="apache_basic_license.status" time="0.052784676"></testcase>
        </testsuite>
      </testsuites>
      ```