### PR TITLE
Update kibana template used in the stack

### DIFF
--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -4,7 +4,7 @@ server.host: "0.0.0.0"
 {{- $kibana_http2_enabled := fact "kibana_http2_enabled" -}}
 {{- if (and (eq $kibana_http2_enabled "true") (not (semverLessThan $version "8.15.0-SNAPSHOT"))) }}
 server.protocol: http2
-{{ end -}}
+{{- end }}
 server.ssl.enabled: true
 server.ssl.certificate: "/usr/share/kibana/config/certs/cert.pem"
 server.ssl.key: "/usr/share/kibana/config/certs/key.pem"


### PR DESCRIPTION
Relates #2873 

This PR fixes the template used for the kibana configuration template:
- It fixes an error rendering the template in stacks <8.15.0 (missing a new line).
- Removes the setting of the debug log level of the fleet.plugin.