### PR TITLE
Update default stack version to 9.1.0

### DIFF
--- a/internal/install/stack_version.go
+++ b/internal/install/stack_version.go
@@ -6,5 +6,5 @@ package install
 
 const (
 	// DefaultStackVersion is the default version of the stack
-	DefaultStackVersion = "9.0.4"
+	DefaultStackVersion = "9.1.0"
 )

--- a/internal/testrunner/runners/policy/policy.go
+++ b/internal/testrunner/runners/policy/policy.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/pmezard/go-difflib/difflib"
@@ -98,6 +99,7 @@ type policyEntryFilter struct {
 	elementsEntries []policyEntryFilter
 	memberReplace   *policyEntryReplace
 	onlyIfEmpty     bool
+	ignoreValues    []any
 }
 
 type policyEntryReplace struct {
@@ -151,7 +153,7 @@ var policyEntryFilters = []policyEntryFilter{
 	}},
 
 	// Namespaces may not be present in older versions of the stack.
-	{name: "namespaces", onlyIfEmpty: true},
+	{name: "namespaces", onlyIfEmpty: true, ignoreValues: []any{"default"}},
 }
 
 // cleanPolicy prepares a policy YAML as returned by the download API to be compared with other
@@ -213,7 +215,7 @@ func cleanPolicyMap(policyMap common.MapStr, entries []policyEntryFilter) (commo
 				}
 			}
 		default:
-			if entry.onlyIfEmpty && !isEmpty(v) {
+			if entry.onlyIfEmpty && !isEmpty(v, entry.ignoreValues) {
 				continue
 			}
 			err := policyMap.Delete(entry.name)
@@ -229,15 +231,21 @@ func cleanPolicyMap(policyMap common.MapStr, entries []policyEntryFilter) (commo
 	return policyMap, nil
 }
 
-func isEmpty(v any) bool {
+func isEmpty(v any, ignoreValues []any) bool {
 	switch v := v.(type) {
 	case nil:
 		return true
 	case []any:
-		return len(v) == 0
+		return len(filterIgnored(v, ignoreValues)) == 0
 	case map[string]any:
 		return len(v) == 0
 	}
 
 	return false
+}
+
+func filterIgnored(v []any, ignoredValues []any) []any {
+	return slices.DeleteFunc(v, func(e any) bool {
+		return slices.Contains(ignoredValues, e)
+	})
 }

--- a/internal/testrunner/runners/policy/policy.go
+++ b/internal/testrunner/runners/policy/policy.go
@@ -154,6 +154,16 @@ var policyEntryFilters = []policyEntryFilter{
 
 	// Namespaces may not be present in older versions of the stack.
 	{name: "namespaces", onlyIfEmpty: true, ignoreValues: []any{"default"}},
+
+	// Values set by Fleet in input packages starting on 9.1.0.
+	{name: "inputs", elementsEntries: []policyEntryFilter{
+		{name: "streams", elementsEntries: []policyEntryFilter{
+			{name: "data_stream.type"},
+			{name: "data_stream.elasticsearch.dynamic_dataset"},
+			{name: "data_stream.elasticsearch.dynamic_namespace"},
+			{name: "data_stream.elasticsearch", onlyIfEmpty: true},
+		}},
+	}},
 }
 
 // cleanPolicy prepares a policy YAML as returned by the download API to be compared with other
@@ -238,6 +248,8 @@ func isEmpty(v any, ignoreValues []any) bool {
 	case []any:
 		return len(filterIgnored(v, ignoreValues)) == 0
 	case map[string]any:
+		return len(v) == 0
+	case common.MapStr:
 		return len(v) == 0
 	}
 

--- a/internal/testrunner/runners/policy/policy_test.go
+++ b/internal/testrunner/runners/policy/policy_test.go
@@ -68,6 +68,15 @@ namespaces: []
 			equal: true,
 		},
 		{
+			title: "clean namespaces if default",
+			expected: `
+`,
+			found: `
+namespaces: [default]
+`,
+			equal: true,
+		},
+		{
 			title: "clean namespaces only if empty",
 			expected: `
 namespaces: []


### PR DESCRIPTION
Policy templates ignore namespaces when they are `default`.

This was originally done in https://github.com/elastic/elastic-package/pull/2784, but updatecli overwrote and close it.