### PR TITLE
Increase TestRunID suffix to 6 digits

### DIFF
--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	testRunMaxID = 99999
-	testRunMinID = 10000
+	testRunMaxID = 999999
+	testRunMinID = 100000
 )
 
 // TrimStringSlice removes whitespace from the beginning and end of the contents of a []string.

--- a/scripts/test-system-test-flags.sh
+++ b/scripts/test-system-test-flags.sh
@@ -266,9 +266,9 @@ run_tests_for_package() {
 
 
 # Set variables depending on whether or not independent Elastic Agents are running
-DEFAULT_AGENT_CONTAINER_NAME="elastic-package-service-[0-9]{5}-docker-custom-agent"
+DEFAULT_AGENT_CONTAINER_NAME="elastic-package-service-[0-9]{6}-docker-custom-agent"
 service_deployer_type="docker"
-service_prefix='elastic-package-service-[0-9]{5}'
+service_prefix='elastic-package-service-[0-9]{6}'
 if [[ "${ELASTIC_PACKAGE_TEST_ENABLE_INDEPENDENT_AGENT:-"false"}" == "true" ]]; then
     service_deployer_type="agent"
 fi


### PR DESCRIPTION
While debugging integrations flaky tests, in [comment](https://github.com/elastic/integrations/issues/13432#issuecomment-2841453546) it is observed that the system tests are failing because there is existing S3 bucket deployed by Terraform that is clashing with current test run.

Increasing TestRunID suffix to 6 digits to avoid clash with existing test resources.

Closes: https://github.com/elastic/integrations/issues/13432

