### PR TITLE
add support for kibana policy overrides in system tests

### DIFF
--- a/docs/howto/system_testing.md
+++ b/docs/howto/system_testing.md
@@ -977,6 +977,23 @@ In this case, `elastic-package test system` will fail with an error and print a 
 skip_ignored_fields:
   - field.to.ignore
 ```
+### Kibana policy overrides
+
+If you need to test a system test with a Kibana policy override you can do that by setting the environment variable `ELASTIC_PACKAGE_KIBANA_POLICY_OVERRIDES` to be a path to a yaml file that contains the policy override.  For example:
+
+```shell
+ELASTIC_PACKAGE_KIBANA_POLICY_OVERRIDES=/tmp/overrides.yml elastic-package test system
+```
+
+and the `/tmp/overrides.yml` file has the following contents:
+
+```yaml
+agent:
+  monitoring:
+    _runtime_experimental: otel
+```
+
+Will result in the system test running with the agent monitoring using the `otel` runtime.
 
 ## Continuous Integration
 

--- a/internal/kibana/policies.go
+++ b/internal/kibana/policies.go
@@ -16,15 +16,16 @@ import (
 
 // Policy represents an Agent Policy in Fleet.
 type Policy struct {
-	ID                   string   `json:"id,omitempty"`
-	Name                 string   `json:"name"`
-	Description          string   `json:"description"`
-	Namespace            string   `json:"namespace"`
-	Revision             int      `json:"revision,omitempty"`
-	MonitoringEnabled    []string `json:"monitoring_enabled,omitempty"`
-	MonitoringOutputID   string   `json:"monitoring_output_id,omitempty"`
-	DataOutputID         string   `json:"data_output_id,omitempty"`
-	IsDefaultFleetServer bool     `json:"is_default_fleet_server,omitempty"`
+	ID                   string         `json:"id,omitempty"`
+	Name                 string         `json:"name"`
+	Description          string         `json:"description"`
+	Namespace            string         `json:"namespace"`
+	Revision             int            `json:"revision,omitempty"`
+	MonitoringEnabled    []string       `json:"monitoring_enabled,omitempty"`
+	MonitoringOutputID   string         `json:"monitoring_output_id,omitempty"`
+	DataOutputID         string         `json:"data_output_id,omitempty"`
+	IsDefaultFleetServer bool           `json:"is_default_fleet_server,omitempty"`
+	Overrides            map[string]any `json:"overrides,omitempty"`
 }
 
 // DownloadedPolicy represents a policy as returned by the download policy API.


### PR DESCRIPTION
Adds support for a new environment variable `ELASTIC_PACKAGE_KIBANA_POLICY_OVERRIDES`

If this variable is set and is a path to a yaml file, then the contents of the yaml file will be used for the [kibana policy overrides](https://www.elastic.co/docs/api/doc/kibana/operation/operation-post-fleet-agent-policies#operation-post-fleet-agent-policies-body-application-json-overrides) in the system tests.

This allows you to test how integrations will behave with experimental settings.

## Example

```shell
ELASTIC_PACKAGE_KIBANA_POLICY_OVERRIDES=/tmp/overrides.yml elastic-package test system
```

and the `/tmp/overrides.yml` file has the following contents:

```yaml
agent:
  monitoring:
    _runtime_experimental: otel
```

Will result in the system test running with the agent monitoring using the `otel` runtime.

Closes #2975 