### PR TITLE
Use testing context when possible

### DIFF
--- a/internal/dump/agentpolicies_test.go
+++ b/internal/dump/agentpolicies_test.go
@@ -5,7 +5,6 @@
 package dump
 
 import (
-	"context"
 	"errors"
 	"os"
 	"testing"
@@ -88,7 +87,7 @@ func (s *agentPoliciesDumpSuite) SetupTest() {
 		s.Require().NoError(err)
 
 		dumper := NewAgentPoliciesDumper(client)
-		n, err := dumper.DumpAll(context.Background(), s.DumpDirAll)
+		n, err := dumper.DumpAll(s.T().Context(), s.DumpDirAll)
 		s.Require().NoError(err)
 		s.Require().Greater(n, 0)
 	} else {
@@ -101,7 +100,7 @@ func (s *agentPoliciesDumpSuite) SetupTest() {
 		s.Require().NoError(err)
 
 		dumper := NewAgentPoliciesDumper(client)
-		n, err := dumper.DumpByPackage(context.Background(), s.DumpDirPackage, s.PackageName)
+		n, err := dumper.DumpByPackage(s.T().Context(), s.DumpDirPackage, s.PackageName)
 		s.Require().NoError(err)
 		s.Require().Greater(n, 0)
 	} else {
@@ -114,7 +113,7 @@ func (s *agentPoliciesDumpSuite) SetupTest() {
 		s.Require().NoError(err)
 
 		dumper := NewAgentPoliciesDumper(client)
-		err = dumper.DumpByName(context.Background(), s.DumpDirAgentPolicy, s.AgentPolicy)
+		err = dumper.DumpByName(s.T().Context(), s.DumpDirAgentPolicy, s.AgentPolicy)
 		s.Require().NoError(err)
 	} else {
 		s.Require().NoError(err)
@@ -126,7 +125,7 @@ func (s *agentPoliciesDumpSuite) TestDumpAll() {
 
 	outputDir := s.T().TempDir()
 	dumper := NewAgentPoliciesDumper(client)
-	n, err := dumper.DumpAll(context.Background(), outputDir)
+	n, err := dumper.DumpAll(s.T().Context(), outputDir)
 	s.Require().NoError(err)
 
 	filesExpected := countFiles(s.T(), s.DumpDirAll)
@@ -143,7 +142,7 @@ func (s *agentPoliciesDumpSuite) TestDumpByPackage() {
 
 	outputDir := s.T().TempDir()
 	dumper := NewAgentPoliciesDumper(client)
-	n, err := dumper.DumpByPackage(context.Background(), outputDir, s.PackageName)
+	n, err := dumper.DumpByPackage(s.T().Context(), outputDir, s.PackageName)
 	s.Require().NoError(err)
 
 	filesExpected := countFiles(s.T(), s.DumpDirPackage)
@@ -160,7 +159,7 @@ func (s *agentPoliciesDumpSuite) TestDumpByName() {
 
 	outputDir := s.T().TempDir()
 	dumper := NewAgentPoliciesDumper(client)
-	err := dumper.DumpByName(context.Background(), outputDir, s.AgentPolicy)
+	err := dumper.DumpByName(s.T().Context(), outputDir, s.AgentPolicy)
 	s.Require().NoError(err)
 
 	filesExpected := countFiles(s.T(), s.DumpDirAgentPolicy)

--- a/internal/dump/installedobjects_test.go
+++ b/internal/dump/installedobjects_test.go
@@ -98,7 +98,7 @@ func (s *installedObjectsDumpSuite) SetupTest() {
 		s.Require().NoError(err)
 
 		dumper := NewInstalledObjectsDumper(client.API, s.PackageName)
-		n, err := dumper.DumpAll(context.Background(), s.DumpDir)
+		n, err := dumper.DumpAll(s.T().Context(), s.DumpDir)
 		s.Require().NoError(err)
 		s.Require().Greater(n, 0)
 	} else {
@@ -111,7 +111,7 @@ func (s *installedObjectsDumpSuite) TestDumpAll() {
 
 	outputDir := s.T().TempDir()
 	dumper := NewInstalledObjectsDumper(client.API, s.PackageName)
-	n, err := dumper.DumpAll(context.Background(), outputDir)
+	n, err := dumper.DumpAll(s.T().Context(), outputDir)
 	s.Require().NoError(err)
 
 	filesExpected := countFiles(s.T(), s.DumpDir)
@@ -139,7 +139,7 @@ func (s *installedObjectsDumpSuite) TestDumpSome() {
 	for dir, dumpFunction := range dumpers {
 		s.Run(dir, func() {
 			outputDir := s.T().TempDir()
-			n, err := dumpFunction(context.Background(), outputDir)
+			n, err := dumpFunction(s.T().Context(), outputDir)
 			s.Require().NoError(err)
 
 			expectedDir := subDir(s.T(), s.DumpDir, dir)

--- a/internal/elasticsearch/client_test.go
+++ b/internal/elasticsearch/client_test.go
@@ -6,7 +6,6 @@ package elasticsearch_test
 
 import (
 	"bytes"
-	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"net/http"
@@ -81,7 +80,7 @@ func TestClusterHealth(t *testing.T) {
 		t.Run(c.Record, func(t *testing.T) {
 			client := test.NewClient(t, c.Record, nil)
 
-			err := client.CheckHealth(context.Background())
+			err := client.CheckHealth(t.Context())
 			if c.Expected != "" {
 				if assert.Error(t, err) {
 					assert.Equal(t, c.Expected, err.Error())
@@ -95,7 +94,7 @@ func TestClusterHealth(t *testing.T) {
 
 func TestClusterInfo(t *testing.T) {
 	client := test.NewClient(t, "./testdata/elasticsearch-9-info", nil)
-	info, err := client.Info(context.Background())
+	info, err := client.Info(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, "9.0.0-SNAPSHOT", info.Version.Number)
 }

--- a/internal/export/ingest_pipelines_test.go
+++ b/internal/export/ingest_pipelines_test.go
@@ -5,7 +5,6 @@
 package export
 
 import (
-	"context"
 	"errors"
 	"io/fs"
 	"net/http"
@@ -77,7 +76,7 @@ func (s *ingestPipelineExportSuite) SetupTest() {
 
 		writeAssignments := createTestWriteAssignments(s.PipelineIds, s.ExportDir)
 
-		err = IngestPipelines((context.Background()), client.API, writeAssignments)
+		err = IngestPipelines(s.T().Context(), client.API, writeAssignments)
 
 		s.Require().NoError(err)
 	} else {
@@ -90,7 +89,7 @@ func (s *ingestPipelineExportSuite) TestExportPipelines() {
 
 	outputDir := s.T().TempDir()
 	writeAssignments := createTestWriteAssignments(s.PipelineIds, outputDir)
-	err := IngestPipelines(context.Background(), client.API, writeAssignments)
+	err := IngestPipelines(s.T().Context(), client.API, writeAssignments)
 	s.Require().NoError(err)
 
 	filesExpected := countFiles(s.T(), s.ExportDir)

--- a/internal/fleetserver/status_test.go
+++ b/internal/fleetserver/status_test.go
@@ -5,7 +5,6 @@
 package fleetserver_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,7 +22,7 @@ func TestStatusAPIKeyAuthenticated(t *testing.T) {
 		fleetserver.TLSSkipVerify(),
 	)
 
-	status, err := client.Status(context.Background())
+	status, err := client.Status(t.Context())
 	require.NoError(t, err)
 
 	assert.Equal(t, status.Name, "fleet-server")
@@ -38,7 +37,7 @@ func TestStatusUnauthenticated(t *testing.T) {
 		fleetserver.TLSSkipVerify(),
 	)
 
-	status, err := client.Status(context.Background())
+	status, err := client.Status(t.Context())
 	require.NoError(t, err)
 
 	assert.Equal(t, status.Name, "fleet-server")

--- a/internal/kibana/client_test.go
+++ b/internal/kibana/client_test.go
@@ -6,7 +6,6 @@ package kibana
 
 import (
 	"bytes"
-	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -38,7 +37,7 @@ func TestClientWithTLS(t *testing.T) {
 		client, err := NewClient(version, Address(server.URL))
 		require.NoError(t, err)
 
-		_, _, err = client.get(context.Background(), "/")
+		_, _, err = client.get(t.Context(), "/")
 		assert.Error(t, err)
 	})
 
@@ -46,7 +45,7 @@ func TestClientWithTLS(t *testing.T) {
 		client, err := NewClient(version, Address(server.URL), CertificateAuthority(caCertFile))
 		require.NoError(t, err)
 
-		_, _, err = client.get(context.Background(), "/")
+		_, _, err = client.get(t.Context(), "/")
 		assert.NoError(t, err)
 	})
 
@@ -54,7 +53,7 @@ func TestClientWithTLS(t *testing.T) {
 		client, err := NewClient(version, Address(server.URL), TLSSkipVerify())
 		require.NoError(t, err)
 
-		_, _, err = client.get(context.Background(), "/")
+		_, _, err = client.get(t.Context(), "/")
 		assert.NoError(t, err)
 	})
 }

--- a/internal/kibana/dashboards_test.go
+++ b/internal/kibana/dashboards_test.go
@@ -5,7 +5,6 @@
 package kibana_test
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -43,7 +42,7 @@ func TestExportDashboards(t *testing.T) {
 			id := preloadDashboard(t, client)
 
 			dashboardIDs := []string{id}
-			dashboards, err := client.Export(context.Background(), dashboardIDs)
+			dashboards, err := client.Export(t.Context(), dashboardIDs)
 			require.NoError(t, err)
 
 			assert.Len(t, dashboards, 1)

--- a/internal/kibana/savedobjects_test.go
+++ b/internal/kibana/savedobjects_test.go
@@ -27,7 +27,7 @@ func TestSetManagedSavedObject(t *testing.T) {
 	id := preloadDashboard(t, client)
 	require.True(t, getManagedSavedObject(t, client, "dashboard", id))
 
-	err := client.SetManagedSavedObject(context.Background(), "dashboard", id, false)
+	err := client.SetManagedSavedObject(t.Context(), "dashboard", id, false)
 	require.NoError(t, err)
 	assert.False(t, getManagedSavedObject(t, client, "dashboard", id))
 }
@@ -47,7 +47,7 @@ func preloadDashboard(t *testing.T, client *kibana.Client) string {
 			},
 		},
 	}
-	_, err := client.ImportSavedObjects(context.Background(), importRequest)
+	_, err := client.ImportSavedObjects(t.Context(), importRequest)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -69,7 +69,7 @@ func getManagedSavedObject(t *testing.T, client *kibana.Client, savedObjectType 
 			},
 		},
 	}
-	export, err := client.ExportSavedObjects(context.Background(), exportRequest)
+	export, err := client.ExportSavedObjects(t.Context(), exportRequest)
 	require.NoError(t, err)
 	require.Len(t, export, 1)
 

--- a/internal/packages/archetype/package_test.go
+++ b/internal/packages/archetype/package_test.go
@@ -5,7 +5,6 @@
 package archetype
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -100,7 +99,7 @@ func buildPackage(t *testing.T, packageRoot string) error {
 		return err
 	}
 
-	_, err = builder.BuildPackage(context.Background(), builder.BuildOptions{
+	_, err = builder.BuildPackage(t.Context(), builder.BuildOptions{
 		PackageRoot: packageRoot,
 		BuildDir:    buildDir,
 	})

--- a/internal/resources/fleetpackage_test.go
+++ b/internal/resources/fleetpackage_test.go
@@ -5,7 +5,6 @@
 package resources
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -92,7 +91,7 @@ func TestSystemPackageIsNotRemoved(t *testing.T) {
 func assertPackageInstalled(t *testing.T, client *kibana.Client, expected string, packageName string) bool {
 	t.Helper()
 
-	p, err := client.GetPackage(context.Background(), packageName)
+	p, err := client.GetPackage(t.Context(), packageName)
 	var notFoundError *kibana.ErrPackageNotFound
 	if errors.As(err, &notFoundError) {
 		return assert.Equal(t, expected, "not_installed")

--- a/internal/resources/fleetpolicy_test.go
+++ b/internal/resources/fleetpolicy_test.go
@@ -5,7 +5,6 @@
 package resources
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -120,7 +119,7 @@ func withPackageResources(agentPolicy *FleetAgentPolicy) resource.Resources {
 func assertPolicyPresent(t *testing.T, client *kibana.Client, expected bool, policyID string) bool {
 	t.Helper()
 
-	_, err := client.GetPolicy(context.Background(), policyID)
+	_, err := client.GetPolicy(t.Context(), policyID)
 	if expected {
 		return assert.NoError(t, err)
 	}

--- a/internal/testrunner/runners/system/tester_test.go
+++ b/internal/testrunner/runners/system/tester_test.go
@@ -5,7 +5,6 @@
 package system
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -436,7 +435,7 @@ func TestIsSyntheticSourceModeEnabled(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.title, func(t *testing.T) {
 			client := estest.NewClient(t, c.record, nil)
-			enabled, err := isSyntheticSourceModeEnabled(context.Background(), client.API, c.dataStreamName)
+			enabled, err := isSyntheticSourceModeEnabled(t.Context(), client.API, c.dataStreamName)
 			require.NoError(t, err)
 			assert.Equal(t, c.expected, enabled)
 		})


### PR DESCRIPTION
Go 1.24.0 introduced a context in `testing` objects that is cancelled after the test is finished, but before registered cleanup functions are executed. See https://tip.golang.org/doc/go1.24#testingpkgtesting.

Apart from providing a non-nil context, this new context helps ensuring that resources that should be finished by context cancellation are actually finished.

In general there is no reason to don't use this context, the only reasons would be:
* Contexts in cleanup functions, as this context will be cancelled at this point.
* Contexts for resources that should persist along tests. Something I think we don't have in this project.