### PR TITLE
catalog-info: grant build access to the obs-ci team

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -60,6 +60,8 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ
+        observablt-ci:
+          access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
 
@@ -152,6 +154,8 @@ spec:
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ
+        observablt-ci:
+          access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
 
@@ -202,6 +206,8 @@ spec:
             SERVERLESS_PROJECT: observability
       teams:
         ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        observablt-ci:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ


### PR DESCRIPTION
So I can run the CI, such as: https://github.com/elastic/elastic-package/pull/2567