### PR TITLE
Ensure errors from boolean flags in CLI are managed

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -59,12 +59,15 @@ func editDashboardsCmd(cmd *cobra.Command, args []string) error {
 	common.TrimStringSlice(dashboardIDs)
 
 	var opts []kibana.ClientOption
-	tlsSkipVerify, _ := cmd.Flags().GetBool(cobraext.TLSSkipVerifyFlagName)
+	tlsSkipVerify, err := cmd.Flags().GetBool(cobraext.TLSSkipVerifyFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.TLSSkipVerifyFlagName)
+	}
 	if tlsSkipVerify {
 		opts = append(opts, kibana.TLSSkipVerify())
 	}
 
-	allowSnapshot, _ := cmd.Flags().GetBool(cobraext.AllowSnapshotFlagName)
+	allowSnapshot, err := cmd.Flags().GetBool(cobraext.AllowSnapshotFlagName)
 	if err != nil {
 		return cobraext.FlagParsingError(err, cobraext.AllowSnapshotFlagName)
 	}

--- a/cmd/export_dashboards.go
+++ b/cmd/export_dashboards.go
@@ -34,7 +34,10 @@ func exportDashboardsCmd(cmd *cobra.Command, args []string) error {
 	common.TrimStringSlice(dashboardIDs)
 
 	var opts []kibana.ClientOption
-	tlsSkipVerify, _ := cmd.Flags().GetBool(cobraext.TLSSkipVerifyFlagName)
+	tlsSkipVerify, err := cmd.Flags().GetBool(cobraext.TLSSkipVerifyFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.TLSSkipVerifyFlagName)
+	}
 	if tlsSkipVerify {
 		opts = append(opts, kibana.TLSSkipVerify())
 	}

--- a/cmd/export_ingest_pipelines.go
+++ b/cmd/export_ingest_pipelines.go
@@ -40,7 +40,10 @@ func exportIngestPipelinesCmd(cmd *cobra.Command, args []string) error {
 	common.TrimStringSlice(pipelineIDs)
 
 	var opts []elasticsearch.ClientOption
-	tlsSkipVerify, _ := cmd.Flags().GetBool(cobraext.TLSSkipVerifyFlagName)
+	tlsSkipVerify, err := cmd.Flags().GetBool(cobraext.TLSSkipVerifyFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.TLSSkipVerifyFlagName)
+	}
 	if tlsSkipVerify {
 		opts = append(opts, elasticsearch.OptionWithSkipTLSVerify())
 	}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -60,7 +60,10 @@ func installCommandAction(cmd *cobra.Command, _ []string) error {
 	}
 
 	var opts []kibana.ClientOption
-	tlsSkipVerify, _ := cmd.Flags().GetBool(cobraext.TLSSkipVerifyFlagName)
+	tlsSkipVerify, err := cmd.Flags().GetBool(cobraext.TLSSkipVerifyFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.TLSSkipVerifyFlagName)
+	}
 	if tlsSkipVerify {
 		opts = append(opts, kibana.TLSSkipVerify())
 	}


### PR DESCRIPTION
Ensure that errors from boolean flags are managed appropriately.
This PR focuses on flags: `--tls-skip-verify` and `--allow-snapshot`