### PR TITLE
buildkite(oidc): access google secrets for the ECH

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -10,7 +10,6 @@ export SERVERLESS=${SERVERLESS:-"false"}
 WORKSPACE=$(pwd)
 export WORKSPACE
 
-EC_TOKEN_PATH=kv/ci-shared/platform-ingest/platform-ingest-ec-qa
 EC_DATA_PATH=secret/ci/elastic-elastic-package/ec_data
 
 # variables required for Terraform
@@ -88,10 +87,6 @@ fi
 
 if [[ "${BUILDKITE_PIPELINE_SLUG}" == "elastic-package-test-serverless" ]]; then
     if [[ "${BUILDKITE_STEP_KEY}" == "test-serverless" ]]; then
-        EC_API_KEY_SECRET=$(retry 5 vault kv get -field apiKey "${EC_TOKEN_PATH}")
-        export EC_API_KEY_SECRET
-        EC_HOST_SECRET=$(retry 5 vault kv get -field url "${EC_TOKEN_PATH}")
-        export EC_HOST_SECRET
         EC_REGION_SECRET=$(retry 5 vault read -field region_qa "${EC_DATA_PATH}")
         export EC_REGION_SECRET
 

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -9,7 +9,7 @@ if [[ "${BUILDKITE_PIPELINE_SLUG}" == "elastic-package-test-serverless" && "${BU
     # BUILDKITE resets PATH contents in pre-exit hook, but elastic-package
     # is already installed in the test_serverless pipeline step, accessing
     # directly to the binary
-    EC_API_KEY="${EC_API_KEY_SECRET}" EC_HOST="${EC_HOST_SECRET}" "${HOME}"/go/bin/elastic-package stack down -v
+    "${HOME}"/go/bin/elastic-package stack down -v
 fi
 
 echo "--- Cleanup"

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -54,6 +54,10 @@ steps:
           lifetime: 10800 # seconds
           project-id: "elastic-observability-ci"
           project-number: "911195782929"
+      - avaly/gcp-secret-manager#v1.2.0:
+          env:
+            EC_API_KEY: elastic-cloud-observability-team-qa-api-key
+            EC_HOST: elastic-cloud-observability-team-qa-endpoint
     artifact_paths:
       - build/test-results/*.xml
       - build/test-coverage/coverage-*.xml

--- a/.buildkite/scripts/tooling.sh
+++ b/.buildkite/scripts/tooling.sh
@@ -74,9 +74,6 @@ prepare_serverless_stack() {
     fi
     create_elastic_package_profile "${profile_name}"
 
-    export EC_API_KEY=${EC_API_KEY_SECRET}
-    export EC_HOST=${EC_HOST_SECRET}
-
     echo "Boot up the Elastic stack"
     # Currently, if STACK_VERSION is not defined, for serverless it will be
     # used as Elastic stack version (for agents) the default version in elastic-package


### PR DESCRIPTION
Similarly done at https://github.com/elastic/integrations/pull/13926

### What

Use the google secrets to fetch the EC credentials we provide and they are ephemeral.

Use [avaly/gcp-secret-manager-buildkite-plugin](https://github.com/avaly/gcp-secret-manager-buildkite-plugin).

### Test

See this [build](https://buildkite.com/elastic/elastic-package-test-serverless/builds/412)

<img width="1129" alt="image" src="https://github.com/user-attachments/assets/17fb0d98-7291-42b0-844d-36e558a81141" />
