### PR TITLE
Show errors if any when updating managed setting in saved object

### DIFF
--- a/internal/kibana/savedobjects.go
+++ b/internal/kibana/savedobjects.go
@@ -203,7 +203,7 @@ func (c *Client) SetManagedSavedObject(ctx context.Context, savedObjectType stri
 			for _, importError := range resp.Errors {
 				errorMessages = append(errorMessages, fmt.Sprintf("ID: %s, Type: %s, Error: %v", importError.ID, importError.Type, importError.Error))
 			}
-			return fmt.Errorf("importing %s %s was not successful: %s", savedObjectType, id, strings.Join(errorMessages, "; "))
+			return fmt.Errorf("failed to import one or more saved objects: %s", strings.Join(errorMessages, "; "))
 		}
 		return fmt.Errorf("importing %s %s was not successful", savedObjectType, id)
 	}


### PR DESCRIPTION
Follows #3007

This PR helps to debug errors when editing dashboards if there is any error importing those saved objects.
In case there are errors, those are shown as part of the error message shown in `elastic-package`.

Before:

>  $ elastic-package edit dashboards 
> Make Kibana dashboards editable
> ? Which package would you like to export dashboards from?: profilingmetrics_otel-0.0.1
> ? Which dashboards would you like to export?: Profilingmetrics (ID: profilingmetrics_otel-cf4d74ec-b406-4314-9519-2569d24002fe, Type: dashboard)
> 
> Error: failed to make one or more dashboards editable: importing dashboard profilingmetrics_otel-cf4d74ec-b406-4314-9519-2569d24002fe was not successful


After:

>  $ elastic-package edit dashboards 
> Make Kibana dashboards editable
> ? Which package would you like to export dashboards from?: profilingmetrics_otel-0.0.1
> ? Which dashboards would you like to export?: Profilingmetrics (ID: profilingmetrics_otel-cf4d74ec-b406-4314-9519-2569d24002fe, Type: dashboard)
> 
> Error: failed to make one or more dashboards editable: importing dashboard profilingmetrics_otel-cf4d74ec-b406-4314-9519-2569d24002fe was not successful: ID: profilingmetrics_otel-cf4d74ec-b406-4314-9519-2569d24002fe, Type: dashboard, Error: map[references:[map[id:72c09aba-3449-477f-aebf-0694d94fed70 type:index-pattern]] type:missing_references]
