### PR TITLE
Remove 'managed' key from exported dashboards

### DIFF
--- a/internal/export/testdata/system-navigation.json
+++ b/internal/export/testdata/system-navigation.json
@@ -11,5 +11,6 @@
   },
   "id": "system-Navigation-ecs",
   "references": [],
+  "managed": false,
   "type": "visualization"
 }

--- a/internal/export/transform_strip.go
+++ b/internal/export/transform_strip.go
@@ -25,5 +25,11 @@ func stripObjectProperties(ctx *transformationContext, object common.MapStr) (co
 	if err != nil && err != common.ErrKeyNotFound {
 		return nil, fmt.Errorf("removing field \"version\" failed: %w", err)
 	}
+
+	err = object.Delete("managed")
+	if err != nil && err != common.ErrKeyNotFound {
+		return nil, fmt.Errorf("removing field \"managed\" failed: %w", err)
+	}
+
 	return object, nil
 }


### PR DESCRIPTION
Resolves: https://github.com/elastic/elastic-package/issues/2258

Removes the "managed" key from dashboards when exported.