### PR TITLE
Update healthcheck settings for fleet-server

### DIFF
--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -103,8 +103,9 @@ services:
         condition: service_healthy
     healthcheck:
       test: "bash /healthcheck.sh {{ $fleet_healthcheck_success_checks }} {{ $fleet_healthcheck_waiting_time }}"
-      start_period: 60s
+      start_period: 360s
       interval: 5s
+      retries: 180
     hostname: docker-fleet-server
     environment:
     - "ELASTICSEARCH_HOST=https://elasticsearch:9200"


### PR DESCRIPTION
Update health-check settings for Fleet-Service container (docker-compose) to be similar to the ones configured for the `elastic-agent` container.

Current settings for `elastic-agent` container:
```yaml
    healthcheck:
      test: "elastic-agent status"
      timeout: 2s
      start_period: 360s
      retries: 180
      interval: 5s
```

Docs Reference: https://docs.docker.com/reference/dockerfile/#healthcheck

### How to test this PR locally

Tested locally with 9.1.0-SNAPSHOT

```shell
#!/bin/bash

set -euo pipefail

VERSION="9.1.0-SNAPSHOT"
ITER_MAX=10
for i in `seq 1 ${ITER_MAX}`; do
    elastic-package stack down -v
    elastic-package stack up -v -d --version "${VERSION}"
    if [[ "$?" != 0 ]]; then
        echo "ERROR: stack up failed"
        exit 1
    fi
done
```