### PR TITLE
ci: move from dependabot reviewers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
+/go.mod @elastic/ecosystem
 /.buildkite/ @elastic/ecosystem
 /.github/ @elastic/ecosystem
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
       interval: "daily"
     labels:
       - automation
-    reviewers:
-      - "elastic/ecosystem"
     open-pull-requests-limit: 10
     groups:
       k8s:


### PR DESCRIPTION
Removed reviewers section in dependabot.yml and moved it's definition to CODEOWNERS.

Reviewers dependabot.yml configuration is being retired option because the functionality overlaps with GitHub code owners.
See: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

Relates: https://github.com/elastic/elastic-package/issues/2698