### PR TITLE
internal/stack: do not remove parent of log dump directory

### DIFF
--- a/internal/stack/dump.go
+++ b/internal/stack/dump.go
@@ -76,12 +76,13 @@ func dumpStackLogs(ctx context.Context, options DumpOptions) ([]DumpResult, erro
 
 	var logsPath string
 	if options.Output != "" {
-		err := os.RemoveAll(options.Output)
+		logsPath = filepath.Join(options.Output, "logs")
+
+		err := os.RemoveAll(logsPath)
 		if err != nil {
 			return nil, fmt.Errorf("can't remove output location: %w", err)
 		}
 
-		logsPath = filepath.Join(options.Output, "logs")
 		err = os.MkdirAll(logsPath, 0755)
 		if err != nil {
 			return nil, fmt.Errorf("can't create output location (path: %s): %w", logsPath, err)


### PR DESCRIPTION
The previous code removed the output directory and then put a new logs directory in it. This makes it impossible to compose a directory at the output level.

The two options to fix this were to not create the "logs" subdirectory or to only remove the "logs" subdirectory if it exists. The latter is chosen to avoid breaking behaviour.

Please take a look.