### PR TITLE
[System tests] Support getting docs when it is set otelcol as policy template input

### DIFF
--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -1596,13 +1596,12 @@ func (r *tester) waitForDocs(ctx context.Context, config *testConfig, dataStream
 }
 
 func (r *tester) validateTestScenario(ctx context.Context, result *testrunner.ResultComposer, scenario *scenarioTest, config *testConfig) ([]testrunner.TestResult, error) {
-	// Validate fields in docs
-	// when reroute processors are used, expectedDatasets should be set depends on the processor config
 	expectedDatasets, err := r.expectedDatasets(scenario, config)
 	if err != nil {
 		return nil, err
 	}
 
+	// Validate fields in docs
 	fieldsValidator, err := fields.CreateValidatorForDirectory(r.dataStreamPath,
 		fields.WithSpecVersion(r.pkgManifest.SpecVersion),
 		fields.WithNumericKeywordFields(config.NumericKeywordFields),


### PR DESCRIPTION
Relates #2885 
Relates #2835

Depends on https://github.com/elastic/kibana/pull/235226
Depends on https://github.com/elastic/fleet-server/pull/5469

This PR adds the initial support to retrieve the documents in system tests when an input package with the `otelcol` policy template input is used.

It also updates the expected datasets for the validation to include the `otel` suffix.

There are still validation issues in fields and mappings, but this PR allows us to get the docs from the right data stream:
```
2025/09/19 12:30:01 DEBUG found 0 hits in metrics-httpcheck.check.otel-82159 data stream
2025/09/19 12:30:02 DEBUG found 174 hits in metrics-httpcheck.check.otel-82159 data stream
2025/09/19 12:30:02 DEBUG Found 0 deprecation warnings for data stream metrics-httpcheck.check.otel-82159
2025/09/19 12:30:02 DEBUG Check whether or not synthetic source mode is enabled (data stream metrics-httpcheck.check.otel-82159)...
2025/09/19 12:30:02 DEBUG Data stream metrics-httpcheck.check.otel-82159 has synthetic source mode enabled: false
```


### How to test this PR locally

Use the kibana code from https://github.com/elastic/kibana/pull/235226. Enable the feature flag `enableOtelIntegrations`.

Enable the test system for `httpcheck`:
```diff
--- test/packages/parallel/httpcheck/_dev/test/system/test-local-config.yml
+++ test/packages/parallel/httpcheck/_dev/test/system/test-local-config.yml
@@ -1,6 +1,6 @@
-skip:
-  reason: Not supported system tests with input type otelcol.
-  link: https://github.com/elastic/elastic-package/issues/2835
+# skip:
+#   reason: Not supported system tests with input type otelcol.
+#   link: https://github.com/elastic/elastic-package/issues/2835
 service: web
 vars:
   period: 1s
```

Using `elastic-package` to install the scenario (with these instructions: https://github.com/elastic/elastic-package/blob/main/docs/howto/use_existing_stack.md).
```
# Build the fleet-server docker image from https://github.com/elastic/fleet-server/pull/5469
mage build:cover docker:customagentimage
export ELASTIC_AGENT_IMAGE_REF_OVERRIDE=<image tag generated in previous step>

export ELASTIC_PACKAGE_ELASTICSEARCH_PASSWORD=changeme
export ELASTIC_PACKAGE_ELASTICSEARCH_USERNAME=elastic
export ELASTIC_PACKAGE_KIBANA_HOST=http://localhost:5601
export ELASTIC_PACKAGE_ELASTICSEARCH_HOST=http://localhost:9200
elastic-package stack up -v -d --provider environment --version 9.2.0-SNAPSHOT

elastic-package -C test/packages/parallel/httpcheck test system -v
```
