### PR TITLE
[CI] Update junit buildkite plugin

### DIFF
--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -70,7 +70,7 @@ steps:
 
   - label: ":junit: Junit annotate"
     agents:
-      image: "ruby:3.1-alpine@sha256:a39e26d0598837f08c75a42c8b0886d9ed5cc862c4b535662922ee1d05272fca"
+      image: "ruby:3.4.5-slim@sha256:8eb53388a8f3a1bad038fa4ea8d8011acaef53c176a9a1182d418123d8a66ccd"
     plugins:
       - junit-annotate#v2.7.0:
           artifacts: "build/test-results/*.xml"

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -71,7 +71,7 @@ steps:
   - label: ":junit: Junit annotate"
     agents:
       # requires at least "bash", "curl" and "git"
-      image: "ruby:3.4.5-bookworm@sha256:64b669025ed6f2f2697a7fc15fc5a59d7b47d190619f3b1147b875815deb2a5f"
+      image: "ruby:3.4.5-bookworm"
     plugins:
       - junit-annotate#v2.7.0:
           artifacts: "build/test-results/*.xml"

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -70,7 +70,8 @@ steps:
 
   - label: ":junit: Junit annotate"
     agents:
-      image: "ruby:3.4.5-slim@sha256:8eb53388a8f3a1bad038fa4ea8d8011acaef53c176a9a1182d418123d8a66ccd"
+      # requires at least "bash", "curl" and "git"
+      image: "ruby:3.4.5-bookworm@sha256:64b669025ed6f2f2697a7fc15fc5a59d7b47d190619f3b1147b875815deb2a5f"
     plugins:
       - junit-annotate#v2.7.0:
           artifacts: "build/test-results/*.xml"

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -69,13 +69,14 @@ steps:
     continue_on_failure: true
 
   - label: ":junit: Junit annotate"
+    agents:
+      image: "ruby:3.1-alpine@sha256:a39e26d0598837f08c75a42c8b0886d9ed5cc862c4b535662922ee1d05272fca"
     plugins:
-      - junit-annotate#v2.5.0:
+      - junit-annotate#v2.7.0:
           artifacts: "build/test-results/*.xml"
           report-skipped: true
           always-annotate: true
-    agents:
-      provider: "gcp"  # junit plugin requires docker
+          run-in-docker: false
 
 notify:
   - email: "$NOTIFY_TO"

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -71,7 +71,7 @@ steps:
   - label: ":junit: Junit annotate"
     agents:
       # requires at least "bash", "curl" and "git"
-      image: "ruby:3.4.5-bookworm"
+      image: "docker.elastic.co/ci-agent-images/buildkite-junit-annotate:1.0"
     plugins:
       - junit-annotate#v2.7.0:
           artifacts: "build/test-results/*.xml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -116,7 +116,6 @@ steps:
           report-skipped: true
           always-annotate: true
           run-in-docker: false
-          report-slowest: 5
 
   - label: ":github: Release"
     key: "release"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -109,7 +109,7 @@ steps:
   - label: ":junit: Junit annotate"
     agents:
       # requires at least "bash", "curl" and "git"
-      image: "ruby:3.4.5-bookworm@sha256:64b669025ed6f2f2697a7fc15fc5a59d7b47d190619f3b1147b875815deb2a5f"
+      image: "ruby:3.4.5-bookworm"
     plugins:
       - junit-annotate#v2.7.0:
           artifacts: "build/test-results/*.xml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -108,7 +108,8 @@ steps:
 
   - label: ":junit: Junit annotate"
     agents:
-      image: "ruby:3.4.5-slim@sha256:8eb53388a8f3a1bad038fa4ea8d8011acaef53c176a9a1182d418123d8a66ccd"
+      # requires at least "bash", "curl" and "git"
+      image: "ruby:3.4.5-bookworm@sha256:64b669025ed6f2f2697a7fc15fc5a59d7b47d190619f3b1147b875815deb2a5f"
     plugins:
       - junit-annotate#v2.7.0:
           artifacts: "build/test-results/*.xml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -107,13 +107,14 @@ steps:
     continue_on_failure: true
 
   - label: ":junit: Junit annotate"
+    agents:
+      image: "ruby:3.1-alpine@sha256:a39e26d0598837f08c75a42c8b0886d9ed5cc862c4b535662922ee1d05272fca"
     plugins:
-      - junit-annotate#v2.5.0:
+      - junit-annotate#v2.7.0:
           artifacts: "build/test-results/*.xml"
           report-skipped: true
           always-annotate: true
-    agents:
-      provider: "gcp"  # junit plugin requires docker
+          run-in-docker: false
 
   - label: ":github: Release"
     key: "release"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -108,7 +108,7 @@ steps:
 
   - label: ":junit: Junit annotate"
     agents:
-      image: "ruby:3.1-alpine@sha256:a39e26d0598837f08c75a42c8b0886d9ed5cc862c4b535662922ee1d05272fca"
+      image: "ruby:3.4.5-slim@sha256:8eb53388a8f3a1bad038fa4ea8d8011acaef53c176a9a1182d418123d8a66ccd"
     plugins:
       - junit-annotate#v2.7.0:
           artifacts: "build/test-results/*.xml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -116,6 +116,7 @@ steps:
           report-skipped: true
           always-annotate: true
           run-in-docker: false
+          report-slowest: 5
 
   - label: ":github: Release"
     key: "release"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -109,7 +109,7 @@ steps:
   - label: ":junit: Junit annotate"
     agents:
       # requires at least "bash", "curl" and "git"
-      image: "ruby:3.4.5-bookworm"
+      image: "docker.elastic.co/ci-agent-images/buildkite-junit-annotate:1.0"
     plugins:
       - junit-annotate#v2.7.0:
           artifacts: "build/test-results/*.xml"


### PR DESCRIPTION
Update [Buildkite junit-annotate plugin](https://github.com/buildkite-plugins/junit-annotate-buildkite-plugin) up to version 2.7.0

Set `run-in-docker: false` to use the ruby from the agent.