### PR TITLE
Update stderr redirections in scripts

### DIFF
--- a/.buildkite/scripts/tooling.sh
+++ b/.buildkite/scripts/tooling.sh
@@ -102,7 +102,7 @@ upload_safe_logs() {
     local target="$3"
 
     if ! ls ${source} > /dev/null 2>&1; then
-        echo "upload_safe_logs: artifacts files not found at ${soure}, nothing will be archived"
+        echo "upload_safe_logs: artifacts files not found at ${source}, nothing will be archived"
         return
     fi
 

--- a/.buildkite/scripts/tooling.sh
+++ b/.buildkite/scripts/tooling.sh
@@ -101,8 +101,8 @@ upload_safe_logs() {
     local source="$2"
     local target="$3"
 
-    if ! ls ${source} 2>&1 > /dev/null ; then
-        echo "upload_safe_logs: artifacts files not found, nothing will be archived"
+    if ! ls ${source} > /dev/null 2>&1; then
+        echo "upload_safe_logs: artifacts files not found at ${soure}, nothing will be archived"
         return
     fi
 

--- a/internal/profile/testdata/migration-home-legacy/profiles/default/stack/kibana_healthcheck.sh
+++ b/internal/profile/testdata/migration-home-legacy/profiles/default/stack/kibana_healthcheck.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-curl -s --cacert /usr/share/kibana/config/certs/ca-cert.pem -f https://localhost:5601/login | grep kbn-injected-metadata 2>&1 >/dev/null
+curl -s --cacert /usr/share/kibana/config/certs/ca-cert.pem -f https://localhost:5601/login | grep kbn-injected-metadata >/dev/null
 curl -s --cacert /usr/share/kibana/config/certs/ca-cert.pem -f -u elastic:changeme "https://elasticsearch:9200/_cat/indices/.security-*?h=health" | grep -v red

--- a/internal/profile/testdata/migration-home-legacy/profiles/default/stack/snapshot.yml
+++ b/internal/profile/testdata/migration-home-legacy/profiles/default/stack/snapshot.yml
@@ -91,7 +91,7 @@ services:
       kibana:
         condition: service_healthy
     healthcheck:
-      test: "curl --cacert /etc/ssl/elastic-agent/ca-cert.pem -f https://localhost:8220/api/status | grep -i healthy 2>&1 >/dev/null"
+      test: "curl --cacert /etc/ssl/elastic-agent/ca-cert.pem -f https://localhost:8220/api/status | grep -i healthy >/dev/null"
       start_period: 60s
       interval: 5s
     hostname: docker-fleet-server

--- a/internal/stack/_static/fleet-server-healthcheck.sh
+++ b/internal/stack/_static/fleet-server-healthcheck.sh
@@ -6,7 +6,7 @@ NUMBER_SUCCESSES="$1"
 WAITING_TIME="$2"
 
 healthcheck() {
-    curl -s --cacert /etc/ssl/certs/elastic-package.pem -f https://localhost:8220/api/status | grep -i healthy 2>&1 >/dev/null
+    curl -s --cacert /etc/ssl/certs/elastic-package.pem -f https://localhost:8220/api/status | grep -i healthy >/dev/null
 }
 
 # Fleet Server can restart after announcing to be healthy, agents connecting during this restart will

--- a/internal/stack/_static/kibana-healthcheck.sh.tmpl
+++ b/internal/stack/_static/kibana-healthcheck.sh.tmpl
@@ -2,5 +2,5 @@
 
 set -e
 
-curl -s --cacert /usr/share/kibana/config/certs/ca-cert.pem -f https://localhost:5601/login | grep kbn-injected-metadata 2>&1 >/dev/null
+curl -s --cacert /usr/share/kibana/config/certs/ca-cert.pem -f https://localhost:5601/login | grep kbn-injected-metadata >/dev/null
 curl -s --cacert /usr/share/kibana/config/certs/ca-cert.pem -f -u {{ fact "username" }}:{{ fact "password" }} "https://elasticsearch:9200/_cat/indices/.security-*?h=health" | grep -v red


### PR DESCRIPTION
This PR updates the scripts or commands that redirect stderr to stdout.
For instance, this command does not redirect stderr to stdout as expected, it keeps showing the stderr:
```shell
 $ ls doesnotexist 2>&1 > /dev/null
ls: cannot access 'doesnotexist': No such file or directory

```
That command should be written as:
```shell
 $ ls doesnotexit > /dev/null 2>&1
```