### PR TITLE
[Serverless] Add retries to get default Fleet Server URL

### DIFF
--- a/internal/stack/serverless.go
+++ b/internal/stack/serverless.go
@@ -127,7 +127,7 @@ func (sp *serverlessProvider) createProject(ctx context.Context, settings projec
 		return Config{}, fmt.Errorf("error while waiting for Fleet Server URL: %w", err)
 	}
 	if !found {
-		return Config{}, fmt.Errorf("Fleet Server URL not found after %s", sp.retriesDefaultFleetServerTimeout)
+		return Config{}, fmt.Errorf("not found Fleet Server URL after %s", sp.retriesDefaultFleetServerTimeout)
 	}
 
 	config.Parameters[ParamServerlessFleetURL] = fleetServerURL

--- a/internal/stack/serverless.go
+++ b/internal/stack/serverless.go
@@ -110,9 +110,8 @@ func (sp *serverlessProvider) createProject(ctx context.Context, settings projec
 		return Config{}, err
 	}
 
-	fleetServerURL := ""
 	found, err := wait.UntilTrue(ctx, func(ctx context.Context) (bool, error) {
-		fleetServerURL, err = project.DefaultFleetServerURL(ctx, sp.kibanaClient)
+		config.Parameters[ParamServerlessFleetURL], err = project.DefaultFleetServerURL(ctx, sp.kibanaClient)
 		if errors.Is(err, kibana.ErrFleetServerNotFound) {
 			logger.Debug("Fleet Server URL not found yet, retrying...")
 			return false, nil
@@ -130,7 +129,6 @@ func (sp *serverlessProvider) createProject(ctx context.Context, settings projec
 		return Config{}, fmt.Errorf("not found Fleet Server URL after %s", sp.retriesDefaultFleetServerTimeout)
 	}
 
-	config.Parameters[ParamServerlessFleetURL] = fleetServerURL
 	project.Endpoints.Fleet = config.Parameters[ParamServerlessFleetURL]
 
 	printUserConfig(options.Printer, config)

--- a/internal/stack/serverless.go
+++ b/internal/stack/serverless.go
@@ -35,6 +35,9 @@ const (
 
 	defaultRegion      = "aws-us-east-1"
 	defaultProjectType = "observability"
+
+	defaultRetriesDefaultFleetServerPeriod  = 2 * time.Second
+	defaultRetriesDefaultFleetServerTimeout = 10 * time.Second
 )
 
 var allowedProjectTypes = []string{
@@ -49,8 +52,8 @@ type serverlessProvider struct {
 	elasticsearchClient *elasticsearch.Client
 	kibanaClient        *kibana.Client
 
-	retriesDefaultFleetServerTimeout  time.Duration
-	retriesDefaultFleetServerInterval time.Duration
+	retriesDefaultFleetServerTimeout time.Duration
+	retriesDefaultFleetServerPeriod  time.Duration
 }
 
 type projectSettings struct {
@@ -119,7 +122,7 @@ func (sp *serverlessProvider) createProject(ctx context.Context, settings projec
 		}
 		logger.Debug("Fleet Server found")
 		return true, nil
-	}, sp.retriesDefaultFleetServerInterval, sp.retriesDefaultFleetServerTimeout)
+	}, sp.retriesDefaultFleetServerPeriod, sp.retriesDefaultFleetServerTimeout)
 	if fleetServerURL == "" {
 		return Config{}, fmt.Errorf("failed to get fleet URL: %w", err)
 	}
@@ -254,12 +257,12 @@ func newServerlessProvider(profile *profile.Profile) (*serverlessProvider, error
 	}
 
 	return &serverlessProvider{
-		profile:                           profile,
-		client:                            client,
-		elasticsearchClient:               nil,
-		kibanaClient:                      nil,
-		retriesDefaultFleetServerTimeout:  10 * time.Second,
-		retriesDefaultFleetServerInterval: 2 * time.Second,
+		profile:                          profile,
+		client:                           client,
+		elasticsearchClient:              nil,
+		kibanaClient:                     nil,
+		retriesDefaultFleetServerTimeout: defaultRetriesDefaultFleetServerTimeout,
+		retriesDefaultFleetServerPeriod:  defaultRetriesDefaultFleetServerPeriod,
 	}, nil
 }
 

--- a/internal/stack/serverless.go
+++ b/internal/stack/serverless.go
@@ -111,12 +111,13 @@ func (sp *serverlessProvider) createProject(ctx context.Context, settings projec
 	wait.UntilTrue(ctx, func(ctx context.Context) (bool, error) {
 		fleetServerURL, err = project.DefaultFleetServerURL(ctx, sp.kibanaClient)
 		if errors.Is(err, kibana.ErrFleetServerNotFound) {
-			logger.Debugf("Fleet Server URL not found yet, retrying...")
+			logger.Debug("Fleet Server URL not found yet, retrying...")
 			return false, nil
 		}
 		if err != nil {
 			return false, err
 		}
+		logger.Debug("Fleet Server found")
 		return true, nil
 	}, sp.retriesDefaultFleetServerInterval, sp.retriesDefaultFleetServerTimeout)
 	if fleetServerURL == "" {


### PR DESCRIPTION
Closes https://github.com/elastic/elastic-package/issues/2902

While creating Elastic stacks using the serverless provider, sometimes the `elastic-package stack up` command fails to find the Fleet Server URL. This can be observed specially in the CI daily jobs. For instance:
- https://buildkite.com/elastic/elastic-package-test-serverless/builds/546#01992cd8-eb64-4fca-8aa8-c841c1f0e045

Considering that the Kibana Client already performs some retries in case of failures, this PR adds retries to the query that gets the default Fleet Server.

Example of this new wait process ([buildkite link](https://buildkite.com/elastic/elastic-package-test-serverless/builds/559#01993d20-71aa-4731-b789-7fd14cc5bdd6/482-511)): 

```
2025/09/12 08:58:17 DEBUG project <project> initialized
2025/09/12 08:58:18 DEBUG Fleet Server URL not found yet, retrying...
2025/09/12 08:58:20 DEBUG Fleet Server found
Elasticsearch host: ...
```