### PR TITLE
Update configuration updatecli for 8.x snapshot

### DIFF
--- a/.github/workflows/updatecli/updatecli.d/bump-latest-8x-snapshot-version.yml
+++ b/.github/workflows/updatecli/updatecli.d/bump-latest-8x-snapshot-version.yml
@@ -29,7 +29,7 @@ sources:
     name: Get latest snapshot build
     kind: json
     spec:
-      file: https://storage.googleapis.com/artifacts-api/snapshots/8.x.json
+      file: https://storage.googleapis.com/artifacts-api/snapshots/8.19.json
       key: .build_id
 
 targets:


### PR DESCRIPTION
This PR updates the URL used to check about 8.x snapshots.
The previous URL was not updated since a few weeks ago.

From the action workflow executed in this PR:
```diff
 test-stack-command-8x:
-	./scripts/test-stack-command.sh 8.19.0-e182bbbc-SNAPSHOT
+	./scripts/test-stack-command.sh 8.19.0-8ddb780e-SNAPSHOT
```