### PR TITLE
[CI] Review output in CI builds

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -11,10 +11,10 @@ if [[ "${BUILDKITE_PIPELINE_SLUG}" == "elastic-package-test-serverless" && "${BU
     # is already installed in the test_serverless pipeline step, accessing
     # directly to the binary
     if ! "${HOME}"/go/bin/elastic-package stack down -v ; then
+        # Ensure that even if this command fails, the script continues
         exit_code=1
     fi
 fi
-echo "Value of SERVERLESS: ${SERVERLESS:-"none"}"
 
 echo "--- Cleanup"
 cleanup

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -4,15 +4,20 @@ source .buildkite/scripts/tooling.sh
 
 set -euo pipefail
 
+exit_code=0
 if [[ "${BUILDKITE_PIPELINE_SLUG}" == "elastic-package-test-serverless" && "${BUILDKITE_STEP_KEY}" == "test-serverless" ]]; then
     echo "--- Take down the Elastic stack"
     # BUILDKITE resets PATH contents in pre-exit hook, but elastic-package
     # is already installed in the test_serverless pipeline step, accessing
     # directly to the binary
-    "${HOME}"/go/bin/elastic-package stack down -v
+    if "${HOME}"/go/bin/elastic-package stack down -v ; then
+        exit_code=1
+    fi
 fi
+echo "Value of SERVERLESS: ${SERVERLESS:-"none"}"
 
 echo "--- Cleanup"
 cleanup
 unset_secrets
 
+exit "$exit_code"

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -10,7 +10,7 @@ if [[ "${BUILDKITE_PIPELINE_SLUG}" == "elastic-package-test-serverless" && "${BU
     # BUILDKITE resets PATH contents in pre-exit hook, but elastic-package
     # is already installed in the test_serverless pipeline step, accessing
     # directly to the binary
-    if "${HOME}"/go/bin/elastic-package stack down -v ; then
+    if ! "${HOME}"/go/bin/elastic-package stack down -v ; then
         exit_code=1
     fi
 fi

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -45,6 +45,7 @@ steps:
       provider: "gcp"
       image: "${UBUNTU_X86_64_AGENT_IMAGE}"
     env:
+      SERVERLESS: "true"
       SERVERLESS_PROJECT: "${SERVERLESS_PROJECT:-observability}"
       UPLOAD_SAFE_LOGS: 1
       # See https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/integrations/01-gcp-buildkite-oidc.tf

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -21,7 +21,8 @@ TEST_BUILD_ZIP_TARGET="test-build-zip"
 TEST_BUILD_INSTALL_ZIP_TARGET="test-build-install-zip"
 
 REPO_NAME=$(repo_name "${BUILDKITE_REPO}")
-export REPO_BUILD_TAG="${REPO_NAME}/$(buildkite_pr_branch_build_id)"
+REPO_BUILD_TAG="${REPO_NAME}/$(buildkite_pr_branch_build_id)"
+export REPO_BUILD_TAG
 TARGET=""
 PACKAGE=""
 SERVERLESS="false"

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -101,15 +101,15 @@ add_bin_path
 if [[ "$SERVERLESS" == "false" ]]; then
     # If packages are tested with Serverless, these action are already performed
     # here: .buildkite/scripts/test_packages_with_serverless.sh
-    echo "--- install go"
+    echo "--- Install go"
     with_go
 
     if [[ "${TARGET}" != "${TEST_BUILD_ZIP_TARGET}" ]]; then
         # Not supported in Macos ARM
-        echo "--- install docker"
+        echo "--- Install docker"
         with_docker
 
-        echo "--- install docker-compose plugin"
+        echo "--- Install docker-compose plugin"
         with_docker_compose_plugin
     fi
 fi
@@ -118,7 +118,7 @@ echo "--- install yq"
 with_yq
 
 if [[ "${TARGET}" == "${KIND_TARGET}" || "${TARGET}" == "${SYSTEM_TEST_FLAGS_TARGET}" ]]; then
-    echo "--- install kubectl & kind"
+    echo "--- Install kubectl & kind"
     with_kubernetes
 fi
 

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -100,6 +100,15 @@ if [[ "${TARGET}" == "" ]]; then
     exit 1
 fi
 
+if [[ "${SERVERLESS}" == "true" && "${TARGET}" != "${PARALLEL_TARGET}" ]]; then
+    # Just tested parallel target to run with Serverless projects, other Makefile targets
+    # have not been tested yet and could fail unexpectedly. For instance, "test-check-package-false-positives"
+    # target would require a different management to not stop Elastic stack after each package test.
+    echo "Target ${TARGET} is not supported for Serverless testing"
+    usage
+    exit 1
+fi
+
 add_bin_path
 
 if [[ "$SERVERLESS" == "false" ]]; then

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -114,7 +114,7 @@ if [[ "$SERVERLESS" == "false" ]]; then
     fi
 fi
 
-echo "--- install yq"
+echo "--- Install yq"
 with_yq
 
 if [[ "${TARGET}" == "${KIND_TARGET}" || "${TARGET}" == "${SYSTEM_TEST_FLAGS_TARGET}" ]]; then

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -73,6 +73,8 @@ upload_package_test_logs() {
         package_folder="${package_folder}_retry_${retry_count}"
     fi
 
+    echo "--- Uploading safe logs to GCP bucket ${JOB_GCS_BUCKET_INTERNAL}"
+
     upload_safe_logs \
         "${JOB_GCS_BUCKET_INTERNAL}" \
         "build/elastic-stack-dump/check-${PACKAGE}/logs/elastic-agent-internal/*.*" \

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -113,6 +113,7 @@ if [[ "$SERVERLESS" == "false" ]]; then
         with_docker_compose_plugin
     fi
 
+    # yq is not required for serverless pipeline
     echo "--- Install yq"
     with_yq
 fi

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -112,10 +112,10 @@ if [[ "$SERVERLESS" == "false" ]]; then
         echo "--- Install docker-compose plugin"
         with_docker_compose_plugin
     fi
-fi
 
-echo "--- Install yq"
-with_yq
+    echo "--- Install yq"
+    with_yq
+fi
 
 if [[ "${TARGET}" == "${KIND_TARGET}" || "${TARGET}" == "${SYSTEM_TEST_FLAGS_TARGET}" ]]; then
     echo "--- Install kubectl & kind"

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -52,6 +52,44 @@ while getopts ":t:p:sh" o; do
     esac
 done
 
+
+upload_package_test_logs() {
+    local retry_count=0
+    local package_folder=""
+
+    retry_count=${BUILDKITE_RETRY_COUNT:-"0"}
+    package_folder="${PACKAGE}"
+
+    if [[ "${ELASTIC_PACKAGE_TEST_ENABLE_INDEPENDENT_AGENT:-""}" == "false" ]]; then
+        package_folder="${package_folder}-stack_agent"
+    fi
+
+    if [[ "${ELASTIC_PACKAGE_FIELD_VALIDATION_TEST_METHOD:-""}" != "" ]]; then
+        package_folder="${package_folder}-${ELASTIC_PACKAGE_FIELD_VALIDATION_TEST_METHOD}"
+    fi
+
+    if [[ "${retry_count}" -ne 0 ]]; then
+        package_folder="${package_folder}_retry_${retry_count}"
+    fi
+
+    upload_safe_logs \
+        "${JOB_GCS_BUCKET_INTERNAL}" \
+        "build/elastic-stack-dump/check-${PACKAGE}/logs/elastic-agent-internal/*.*" \
+        "insecure-logs/${package_folder}/elastic-agent-logs/"
+
+    # required for <8.6.0
+    upload_safe_logs \
+        "${JOB_GCS_BUCKET_INTERNAL}" \
+        "build/elastic-stack-dump/check-${PACKAGE}/logs/elastic-agent-internal/default/*" \
+        "insecure-logs/${package_folder}/elastic-agent-logs/default/"
+
+    upload_safe_logs \
+        "${JOB_GCS_BUCKET_INTERNAL}" \
+        "build/container-logs/*.log" \
+        "insecure-logs/${package_folder}/container-logs/"
+
+}
+
 if [[ "${TARGET}" == "" ]]; then
     echo "Missing target"
     usage
@@ -88,56 +126,31 @@ label="${TARGET}"
 if [ -n "${PACKAGE}" ]; then
     label="${label} - ${PACKAGE}"
 fi
+
+echo "--- Install elastic-package"
+make install
+
 echo "--- Run integration test ${label}"
 if [[ "${TARGET}" == "${PARALLEL_TARGET}" ]] || [[ "${TARGET}" == "${FALSE_POSITIVES_TARGET}" ]]; then
-    make install
-
     # allow to fail this command, to be able to upload safe logs
     set +e
     make SERVERLESS="${SERVERLESS}" PACKAGE_UNDER_TEST="${PACKAGE}" "${TARGET}"
     testReturnCode=$?
     set -e
 
-    retry_count=${BUILDKITE_RETRY_COUNT:-"0"}
 
     if [[ "${UPLOAD_SAFE_LOGS}" -eq 1 ]] ; then
-        package_folder="${PACKAGE}"
-        if [[ "${ELASTIC_PACKAGE_TEST_ENABLE_INDEPENDENT_AGENT:-""}" == "false" ]]; then
-            package_folder="${package_folder}-stack_agent"
-        fi
-
-        if [[ "${ELASTIC_PACKAGE_FIELD_VALIDATION_TEST_METHOD:-""}" != "" ]]; then
-            package_folder="${package_folder}-${ELASTIC_PACKAGE_FIELD_VALIDATION_TEST_METHOD}"
-        fi
-
-        if [[ "${retry_count}" -ne 0 ]]; then
-            package_folder="${package_folder}_retry_${retry_count}"
-        fi
-
-        upload_safe_logs \
-            "${JOB_GCS_BUCKET_INTERNAL}" \
-            "build/elastic-stack-dump/check-${PACKAGE}/logs/elastic-agent-internal/*.*" \
-            "insecure-logs/${package_folder}/elastic-agent-logs/"
-
-        # required for <8.6.0
-        upload_safe_logs \
-            "${JOB_GCS_BUCKET_INTERNAL}" \
-            "build/elastic-stack-dump/check-${PACKAGE}/logs/elastic-agent-internal/default/*" \
-            "insecure-logs/${package_folder}/elastic-agent-logs/default/"
-
-        upload_safe_logs \
-            "${JOB_GCS_BUCKET_INTERNAL}" \
-            "build/container-logs/*.log" \
-            "insecure-logs/${package_folder}/container-logs/"
+        upload_package_test_logs
     fi
 
     if [ $testReturnCode != 0 ]; then
         echo "make SERVERLESS=${SERVERLESS} PACKAGE_UNDER_TEST=${PACKAGE} ${TARGET} failed with ${testReturnCode}"
         exit ${testReturnCode}
     fi
-
-    make check-git-clean
-    exit 0
+else
+    make "${TARGET}"
 fi
 
-make install "${TARGET}" check-git-clean
+echo "--- Check git clean"
+make check-git-clean
+exit 0

--- a/.buildkite/scripts/release.sh
+++ b/.buildkite/scripts/release.sh
@@ -17,11 +17,11 @@ VERSION=""
 add_bin_path
 with_go
 
-echo "--- fetching tags"
+echo "--- Fetching tags"
 # Ensure that tags are present so goreleaser can build the changelog from the last release.
 git rev-parse --is-shallow-repository
 git fetch origin --tags
 
-echo "--- running goreleaser"
+echo "--- Running goreleaser"
 # Run latest version of goreleaser
 curl -sL https://git.io/goreleaser | bash

--- a/.buildkite/scripts/test-with-integrations.sh
+++ b/.buildkite/scripts/test-with-integrations.sh
@@ -5,10 +5,10 @@ set -euo pipefail
 
 add_bin_path
 
-echo "--- install gh cli"
+echo "--- Install gh cli"
 with_github_cli
 
-echo "--- install jq"
+echo "--- Install jq"
 with_jq
 
 
@@ -87,7 +87,7 @@ create_integrations_pull_request() {
 
 update_dependency() {
     # it needs to set the Golang version from the integrations repository (.go-version file)
-    echo "--- install go for integrations repository :go:"
+    echo "--- Install go for integrations repository :go:"
     with_go
 
     echo "--- Updating go.mod and go.sum with ${GITHUB_PR_HEAD_SHA} :hammer_and_wrench:"
@@ -167,7 +167,7 @@ create_or_update_pull_request() {
 
     rm -rf "${temp_path}"
 
-    echo "--- adding comment into ${GITHUB_PR_BASE_REPO} pull request :memo:"
+    echo "--- Adding comment into ${GITHUB_PR_BASE_REPO} pull request :memo:"
     add_pr_comment "${BUILDKITE_PULL_REQUEST}" "$(get_integrations_pr_link "${integrations_pr_number}")"
 }
 
@@ -186,5 +186,5 @@ if [[ "${BUILDKITE_PULL_REQUEST}" == "false" ]]; then
     exit 1
 fi
 
-echo "--- creating or updating integrations pull request"
+echo "--- Creating or updating integrations pull request"
 create_or_update_pull_request

--- a/.buildkite/scripts/test_packages_with_serverless.sh
+++ b/.buildkite/scripts/test_packages_with_serverless.sh
@@ -32,7 +32,7 @@ fi
 
 add_bin_path
 
-echo "--- install go"
+echo "--- Install go"
 with_go
 
 echo "--- Install docker"
@@ -42,7 +42,7 @@ echo "--- Install docker-compose"
 with_docker_compose_plugin
 
 if [[ "${BUILDKITE_PULL_REQUEST}" != "false" ]]; then
-    echo "--- install gh cli"
+    echo "--- Install gh cli"
     with_github_cli
 
     add_pr_comment "${BUILDKITE_PULL_REQUEST}" "${BUILDKITE_BUILD_URL}"

--- a/.buildkite/scripts/test_packages_with_serverless.sh
+++ b/.buildkite/scripts/test_packages_with_serverless.sh
@@ -10,7 +10,6 @@ UPLOAD_SAFE_LOGS=${UPLOAD_SAFE_LOGS:-"0"}
 SKIPPED_PACKAGES_FILE_PATH="${WORKSPACE}/skipped_packages.txt"
 FAILED_PACKAGES_FILE_PATH="${WORKSPACE}/failed_packages.txt"
 
-export SERVERLESS="true"
 SERVERLESS_PROJECT=${SERVERLESS_PROJECT:-"observability"}
 
 add_pr_comment() {

--- a/.buildkite/scripts/tooling.sh
+++ b/.buildkite/scripts/tooling.sh
@@ -101,8 +101,6 @@ upload_safe_logs() {
     local source="$2"
     local target="$3"
 
-    echo "--- Uploading safe logs to GCP bucket ${bucket}"
-
     if ! ls ${source} 2>&1 > /dev/null ; then
         echo "upload_safe_logs: artifacts files not found, nothing will be archived"
         return

--- a/.buildkite/scripts/unit_tests_macos_arm.sh
+++ b/.buildkite/scripts/unit_tests_macos_arm.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 add_bin_path
 
-echo "--- install go"
+echo "--- Install go"
 with_go
 
 echo "--- Running unit tests"

--- a/scripts/stack_helpers.sh
+++ b/scripts/stack_helpers.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+is_stack_created() {
+    local files=0
+    files=$(find ~/.elastic-package -type f -name "docker-compose.yml" | wc -l)
+    if [ "${files}" -gt 0 ]; then
+        return 0
+    fi
+    return 1
+}
+

--- a/scripts/test-build-install-zip-file.sh
+++ b/scripts/test-build-install-zip-file.sh
@@ -18,10 +18,10 @@ cleanup() {
   if [ "${ELASTIC_PACKAGE_STARTED}" -eq 1 ]; then
     # Dump stack logs
     elastic-package stack dump -v --output ${output_path}
-
-    # Take down the stack
-    elastic-package stack down -v
   fi
+
+  # Take down the stack
+  elastic-package stack down -v
 
   for d in test/packages/*/*/; do
     elastic-package clean -C "$d" -v

--- a/scripts/test-build-install-zip-file.sh
+++ b/scripts/test-build-install-zip-file.sh
@@ -16,6 +16,7 @@ cleanup() {
   fi
 
   # Dump stack logs
+  # Required containers could not be running, so ignore the error
   elastic-package stack dump -v --output ${output_path} || true
 
   # Take down the stack

--- a/scripts/test-build-install-zip-file.sh
+++ b/scripts/test-build-install-zip-file.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euxo pipefail
+set -euo pipefail
 
 cleanup() {
   local r=$?

--- a/scripts/test-build-install-zip-file.sh
+++ b/scripts/test-build-install-zip-file.sh
@@ -15,10 +15,8 @@ cleanup() {
       output_path="${output_path}-shellinit"
   fi
 
-  if [ "${ELASTIC_PACKAGE_STARTED}" -eq 1 ]; then
-    # Dump stack logs
-    elastic-package stack dump -v --output ${output_path}
-  fi
+  # Dump stack logs
+  elastic-package stack dump -v --output ${output_path} || true
 
   # Take down the stack
   elastic-package stack down -v
@@ -97,13 +95,11 @@ if [ "${STACK_VERSION}" != "default" ]; then
   ARG_VERSION="--version ${STACK_VERSION}"
 fi
 
-ELASTIC_PACKAGE_STARTED=0
 # Update the stack
 elastic-package stack update -v ${ARG_VERSION}
 
 # Boot up the stack
 elastic-package stack up -d -v ${ARG_VERSION}
-ELASTIC_PACKAGE_STARTED=1
 
 ELASTIC_PACKAGE_LINKS_FILE_PATH="$(pwd)/scripts/links_table.yml"
 export ELASTIC_PACKAGE_LINKS_FILE_PATH

--- a/scripts/test-build-install-zip-file.sh
+++ b/scripts/test-build-install-zip-file.sh
@@ -4,6 +4,10 @@ set -euxo pipefail
 
 cleanup() {
   local r=$?
+  if [ "${r}" -ne 0 ]; then
+    # Ensure that the group where the failure happened is opened.
+    echo "^^^ +++"
+  fi
   echo "~~~ elastic-package cleanup"
 
   local output_path="build/elastic-stack-dump/install-zip"

--- a/scripts/test-build-install-zip-file.sh
+++ b/scripts/test-build-install-zip-file.sh
@@ -4,6 +4,7 @@ set -euxo pipefail
 
 cleanup() {
   local r=$?
+  echo "--- elastic-package cleanup"
 
   local output_path="build/elastic-stack-dump/install-zip"
   if [ ${USE_SHELLINIT} -eq 1 ]; then

--- a/scripts/test-build-install-zip.sh
+++ b/scripts/test-build-install-zip.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euxo pipefail
+set -euo pipefail
 
 cleanup() {
   local r=$?
@@ -42,7 +42,7 @@ go run ./scripts/gpgkey
 
 for d in test/packages/*/*/; do
   # Packages in false_positives can have issues.
-  if [ "$(testype $d)" == "false_positives" ]; then
+  if [ "$(testype "$d")" == "false_positives" ]; then
     continue
   fi
   echo "--- Building package: ${d}"
@@ -61,13 +61,13 @@ eval "$(elastic-package stack shellinit)"
 # Install packages from working copy
 for d in test/packages/*/*/; do
   # Packages in false_positives can have issues.
-  if [ "$(testype $d)" == "false_positives" ]; then
+  if [ "$(testype "$d")" == "false_positives" ]; then
     continue
   fi
   package_name=$(yq -r '.name' "${d}/manifest.yml")
   package_version=$(yq -r '.version' "${d}/manifest.yml")
 
-  echo "--- Installing package: ${PACKAGE_NAME_VERSION}"
+  echo "--- Installing package: ${package_name} (${package_version})"
   elastic-package install -C "$d" -v
 
   # check that the package is installed

--- a/scripts/test-build-install-zip.sh
+++ b/scripts/test-build-install-zip.sh
@@ -64,8 +64,11 @@ eval "$(elastic-package stack shellinit)"
 
 # Install packages from working copy
 for d in test/packages/*/*/; do
+  # Added set +x in a sub-shell to avoid printing the testype command in the output
+  # This helps to keep the CI output cleaner
+  packageTestType=$(set +x ; testype "$d")
   # Packages in false_positives can have issues.
-  if [ "$(testype "$d")" == "false_positives" ]; then
+  if [ "${packageTestType}" == "false_positives" ]; then
     continue
   fi
   package_name=$(yq -r '.name' "${d}/manifest.yml")

--- a/scripts/test-build-install-zip.sh
+++ b/scripts/test-build-install-zip.sh
@@ -13,10 +13,10 @@ cleanup() {
   if [ "${ELASTIC_PACKAGE_STARTED}" -eq 1 ]; then
     # Dump stack logs
     elastic-package stack dump -v --output build/elastic-stack-dump/build-zip
-
-    # Take down the stack
-    elastic-package stack down -v
   fi
+
+  # Take down the stack
+  elastic-package stack down -v
 
   # Clean used resources
   for d in test/packages/*/*/; do

--- a/scripts/test-build-install-zip.sh
+++ b/scripts/test-build-install-zip.sh
@@ -10,10 +10,8 @@ cleanup() {
   fi
   echo "~~~ elastic-package cleanup"
 
-  if [ "${ELASTIC_PACKAGE_STARTED}" -eq 1 ]; then
-    # Dump stack logs
-    elastic-package stack dump -v --output build/elastic-stack-dump/build-zip
-  fi
+  # Dump stack logs
+  elastic-package stack dump -v --output build/elastic-stack-dump/build-zip || true
 
   # Take down the stack
   elastic-package stack down -v
@@ -39,7 +37,6 @@ ELASTIC_PACKAGE_SIGNER_PASSPHRASE=$(cat "$OLDPWD/scripts/gpg-pass.txt")
 export ELASTIC_PACKAGE_SIGNER_PASSPHRASE
 ELASTIC_PACKAGE_LINKS_FILE_PATH="$(pwd)/scripts/links_table.yml"
 export ELASTIC_PACKAGE_LINKS_FILE_PATH
-ELASTIC_PACKAGE_STARTED=0
 
 go run ./scripts/gpgkey
 
@@ -58,7 +55,6 @@ rm -r build/packages/*/
 echo "--- Prepare Elastic stack"
 # Boot up the stack
 elastic-package stack up -d -v
-ELASTIC_PACKAGE_STARTED=1
 
 eval "$(elastic-package stack shellinit)"
 

--- a/scripts/test-build-install-zip.sh
+++ b/scripts/test-build-install-zip.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -euxo pipefail
 
 cleanup() {
   local r=$?
@@ -41,8 +41,11 @@ export ELASTIC_PACKAGE_LINKS_FILE_PATH
 go run ./scripts/gpgkey
 
 for d in test/packages/*/*/; do
+  # Added set +x in a sub-shell to avoid printing the testype command in the output
+  # This helps to keep the CI output cleaner
+  packageTestType=$(set +x ; testype "$d")
   # Packages in false_positives can have issues.
-  if [ "$(testype "$d")" == "false_positives" ]; then
+  if [ "${packageTestType}" == "false_positives" ]; then
     continue
   fi
   echo "--- Building package: ${d}"

--- a/scripts/test-build-install-zip.sh
+++ b/scripts/test-build-install-zip.sh
@@ -4,6 +4,10 @@ set -euxo pipefail
 
 cleanup() {
   local r=$?
+  if [ "${r}" -ne 0 ]; then
+    # Ensure that the group where the failure happened is opened.
+    echo "^^^ +++"
+  fi
   echo "~~~ elastic-package cleanup"
 
   if [ "${ELASTIC_PACKAGE_STARTED}" -eq 1 ]; then

--- a/scripts/test-build-install-zip.sh
+++ b/scripts/test-build-install-zip.sh
@@ -3,7 +3,8 @@
 set -euxo pipefail
 
 cleanup() {
-  r=$?
+  local r=$?
+  echo "--- elastic-package cleanup"
 
   # Dump stack logs
   elastic-package stack dump -v --output build/elastic-stack-dump/build-zip
@@ -40,12 +41,14 @@ for d in test/packages/*/*/; do
   if [ "$(testype $d)" == "false_positives" ]; then
     continue
   fi
+  echo "--- Building package: ${d}"
   elastic-package build -C "$d" --zip --sign -v
 done
 
 # Remove unzipped built packages, leave .zip files
 rm -r build/packages/*/
 
+echo "--- Prepare Elastic stack"
 # Boot up the stack
 elastic-package stack up -d -v
 
@@ -60,6 +63,7 @@ for d in test/packages/*/*/; do
   package_name=$(yq -r '.name' "${d}/manifest.yml")
   package_version=$(yq -r '.version' "${d}/manifest.yml")
 
+  echo "--- Installing package: ${PACKAGE_NAME_VERSION}"
   elastic-package install -C "$d" -v
 
   # check that the package is installed

--- a/scripts/test-build-install-zip.sh
+++ b/scripts/test-build-install-zip.sh
@@ -11,6 +11,7 @@ cleanup() {
   echo "~~~ elastic-package cleanup"
 
   # Dump stack logs
+  # Required containers could not be running, so ignore the error
   elastic-package stack dump -v --output build/elastic-stack-dump/build-zip || true
 
   # Take down the stack

--- a/scripts/test-build-install-zip.sh
+++ b/scripts/test-build-install-zip.sh
@@ -4,13 +4,15 @@ set -euxo pipefail
 
 cleanup() {
   local r=$?
-  echo "--- elastic-package cleanup"
+  echo "~~~ elastic-package cleanup"
 
-  # Dump stack logs
-  elastic-package stack dump -v --output build/elastic-stack-dump/build-zip
+  if [ "${ELASTIC_PACKAGE_STARTED}" -eq 1 ]; then
+    # Dump stack logs
+    elastic-package stack dump -v --output build/elastic-stack-dump/build-zip
 
-  # Take down the stack
-  elastic-package stack down -v
+    # Take down the stack
+    elastic-package stack down -v
+  fi
 
   # Clean used resources
   for d in test/packages/*/*/; do
@@ -33,6 +35,7 @@ ELASTIC_PACKAGE_SIGNER_PASSPHRASE=$(cat "$OLDPWD/scripts/gpg-pass.txt")
 export ELASTIC_PACKAGE_SIGNER_PASSPHRASE
 ELASTIC_PACKAGE_LINKS_FILE_PATH="$(pwd)/scripts/links_table.yml"
 export ELASTIC_PACKAGE_LINKS_FILE_PATH
+ELASTIC_PACKAGE_STARTED=0
 
 go run ./scripts/gpgkey
 
@@ -51,6 +54,7 @@ rm -r build/packages/*/
 echo "--- Prepare Elastic stack"
 # Boot up the stack
 elastic-package stack up -d -v
+ELASTIC_PACKAGE_STARTED=1
 
 eval "$(elastic-package stack shellinit)"
 

--- a/scripts/test-build-zip.sh
+++ b/scripts/test-build-zip.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -euxo pipefail
 
 cleanup() {
   local r=$?

--- a/scripts/test-build-zip.sh
+++ b/scripts/test-build-zip.sh
@@ -3,7 +3,8 @@
 set -euxo pipefail
 
 cleanup() {
-  r=$?
+  local r=$?
+  echo "--- elastic-package cleanup"
 
   # Clean used resources
   for d in test/packages/*/*/; do
@@ -34,6 +35,7 @@ for d in test/packages/*/*/; do
   if [ "$(testype $d)" == "false_positives" ]; then
     continue
   fi
+  echo "--- Building zip package: ${d}"
   elastic-package build -C "$d" --zip --sign -v
 done
 

--- a/scripts/test-build-zip.sh
+++ b/scripts/test-build-zip.sh
@@ -4,7 +4,11 @@ set -euxo pipefail
 
 cleanup() {
   local r=$?
-  echo "--- elastic-package cleanup"
+  if [ "${r}" -ne 0 ]; then
+    # Ensure that the group where the failure happened is opened.
+    echo "^^^ +++"
+  fi
+  echo "~~~ elastic-package cleanup"
 
   # Clean used resources
   for d in test/packages/*/*/; do

--- a/scripts/test-build-zip.sh
+++ b/scripts/test-build-zip.sh
@@ -34,8 +34,11 @@ export ELASTIC_PACKAGE_LINKS_FILE_PATH
 go run ./scripts/gpgkey
 
 for d in test/packages/*/*/; do
+  # Added set +x in a sub-shell to avoid printing the testype command in the output
+  # This helps to keep the CI output cleaner
+  packageTestType=$(set +x ; testype "$d")
   # Packages in false_positives can have issues.
-  if [ "$(testype "$d")" == "false_positives" ]; then
+  if [ "${packageTestType}" == "false_positives" ]; then
     continue
   fi
   echo "--- Building zip package: ${d}"

--- a/scripts/test-build-zip.sh
+++ b/scripts/test-build-zip.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-set -euxo pipefail
+set -euo pipefail
 
 cleanup() {
   local r=$?
@@ -36,7 +35,7 @@ go run ./scripts/gpgkey
 
 for d in test/packages/*/*/; do
   # Packages in false_positives can have issues.
-  if [ "$(testype $d)" == "false_positives" ]; then
+  if [ "$(testype "$d")" == "false_positives" ]; then
     continue
   fi
   echo "--- Building zip package: ${d}"

--- a/scripts/test-check-false-positives.sh
+++ b/scripts/test-check-false-positives.sh
@@ -101,7 +101,7 @@ trap cleanup EXIT
 ELASTIC_PACKAGE_LINKS_FILE_PATH="$(pwd)/scripts/links_table.yml"
 export ELASTIC_PACKAGE_LINKS_FILE_PATH
 
-stack_args=$(stack_version_args) # --version <version>
+stack_args=$(set +x; stack_version_args) # --version <version>
 
 echo "--- Prepare Elastic stack"
 # Update the stack
@@ -109,7 +109,7 @@ elastic-package stack update -v ${stack_args}
 
 # NOTE: if any provider argument is defined, the stack must be shutdown first to ensure
 # that all parameters are taken into account by the services
-stack_args="${stack_args} $(stack_provider_args)" # -U <setting=1,settings=2>
+stack_args="${stack_args} $(set +x; stack_provider_args)" # -U <setting=1,settings=2>
 
 # Boot up the stack
 elastic-package stack up -d -v ${stack_args}

--- a/scripts/test-check-false-positives.sh
+++ b/scripts/test-check-false-positives.sh
@@ -14,10 +14,8 @@ function cleanup() {
   fi
   echo "~~~ elastic-package cleanup"
 
-  if [ "${ELASTIC_PACKAGE_STARTED}" -eq 1 ]; then
-    # Dump stack logs
-    elastic-package stack dump -v --output "build/elastic-stack-dump/check-${PACKAGE_UNDER_TEST:-${PACKAGE_TEST_TYPE:-*}}"
-  fi
+  # Dump stack logs
+  elastic-package stack dump -v --output "build/elastic-stack-dump/check-${PACKAGE_UNDER_TEST:-${PACKAGE_TEST_TYPE:-*}}" || true
 
   # Take down the stack
   elastic-package stack down -v
@@ -98,7 +96,6 @@ trap cleanup EXIT
 
 ELASTIC_PACKAGE_LINKS_FILE_PATH="$(pwd)/scripts/links_table.yml"
 export ELASTIC_PACKAGE_LINKS_FILE_PATH
-ELASTIC_PACKAGE_STARTED=0
 
 stack_args=$(stack_version_args) # --version <version>
 
@@ -113,7 +110,6 @@ stack_args="${stack_args} $(stack_provider_args)" # -U <setting=1,settings=2>
 # Boot up the stack
 elastic-package stack up -d -v ${stack_args}
 
-ELASTIC_PACKAGE_STARTED=1
 elastic-package stack status
 
 # Run package tests

--- a/scripts/test-check-false-positives.sh
+++ b/scripts/test-check-false-positives.sh
@@ -8,7 +8,7 @@ set -euxo pipefail
 
 function cleanup() {
   r=$?
-  echo "--- Cleanup"
+  echo "--- elastic-package cleanup"
 
   # Dump stack logs
   elastic-package stack dump -v --output "build/elastic-stack-dump/check-${PACKAGE_UNDER_TEST:-${PACKAGE_TEST_TYPE:-*}}"

--- a/scripts/test-check-false-positives.sh
+++ b/scripts/test-check-false-positives.sh
@@ -8,6 +8,7 @@ set -euxo pipefail
 
 function cleanup() {
   r=$?
+  echo "--- Cleanup"
 
   # Dump stack logs
   elastic-package stack dump -v --output "build/elastic-stack-dump/check-${PACKAGE_UNDER_TEST:-${PACKAGE_TEST_TYPE:-*}}"
@@ -94,6 +95,7 @@ export ELASTIC_PACKAGE_LINKS_FILE_PATH
 
 stack_args=$(stack_version_args) # --version <version>
 
+echo "--- Prepare Elastic stack"
 # Update the stack
 elastic-package stack update -v ${stack_args}
 
@@ -108,6 +110,8 @@ elastic-package stack status
 
 # Run package tests
 for d in test/packages/${PACKAGE_TEST_TYPE:-false_positives}/${PACKAGE_UNDER_TEST:-*}/; do
+  echo "--- Check build output: ${d}"
   check_build_output "$d"
+  echo "--- Check expected errors: ${d}"
   check_expected_errors "$d"
 done

--- a/scripts/test-check-false-positives.sh
+++ b/scripts/test-check-false-positives.sh
@@ -17,10 +17,10 @@ function cleanup() {
   if [ "${ELASTIC_PACKAGE_STARTED}" -eq 1 ]; then
     # Dump stack logs
     elastic-package stack dump -v --output "build/elastic-stack-dump/check-${PACKAGE_UNDER_TEST:-${PACKAGE_TEST_TYPE:-*}}"
-
-    # Take down the stack
-    elastic-package stack down -v
   fi
+
+  # Take down the stack
+  elastic-package stack down -v
 
   # Clean used resources
   for d in test/packages/${PACKAGE_TEST_TYPE:-false_positives}/${PACKAGE_UNDER_TEST:-*}/; do

--- a/scripts/test-check-false-positives.sh
+++ b/scripts/test-check-false-positives.sh
@@ -3,6 +3,7 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 source "${SCRIPT_DIR}/stack_parameters.sh"
+source "${SCRIPT_DIR}/stack_helpers.sh"
 
 set -euxo pipefail
 
@@ -14,11 +15,13 @@ function cleanup() {
   fi
   echo "~~~ elastic-package cleanup"
 
-  # Dump stack logs
-  elastic-package stack dump -v --output "build/elastic-stack-dump/check-${PACKAGE_UNDER_TEST:-${PACKAGE_TEST_TYPE:-*}}" || true
+  if is_stack_created ; then
+    # Dump stack logs
+    elastic-package stack dump -v --output "build/elastic-stack-dump/check-${PACKAGE_UNDER_TEST:-${PACKAGE_TEST_TYPE:-*}}"
 
-  # Take down the stack
-  elastic-package stack down -v
+    # Take down the stack
+    elastic-package stack down -v
+  fi
 
   # Clean used resources
   for d in test/packages/${PACKAGE_TEST_TYPE:-false_positives}/${PACKAGE_UNDER_TEST:-*}/; do

--- a/scripts/test-check-false-positives.sh
+++ b/scripts/test-check-false-positives.sh
@@ -8,13 +8,15 @@ set -euxo pipefail
 
 function cleanup() {
   r=$?
-  echo "--- elastic-package cleanup"
+  echo "~~~ elastic-package cleanup"
 
-  # Dump stack logs
-  elastic-package stack dump -v --output "build/elastic-stack-dump/check-${PACKAGE_UNDER_TEST:-${PACKAGE_TEST_TYPE:-*}}"
+  if [ "${ELASTIC_PACKAGE_STARTED}" -eq 1 ]; then
+    # Dump stack logs
+    elastic-package stack dump -v --output "build/elastic-stack-dump/check-${PACKAGE_UNDER_TEST:-${PACKAGE_TEST_TYPE:-*}}"
 
-  # Take down the stack
-  elastic-package stack down -v
+    # Take down the stack
+    elastic-package stack down -v
+  fi
 
   # Clean used resources
   for d in test/packages/${PACKAGE_TEST_TYPE:-false_positives}/${PACKAGE_UNDER_TEST:-*}/; do
@@ -92,6 +94,7 @@ trap cleanup EXIT
 
 ELASTIC_PACKAGE_LINKS_FILE_PATH="$(pwd)/scripts/links_table.yml"
 export ELASTIC_PACKAGE_LINKS_FILE_PATH
+ELASTIC_PACKAGE_STARTED=0
 
 stack_args=$(stack_version_args) # --version <version>
 
@@ -106,6 +109,7 @@ stack_args="${stack_args} $(stack_provider_args)" # -U <setting=1,settings=2>
 # Boot up the stack
 elastic-package stack up -d -v ${stack_args}
 
+ELASTIC_PACKAGE_STARTED=1
 elastic-package stack status
 
 # Run package tests

--- a/scripts/test-check-false-positives.sh
+++ b/scripts/test-check-false-positives.sh
@@ -8,6 +8,10 @@ set -euxo pipefail
 
 function cleanup() {
   r=$?
+  if [ "${r}" -ne 0 ]; then
+    # Ensure that the group where the failure happened is opened.
+    echo "^^^ +++"
+  fi
   echo "~~~ elastic-package cleanup"
 
   if [ "${ELASTIC_PACKAGE_STARTED}" -eq 1 ]; then

--- a/scripts/test-check-false-positives.sh
+++ b/scripts/test-check-false-positives.sh
@@ -17,7 +17,8 @@ function cleanup() {
 
   if is_stack_created ; then
     # Dump stack logs
-    elastic-package stack dump -v --output "build/elastic-stack-dump/check-${PACKAGE_UNDER_TEST:-${PACKAGE_TEST_TYPE:-*}}"
+    # Required containers could not be running, so ignore the error
+    elastic-package stack dump -v --output "build/elastic-stack-dump/check-${PACKAGE_UNDER_TEST:-${PACKAGE_TEST_TYPE:-*}}" || true
 
     # Take down the stack
     elastic-package stack down -v

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -35,7 +35,7 @@ cleanup() {
   # started to test all packages. In our CI, this Elastic serverless stack is started 
   # at the beginning of the pipeline and must be running for all packages without stopping it between
   # packages.
-  if [[ "$SERVERLESS" != "true" && "${ELASTIC_PACKAGE_STARTED}" == 1 ]]; then
+  if [[ "$SERVERLESS" != "true" ]]; then
       # Take down the stack
       elastic-package stack down -v
   fi

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -8,6 +8,10 @@ set -euxo pipefail
 
 cleanup() {
   r=$?
+  if [ "${r}" -ne 0 ]; then
+    # Ensure that the group where the failure happened is opened.
+    echo "^^^ +++"
+  fi
   echo "~~~ elastic-package cleanup"
 
   if [[ "${SERVERLESS}" == "true" || "${ELASTIC_PACKAGE_STARTED}" == "1" ]]; then
@@ -94,9 +98,6 @@ if [[ "${SERVERLESS}" != "true" ]]; then
   elastic-package stack up -d -v ${stack_args}
 
   ELASTIC_PACKAGE_STARTED=1
-  if [ "${PACKAGE_TEST_TYPE:-other}/${PACKAGE_UNDER_TEST:-*}" == "parallel/nginx" ]; then
-    ls -l not_exist_file
-  fi
 
   elastic-package stack status
 fi

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -94,6 +94,9 @@ if [[ "${SERVERLESS}" != "true" ]]; then
   elastic-package stack up -d -v ${stack_args}
 
   ELASTIC_PACKAGE_STARTED=1
+  if [ "${PACKAGE_TEST_TYPE:-other}/${PACKAGE_UNDER_TEST:-*}" == "parallel/nginx" ]; then
+    ls -l not_exist_file
+  fi
 
   elastic-package stack status
 fi

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -126,12 +126,12 @@ for d in test/packages/${PACKAGE_TEST_TYPE:-other}/${PACKAGE_UNDER_TEST:-*}/; do
         --threshold 1 --report-output-path="${PWD}/build/benchreport"
     fi
     if [ "${package_to_test}" == "system_benchmark" ]; then
-      echo "--- Run system benchmarks and report for package ${package_to_test}"
+      echo "--- Run system benchmarks for package ${package_to_test}"
 
       elastic-package benchmark system -C "$d" --benchmark logs-benchmark -v --defer-cleanup 1s
     fi
   elif [ "${PACKAGE_TEST_TYPE:-other}" == "with-logstash" ] && [ "${package_to_test}" == "system_benchmark" ]; then
-      echo "--- Run system benchmarks and report for package ${package_to_test}"
+      echo "--- Run system benchmarks for package ${package_to_test}"
       elastic-package benchmark system -C "$d" --benchmark logs-benchmark -v --defer-cleanup 1s
   else
     if [[ "${SERVERLESS}" == "true" ]]; then

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -8,7 +8,7 @@ set -euxo pipefail
 
 cleanup() {
   r=$?
-  echo "--- Cleaning up"
+  echo "--- elastic-package cleanup"
 
   # Dump stack logs
   elastic-package stack dump -v \

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -17,8 +17,9 @@ cleanup() {
 
   if is_stack_created; then
     # Dump stack logs
+    # Required containers could not be running, so ignore the error
     elastic-package stack dump -v \
-        --output "build/elastic-stack-dump/check-${PACKAGE_UNDER_TEST:-${PACKAGE_TEST_TYPE:-any}}"
+        --output "build/elastic-stack-dump/check-${PACKAGE_UNDER_TEST:-${PACKAGE_TEST_TYPE:-any}}" || true
   fi
 
   if [ "${PACKAGE_TEST_TYPE:-other}" == "with-kind" ]; then

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -88,14 +88,14 @@ fi
 # at the beginning of the pipeline and must be running for all packages.
 if [[ "${SERVERLESS}" != "true" ]]; then
   echo "--- Prepare Elastic stack"
-  stack_args=$(stack_version_args) # --version <version>
+  stack_args=$(set +x;stack_version_args) # --version <version>
 
   # Update the stack
   elastic-package stack update -v ${stack_args}
 
   # NOTE: if any provider argument is defined, the stack must be shutdown first to ensure
   # that all parameters are taken into account by the services
-  stack_args="${stack_args} $(stack_provider_args)" # -U <setting=1,settings=2>
+  stack_args="${stack_args} $(set +x; stack_provider_args)" # -U <setting=1,settings=2>
 
   # Boot up the stack
   elastic-package stack up -d -v ${stack_args}

--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -14,11 +14,9 @@ cleanup() {
   fi
   echo "~~~ elastic-package cleanup"
 
-  if [[ "${SERVERLESS}" == "true" || "${ELASTIC_PACKAGE_STARTED}" == "1" ]]; then
-    # Dump stack logs
-    elastic-package stack dump -v \
-        --output "build/elastic-stack-dump/check-${PACKAGE_UNDER_TEST:-${PACKAGE_TEST_TYPE:-any}}"
-  fi
+  # Dump stack logs
+  elastic-package stack dump -v \
+      --output "build/elastic-stack-dump/check-${PACKAGE_UNDER_TEST:-${PACKAGE_TEST_TYPE:-any}}" || true
 
   if [ "${PACKAGE_TEST_TYPE:-other}" == "with-kind" ]; then
     # Dump kubectl details
@@ -82,7 +80,6 @@ fi
 # In case it is tested with Elastic serverless, there should be just one Elastic stack
 # started to test all packages. In our CI, this Elastic serverless stack is started 
 # at the beginning of the pipeline and must be running for all packages.
-ELASTIC_PACKAGE_STARTED=0
 if [[ "${SERVERLESS}" != "true" ]]; then
   echo "--- Prepare Elastic stack"
   stack_args=$(stack_version_args) # --version <version>
@@ -96,8 +93,6 @@ if [[ "${SERVERLESS}" != "true" ]]; then
 
   # Boot up the stack
   elastic-package stack up -d -v ${stack_args}
-
-  ELASTIC_PACKAGE_STARTED=1
 
   elastic-package stack status
 fi

--- a/scripts/test-profiles-command.sh
+++ b/scripts/test-profiles-command.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 cleanup() {
-  r=$?
+  local r=$?
 
   # Delete extra profiles
   elastic-package profiles delete test_default

--- a/scripts/test-stack-command.sh
+++ b/scripts/test-stack-command.sh
@@ -18,10 +18,10 @@ cleanup() {
   if [ "${ELASTIC_PACKAGE_STARTED}" -eq 1 ]; then
     # Dump stack logs
     elastic-package stack dump -v --output "build/elastic-stack-dump/stack/${VERSION}"
-
-    # Take down the stack
-    elastic-package stack down -v
   fi
+
+  # Take down the stack
+  elastic-package stack down -v
 
   if [ "${APM_SERVER_ENABLED}" = true ]; then
     elastic-package profiles delete with-apm-server

--- a/scripts/test-stack-command.sh
+++ b/scripts/test-stack-command.sh
@@ -9,6 +9,10 @@ ELASTIC_SUBSCRIPTION=${ELASTIC_SUBSCRIPTION:-""}
 
 cleanup() {
   local r=$?
+  if [ "${r}" -ne 0 ]; then
+    # Ensure that the group where the failure happened is opened.
+    echo "^^^ +++"
+  fi
   echo "~~~ elastic-package cleanup"
 
   if [ "${ELASTIC_PACKAGE_STARTED}" -eq 1 ]; then

--- a/scripts/test-stack-command.sh
+++ b/scripts/test-stack-command.sh
@@ -2,6 +2,10 @@
 
 set -euxo pipefail
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+source "${SCRIPT_DIR}/stack_helpers.sh"
+
 VERSION=${1:-default}
 APM_SERVER_ENABLED=${APM_SERVER_ENABLED:-false}
 SELF_MONITOR_ENABLED=${SELF_MONITOR_ENABLED:-false}
@@ -15,11 +19,13 @@ cleanup() {
   fi
   echo "~~~ elastic-package cleanup"
 
-  # Dump stack logs
-  elastic-package stack dump -v --output "build/elastic-stack-dump/stack/${VERSION}" || true
+  if is_stack_created; then
+    # Dump stack logs
+    elastic-package stack dump -v --output "build/elastic-stack-dump/stack/${VERSION}"
 
-  # Take down the stack
-  elastic-package stack down -v
+    # Take down the stack
+    elastic-package stack down -v
+  fi
 
   if [ "${APM_SERVER_ENABLED}" = true ]; then
     elastic-package profiles delete with-apm-server

--- a/scripts/test-stack-command.sh
+++ b/scripts/test-stack-command.sh
@@ -15,10 +15,8 @@ cleanup() {
   fi
   echo "~~~ elastic-package cleanup"
 
-  if [ "${ELASTIC_PACKAGE_STARTED}" -eq 1 ]; then
-    # Dump stack logs
-    elastic-package stack dump -v --output "build/elastic-stack-dump/stack/${VERSION}"
-  fi
+  # Dump stack logs
+  elastic-package stack dump -v --output "build/elastic-stack-dump/stack/${VERSION}" || true
 
   # Take down the stack
   elastic-package stack down -v
@@ -107,13 +105,11 @@ if [[ "${EXPECTED_VERSION}" =~ ^7\.17 ]] ; then
     echo "Override elastic-agent docker image: ${ELASTIC_AGENT_IMAGE_REF_OVERRIDE}"
 fi
 
-ELASTIC_PACKAGE_STARTED=0
 # Update the stack
 elastic-package stack update -v ${ARG_VERSION}
 
 # Boot up the stack
 elastic-package stack up -d -v ${ARG_VERSION}
-ELASTIC_PACKAGE_STARTED=1
 
 # Verify it's accessible
 eval "$(elastic-package stack shellinit)"

--- a/scripts/test-stack-command.sh
+++ b/scripts/test-stack-command.sh
@@ -21,7 +21,8 @@ cleanup() {
 
   if is_stack_created; then
     # Dump stack logs
-    elastic-package stack dump -v --output "build/elastic-stack-dump/stack/${VERSION}"
+    # Required containers could not be running, so ignore the error
+    elastic-package stack dump -v --output "build/elastic-stack-dump/stack/${VERSION}" || true
 
     # Take down the stack
     elastic-package stack down -v

--- a/scripts/test-stack-command.sh
+++ b/scripts/test-stack-command.sh
@@ -8,7 +8,8 @@ SELF_MONITOR_ENABLED=${SELF_MONITOR_ENABLED:-false}
 ELASTIC_SUBSCRIPTION=${ELASTIC_SUBSCRIPTION:-""}
 
 cleanup() {
-  r=$?
+  local r=$?
+  echo "--- elastic-package cleanup"
 
   # Dump stack logs
   elastic-package stack dump -v --output "build/elastic-stack-dump/stack/${VERSION}"

--- a/scripts/test-stack-command.sh
+++ b/scripts/test-stack-command.sh
@@ -9,13 +9,15 @@ ELASTIC_SUBSCRIPTION=${ELASTIC_SUBSCRIPTION:-""}
 
 cleanup() {
   local r=$?
-  echo "--- elastic-package cleanup"
+  echo "~~~ elastic-package cleanup"
 
-  # Dump stack logs
-  elastic-package stack dump -v --output "build/elastic-stack-dump/stack/${VERSION}"
+  if [ "${ELASTIC_PACKAGE_STARTED}" -eq 1 ]; then
+    # Dump stack logs
+    elastic-package stack dump -v --output "build/elastic-stack-dump/stack/${VERSION}"
 
-  # Take down the stack
-  elastic-package stack down -v
+    # Take down the stack
+    elastic-package stack down -v
+  fi
 
   if [ "${APM_SERVER_ENABLED}" = true ]; then
     elastic-package profiles delete with-apm-server
@@ -101,11 +103,13 @@ if [[ "${EXPECTED_VERSION}" =~ ^7\.17 ]] ; then
     echo "Override elastic-agent docker image: ${ELASTIC_AGENT_IMAGE_REF_OVERRIDE}"
 fi
 
+ELASTIC_PACKAGE_STARTED=0
 # Update the stack
 elastic-package stack update -v ${ARG_VERSION}
 
 # Boot up the stack
 elastic-package stack up -d -v ${ARG_VERSION}
+ELASTIC_PACKAGE_STARTED=1
 
 # Verify it's accessible
 eval "$(elastic-package stack shellinit)"

--- a/scripts/test-system-test-flags.sh
+++ b/scripts/test-system-test-flags.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-set -euxo pipefail
-
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+set -euxo pipefail
 
 source "${SCRIPT_DIR}/stack_helpers.sh"
 

--- a/scripts/test-system-test-flags.sh
+++ b/scripts/test-system-test-flags.sh
@@ -5,7 +5,11 @@ set -euxo pipefail
 cleanup() {
     local r=$?
     local container_id=""
-    local agent_ids
+    local agent_ids=""
+    if [ "${r}" -ne 0 ]; then
+      # Ensure that the group where the failure happened is opened.
+      echo "^^^ +++"
+    fi
 
     echo "~~~ elastic-package cleanup"
 

--- a/scripts/test-system-test-flags.sh
+++ b/scripts/test-system-test-flags.sh
@@ -7,10 +7,12 @@ cleanup() {
     local container_id=""
     local agent_ids
 
-    echo "--- elastic-package cleanup"
+    echo "~~~ elastic-package cleanup"
 
     # Dump stack logs
-    elastic-package stack dump -v --output build/elastic-stack-dump/system-test-flags
+    if [ "${ELASTIC_PACKAGE_STARTED}" -eq 1 ]; then
+        elastic-package stack dump -v --output build/elastic-stack-dump/system-test-flags
+    fi
 
     if is_service_container_running "${DEFAULT_AGENT_CONTAINER_NAME}" ; then
         container_id=$(container_ids "${DEFAULT_AGENT_CONTAINER_NAME}")
@@ -281,10 +283,12 @@ SERVICE_CONTAINER_NAME=""
 
 ELASTIC_PACKAGE_LINKS_FILE_PATH="$(pwd)/scripts/links_table.yml"
 export ELASTIC_PACKAGE_LINKS_FILE_PATH
+ELASTIC_PACKAGE_STARTED=0
 
 # Run default stack version
 echo "--- Start Elastic stack"
 elastic-package stack up -v -d
+ELASTIC_PACKAGE_STARTED=1
 
 elastic-package stack status
 

--- a/scripts/test-system-test-flags.sh
+++ b/scripts/test-system-test-flags.sh
@@ -7,7 +7,7 @@ cleanup() {
     local container_id=""
     local agent_ids
 
-    echo "--- Cleanup"
+    echo "--- elastic-package cleanup"
 
     # Dump stack logs
     elastic-package stack dump -v --output build/elastic-stack-dump/system-test-flags

--- a/scripts/test-system-test-flags.sh
+++ b/scripts/test-system-test-flags.sh
@@ -2,6 +2,10 @@
 
 set -euxo pipefail
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+source "${SCRIPT_DIR}/stack_helpers.sh"
+
 cleanup() {
     local r=$?
     local container_id=""
@@ -13,8 +17,10 @@ cleanup() {
 
     echo "~~~ elastic-package cleanup"
 
-    # Dump stack logs
-    elastic-package stack dump -v --output build/elastic-stack-dump/system-test-flags ||true
+    if is_stack_created; then
+        # Dump stack logs
+        elastic-package stack dump -v --output build/elastic-stack-dump/system-test-flags
+    fi
 
     if is_service_container_running "${DEFAULT_AGENT_CONTAINER_NAME}" ; then
         container_id=$(container_ids "${DEFAULT_AGENT_CONTAINER_NAME}")
@@ -38,8 +44,10 @@ cleanup() {
 
     kind delete cluster || true
 
-    # Take down the stack
-    elastic-package stack down -v
+    if is_stack_created; then
+        # Take down the stack
+        elastic-package stack down -v
+    fi
 
     # Clean used resources
     for d in test/packages/*/*/; do

--- a/scripts/test-system-test-flags.sh
+++ b/scripts/test-system-test-flags.sh
@@ -14,9 +14,7 @@ cleanup() {
     echo "~~~ elastic-package cleanup"
 
     # Dump stack logs
-    if [ "${ELASTIC_PACKAGE_STARTED}" -eq 1 ]; then
-        elastic-package stack dump -v --output build/elastic-stack-dump/system-test-flags
-    fi
+    elastic-package stack dump -v --output build/elastic-stack-dump/system-test-flags ||true
 
     if is_service_container_running "${DEFAULT_AGENT_CONTAINER_NAME}" ; then
         container_id=$(container_ids "${DEFAULT_AGENT_CONTAINER_NAME}")
@@ -287,12 +285,10 @@ SERVICE_CONTAINER_NAME=""
 
 ELASTIC_PACKAGE_LINKS_FILE_PATH="$(pwd)/scripts/links_table.yml"
 export ELASTIC_PACKAGE_LINKS_FILE_PATH
-ELASTIC_PACKAGE_STARTED=0
 
 # Run default stack version
 echo "--- Start Elastic stack"
 elastic-package stack up -v -d
-ELASTIC_PACKAGE_STARTED=1
 
 elastic-package stack status
 

--- a/scripts/test-system-test-flags.sh
+++ b/scripts/test-system-test-flags.sh
@@ -19,7 +19,8 @@ cleanup() {
 
     if is_stack_created; then
         # Dump stack logs
-        elastic-package stack dump -v --output build/elastic-stack-dump/system-test-flags
+        # Required containers could not be running, so ignore the error
+        elastic-package stack dump -v --output build/elastic-stack-dump/system-test-flags || true
     fi
 
     if is_service_container_running "${DEFAULT_AGENT_CONTAINER_NAME}" ; then

--- a/scripts/test-system-test-flags.sh
+++ b/scripts/test-system-test-flags.sh
@@ -7,6 +7,8 @@ cleanup() {
     local container_id=""
     local agent_ids
 
+    echo "--- Cleanup"
+
     # Dump stack logs
     elastic-package stack dump -v --output build/elastic-stack-dump/system-test-flags
 


### PR DESCRIPTION
Make easier to read Buidkite output:
- Add more groups in Buildkite output
- Avoid executing some commands in clean up process if the Elastic stack failed to start.
- Ensure that the failed group in the Buildkite output is opened ([link](https://buildkite.com/docs/pipelines/configure/managing-log-output#collapsing-output))

### Author's checklist
- [x] Validate that parallel and false positive targets run each package in a different Buildkite step
- [x] Validate that other targets test all the corresponding packages in the same Buildkite step.
- [x] Validate that Serverless pipeline works testing all the packages in the same Buildkite step. https://buildkite.com/elastic/elastic-package-test-serverless/builds/490