### PR TITLE
Refactor survey validators to don't need chdirs

### DIFF
--- a/cmd/create_data_stream.go
+++ b/cmd/create_data_stream.go
@@ -50,6 +50,7 @@ func createDataStreamCommandAction(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("data-streams are not supported in input packages")
 	}
 
+	validator := surveyext.Validator{Cwd: "."}
 	qs := []*survey.Question{
 		{
 			Name: "name",
@@ -57,7 +58,7 @@ func createDataStreamCommandAction(cmd *cobra.Command, args []string) error {
 				Message: "Data stream name:",
 				Default: "new_data_stream",
 			},
-			Validate: survey.ComposeValidators(survey.Required, surveyext.DataStreamDoesNotExistValidator, surveyext.DataStreamNameValidator),
+			Validate: survey.ComposeValidators(survey.Required, validator.DataStreamDoesNotExist, validator.DataStreamName),
 		},
 		{
 			Name: "title",

--- a/cmd/create_package.go
+++ b/cmd/create_package.go
@@ -62,6 +62,7 @@ func createPackageCommandAction(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("prompt failed: %w", err)
 	}
 
+	validator := surveyext.Validator{Cwd: "."}
 	qs = []*survey.Question{
 		{
 			Name: "name",
@@ -69,7 +70,7 @@ func createPackageCommandAction(cmd *cobra.Command, args []string) error {
 				Message: "Package name:",
 				Default: "new_package",
 			},
-			Validate: survey.ComposeValidators(survey.Required, surveyext.PackageDoesNotExistValidator, surveyext.PackageNameValidator),
+			Validate: survey.ComposeValidators(survey.Required, validator.PackageDoesNotExist, validator.PackageName),
 		},
 		{
 			Name: "version",
@@ -77,7 +78,7 @@ func createPackageCommandAction(cmd *cobra.Command, args []string) error {
 				Message: "Version:",
 				Default: "0.0.1",
 			},
-			Validate: survey.ComposeValidators(survey.Required, surveyext.SemverValidator),
+			Validate: survey.ComposeValidators(survey.Required, validator.Semver),
 		},
 		{
 			Name: "source_license",
@@ -132,7 +133,7 @@ func createPackageCommandAction(cmd *cobra.Command, args []string) error {
 				Message: "Kibana version constraint:",
 				Default: surveyext.DefaultKibanaVersionConditionValue(),
 			},
-			Validate: survey.ComposeValidators(survey.Required, surveyext.ConstraintValidator),
+			Validate: survey.ComposeValidators(survey.Required, validator.Constraint),
 		},
 		{
 			Name: "elastic_subscription",
@@ -149,7 +150,7 @@ func createPackageCommandAction(cmd *cobra.Command, args []string) error {
 				Message: "Github owner:",
 				Default: "elastic/integrations",
 			},
-			Validate: survey.ComposeValidators(survey.Required, surveyext.GithubOwnerValidator),
+			Validate: survey.ComposeValidators(survey.Required, validator.GithubOwner),
 		},
 		{
 			Name: "owner_type",

--- a/internal/surveyext/validators.go
+++ b/internal/surveyext/validators.go
@@ -21,27 +21,31 @@ var (
 	dataStreamNameRegexp = regexp.MustCompile(`^([a-z0-9]{2}|[a-z0-9][a-z0-9_]+[a-z0-9])$`)
 )
 
-// PackageDoesNotExistValidator function checks if the package hasn't been already created.
-func PackageDoesNotExistValidator(val interface{}) error {
+type Validator struct {
+	Cwd string
+}
+
+// PackageDoesNotExist function checks if the package hasn't been already created.
+func (v Validator) PackageDoesNotExist(val interface{}) error {
 	baseDir, ok := val.(string)
 	if !ok {
 		return errors.New("string type expected")
 	}
-	_, err := os.Stat(baseDir)
+	_, err := os.Stat(filepath.Join(v.Cwd, baseDir))
 	if err == nil {
 		return fmt.Errorf(`package "%s" already exists`, baseDir)
 	}
 	return nil
 }
 
-// DataStreamDoesNotExistValidator function checks if the package doesn't contain the data stream.
-func DataStreamDoesNotExistValidator(val interface{}) error {
+// DataStreamDoesNotExist function checks if the package doesn't contain the data stream.
+func (v Validator) DataStreamDoesNotExist(val interface{}) error {
 	name, ok := val.(string)
 	if !ok {
 		return errors.New("string type expected")
 	}
 
-	dataStreamDir := filepath.Join("data_stream", name)
+	dataStreamDir := filepath.Join(v.Cwd, "data_stream", name)
 	_, err := os.Stat(dataStreamDir)
 	if err == nil {
 		return fmt.Errorf(`data stream "%s" already exists`, name)
@@ -49,8 +53,8 @@ func DataStreamDoesNotExistValidator(val interface{}) error {
 	return nil
 }
 
-// SemverValidator function checks if the value is a correct semver.
-func SemverValidator(val interface{}) error {
+// Semver function checks if the value is a correct semver.
+func (v Validator) Semver(val interface{}) error {
 	ver, ok := val.(string)
 	if !ok {
 		return errors.New("string type expected")
@@ -62,8 +66,8 @@ func SemverValidator(val interface{}) error {
 	return nil
 }
 
-// ConstraintValidator function checks if the value is a correct version constraint.
-func ConstraintValidator(val interface{}) error {
+// Constraint function checks if the value is a correct version constraint.
+func (v Validator) Constraint(val interface{}) error {
 	c, ok := val.(string)
 	if !ok {
 		return errors.New("string type expected")
@@ -75,8 +79,8 @@ func ConstraintValidator(val interface{}) error {
 	return nil
 }
 
-// GithubOwnerValidator function checks if the Github owner is valid (team or user)
-func GithubOwnerValidator(val interface{}) error {
+// GithubOwner function checks if the Github owner is valid (team or user)
+func (v Validator) GithubOwner(val interface{}) error {
 	githubOwner, ok := val.(string)
 	if !ok {
 		return errors.New("string type expected")
@@ -88,7 +92,7 @@ func GithubOwnerValidator(val interface{}) error {
 	return nil
 }
 
-func PackageNameValidator(val interface{}) error {
+func (v Validator) PackageName(val interface{}) error {
 	packageName, ok := val.(string)
 	if !ok {
 		return errors.New("string type expected")
@@ -100,7 +104,7 @@ func PackageNameValidator(val interface{}) error {
 	return nil
 }
 
-func DataStreamNameValidator(val interface{}) error {
+func (v Validator) DataStreamName(val interface{}) error {
 	dataStreamFolderName, ok := val.(string)
 	if !ok {
 		return errors.New("string type expected")

--- a/internal/surveyext/validators_test.go
+++ b/internal/surveyext/validators_test.go
@@ -5,92 +5,72 @@
 package surveyext
 
 import (
-	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestPackageDoesNotExistValidator_Exists(t *testing.T) {
-	wd, err := os.Getwd()
-	require.NoError(t, err)
-
-	os.Chdir("testdata")
-	defer os.Chdir(wd)
-
-	err = PackageDoesNotExistValidator("hello-world")
+	validator := Validator{Cwd: "testdata"}
+	err := validator.PackageDoesNotExist("hello-world")
 	require.Error(t, err)
 }
 
 func TestPackageDoesNotExistValidator_NotExists(t *testing.T) {
-	wd, err := os.Getwd()
-	require.NoError(t, err)
-
-	os.Chdir("testdata")
-	defer os.Chdir(wd)
-
-	err = PackageDoesNotExistValidator("lost-world")
+	validator := Validator{Cwd: "testdata"}
+	err := validator.PackageDoesNotExist("lost-world")
 	require.NoError(t, err)
 }
 
 func TestDataStreamDoesNotExistValidator_Exists(t *testing.T) {
-	wd, err := os.Getwd()
-	require.NoError(t, err)
-
-	os.Chdir("testdata/hello-world")
-	defer os.Chdir(wd)
-
-	err = DataStreamDoesNotExistValidator("magic")
+	validator := Validator{Cwd: filepath.Join("testdata", "hello-world")}
+	err := validator.DataStreamDoesNotExist("magic")
 	require.Error(t, err)
 }
 
 func TestDataStreamDoesNotExistValidator_NotExists(t *testing.T) {
-	wd, err := os.Getwd()
-	require.NoError(t, err)
-
-	os.Chdir("testdata/hello-world")
-	defer os.Chdir(wd)
-
-	err = DataStreamDoesNotExistValidator("no-magic")
+	validator := Validator{Cwd: filepath.Join("testdata", "hello-world")}
+	err := validator.DataStreamDoesNotExist("no-magic")
 	require.NoError(t, err)
 }
 
 func TestSemverValidator_Valid(t *testing.T) {
-	err := SemverValidator("1.2.3-FOOBAR")
+	err := Validator{}.Semver("1.2.3-FOOBAR")
 	require.NoError(t, err)
 }
 
 func TestSemverValidator_Invalid(t *testing.T) {
-	err := SemverValidator("1.2.3.4")
+	err := Validator{}.Semver("1.2.3.4")
 	require.Error(t, err)
 }
 
 func TestConstraintValidator_Valid(t *testing.T) {
-	err := ConstraintValidator("^1.2.3")
+	err := Validator{}.Constraint("^1.2.3")
 	require.NoError(t, err)
 }
 
 func TestConstraintValidator_Invalid(t *testing.T) {
-	err := ConstraintValidator("+1.2.3")
+	err := Validator{}.Constraint("+1.2.3")
 	require.Error(t, err)
 }
 
 func TestGithubOwnerValidator_ValidUser(t *testing.T) {
-	err := GithubOwnerValidator("mtojek")
+	err := Validator{}.GithubOwner("mtojek")
 	require.NoError(t, err)
 }
 
 func TestGithubOwnerValidator_InvalidUser(t *testing.T) {
-	err := GithubOwnerValidator("mtojek%")
+	err := Validator{}.GithubOwner("mtojek%")
 	require.Error(t, err)
 }
 
 func TestGithubOwnerValidator_ValidTeam(t *testing.T) {
-	err := GithubOwnerValidator("elastic/integrations")
+	err := Validator{}.GithubOwner("elastic/integrations")
 	require.NoError(t, err)
 }
 
 func TestGithubOwnerValidator_InvalidTeam(t *testing.T) {
-	err := GithubOwnerValidator("elastic/integrations/123")
+	err := Validator{}.GithubOwner("elastic/integrations/123")
 	require.Error(t, err)
 }


### PR DESCRIPTION
After https://github.com/elastic/elastic-package/pull/2796, these would be the last use of chdir in tests.

Chdir can be problematic because it is global, and might affect other tests, or other functions tested in the same test. It is also error-prone as one may forget to go back to the previous working directory.

An object is created now that can keep as context the working directory, and validators are added as members of this object.