### PR TITLE
Remove leftovers from cloud-cleanup pipeline

### DIFF
--- a/.buildkite/pipeline.cloud-cleanup.yml
+++ b/.buildkite/pipeline.cloud-cleanup.yml
@@ -19,15 +19,6 @@ steps:
         - label: "False"
           value: "false"
       default: "true"
-    - select: "DRY_RUN (Deprecated step)"
-      key: "DRY_RUN_DEPRECATED"
-      options:
-        - label: "True"
-          value: "true"
-        - label: "False"
-          value: "false"
-      default: "true"
-    if: "build.source == 'ui'"
 
   - wait: ~
     if: "build.source == 'ui'"


### PR DESCRIPTION
The input key `DRY_RUN_DEPRECATED` is not used anymore. The step using it was removed in #2573.