### PR TITLE
Add retry for fork/exec pty errors

### DIFF
--- a/internal/compose/compose_other.go
+++ b/internal/compose/compose_other.go
@@ -47,6 +47,7 @@ func (p *Project) runDockerComposeCmd(ctx context.Context, opts dockerComposeOpt
 
 	// FIXME: Added retries to avoid errors like
 	// failed to start command with pseudo-tty: fork/exec /usr/bin/docker: operation not permitted
+	// Related to: https://github.com/creack/pty/issues/196
 	var ptty *os.File
 	var err error
 	retried := false

--- a/internal/compose/compose_other.go
+++ b/internal/compose/compose_other.go
@@ -73,7 +73,7 @@ func (p *Project) runDockerComposeCmd(ctx context.Context, opts dockerComposeOpt
 	logger.Debugf("running command: %s", cmd)
 
 	if retried {
-		return fmt.Errorf("Failed command but successfully retried: %s", cmd)
+		return fmt.Errorf("failed command but successfully retried: %s", cmd)
 	}
 
 	io.Copy(stderr, ptty)

--- a/internal/compose/compose_other.go
+++ b/internal/compose/compose_other.go
@@ -58,6 +58,7 @@ func (p *Project) runDockerComposeCmd(ctx context.Context, opts dockerComposeOpt
 		if errors.As(err, &pathErr) && pathErr.Op == "fork/exec" && pathErr.Path == "/usr/bin/docker" {
 			logger.Debugf("Repeating docker command (failure fork/exec)")
 			time.Sleep(1 * time.Second)
+			continue
 		}
 
 		// Other error

--- a/internal/compose/compose_other.go
+++ b/internal/compose/compose_other.go
@@ -57,12 +57,13 @@ func (p *Project) runDockerComposeCmd(ctx context.Context, opts dockerComposeOpt
 		}
 		var pathErr *fs.PathError
 		if errors.As(err, &pathErr) && pathErr.Op == "fork/exec" && pathErr.Path == "/usr/bin/docker" {
-			logger.Debugf("Repeating docker command (failure fork/exec): %s", cmd)
+			logger.Debugf("Repeating docker command (failure fork/exec): %s (Error: %s)", cmd, err.Error())
 			time.Sleep(1 * time.Second)
 			retried = true
 			continue
 		}
 
+		logger.Debugf("Other error: %s", err)
 		// Other error
 		break
 	}


### PR DESCRIPTION
This PR tries a workaround for the errors shown from time to time in the integrations build:

```
Error: error running package system tests: could not complete test run: dump failed: can't dump Elastic stack logs: can't fetch service logs (service: kibana): could not create docker compose project: unable to determine Docker Compose version: running Docker Compose version command failed: failed to start command with pseudo-tty: fork/exec /usr/bin/docker: operation not permitted
```