### PR TITLE
Decouple repository root resolver from internal logic

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -61,6 +61,16 @@ func buildCommandAction(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	repoRoot, err := files.FindRepositoryRootDirectory()
+	if err != nil {
+		return fmt.Errorf("locating repository root failed: %w", err)
+	}
+
+	linksFilePath, err := docs.LinksDefinitionsFilePath(repoRoot)
+	if err != nil {
+		return fmt.Errorf("locating links file failed: %w", err)
+	}
+
 	packageRoot, err := packages.MustFindPackageRoot()
 	if err != nil {
 		return fmt.Errorf("locating package root failed: %w", err)
@@ -72,7 +82,7 @@ func buildCommandAction(cmd *cobra.Command, args []string) error {
 	}
 	logger.Debugf("Use build directory: %s", buildDir)
 
-	targets, err := docs.UpdateReadmes(packageRoot, buildDir)
+	targets, err := docs.UpdateReadmes(linksFilePath, packageRoot, buildDir)
 	if err != nil {
 		return fmt.Errorf("updating files failed: %w", err)
 	}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -65,6 +65,7 @@ func buildCommandAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("locating repository root failed: %w", err)
 	}
+	defer repoRoot.Close()
 
 	linksFilePath, err := docs.LinksDefinitionsFilePath(repoRoot)
 	if err != nil {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -61,7 +61,7 @@ func buildCommandAction(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	repoRoot, err := files.FindRepositoryRootDirectory()
+	repoRoot, err := files.FindRepositoryRoot()
 	if err != nil {
 		return fmt.Errorf("locating repository root failed: %w", err)
 	}

--- a/cmd/links.go
+++ b/cmd/links.go
@@ -61,6 +61,7 @@ func linksCheckCommandAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("finding repository root: %w", err)
 	}
+	defer repoRoot.Close()
 
 	linksFS, err := files.CreateLinksFSFromPath(repoRoot, pwd)
 	if err != nil {
@@ -105,6 +106,7 @@ func linksUpdateCommandAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("finding repository root: %w", err)
 	}
+	defer repoRoot.Close()
 
 	linksFS, err := files.CreateLinksFSFromPath(repoRoot, pwd)
 	if err != nil {
@@ -151,6 +153,7 @@ func linksListCommandAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("finding repository root: %w", err)
 	}
+	defer repoRoot.Close()
 
 	linksFS, err := files.CreateLinksFSFromPath(repoRoot, pwd)
 	if err != nil {

--- a/cmd/links.go
+++ b/cmd/links.go
@@ -56,8 +56,13 @@ func linksCheckCommandAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("reading current working directory failed: %w", err)
 	}
+	// Find the repository root to create the links filesystem reference tied to the repository root
+	repoRoot, err := files.FindRepositoryRoot()
+	if err != nil {
+		return fmt.Errorf("finding repository root: %w", err)
+	}
 
-	linksFS, err := files.CreateLinksFSFromPath(pwd)
+	linksFS, err := files.CreateLinksFSFromPath(repoRoot, pwd)
 	if err != nil {
 		return fmt.Errorf("creating links filesystem failed: %w", err)
 	}
@@ -95,7 +100,13 @@ func linksUpdateCommandAction(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("reading current working directory failed: %w", err)
 	}
 
-	linksFS, err := files.CreateLinksFSFromPath(pwd)
+	// Find the repository root to create the links filesystem reference tied to the repository root
+	repoRoot, err := files.FindRepositoryRoot()
+	if err != nil {
+		return fmt.Errorf("finding repository root: %w", err)
+	}
+
+	linksFS, err := files.CreateLinksFSFromPath(repoRoot, pwd)
 	if err != nil {
 		return fmt.Errorf("creating links filesystem failed: %w", err)
 	}
@@ -135,7 +146,13 @@ func linksListCommandAction(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("reading current working directory failed: %w", err)
 	}
 
-	linksFS, err := files.CreateLinksFSFromPath(pwd)
+	// Find the repository root to create the links filesystem reference tied to the repository root
+	repoRoot, err := files.FindRepositoryRoot()
+	if err != nil {
+		return fmt.Errorf("finding repository root: %w", err)
+	}
+
+	linksFS, err := files.CreateLinksFSFromPath(repoRoot, pwd)
 	if err != nil {
 		return fmt.Errorf("creating links filesystem failed: %w", err)
 	}

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -51,6 +51,7 @@ func lintCommandAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("locating repository root failed: %w", err)
 	}
+	defer repoRoot.Close()
 
 	linksFilePath, err := docs.LinksDefinitionsFilePath(repoRoot)
 	if err != nil {

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -47,7 +47,7 @@ func setupLintCommand() *cobraext.Command {
 func lintCommandAction(cmd *cobra.Command, args []string) error {
 	cmd.Println("Lint the package")
 
-	repoRoot, err := files.FindRepositoryRootDirectory()
+	repoRoot, err := files.FindRepositoryRoot()
 	if err != nil {
 		return fmt.Errorf("locating repository root failed: %w", err)
 	}

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/elastic/elastic-package/internal/cobraext"
 	"github.com/elastic/elastic-package/internal/docs"
+	"github.com/elastic/elastic-package/internal/files"
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/validation"
@@ -45,7 +46,18 @@ func setupLintCommand() *cobraext.Command {
 
 func lintCommandAction(cmd *cobra.Command, args []string) error {
 	cmd.Println("Lint the package")
-	readmeFiles, err := docs.AreReadmesUpToDate()
+
+	repoRoot, err := files.FindRepositoryRootDirectory()
+	if err != nil {
+		return fmt.Errorf("locating repository root failed: %w", err)
+	}
+
+	linksFilePath, err := docs.LinksDefinitionsFilePath(repoRoot)
+	if err != nil {
+		return fmt.Errorf("locating links file failed: %w", err)
+	}
+
+	readmeFiles, err := docs.AreReadmesUpToDate(linksFilePath)
 	if err != nil {
 		for _, f := range readmeFiles {
 			if !f.UpToDate {

--- a/internal/builder/packages_test.go
+++ b/internal/builder/packages_test.go
@@ -36,6 +36,7 @@ func TestCopyLicenseTextFile_UsesExistingLicenseFile(t *testing.T) {
 
 	repoRoot, err := os.OpenRoot(t.TempDir())
 	require.NoError(t, err)
+	defer repoRoot.Close()
 
 	// Should not attempt to copy, just return nil
 	err = copyLicenseTextFile(repoRoot, licensePath)
@@ -50,6 +51,7 @@ func TestCopyLicenseTextFile_UsesExistingLicenseFile(t *testing.T) {
 func TestCopyLicenseTextFile_CopiesFromRepo(t *testing.T) {
 	repoRoot, err := os.OpenRoot(t.TempDir())
 	require.NoError(t, err)
+	defer repoRoot.Close()
 
 	licensePath := filepath.Join(repoRoot.Name(), "LICENSE.txt")
 	err = os.WriteFile(licensePath, []byte("repo license"), 0644)
@@ -69,6 +71,7 @@ func TestCopyLicenseTextFile_CopiesFromRepo(t *testing.T) {
 func TestCopyLicenseTextFile_NoRepoLicense_ReturnsNil(t *testing.T) {
 	repoRoot, err := os.OpenRoot(t.TempDir())
 	require.NoError(t, err)
+	defer repoRoot.Close()
 
 	destDir := t.TempDir()
 	destLicensePath := filepath.Join(destDir, "LICENSE.txt")
@@ -83,6 +86,7 @@ func TestCopyLicenseTextFile_NoRepoLicense_ReturnsNil(t *testing.T) {
 func TestCopyLicenseTextFile_EnvOverridesLicenseName(t *testing.T) {
 	repoRoot, err := os.OpenRoot(t.TempDir())
 	require.NoError(t, err)
+	defer repoRoot.Close()
 
 	customLicenseName := "CUSTOM_LICENSE.txt"
 	customLicensePath := filepath.Join(repoRoot.Name(), customLicenseName)
@@ -104,6 +108,7 @@ func TestCopyLicenseTextFile_EnvOverridesLicenseName(t *testing.T) {
 func TestCopyLicenseTextFile_ErrorCopyingFile(t *testing.T) {
 	repoRoot, err := os.OpenRoot(t.TempDir())
 	require.NoError(t, err)
+	defer repoRoot.Close()
 
 	licensePath := filepath.Join(repoRoot.Name(), "LICENSE.txt")
 	err = os.WriteFile(licensePath, []byte("repo license"), 0644)

--- a/internal/builder/packages_test.go
+++ b/internal/builder/packages_test.go
@@ -1,0 +1,117 @@
+package builder
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindRepositoryLicense_FileExists(t *testing.T) {
+	dir := t.TempDir()
+	licensePath := filepath.Join(dir, "LICENSE.txt")
+	err := os.WriteFile(licensePath, []byte("license content"), 0644)
+	require.NoError(t, err)
+
+	path, err := findRepositoryLicense(licensePath)
+	require.NoError(t, err)
+	assert.Equal(t, licensePath, path)
+}
+
+func TestFindRepositoryLicense_FileDoesNotExist(t *testing.T) {
+	dir := t.TempDir()
+	licensePath := filepath.Join(dir, "NON_EXISTENT_LICENSE.txt")
+
+	path, err := findRepositoryLicense(licensePath)
+	require.Error(t, err)
+	assert.Empty(t, path)
+}
+func TestCopyLicenseTextFile_UsesExistingLicenseFile(t *testing.T) {
+	dir := t.TempDir()
+	licensePath := filepath.Join(dir, "LICENSE.txt")
+	err := os.WriteFile(licensePath, []byte("existing license"), 0644)
+	require.NoError(t, err)
+
+	repoRoot, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+
+	// Should not attempt to copy, just return nil
+	err = copyLicenseTextFile(repoRoot, licensePath)
+	assert.NoError(t, err)
+
+	// License file should remain unchanged
+	content, err := os.ReadFile(licensePath)
+	require.NoError(t, err)
+	assert.Equal(t, "existing license", string(content))
+}
+
+func TestCopyLicenseTextFile_CopiesFromRepo(t *testing.T) {
+	repoRoot, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+
+	licensePath := filepath.Join(repoRoot.Name(), "LICENSE.txt")
+	err = os.WriteFile(licensePath, []byte("repo license"), 0644)
+	require.NoError(t, err)
+
+	destDir := t.TempDir()
+	destLicensePath := filepath.Join(destDir, "LICENSE.txt")
+
+	err = copyLicenseTextFile(repoRoot, destLicensePath)
+	assert.NoError(t, err)
+
+	content, err := os.ReadFile(destLicensePath)
+	require.NoError(t, err)
+	assert.Equal(t, "repo license", string(content))
+}
+
+func TestCopyLicenseTextFile_NoRepoLicense_ReturnsNil(t *testing.T) {
+	repoRoot, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+
+	destDir := t.TempDir()
+	destLicensePath := filepath.Join(destDir, "LICENSE.txt")
+
+	err = copyLicenseTextFile(repoRoot, destLicensePath)
+	assert.NoError(t, err)
+
+	_, err = os.Stat(destLicensePath)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestCopyLicenseTextFile_EnvOverridesLicenseName(t *testing.T) {
+	repoRoot, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+
+	customLicenseName := "CUSTOM_LICENSE.txt"
+	customLicensePath := filepath.Join(repoRoot.Name(), customLicenseName)
+	err = os.WriteFile(customLicensePath, []byte("custom license"), 0644)
+	require.NoError(t, err)
+
+	destDir := t.TempDir()
+	destLicensePath := filepath.Join(destDir, "LICENSE.txt")
+
+	t.Setenv(repositoryLicenseEnv, customLicenseName)
+	err = copyLicenseTextFile(repoRoot, destLicensePath)
+	assert.NoError(t, err)
+
+	content, err := os.ReadFile(destLicensePath)
+	require.NoError(t, err)
+	assert.Equal(t, "custom license", string(content))
+}
+
+func TestCopyLicenseTextFile_ErrorCopyingFile(t *testing.T) {
+	repoRoot, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+
+	licensePath := filepath.Join(repoRoot.Name(), "LICENSE.txt")
+	err = os.WriteFile(licensePath, []byte("repo license"), 0644)
+	require.NoError(t, err)
+
+	// Use a destination path that is a directory, so sh.Copy should fail
+	destDir := t.TempDir()
+
+	err = copyLicenseTextFile(repoRoot, destDir)
+	assert.Error(t, err)
+}

--- a/internal/docs/links_map.go
+++ b/internal/docs/links_map.go
@@ -89,7 +89,7 @@ func (l linkMap) RenderLink(key string, options linkOptions) (string, error) {
 // If the environment variable is not set, it falls back to the default file path
 // constructed from repoRoot and linksMapFileNameDefault, returning the path if the file exists,
 // or nil if it does not.
-func LinksDefinitionsFilePath(repoRoot string) (string, error) {
+func LinksDefinitionsFilePath(repoRoot *os.Root) (string, error) {
 	linksFilePath := os.Getenv(linksMapFilePathEnvVar)
 	if linksFilePath != "" {
 		if _, err := os.Stat(linksFilePath); err != nil {
@@ -99,7 +99,7 @@ func LinksDefinitionsFilePath(repoRoot string) (string, error) {
 		return linksFilePath, nil
 	}
 
-	linksFilePath = filepath.Join(repoRoot, linksMapFileNameDefault)
+	linksFilePath = filepath.Join(repoRoot.Name(), linksMapFileNameDefault)
 	if _, err := os.Stat(linksFilePath); err != nil {
 		logger.Debugf("links definitions default file doesn't exist: %s", linksFilePath)
 		return "", nil

--- a/internal/docs/links_map.go
+++ b/internal/docs/links_map.go
@@ -12,7 +12,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/elastic-package/internal/environment"
-	"github.com/elastic/elastic-package/internal/files"
 	"github.com/elastic/elastic-package/internal/logger"
 )
 
@@ -28,20 +27,20 @@ type linkOptions struct {
 	caption string
 }
 
-func newLinkMap() linkMap {
-	var links linkMap
-	links.Links = make(map[string]string)
-	return links
+func newLinkMap() *linkMap {
+	return &linkMap{
+		Links: make(map[string]string),
+	}
 }
 
-func (l linkMap) Get(key string) (string, error) {
+func (l *linkMap) Get(key string) (string, error) {
 	if url, ok := l.Links[key]; ok {
 		return url, nil
 	}
 	return "", fmt.Errorf("link key not found: %s", key)
 }
 
-func (l linkMap) Add(key, value string) error {
+func (l *linkMap) Add(key, value string) error {
 	if _, ok := l.Links[key]; ok {
 		return fmt.Errorf("link key already present: %s", key)
 	}
@@ -49,29 +48,28 @@ func (l linkMap) Add(key, value string) error {
 	return nil
 }
 
-func readLinksMap() (linkMap, error) {
-	linksFilePath, err := linksDefinitionsFilePath()
-	if err != nil {
-		return linkMap{}, fmt.Errorf("locating links file failed: %w", err)
-	}
-
-	links := newLinkMap()
+// readLinksMap reads the links definitions file from the given repository root directory,
+// parses its YAML contents, and returns a populated linkMap. If the links file does not exist,
+// it returns an empty linkMap. Returns an error if locating, reading, or unmarshalling the file fails.
+func readLinksMap(linksFilePath string) (*linkMap, error) {
+	// No links file, return empty map with Links initialized
 	if linksFilePath == "" {
-		return links, nil
+		return newLinkMap(), nil
 	}
 
 	logger.Debugf("Using links definitions file: %s", linksFilePath)
 	contents, err := os.ReadFile(linksFilePath)
 	if err != nil {
-		return linkMap{}, fmt.Errorf("readfile failed (path: %s): %w", linksFilePath, err)
+		return nil, fmt.Errorf("readfile failed (path: %s): %w", linksFilePath, err)
 	}
 
-	err = yaml.Unmarshal(contents, &links)
+	var lmap linkMap
+	err = yaml.Unmarshal(contents, &lmap)
 	if err != nil {
-		return linkMap{}, err
+		return nil, err
 	}
 
-	return links, nil
+	return &lmap, nil
 }
 
 func (l linkMap) RenderLink(key string, options linkOptions) (string, error) {
@@ -85,32 +83,27 @@ func (l linkMap) RenderLink(key string, options linkOptions) (string, error) {
 	return url, nil
 }
 
-// linksDefinitionsFilePath returns the path where links definitions are located or empty string if the file does not exist.
-// If linksMapFilePathEnvVar is defined, it returns the value of that env var.
-func linksDefinitionsFilePath() (string, error) {
-	var err error
-	linksFilePath, ok := os.LookupEnv(linksMapFilePathEnvVar)
-	if ok {
-		_, err = os.Stat(linksFilePath)
-		if err != nil {
+// LinksDefinitionsFilePath returns the file path to the links definitions file.
+// It first checks if the environment variable specified by linksMapFilePathEnvVar is set.
+// If set, it verifies that the file exists and returns its path, or an error if not found.
+// If the environment variable is not set, it falls back to the default file path
+// constructed from repoRoot and linksMapFileNameDefault, returning the path if the file exists,
+// or nil if it does not.
+func LinksDefinitionsFilePath(repoRoot string) (string, error) {
+	linksFilePath := os.Getenv(linksMapFilePathEnvVar)
+	if linksFilePath != "" {
+		if _, err := os.Stat(linksFilePath); err != nil {
 			// if env var is defined, file must exist
 			return "", fmt.Errorf("links definitions file set with %s doesn't exist: %s", linksMapFilePathEnvVar, linksFilePath)
 		}
 		return linksFilePath, nil
 	}
 
-	dir, err := files.FindRepositoryRootDirectory()
-	if err != nil {
-		return "", err
-	}
-
-	linksFilePath = filepath.Join(dir, linksMapFileNameDefault)
-	_, err = os.Stat(linksFilePath)
-	if err != nil {
+	linksFilePath = filepath.Join(repoRoot, linksMapFileNameDefault)
+	if _, err := os.Stat(linksFilePath); err != nil {
 		logger.Debugf("links definitions default file doesn't exist: %s", linksFilePath)
 		return "", nil
 	}
 
 	return linksFilePath, nil
-
 }

--- a/internal/docs/links_map_test.go
+++ b/internal/docs/links_map_test.go
@@ -91,9 +91,12 @@ func TestRenderLink(t *testing.T) {
 
 func TestLinksDefinitionsFilePath(t *testing.T) {
 	t.Run("env var set and file exists", func(t *testing.T) {
-		repoRoot := t.TempDir()
-		defaultFilePath := filepath.Join(repoRoot, linksMapFileNameDefault)
-		testFile := filepath.Join(repoRoot, "custom_links.yml")
+		repoRoot, err := os.OpenRoot(t.TempDir())
+		require.NoError(t, err)
+		defer repoRoot.Close()
+
+		defaultFilePath := filepath.Join(repoRoot.Name(), linksMapFileNameDefault)
+		testFile := filepath.Join(repoRoot.Name(), "custom_links.yml")
 		require.NoError(t, createLinksFile(testFile))
 		require.NoError(t, createLinksFile(defaultFilePath)) // to ensure default file is ignored
 		t.Setenv(linksMapFilePathEnvVar, testFile)
@@ -104,9 +107,11 @@ func TestLinksDefinitionsFilePath(t *testing.T) {
 	})
 
 	t.Run("env var set but file does not exist", func(t *testing.T) {
-		repoRoot := t.TempDir()
+		repoRoot, err := os.OpenRoot(t.TempDir())
+		require.NoError(t, err)
+		defer repoRoot.Close()
 
-		missingFile := filepath.Join(repoRoot, "missing_links.yml")
+		missingFile := filepath.Join(repoRoot.Name(), "missing_links.yml")
 		t.Setenv(linksMapFilePathEnvVar, missingFile)
 
 		path, err := LinksDefinitionsFilePath(repoRoot)
@@ -115,8 +120,10 @@ func TestLinksDefinitionsFilePath(t *testing.T) {
 	})
 
 	t.Run("env var not set, default file exists", func(t *testing.T) {
-		repoRoot := t.TempDir()
-		defaultFilePath := filepath.Join(repoRoot, linksMapFileNameDefault)
+		repoRoot, err := os.OpenRoot(t.TempDir())
+		require.NoError(t, err)
+		defer repoRoot.Close()
+		defaultFilePath := filepath.Join(repoRoot.Name(), linksMapFileNameDefault)
 
 		require.NoError(t, createLinksFile(defaultFilePath))
 
@@ -128,10 +135,12 @@ func TestLinksDefinitionsFilePath(t *testing.T) {
 	})
 
 	t.Run("env var not set, default file does not exist", func(t *testing.T) {
-		repoRoot := t.TempDir()
-		defaultFilePath := filepath.Join(repoRoot, linksMapFileNameDefault)
+		repoRoot, err := os.OpenRoot(t.TempDir())
+		require.NoError(t, err)
+		defer repoRoot.Close()
+		defaultFilePath := filepath.Join(repoRoot.Name(), linksMapFileNameDefault)
 
-		_, err := os.Stat(defaultFilePath)
+		_, err = os.Stat(defaultFilePath)
 		require.True(t, os.IsNotExist(err))
 
 		path, err := LinksDefinitionsFilePath(repoRoot)

--- a/internal/docs/readme_test.go
+++ b/internal/docs/readme_test.go
@@ -18,15 +18,13 @@ import (
 func TestGenerateReadme(t *testing.T) {
 	cases := []struct {
 		title                  string
-		packageRoot            string
 		filename               string
 		readmeTemplateContents string
 		expected               string
 	}{
 		{
-			title:       "Pure markdown",
-			packageRoot: t.TempDir(),
-			filename:    "README.md",
+			title:    "Pure markdown",
+			filename: "README.md",
 			readmeTemplateContents: `
 # README
 Introduction to the package`,
@@ -35,9 +33,8 @@ Introduction to the package`,
 Introduction to the package`,
 		},
 		{
-			title:       "Generated headers",
-			packageRoot: t.TempDir(),
-			filename:    "README.md",
+			title:    "Generated headers",
+			filename: "README.md",
 			readmeTemplateContents: `
 {{- generatedHeader }}
 # README
@@ -49,7 +46,6 @@ Introduction to the package`,
 		},
 		{
 			title:                  "Static README",
-			packageRoot:            t.TempDir(),
 			filename:               "README.md",
 			readmeTemplateContents: "",
 			expected:               "",
@@ -57,10 +53,12 @@ Introduction to the package`,
 	}
 	for _, c := range cases {
 		t.Run(c.title, func(t *testing.T) {
-			err := createReadmeFile(c.packageRoot, c.readmeTemplateContents)
+
+			dir := t.TempDir()
+			err := createReadmeFile(dir, c.readmeTemplateContents)
 			require.NoError(t, err)
 
-			rendered, isTemplate, err := generateReadme(c.filename, c.packageRoot)
+			rendered, isTemplate, err := generateReadme(c.filename, "", dir)
 			require.NoError(t, err)
 
 			if c.readmeTemplateContents != "" {
@@ -84,7 +82,7 @@ func TestRenderReadmeWithLinks(t *testing.T) {
 		packageRoot            string
 		templatePath           string
 		readmeTemplateContents string
-		linksMap               linkMap
+		linksMap               *linkMap
 		expected               string
 	}{
 		{

--- a/internal/elasticsearch/ingest/datastream.go
+++ b/internal/elasticsearch/ingest/datastream.go
@@ -82,7 +82,12 @@ func loadIngestPipelineFiles(dataStreamPath string, nonce int64) ([]Pipeline, er
 		pipelineFiles = append(pipelineFiles, files...)
 	}
 
-	linksFS, err := files.CreateLinksFSFromPath(elasticsearchPath)
+	root, err := files.FindRepositoryRoot()
+	if err != nil {
+		return nil, fmt.Errorf("finding repository root failed: %w", err)
+	}
+
+	linksFS, err := files.CreateLinksFSFromPath(root, elasticsearchPath)
 	if err != nil {
 		return nil, fmt.Errorf("creating links filesystem failed: %w", err)
 	}

--- a/internal/elasticsearch/ingest/datastream.go
+++ b/internal/elasticsearch/ingest/datastream.go
@@ -86,6 +86,7 @@ func loadIngestPipelineFiles(dataStreamPath string, nonce int64) ([]Pipeline, er
 	if err != nil {
 		return nil, fmt.Errorf("finding repository root failed: %w", err)
 	}
+	defer root.Close()
 
 	linksFS, err := files.CreateLinksFSFromPath(root, elasticsearchPath)
 	if err != nil {

--- a/internal/files/linkedfiles.go
+++ b/internal/files/linkedfiles.go
@@ -41,11 +41,6 @@ func CreateLinksFSFromPath(repoRoot *os.Root, workDir string) (*LinksFS, error) 
 		workDir = filepath.Join(repoRoot.Name(), workDir)
 	}
 
-	// root, err := os.OpenRoot(rootPath)
-	// if err != nil {
-	// 	return nil, fmt.Errorf("opening repository root: %w", err)
-	// }
-
 	return NewLinksFS(repoRoot, workDir)
 }
 

--- a/internal/files/linkedfiles.go
+++ b/internal/files/linkedfiles.go
@@ -167,21 +167,20 @@ func (lfs *LinksFS) ListLinkedFilesByPackage() ([]PackageLinks, error) {
 }
 
 // A Link represents a linked file.
-// It contains the path to the link file, the checksum of the link file,
-// the path to the included file, and the checksum of the included file contents.
-// It also contains a boolean indicating whether the link is up to date.
+// A linked file is a file with the ".link" extension that contains a reference to another file in an other package.
+// The link file contains the relative path to the included file and an optional checksum of the included file contents.
 type Link struct {
-	WorkDir string
+	WorkDir string // WorkDir is the path to the directory containing the link file. This is where the copy of the included file will be placed.
 
-	LinkFilePath    string
+	LinkFilePath    string // LinkFilePath is the relative path of the linked file and the package root
 	LinkChecksum    string
-	LinkPackageName string
+	LinkPackageName string // Package where the link file is located
 
-	IncludedFilePath             string
-	IncludedFileContentsChecksum string
-	IncludedPackageName          string
+	IncludedFilePath             string // IncludedFilePath is the path to the included file, this is the content of the link file
+	IncludedFileContentsChecksum string // IncludedFileContentsChecksum is the checksum of the included file contents, this is the second field in the link file
+	IncludedPackageName          string // IncludedPackageName is the package where the included file is located
 
-	UpToDate bool
+	UpToDate bool // UpToDate indicates whether the content of the included file matches the checksum in the link file
 }
 
 // NewLinkedFile creates a new Link from the given link file path.

--- a/internal/files/linkedfiles_test.go
+++ b/internal/files/linkedfiles_test.go
@@ -522,6 +522,7 @@ func TestLinksFSSecurityIsolation(t *testing.T) {
 	// Create LinksFS
 	root, err := os.OpenRoot(repoDir)
 	require.NoError(t, err)
+	defer root.Close()
 
 	// Get the relative path from repo root to work directory
 	relWorkDir, err := filepath.Rel(repoDir, workDir)

--- a/internal/packages/archetype/data_stream_test.go
+++ b/internal/packages/archetype/data_stream_test.go
@@ -61,6 +61,7 @@ func createDataStreamDescriptorForTest() DataStreamDescriptor {
 func createAndCheckDataStream(t *testing.T, pd PackageDescriptor, dd DataStreamDescriptor, valid bool) {
 	repoRoot, err := os.OpenRoot(t.TempDir())
 	require.NoError(t, err)
+	defer repoRoot.Close()
 
 	linksFilePath := ""
 

--- a/internal/packages/archetype/package_test.go
+++ b/internal/packages/archetype/package_test.go
@@ -40,6 +40,7 @@ func TestPackage(t *testing.T) {
 func createAndCheckPackage(t *testing.T, pd PackageDescriptor, valid bool) {
 	repoRoot, err := os.OpenRoot(t.TempDir())
 	require.NoError(t, err)
+	defer repoRoot.Close()
 
 	linksFilePath := ""
 	packagesDir := filepath.Join(repoRoot.Name(), "packages")

--- a/internal/packages/installer/factory.go
+++ b/internal/packages/installer/factory.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/Masterminds/semver/v3"
 
@@ -37,6 +38,7 @@ type Options struct {
 	RootPath       string
 	ZipPath        string
 	SkipValidation bool
+	RepoRoot       *os.Root
 }
 
 // NewForPackage creates a new installer for a package, given its root path, or its prebuilt zip.
@@ -85,6 +87,7 @@ func NewForPackage(ctx context.Context, options Options) (Installer, error) {
 		CreateZip:      supportsUploadZip,
 		SignPackage:    false,
 		SkipValidation: options.SkipValidation,
+		RepoRoot:       options.RepoRoot,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to build package: %v", err)

--- a/internal/resources/fleetpackage.go
+++ b/internal/resources/fleetpackage.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/elastic/go-resource"
@@ -23,6 +24,9 @@ type FleetPackage struct {
 
 	// RootPath is the root of the package source to install.
 	RootPath string
+
+	// RepoPath is the root of the repository.
+	RepoRoot *os.Root
 
 	// Absent is set to true to indicate that the package should not be installed.
 	Absent bool
@@ -59,6 +63,7 @@ func (f *FleetPackage) installer(ctx resource.Context) (installer.Installer, err
 		Kibana:         provider.Client,
 		RootPath:       f.RootPath,
 		SkipValidation: true,
+		RepoRoot:       f.RepoRoot,
 	})
 }
 

--- a/internal/resources/fleetpackage_test.go
+++ b/internal/resources/fleetpackage_test.go
@@ -50,6 +50,7 @@ func TestPackageLifecycle(t *testing.T) {
 
 			repoRoot, err := files.FindRepositoryRoot()
 			require.NoError(t, err)
+			defer repoRoot.Close()
 
 			packageRootPath := filepath.Join(repoRoot.Name(), "test", "packages", "parallel", c.name)
 

--- a/internal/resources/fleetpackage_test.go
+++ b/internal/resources/fleetpackage_test.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/elastic/go-resource"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/elastic-package/internal/files"
 	"github.com/elastic/elastic-package/internal/kibana"
 	kibanatest "github.com/elastic/elastic-package/internal/kibana/test"
 )
@@ -46,12 +48,18 @@ func TestPackageLifecycle(t *testing.T) {
 				t.FailNow()
 			}
 
+			repoRoot, err := files.FindRepositoryRoot()
+			require.NoError(t, err)
+
+			packageRootPath := filepath.Join(repoRoot.Name(), "test", "packages", "parallel", c.name)
+
 			fleetPackage := FleetPackage{
-				RootPath: filepath.Join("..", "..", "test", "packages", "parallel", c.name),
+				RootPath: packageRootPath,
+				RepoRoot: repoRoot,
 			}
 			manager := resource.NewManager()
 			manager.RegisterProvider(DefaultKibanaProviderName, &KibanaProvider{Client: kibanaClient})
-			_, err := manager.Apply(resource.Resources{&fleetPackage})
+			_, err = manager.Apply(resource.Resources{&fleetPackage})
 			assert.NoError(t, err)
 			assertPackageInstalled(t, kibanaClient, "installed", c.name)
 

--- a/internal/resources/fleetpolicy.go
+++ b/internal/resources/fleetpolicy.go
@@ -7,6 +7,7 @@ package resources
 import (
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 
@@ -41,6 +42,9 @@ type FleetAgentPolicy struct {
 
 	// PackagePolicies
 	PackagePolicies []FleetPackagePolicy
+
+	// RepoPath is the root of the repository.
+	RepoRoot *os.Root
 }
 
 type FleetPackagePolicy struct {

--- a/internal/resources/fleetpolicy_test.go
+++ b/internal/resources/fleetpolicy_test.go
@@ -34,6 +34,7 @@ func TestRequiredProviderFleetPolicy(t *testing.T) {
 func TestPolicyLifecycle(t *testing.T) {
 	repoRoot, err := files.FindRepositoryRoot()
 	require.NoError(t, err)
+	defer repoRoot.Close()
 
 	cases := []struct {
 		title           string

--- a/internal/resources/fleetpolicy_test.go
+++ b/internal/resources/fleetpolicy_test.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/elastic/go-resource"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/elastic-package/internal/files"
 	"github.com/elastic/elastic-package/internal/kibana"
 	kibanatest "github.com/elastic/elastic-package/internal/kibana/test"
 )
@@ -30,6 +32,9 @@ func TestRequiredProviderFleetPolicy(t *testing.T) {
 }
 
 func TestPolicyLifecycle(t *testing.T) {
+	repoRoot, err := files.FindRepositoryRoot()
+	require.NoError(t, err)
+
 	cases := []struct {
 		title           string
 		packagePolicies []FleetPackagePolicy
@@ -42,7 +47,7 @@ func TestPolicyLifecycle(t *testing.T) {
 			packagePolicies: []FleetPackagePolicy{
 				{
 					Name:           "nginx-1",
-					RootPath:       "../../test/packages/parallel/nginx",
+					RootPath:       filepath.Join(repoRoot.Name(), "test", "packages", "parallel", "nginx"),
 					DataStreamName: "stubstatus",
 				},
 			},
@@ -52,12 +57,12 @@ func TestPolicyLifecycle(t *testing.T) {
 			packagePolicies: []FleetPackagePolicy{
 				{
 					Name:           "nginx-1",
-					RootPath:       "../../test/packages/parallel/nginx",
+					RootPath:       filepath.Join(repoRoot.Name(), "test", "packages", "parallel", "nginx"),
 					DataStreamName: "stubstatus",
 				},
 				{
 					Name:           "system-1",
-					RootPath:       "../../test/packages/parallel/system",
+					RootPath:       filepath.Join(repoRoot.Name(), "test", "packages", "parallel", "system"),
 					DataStreamName: "process",
 				},
 			},
@@ -67,7 +72,7 @@ func TestPolicyLifecycle(t *testing.T) {
 			packagePolicies: []FleetPackagePolicy{
 				{
 					Name:     "input-1",
-					RootPath: "../../test/packages/parallel/sql_input",
+					RootPath: filepath.Join(repoRoot.Name(), "test", "packages", "parallel", "sql_input"),
 				},
 			},
 		},
@@ -88,6 +93,7 @@ func TestPolicyLifecycle(t *testing.T) {
 				Description:     fmt.Sprintf("Test policy for %s", c.title),
 				Namespace:       "eptest",
 				PackagePolicies: c.packagePolicies,
+				RepoRoot:        repoRoot,
 			}
 			t.Cleanup(func() { deletePolicy(t, manager, agentPolicy) })
 
@@ -111,6 +117,7 @@ func withPackageResources(agentPolicy *FleetAgentPolicy) resource.Resources {
 		resources = append(resources, &FleetPackage{
 			RootPath: policy.RootPath,
 			Absent:   agentPolicy.Absent,
+			RepoRoot: agentPolicy.RepoRoot,
 		})
 	}
 	return append(resources, agentPolicy)


### PR DESCRIPTION
This pull request refactors how repository root and links definitions files are discovered and used throughout the codebase, improving consistency, error handling, and test coverage. The main changes include passing the repository root explicitly to functions that need it, updating the logic for finding and reading the links definitions file, and enhancing license file handling during package builds. Comprehensive unit tests have been added for these new behaviors.

**Repository root and links file handling:**

* All commands (`build`, `lint`, and links-related commands in `cmd/build.go`, `cmd/lint.go`, `cmd/links.go`) now explicitly locate and pass the repository root using `files.FindRepositoryRoot()`, and use this to find the links definitions file via `docs.LinksDefinitionsFilePath(repoRoot)`. This improves reliability and consistency in locating project resources. [[1]](diffhunk://#diff-5794c40aa4c9301aaf9c39eacf7d3c8511f2511cb24bdd95e0a08704ba583a5fR64-R74) [[2]](diffhunk://#diff-5794c40aa4c9301aaf9c39eacf7d3c8511f2511cb24bdd95e0a08704ba583a5fL75-R86) [[3]](diffhunk://#diff-ea924d90ffbba283b49a80bff998792cd4148b5f27ea9a84d7c62ea4d4885edaR59-R66) [[4]](diffhunk://#diff-ea924d90ffbba283b49a80bff998792cd4148b5f27ea9a84d7c62ea4d4885edaL98-R111) [[5]](diffhunk://#diff-ea924d90ffbba283b49a80bff998792cd4148b5f27ea9a84d7c62ea4d4885edaL138-R158) [[6]](diffhunk://#diff-c192182bd1736dfde898947b8eef754b5381e85cc177945f935c65b4b087b2ceL48-R61)

**License file handling during build:**

* The build logic in `internal/builder/packages.go` now takes the repository root as a parameter and uses it to locate and copy the license file into the package, supporting overrides via environment variable and handling missing files gracefully. The helper functions have been refactored for clarity and improved error handling. [[1]](diffhunk://#diff-a018efea59016591a1ef36042025a57b31c426b7f3c0c45f83b6e8af81580585R31) [[2]](diffhunk://#diff-a018efea59016591a1ef36042025a57b31c426b7f3c0c45f83b6e8af81580585L185-R187) [[3]](diffhunk://#diff-a018efea59016591a1ef36042025a57b31c426b7f3c0c45f83b6e8af81580585L208-R210) [[4]](diffhunk://#diff-a018efea59016591a1ef36042025a57b31c426b7f3c0c45f83b6e8af81580585L293-R311) [[5]](diffhunk://#diff-a018efea59016591a1ef36042025a57b31c426b7f3c0c45f83b6e8af81580585L344-R367)

**Links map logic and API changes:**

* The links map implementation in `internal/docs/links_map.go` has been refactored to use pointer receivers, provide clearer error handling, and accept the links file path explicitly. The logic for finding the links definitions file now checks environment variables first and falls back to the default file in the repository root, returning an empty string if not found. [[1]](diffhunk://#diff-16d1ecb8f8b578d6505190ec5f5f9e540869d8638131d112c6d28043a066d9dbL15) [[2]](diffhunk://#diff-16d1ecb8f8b578d6505190ec5f5f9e540869d8638131d112c6d28043a066d9dbL31-R72) [[3]](diffhunk://#diff-16d1ecb8f8b578d6505190ec5f5f9e540869d8638131d112c6d28043a066d9dbL88-L115)

**Unit tests for new behaviors:**

* New and updated tests in `internal/builder/packages_test.go` and `internal/docs/links_map_test.go` cover repository license file discovery, license copying logic, and links file resolution under various scenarios (env var, missing file, default file, YAML parsing). [[1]](diffhunk://#diff-c3d6209bf014e031e77a4105e436376477e0e266367da998433d2d5ce7cc99edR1-R122) [[2]](diffhunk://#diff-15984caaad4396dfa72e7d9b6f4f7fd61137d121d165e1a9067b08b8db11ca82L93-R201)

**Imports and cleanup:**

* Imports have been updated to support the new logic, and unused imports have been removed for clarity. [[1]](diffhunk://#diff-c192182bd1736dfde898947b8eef754b5381e85cc177945f935c65b4b087b2ceR15) [[2]](diffhunk://#diff-16d1ecb8f8b578d6505190ec5f5f9e540869d8638131d112c6d28043a066d9dbL15)