### PR TITLE
Support system tests otel input

### DIFF
--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -1887,8 +1887,13 @@ func createInputPackageDatastream(
 	config testConfig,
 	suffix string,
 ) kibana.PackageDataStream {
+	dataset := fmt.Sprintf("%s-%s", pkg.Name, policyTemplate.Name)
+	if policyTemplate.Input == "otelcol" {
+		dataset = fmt.Sprintf("%s.otel", dataset)
+	}
+
 	r := kibana.PackageDataStream{
-		Name:      fmt.Sprintf("%s-%s-%s", pkg.Name, policyTemplate.Name, suffix),
+		Name:      fmt.Sprintf("%s-%s", dataset, suffix),
 		Namespace: kibanaPolicy.Namespace,
 		PolicyID:  kibanaPolicy.ID,
 		Enabled:   true,
@@ -1901,16 +1906,13 @@ func createInputPackageDatastream(
 			PolicyTemplate: policyTemplate.Name,
 			Enabled:        true,
 			Vars:           kibana.Vars{},
+			Type:           policyTemplate.Input,
 		},
 	}
 
-	streamInput := policyTemplate.Input
-	r.Inputs[0].Type = streamInput
-
-	dataset := fmt.Sprintf("%s.%s", pkg.Name, policyTemplate.Name)
 	streams := []kibana.Stream{
 		{
-			ID:      fmt.Sprintf("%s-%s.%s", streamInput, pkg.Name, policyTemplate.Name),
+			ID:      fmt.Sprintf("%s-%s.%s", policyTemplate.Input, pkg.Name, policyTemplate.Name),
 			Enabled: true,
 			DataStream: kibana.DataStream{
 				Type:    policyTemplate.Type,

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -1899,16 +1899,8 @@ func createInputPackageDatastream(
 	config testConfig,
 	suffix string,
 ) kibana.PackageDataStream {
-	policyName := fmt.Sprintf("%s-%s", pkg.Name, policyTemplate.Name)
-	dataset := fmt.Sprintf("%s.%s", pkg.Name, policyTemplate.Name)
-
-	if policyTemplate.Input == otelCollectorInputName {
-		dataset = fmt.Sprintf("%s.%s", dataset, otelSuffixDataset)
-		policyName = fmt.Sprintf("%s.%s", policyName, otelSuffixDataset)
-	}
-
 	r := kibana.PackageDataStream{
-		Name:      fmt.Sprintf("%s-%s", policyName, suffix),
+		Name:      fmt.Sprintf("%s-%s-%s", pkg.Name, policyTemplate.Name, suffix),
 		Namespace: kibanaPolicy.Namespace,
 		PolicyID:  kibanaPolicy.ID,
 		Enabled:   true,
@@ -1925,6 +1917,7 @@ func createInputPackageDatastream(
 		},
 	}
 
+	dataset := fmt.Sprintf("%s.%s", pkg.Name, policyTemplate.Name)
 	streams := []kibana.Stream{
 		{
 			ID:      fmt.Sprintf("%s-%s.%s", policyTemplate.Input, pkg.Name, policyTemplate.Name),

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -1007,9 +1007,86 @@ func (r *tester) prepareScenario(ctx context.Context, config *testConfig, stackC
 		return nil, fmt.Errorf("failed to find the selected policy_template: %w", err)
 	}
 
-	policyCurrent, policyToEnroll, policyToTest, err := r.createKibanaPolicies(ctx, serviceStateData, stackConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kibana policies: %w", err)
+	// Configure package (single data stream) via Fleet APIs.
+	testTime := time.Now().Format("20060102T15:04:05Z")
+	var policyToTest, policyCurrent, policyToEnroll *kibana.Policy
+	if r.runTearDown || r.runTestsOnly {
+		policyCurrent = &serviceStateData.CurrentPolicy
+		policyToEnroll = &serviceStateData.EnrollPolicy
+		logger.Debugf("Got current policy from file: %q - %q", policyCurrent.Name, policyCurrent.ID)
+	} else {
+		// Created a specific Agent Policy to enrolling purposes
+		// There are some issues when the stack is running for some time,
+		// agents cannot enroll with the default policy
+		// This enroll policy must be created even if independent Elastic Agents are not used. Agents created
+		// in Kubernetes or Custom Agents require this enroll policy too (service deployer).
+		logger.Debug("creating enroll policy...")
+		policyEnroll := kibana.Policy{
+			Name:        fmt.Sprintf("ep-test-system-enroll-%s-%s-%s-%s-%s", r.testFolder.Package, r.testFolder.DataStream, r.serviceVariant, r.configFileName, testTime),
+			Description: fmt.Sprintf("test policy created by elastic-package to enroll agent for data stream %s/%s", r.testFolder.Package, r.testFolder.DataStream),
+			Namespace:   common.CreateTestRunID(),
+		}
+
+		policyToEnroll, err = r.kibanaClient.CreatePolicy(ctx, policyEnroll)
+		if err != nil {
+			return nil, fmt.Errorf("could not create test policy: %w", err)
+		}
+	}
+
+	r.deleteTestPolicyHandler = func(ctx context.Context) error {
+		// ensure that policyToEnroll policy gets deleted if the execution receives a signal
+		// before creating the test policy
+		// This handler is going to be redefined after creating the test policy
+		if r.runTestsOnly {
+			return nil
+		}
+		if err := r.kibanaClient.DeletePolicy(ctx, policyToEnroll.ID); err != nil {
+			return fmt.Errorf("error cleaning up test policy: %w", err)
+		}
+		return nil
+	}
+
+	if r.runTearDown {
+		// required to assign the policy stored in the service state file
+		// so data stream related to this Agent Policy can be obtained (and deleted)
+		// in the cleanTestScenarioHandler handler
+		policyToTest = policyCurrent
+	} else {
+		// Create a specific Agent Policy just for testing this test.
+		// This allows us to ensure that the Agent Policy used for testing is
+		// assigned to the agent with all the required changes (e.g. Package DataStream)
+		logger.Debug("creating test policy...")
+		policy := kibana.Policy{
+			Name:        fmt.Sprintf("ep-test-system-%s-%s-%s-%s-%s", r.testFolder.Package, r.testFolder.DataStream, r.serviceVariant, r.configFileName, testTime),
+			Description: fmt.Sprintf("test policy created by elastic-package test system for data stream %s/%s", r.testFolder.Package, r.testFolder.DataStream),
+			Namespace:   common.CreateTestRunID(),
+		}
+		// Assign the data_output_id to the agent policy to configure the output to logstash. The value is inferred from stack/_static/kibana.yml.tmpl
+		// TODO: Migrate from stack.logstash_enabled to the stack config.
+		if r.profile.Config("stack.logstash_enabled", "false") == "true" {
+			policy.DataOutputID = "fleet-logstash-output"
+		}
+		if stackConfig.OutputID != "" {
+			policy.DataOutputID = stackConfig.OutputID
+		}
+		policyToTest, err = r.kibanaClient.CreatePolicy(ctx, policy)
+		if err != nil {
+			return nil, fmt.Errorf("could not create test policy: %w", err)
+		}
+	}
+
+	r.deleteTestPolicyHandler = func(ctx context.Context) error {
+		logger.Debug("deleting test policies...")
+		if err := r.kibanaClient.DeletePolicy(ctx, policyToTest.ID); err != nil {
+			return fmt.Errorf("error cleaning up test policy: %w", err)
+		}
+		if r.runTestsOnly {
+			return nil
+		}
+		if err := r.kibanaClient.DeletePolicy(ctx, policyToEnroll.ID); err != nil {
+			return fmt.Errorf("error cleaning up test policy: %w", err)
+		}
+		return nil
 	}
 
 	// policyToEnroll is used in both independent agents and agents created by servicedeployer (custom or kubernetes agents)
@@ -1240,94 +1317,6 @@ func (r *tester) prepareScenario(ctx context.Context, config *testConfig, stackC
 	}
 
 	return &scenario, nil
-}
-
-func (r *tester) createKibanaPolicies(ctx context.Context, serviceStateData ServiceState, stackConfig stack.Config) (*kibana.Policy, *kibana.Policy, *kibana.Policy, error) {
-	// Configure package (single data stream) via Fleet APIs.
-	testTime := time.Now().Format("20060102T15:04:05Z")
-	var policyToTest, policyCurrent, policyToEnroll *kibana.Policy
-	var err error
-
-	if r.runTearDown || r.runTestsOnly {
-		policyCurrent = &serviceStateData.CurrentPolicy
-		policyToEnroll = &serviceStateData.EnrollPolicy
-		logger.Debugf("Got current policy from file: %q - %q", policyCurrent.Name, policyCurrent.ID)
-	} else {
-		// Created a specific Agent Policy to enrolling purposes
-		// There are some issues when the stack is running for some time,
-		// agents cannot enroll with the default policy
-		// This enroll policy must be created even if independent Elastic Agents are not used. Agents created
-		// in Kubernetes or Custom Agents require this enroll policy too (service deployer).
-		logger.Debug("creating enroll policy...")
-		policyEnroll := kibana.Policy{
-			Name:        fmt.Sprintf("ep-test-system-enroll-%s-%s-%s-%s-%s", r.testFolder.Package, r.testFolder.DataStream, r.serviceVariant, r.configFileName, testTime),
-			Description: fmt.Sprintf("test policy created by elastic-package to enroll agent for data stream %s/%s", r.testFolder.Package, r.testFolder.DataStream),
-			Namespace:   common.CreateTestRunID(),
-		}
-
-		policyToEnroll, err = r.kibanaClient.CreatePolicy(ctx, policyEnroll)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("could not create test policy: %w", err)
-		}
-	}
-
-	r.deleteTestPolicyHandler = func(ctx context.Context) error {
-		// ensure that policyToEnroll policy gets deleted if the execution receives a signal
-		// before creating the test policy
-		// This handler is going to be redefined after creating the test policy
-		if r.runTestsOnly {
-			return nil
-		}
-		if err := r.kibanaClient.DeletePolicy(ctx, policyToEnroll.ID); err != nil {
-			return fmt.Errorf("error cleaning up test policy: %w", err)
-		}
-		return nil
-	}
-
-	if r.runTearDown {
-		// required to assign the policy stored in the service state file
-		// so data stream related to this Agent Policy can be obtained (and deleted)
-		// in the cleanTestScenarioHandler handler
-		policyToTest = policyCurrent
-	} else {
-		// Create a specific Agent Policy just for testing this test.
-		// This allows us to ensure that the Agent Policy used for testing is
-		// assigned to the agent with all the required changes (e.g. Package DataStream)
-		logger.Debug("creating test policy...")
-		policy := kibana.Policy{
-			Name:        fmt.Sprintf("ep-test-system-%s-%s-%s-%s-%s", r.testFolder.Package, r.testFolder.DataStream, r.serviceVariant, r.configFileName, testTime),
-			Description: fmt.Sprintf("test policy created by elastic-package test system for data stream %s/%s", r.testFolder.Package, r.testFolder.DataStream),
-			Namespace:   common.CreateTestRunID(),
-		}
-		// Assign the data_output_id to the agent policy to configure the output to logstash. The value is inferred from stack/_static/kibana.yml.tmpl
-		// TODO: Migrate from stack.logstash_enabled to the stack config.
-		if r.profile.Config("stack.logstash_enabled", "false") == "true" {
-			policy.DataOutputID = "fleet-logstash-output"
-		}
-		if stackConfig.OutputID != "" {
-			policy.DataOutputID = stackConfig.OutputID
-		}
-		policyToTest, err = r.kibanaClient.CreatePolicy(ctx, policy)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("could not create test policy: %w", err)
-		}
-	}
-
-	r.deleteTestPolicyHandler = func(ctx context.Context) error {
-		logger.Debug("deleting test policies...")
-		if err := r.kibanaClient.DeletePolicy(ctx, policyToTest.ID); err != nil {
-			return fmt.Errorf("error cleaning up test policy: %w", err)
-		}
-		if r.runTestsOnly {
-			return nil
-		}
-		if err := r.kibanaClient.DeletePolicy(ctx, policyToEnroll.ID); err != nil {
-			return fmt.Errorf("error cleaning up test policy: %w", err)
-		}
-		return nil
-	}
-
-	return policyCurrent, policyToEnroll, policyToTest, nil
 }
 
 func (r *tester) buildIndexTemplateName(ds kibana.PackageDataStream, policyTemplate packages.PolicyTemplate, config *testConfig) string {

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -1147,9 +1147,6 @@ func (r *tester) prepareScenario(ctx context.Context, config *testConfig, stackC
 	}
 	scenario.kibanaDataStream = ds
 
-	// Delete old data
-	logger.Debug("deleting old data in data stream...")
-
 	scenario.indexTemplateName = r.buildIndexTemplateName(ds, policyTemplate, config)
 	scenario.dataStream = fmt.Sprintf(
 		"%s-%s",

--- a/test/packages/parallel/httpcheck/_dev/test/system/test-local-config.yml
+++ b/test/packages/parallel/httpcheck/_dev/test/system/test-local-config.yml
@@ -1,6 +1,6 @@
-skip:
-  reason: Not supported system tests with input type otelcol.
-  link: https://github.com/elastic/elastic-package/issues/2835
+# skip:
+#   reason: Not supported system tests with input type otelcol.
+#   link: https://github.com/elastic/elastic-package/issues/2835
 service: web
 vars:
   period: 1s


### PR DESCRIPTION
Relates #2835
Depends on https://github.com/elastic/kibana/pull/233090
Depends on https://github.com/elastic/fleet-server/pull/5469

Add support of system tests in input packages using otelcol input.

### How to test this PR locally

Use the kibana code from https://github.com/elastic/kibana/pull/233090. Enable the feature flag `enableOtelIntegrations`.

Using elastic-package to install the scenario (with these instructions: https://github.com/elastic/elastic-package/blob/main/docs/howto/use_existing_stack.md).
```
mage build:cover docker:customagentimage
export ELASTIC_AGENT_IMAGE_REF_OVERRIDE=<image tag generated in previous step>
export ELASTIC_PACKAGE_ELASTICSEARCH_PASSWORD=changeme
export ELASTIC_PACKAGE_ELASTICSEARCH_USERNAME=elastic
export ELASTIC_PACKAGE_KIBANA_HOST=http://localhost:5601
export ELASTIC_PACKAGE_ELASTICSEARCH_HOST=http://localhost:9200
elastic-package stack up -v -d --provider environment --version 9.2.0-SNAPSHOT

elastic-package -C test/packages/parallel/httpcheck test system -v
```

