### PR TITLE
[CI] Use buildkite plugin to set GitHub token

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -71,26 +71,9 @@ if is_step_required_to_upload_safe_logs; then
     export JOB_GCS_BUCKET_INTERNAL="ecosystem-ci-internal"
 fi
 
-if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-package" && "$BUILDKITE_STEP_KEY" == "release" ]]; then
-    GITHUB_TOKEN=$VAULT_GITHUB_TOKEN
-    export GITHUB_TOKEN
-fi
-
-if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-package-test-with-integrations" && "$BUILDKITE_STEP_KEY" == "pr-integrations" ]]; then
-    # required to set the git commit information
-    GITHUB_USERNAME_SECRET="elasticmachine"
-    export GITHUB_USERNAME_SECRET=$GITHUB_USERNAME_SECRET
-    export GITHUB_EMAIL_SECRET="elasticmachine@elastic.co"
-    # required by `gh` commands
-    export GITHUB_TOKEN=$VAULT_GITHUB_TOKEN
-fi
-
 if [[ "${BUILDKITE_PIPELINE_SLUG}" == "elastic-package-test-serverless" ]]; then
     if [[ "${BUILDKITE_STEP_KEY}" == "test-serverless" ]]; then
         EC_REGION_SECRET=$(retry 5 vault read -field region_qa "${EC_DATA_PATH}")
         export EC_REGION_SECRET
-
-        GITHUB_TOKEN=$VAULT_GITHUB_TOKEN
-        export GITHUB_TOKEN
     fi
 fi

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -58,6 +58,8 @@ steps:
           env:
             EC_API_KEY: elastic-cloud-observability-team-qa-api-key
             EC_HOST: elastic-cloud-observability-team-qa-endpoint
+      # Required to post comments on PRs
+      - elastic/vault-github-token#v0.1.0:
     artifact_paths:
       - build/test-results/*.xml
       - build/test-coverage/coverage-*.xml

--- a/.buildkite/pipeline.test-with-integrations-repo.yml
+++ b/.buildkite/pipeline.test-with-integrations-repo.yml
@@ -26,6 +26,12 @@ steps:
   - label: ":hammer: Create PR in integrations"
     key: pr-integrations
     command: ".buildkite/scripts/test-with-integrations.sh"
+    env:
+      GITHUB_EMAIL: "elasticmachine@elastic.co"
+      GITHUB_USERNAME: "elastic-vault-github-plugin-prod"
+    plugins:
+      # Required to push branches, create PRs and post comments on PRs
+      - elastic/vault-github-token#v0.1.0:
     agents:
       provider: "gcp"
     depends_on:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -122,3 +122,6 @@ steps:
     command: ".buildkite/scripts/release.sh"
     agents:
       provider: "gcp"
+    plugins:
+      # required to create Github releases
+      - elastic/vault-github-token#v0.1.0:

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -74,10 +74,11 @@ if [[ "$SERVERLESS" == "false" ]]; then
         echo "--- install docker-compose plugin"
         with_docker_compose_plugin
     fi
-fi
 
-echo "--- install yq"
-with_yq
+    # yq is not required for serverless pipeline
+    echo "--- install yq"
+    with_yq
+fi
 
 if [[ "${TARGET}" == "${KIND_TARGET}" || "${TARGET}" == "${SYSTEM_TEST_FLAGS_TARGET}" ]]; then
     echo "--- install kubectl & kind"

--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -74,11 +74,10 @@ if [[ "$SERVERLESS" == "false" ]]; then
         echo "--- install docker-compose plugin"
         with_docker_compose_plugin
     fi
-
-    # yq is not required for serverless pipeline
-    echo "--- install yq"
-    with_yq
 fi
+
+echo "--- install yq"
+with_yq
 
 if [[ "${TARGET}" == "${KIND_TARGET}" || "${TARGET}" == "${SYSTEM_TEST_FLAGS_TARGET}" ]]; then
     echo "--- install kubectl & kind"

--- a/.buildkite/scripts/test-with-integrations.sh
+++ b/.buildkite/scripts/test-with-integrations.sh
@@ -39,8 +39,8 @@ get_source_commit_link() {
 }
 
 set_git_config() {
-    git config user.name "${GITHUB_USERNAME_SECRET}"
-    git config user.email "${GITHUB_EMAIL_SECRET}"
+    git config user.name "${GITHUB_USERNAME}"
+    git config user.email "${GITHUB_EMAIL}"
 }
 
 git_push() {


### PR DESCRIPTION
## What does this PR do?

Use https://github.com/elastic/vault-github-token-buildkite-plugin instead of using pre-command hooks with complicated conditions.
This helps to know what Buildkite step uses `VAULT_GITHUB_TOKEN` and self-document those sensitive details as it's a declarative syntax.

PR created after adding `test integrations` comment: https://github.com/elastic/integrations/pull/14611

### Author's checklist
- [x] Create integrations PR with `test integrations`
- [x] Posted the expected comments in the PR after `test integrations` comment.
- [x] Posted the expected comments in the PR after `test serverless` comment

## Related issues

- Relates https://github.com/elastic/integrations/pull/14408
