### PR TITLE
Fix `build` updateReadme inside zip package

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/elastic/elastic-package/internal/builder"
 	"github.com/elastic/elastic-package/internal/cobraext"
-	"github.com/elastic/elastic-package/internal/docs"
 	"github.com/elastic/elastic-package/internal/files"
 	"github.com/elastic/elastic-package/internal/logger"
 	"github.com/elastic/elastic-package/internal/packages"
@@ -86,7 +85,8 @@ func buildCommandAction(cmd *cobra.Command, args []string) error {
 		SignPackage:     signPackage,
 		SkipValidation:  skipValidation,
 		RepositoryRoot:  repositoryRoot,
-	}, docs.UpdateReadmes)
+		UpdateReadmes:   true,
+	})
 	if err != nil {
 		return fmt.Errorf("building package failed: %w", err)
 	}

--- a/internal/docs/readme.go
+++ b/internal/docs/readme.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/pmezard/go-difflib/difflib"
 
-	"github.com/elastic/elastic-package/internal/builder"
 	"github.com/elastic/elastic-package/internal/logger"
 )
 
@@ -100,7 +99,7 @@ func isReadmeUpToDate(fileName, linksFilePath, packageRoot string) (bool, string
 
 // UpdateReadmes function updates all .md readme files using a defined template
 // files. The function doesn't perform any action if the template file is not present.
-func UpdateReadmes(repositoryRoot *os.Root, packageRoot, buildDir string) error {
+func UpdateReadmes(repositoryRoot *os.Root, packageRoot, packageBuildRoot string) error {
 	linksFilePath, err := linksDefinitionsFilePath(repositoryRoot)
 	if err != nil {
 		return fmt.Errorf("locating links file failed: %w", err)
@@ -113,7 +112,7 @@ func UpdateReadmes(repositoryRoot *os.Root, packageRoot, buildDir string) error 
 
 	for _, filePath := range readmeFiles {
 		fileName := filepath.Base(filePath)
-		target, err := updateReadme(fileName, linksFilePath, packageRoot, buildDir)
+		target, err := updateReadme(fileName, linksFilePath, packageRoot, packageBuildRoot)
 		if err != nil {
 			return fmt.Errorf("updating readme file %s failed: %w", fileName, err)
 		}
@@ -129,13 +128,8 @@ func UpdateReadmes(repositoryRoot *os.Root, packageRoot, buildDir string) error 
 
 // updateReadme function updates a single readme file using a defined template file.
 // It writes the rendered file to both the package directory and the package build directory.
-func updateReadme(fileName, linksFilePath, packageRoot, buildDir string) (string, error) {
+func updateReadme(fileName, linksFilePath, packageRoot, packageBuildRoot string) (string, error) {
 	logger.Debugf("Update the %s file", fileName)
-
-	packageBuildRoot, err := builder.BuildPackagesDirectory(packageRoot, buildDir)
-	if err != nil {
-		return "", fmt.Errorf("package build root not found: %w", err)
-	}
 
 	rendered, shouldBeRendered, err := generateReadme(fileName, linksFilePath, packageRoot, packageBuildRoot)
 	if err != nil {

--- a/internal/packages/archetype/package_test.go
+++ b/internal/packages/archetype/package_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-package/internal/builder"
-	"github.com/elastic/elastic-package/internal/docs"
 	"github.com/elastic/elastic-package/internal/packages"
 )
 
@@ -105,7 +104,8 @@ func buildPackage(t *testing.T, repositoryRoot *os.Root, packageRootPath string)
 		PackageRootPath: packageRootPath,
 		BuildDir:        buildDir,
 		RepositoryRoot:  repositoryRoot,
-	}, docs.UpdateReadmes)
+		UpdateReadmes:   true,
+	})
 	return err
 }
 

--- a/internal/packages/installer/factory.go
+++ b/internal/packages/installer/factory.go
@@ -91,9 +91,7 @@ func NewForPackage(options Options) (Installer, error) {
 		SignPackage:     false,
 		SkipValidation:  options.SkipValidation,
 		RepositoryRoot:  options.RepositoryRoot,
-	}, func(repositoryRoot *os.Root, packageRootPath, buildDir string) error {
-		// noop readme updater
-		return nil
+		UpdateReadmes:   false,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to build package: %v", err)


### PR DESCRIPTION
Bug introduced at #2957 

When a package is built, the readme is not being updated at the zip bundle. When working on the mentioned PR, the readme updater was moved after the built so the linked fields where already there when doing the update. The bundle zip is already created when this happens, so the readme inside the zip is the one at source before running the updater.

~~This changes propose to inject the updater function in order to run it after the linked files and the external fields are resolved. This way all the files in the bundle are the updated ones.~~

~~I've also explored the option of removing from the Builder function the link resolver, but still, the external fields have to be resolved inside the Builder, and if the readme updater runs before this, the readme wont have the external fields documented.~~

The PR adds a new option to update readmes inside the builder function.
