### PR TITLE
#3043 Add xUnit as report-format output

### DIFF
--- a/internal/cobraext/flags.go
+++ b/internal/cobraext/flags.go
@@ -154,7 +154,7 @@ const (
 	ProfileFormatFlagDescription = "format of the profiles list (table | json)"
 
 	ReportFormatFlagName        = "report-format"
-	ReportFormatFlagDescription = "format of test report"
+	ReportFormatFlagDescription = "format of test report, eg: human, xUnit"
 
 	ReportFullFlagName        = "full"
 	ReportFullFlagDescription = "whether to show the full report or a summary"


### PR DESCRIPTION
With this change, the helper shows the report-format output available (xUnit, human)

Before : 

```bash
elastic-package test pipeline --help
Run pipeline tests for the package.

Usage:
  elastic-package test pipeline [flags]

Flags:
  -d, --data-streams strings   comma-separated data streams to test
  -m, --fail-on-missing        fail if tests are missing
  -g, --generate               generate test result file
  -h, --help                   help for pipeline

Global Flags:
  -C, --change-directory string   change to the specified directory before running the command
      --coverage-format string    set format for coverage reports: cobertura,generic (default "cobertura")
      --defer-cleanup duration    defer test cleanup for debugging purposes
  -p, --profile string            select a profile to use for the stack configuration. Can also be set with ELASTIC_PACKAGE_PROFILE
      --report-format string      format of test report (default "human")
      --report-output string      output type for test report, eg: stdout, file (default "stdout")
      --test-coverage             enable test coverage reports
  -v, --verbose count             verbose mode
```

after

```bash
Run pipeline tests for the package.

Usage:
  elastic-package test pipeline [flags]

Flags:
  -d, --data-streams strings   comma-separated data streams to test
  -m, --fail-on-missing        fail if tests are missing
  -g, --generate               generate test result file
  -h, --help                   help for pipeline

Global Flags:
  -C, --change-directory string   change to the specified directory before running the command
      --coverage-format string    set format for coverage reports: cobertura,generic (default "cobertura")
      --defer-cleanup duration    defer test cleanup for debugging purposes
  -p, --profile string            select a profile to use for the stack configuration. Can also be set with ELASTIC_PACKAGE_PROFILE
      --report-format string      format of test report, eg: human, xUnit (default "human")
      --report-output string      output type for test report, eg: stdout, file (default "stdout")
      --test-coverage             enable test coverage reports
  -v, --verbose count             verbose mode
```