### PR TITLE
Set empty arrays in unset multi values, even if they are not required

### DIFF
--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -2069,8 +2069,14 @@ func setKibanaVariables(definitions []packages.Variable, values common.MapStr) k
 			val = &packages.VarValue{}
 			val.Unpack(value)
 		} else if errors.Is(err, common.ErrKeyNotFound) && definition.Default == nil {
-			// Do not include nulls for unset variables.
-			continue
+			if definition.Multi && definition.Type == "yaml" {
+				// Fleet expects some multi variables to contain something, even if they don't have a value or are required.
+				val = &packages.VarValue{}
+				val.Unpack([]any{})
+			} else {
+				// Do not include nulls for unset variables.
+				continue
+			}
 		}
 
 		vars[definition.Name] = kibana.Var{

--- a/test/packages/parallel/apache/data_stream/status/manifest.yml
+++ b/test/packages/parallel/apache/data_stream/status/manifest.yml
@@ -17,5 +17,11 @@ streams:
         required: true
         show_user: false
         default: /server-status
+      - name: unused_multi
+        title: Unused YAML multi variable that is artificially required to have a value by Fleet.
+        type: yaml
+        multi: true
+        required: false
+        show_user: false
     title: Apache status metrics
     description: Collect Apache status metrics


### PR DESCRIPTION
Fleet expects fields defined with `multi: true` and `type: yaml` to be arrays, even when they are not required or don't have any default.

Not setting these values produces this kind of failures:
```
Package policy is invalid: inputs.prometheus/metrics.streams.nvidia_gpu.stats.vars.ssl: Invalid format for SSL Configuration: expected array
```

We should follow-up fixing this in Fleet, but in the meantime we should support this behavior for current implementation.