### PR TITLE
[System tests] Skip dynamic templates that do not contain match conditions

### DIFF
--- a/internal/fields/dynamictemplate.go
+++ b/internal/fields/dynamictemplate.go
@@ -147,6 +147,7 @@ func parseDynamicTemplates(rawDynamicTemplates []map[string]any) ([]dynamicTempl
 			return nil, fmt.Errorf("unexpected dynamic template format found for %q", templateName)
 		}
 
+		isMatchAttributeDefined := false
 		isRuntime := false
 		for setting, value := range contents {
 			switch setting {
@@ -160,6 +161,7 @@ func parseDynamicTemplates(rawDynamicTemplates []map[string]any) ([]dynamicTempl
 					return nil, fmt.Errorf("invalid type for \"match_pattern\": %T", value)
 				}
 				aDynamicTemplate.matchPattern = s
+				isMatchAttributeDefined = true
 			case "match":
 				values, err := parseDynamicTemplateParameter(value)
 				if err != nil {
@@ -167,25 +169,30 @@ func parseDynamicTemplates(rawDynamicTemplates []map[string]any) ([]dynamicTempl
 					return nil, fmt.Errorf("failed to check match setting: %w", err)
 				}
 				aDynamicTemplate.match = values
+				isMatchAttributeDefined = true
 			case "unmatch":
 				values, err := parseDynamicTemplateParameter(value)
 				if err != nil {
 					return nil, fmt.Errorf("failed to check unmatch setting: %w", err)
 				}
 				aDynamicTemplate.unmatch = values
+				isMatchAttributeDefined = true
 			case "path_match":
 				values, err := parseDynamicTemplateParameter(value)
 				if err != nil {
 					return nil, fmt.Errorf("failed to check path_match setting: %w", err)
 				}
 				aDynamicTemplate.pathMatch = values
+				isMatchAttributeDefined = true
 			case "path_unmatch":
 				values, err := parseDynamicTemplateParameter(value)
 				if err != nil {
 					return nil, fmt.Errorf("failed to check path_unmatch setting: %w", err)
 				}
 				aDynamicTemplate.unpathMatch = values
+				isMatchAttributeDefined = true
 			case "match_mapping_type", "unmatch_mapping_type":
+				isMatchAttributeDefined = true
 				// Do nothing
 				// These parameters require to check the original type (before the document is ingested)
 				// but the dynamic template just contains the type from the `mapping` field
@@ -195,6 +202,9 @@ func parseDynamicTemplates(rawDynamicTemplates []map[string]any) ([]dynamicTempl
 		}
 
 		if isRuntime {
+			continue
+		}
+		if !isMatchAttributeDefined {
 			continue
 		}
 		dynamicTemplates = append(dynamicTemplates, aDynamicTemplate)


### PR DESCRIPTION
Relates #2885

This PR skips dynamic templates that do not contain any match condition:
- `match` and `unmatch`
- `path_match`and `path_unmatch`
- `match_mapping_type` and `unmatch_mapping_type`

Related docs: https://www.elastic.co/docs/manage-data/data-store/mapping/dynamic-templates#match-mapping-type