### PR TITLE
[CI] Fix issue downloading golang via gvm

### DIFF
--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -1,6 +1,6 @@
 env:
   NOTIFY_TO: "ecosystem-team@elastic.co"
-  SETUP_GVM_VERSION: 'v0.5.2' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
+  SETUP_GVM_VERSION: 'v0.6.0' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
   DOCKER_COMPOSE_VERSION: "v2.24.1"
   DOCKER_VERSION: "26.1.2"
   KIND_VERSION: 'v0.27.0'

--- a/.buildkite/pipeline.test-with-integrations-repo.yml
+++ b/.buildkite/pipeline.test-with-integrations-repo.yml
@@ -1,5 +1,5 @@
 env:
-  SETUP_GVM_VERSION: 'v0.5.1' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
+  SETUP_GVM_VERSION: 'v0.6.0' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
   GH_CLI_VERSION: "2.29.0"
   JQ_VERSION: "1.7"
   # Agent images used in pipeline steps

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  SETUP_GVM_VERSION: 'v0.5.2' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
+  SETUP_GVM_VERSION: 'v0.6.0' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
   DOCKER_COMPOSE_VERSION: "v2.24.1"
   DOCKER_VERSION: "26.1.2"
   KIND_VERSION: 'v0.27.0'


### PR DESCRIPTION
Update GVM version to the latest version ([v0.6.0](https://github.com/andrewkroh/gvm/releases/tag/v0.6.0)) to allow installing Golang versions without errors:
Reference:
- https://github.com/elastic/integrations/pull/15675#issuecomment-3416806751
- https://github.com/elastic/integrations/pull/15675
