### PR TITLE
[CI] Add retry to test serverless pipeline

### DIFF
--- a/.buildkite/scripts/tooling.sh
+++ b/.buildkite/scripts/tooling.sh
@@ -95,7 +95,9 @@ prepare_serverless_stack() {
             -U "stack.serverless.region=${EC_REGION_SECRET},stack.serverless.type=${SERVERLESS_PROJECT}" 2>&1 | grep -E -v "^Password: " ; then
 
             echo "Failed to start Elastic stack with Serverless provider"
-            elastic-package stack down
+            # This command could fail since the docker-compose project could not be initialized
+            # or even when deleting the Serverless project
+            elastic-package stack down || true
             sleep 10
         else
             echo "Elastic stack with Serverless provider started"


### PR DESCRIPTION
Sometimes CI pipeline in charge of testing `elastic-package` with Serverless fails when creating the Serverless project:

```
Error: booting up the stack failed: failed to create deployment: failed to get fleet URL: failed to query fleet server hosts: could not find a fleet server URL
```

Example build: https://buildkite.com/elastic/elastic-package-test-serverless/builds/548#01993725-bd96-4312-aca7-f7bc1d972eaa/441-469

This PR adds automatic retries in the Buildkite pipeline just if the error happens when creating the Serverless project when running `elastic-package stack up` command.