### PR TITLE
github-action: add catalog-validate for GitHub actions

### DIFF
--- a/.github/workflows/catalog-info.yml
+++ b/.github/workflows/catalog-info.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'catalog-info.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/catalog-info.yml
+++ b/.github/workflows/catalog-info.yml
@@ -1,0 +1,21 @@
+---
+name: catalog-info
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'catalog-info.yaml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: elastic/oblt-actions/elastic/validate-catalog@v1
+


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

We want to enable the Catalog Info validation using GitHub actions.

## Why

We want to make sure that the catalog-info file is valid and does not break the Catalog Ecosystem.

If there are any questions, please reach out to the @elastic/observablt-ci

## Further details

Requires https://github.com/elastic/oblt-actions/pull/272

## Tasks
- [ ] Grant read access in [the private container](https://github.com/orgs/elastic/packages/container/observability-robots%2Fci-agent-images%2Fpipelib/settings).

