### PR TITLE
Fix template placeholder in readme

### DIFF
--- a/internal/packages/archetype/_static/package-docs-readme.md.tmpl
+++ b/internal/packages/archetype/_static/package-docs-readme.md.tmpl
@@ -21,7 +21,7 @@ This integration is compatible with ...
 
 ## What data does this integration collect?
 {{/* Complete this section with information on what types of data the integration collects, and link to reference documentation if available */}}
-The {{.Manifest.Title}} integration collects log messages of the following types:
+The {[.Manifest.Title]} integration collects log messages of the following types:
 * ...
 
 ### Supported use cases
@@ -47,7 +47,7 @@ For more information, refer to [Agentless integrations](https://www.elastic.co/g
 */}}
 
 ### Onboard / configure
-{{/* List the steps that will need to be followed in order to completely set up a working inte completely set up a working integration.
+{{/* List the steps that will need to be followed in order to completely set up a working integration.
 For integrations that support multiple input types, be sure to add steps for all inputs.
 */}}
 


### PR DESCRIPTION
This placeholder is expected to be rendered when generating the template file, so it should use `{[`/`]}`.

Fixed also a partially duplicated line.