### PR TITLE
internal/testrunner/runners/system: export policy helper functions

### DIFF
--- a/internal/testrunner/runners/system/tester_test.go
+++ b/internal/testrunner/runners/system/tester_test.go
@@ -30,12 +30,12 @@ func TestFindPolicyTemplateForInput(t *testing.T) {
 	var testCases = []struct {
 		testName string
 		err      string
-		pkg      packages.PackageManifest
+		pkg      *packages.PackageManifest
 		input    string
 	}{
 		{
 			testName: "single policy_template",
-			pkg: packages.PackageManifest{
+			pkg: &packages.PackageManifest{
 				PolicyTemplates: []packages.PolicyTemplate{
 					{
 						Name:        policyTemplateName,
@@ -52,7 +52,7 @@ func TestFindPolicyTemplateForInput(t *testing.T) {
 		},
 		{
 			testName: "unspecified input name",
-			pkg: packages.PackageManifest{
+			pkg: &packages.PackageManifest{
 				PolicyTemplates: []packages.PolicyTemplate{
 					{
 						Name:        policyTemplateName,
@@ -68,7 +68,7 @@ func TestFindPolicyTemplateForInput(t *testing.T) {
 		},
 		{
 			testName: "input matching",
-			pkg: packages.PackageManifest{
+			pkg: &packages.PackageManifest{
 				PolicyTemplates: []packages.PolicyTemplate{
 					{
 						Name:        policyTemplateName,
@@ -95,7 +95,7 @@ func TestFindPolicyTemplateForInput(t *testing.T) {
 		{
 			testName: "data stream not specified",
 			err:      "no policy template was found",
-			pkg: packages.PackageManifest{
+			pkg: &packages.PackageManifest{
 				PolicyTemplates: []packages.PolicyTemplate{
 					{
 						Name:        policyTemplateName,
@@ -113,7 +113,7 @@ func TestFindPolicyTemplateForInput(t *testing.T) {
 		{
 			testName: "multiple matches",
 			err:      "ambiguous result",
-			pkg: packages.PackageManifest{
+			pkg: &packages.PackageManifest{
 				PolicyTemplates: []packages.PolicyTemplate{
 					{
 						Name:        policyTemplateName,
@@ -151,7 +151,7 @@ func TestFindPolicyTemplateForInput(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.testName, func(t *testing.T) {
-			name, err := findPolicyTemplateForInput(tc.pkg, ds, inputName)
+			name, err := FindPolicyTemplateForInput(tc.pkg, ds, inputName)
 
 			if tc.err != "" {
 				require.Errorf(t, err, "expected err containing %q", tc.err)


### PR DESCRIPTION
Export and liberate from method status:

* CreatePackageDatastream
* BuildDataStreamName
* BuildIndexTemplateName
* FindPolicyTemplateForInput
* SelectPolicyTemplateByName

Also harmonise pointiness of parameter types to avoid copies.

For #2868

Please take a look.