### PR TITLE
bk: use OIDC to tear-down the cloud resources

### DIFF
--- a/.buildkite/configs/cleanup.aws.yml
+++ b/.buildkite/configs/cleanup.aws.yml
@@ -5,8 +5,8 @@ accounts:
   - name: "${ACCOUNT_PROJECT}"
     driver: "aws"
     options:
-      key: '${ACCOUNT_KEY}'
-      secret: '${ACCOUNT_SECRET}'
+      key: '${AWS_ACCESS_KEY_ID}'
+      secret: '${AWS_SECRET_ACCESS_KEY}'
 
 scanners:
   - account_name: "${ACCOUNT_PROJECT}"

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -10,7 +10,6 @@ export SERVERLESS=${SERVERLESS:-"false"}
 WORKSPACE=$(pwd)
 export WORKSPACE
 
-AWS_SERVICE_ACCOUNT_SECRET_PATH=kv/ci-shared/platform-ingest/aws_ingest_ci
 PRIVATE_CI_GCS_CREDENTIALS_PATH=kv/ci-shared/platform-ingest/gcp-platform-ingest-ci-service-account
 
 EC_TOKEN_PATH=kv/ci-shared/platform-ingest/platform-ingest-ec-qa
@@ -91,7 +90,10 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-package-test-with-integrations" && 
     export GITHUB_TOKEN=$VAULT_GITHUB_TOKEN
 fi
 
-if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-package-cloud-cleanup" && "$BUILDKITE_STEP_KEY" == "cloud-cleanup" ]]; then
+# NOTE: this approach is deprecated and will be removed in the near future.
+#       see https://github.com/elastic/observability-robots/issues/2771 (only accessible by Elastic employees)
+if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-package-cloud-cleanup" && "$BUILDKITE_STEP_KEY" == "cloud-cleanup-deprecated" ]]; then
+    AWS_SERVICE_ACCOUNT_SECRET_PATH=kv/ci-shared/platform-ingest/aws_ingest_ci
     ELASTIC_PACKAGE_AWS_SECRET_KEY=$(retry 5 vault kv get -field secret_key ${AWS_SERVICE_ACCOUNT_SECRET_PATH})
     export ELASTIC_PACKAGE_AWS_SECRET_KEY
     ELASTIC_PACKAGE_AWS_ACCESS_KEY=$(retry 5 vault kv get -field access_key ${AWS_SERVICE_ACCOUNT_SECRET_PATH})

--- a/.buildkite/pipeline.cloud-cleanup.yml
+++ b/.buildkite/pipeline.cloud-cleanup.yml
@@ -25,7 +25,19 @@ steps:
     if: "build.source == 'ui'"
     allow_dependency_failure: false
 
-  - label: "Cloud Cleanup"
+  - label: "Cloud Cleanup OIDC"
+    key: "cloud-cleanup-oidc"
+    command: ".buildkite/scripts/cloud-cleanup-oidc.sh"
+    env:
+      RESOURCE_RETENTION_PERIOD: "24 hours"
+      DRY_RUN: "${DRY_RUN:-true}"
+    agents:
+      provider: "gcp" # this step requires docker
+    plugins:
+      - elastic/oblt-aws-auth#v0.1.0:
+          duration: 3600 # seconds
+
+  - label: "Cloud Cleanup (deprecated)"
     key: "cloud-cleanup"
     command: ".buildkite/scripts/cloud-cleanup.sh"
     env:

--- a/.buildkite/scripts/cloud-cleanup-oidc.sh
+++ b/.buildkite/scripts/cloud-cleanup-oidc.sh
@@ -55,9 +55,10 @@ any_resources_to_delete() {
 cloud_reaper_aws() {
     echo "Validating configuration"
     docker run --rm -v "$(pwd)/.buildkite/configs/cleanup.aws.yml":/etc/cloud-reaper/config.yml \
-      -e AWS_SECRET_ACCESS_KEY="${ELASTIC_PACKAGE_AWS_SECRET_KEY}" \
-      -e AWS_ACCESS_KEY_ID="${ELASTIC_PACKAGE_AWS_ACCESS_KEY}" \
-      -e ACCOUNT_PROJECT="${ELASTIC_PACKAGE_AWS_USER_SECRET}" \
+      -e AWS_ACCESS_KEY_ID \
+      -e AWS_SECRET_ACCESS_KEY \
+      -e AWS_SESSION_TOKEN \
+      -e ACCOUNT_PROJECT="observability-ci" \
       -e CREATION_DATE="${DELETE_RESOURCES_BEFORE_DATE}" \
       "${CLOUD_REAPER_IMAGE}" \
         cloud-reaper \
@@ -66,9 +67,10 @@ cloud_reaper_aws() {
 
     echo "Scanning resources"
     docker run --rm -v "$(pwd)/.buildkite/configs/cleanup.aws.yml":/etc/cloud-reaper/config.yml \
-      -e AWS_SECRET_ACCESS_KEY="${ELASTIC_PACKAGE_AWS_SECRET_KEY}" \
-      -e AWS_ACCESS_KEY_ID="${ELASTIC_PACKAGE_AWS_ACCESS_KEY}" \
-      -e ACCOUNT_PROJECT="${ELASTIC_PACKAGE_AWS_USER_SECRET}" \
+      -e AWS_ACCESS_KEY_ID \
+      -e AWS_SECRET_ACCESS_KEY \
+      -e AWS_SESSION_TOKEN \
+      -e ACCOUNT_PROJECT="observability-ci" \
       -e CREATION_DATE="${DELETE_RESOURCES_BEFORE_DATE}" \
       "${CLOUD_REAPER_IMAGE}" \
         cloud-reaper \
@@ -99,8 +101,6 @@ echo "--- Cleaning up other AWS resources older than ${DELETE_RESOURCES_BEFORE_D
 echo "--- Installing awscli"
 with_aws_cli
 
-export AWS_ACCESS_KEY_ID="${ELASTIC_PACKAGE_AWS_ACCESS_KEY}"
-export AWS_SECRET_ACCESS_KEY="${ELASTIC_PACKAGE_AWS_SECRET_KEY}"
 export AWS_DEFAULT_REGION=us-east-1
 # Avoid to send the output of the CLI to a pager
 export AWS_PAGER=""


### PR DESCRIPTION
### What

Use OIDC to access the AWS cloud resources and run the tear-down.

This will run in parallel while we migrate.

### Why

Avoid using service accounts and use the Keyless/OIDC approach

### Further details

Uses https://github.com/elastic/oblt-aws-auth-buildkite-plugin