### PR TITLE
[OOTB Alerting rules] Updates new docs link

### DIFF
--- a/scripts/links_table.yml
+++ b/scripts/links_table.yml
@@ -2,4 +2,4 @@ links:
   elastic-main: "https://www.elastic.co/guide"
   getting-started-observability: "https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html"
   elasticsearch-histograms: https://www.elastic.co/guide/en/elasticsearch/reference/current/histogram.html
-  alert-rule-templates: https://www.elastic.co/docs/reference/fleet/alert-templates#alert-templates
+  alert-rule-templates: https://www.elastic.co/docs/reference/fleet/alerting-rule-templates

--- a/test/packages/other/alert_rule_templates/docs/README.md
+++ b/test/packages/other/alert_rule_templates/docs/README.md
@@ -4,7 +4,7 @@
 
 Alert rule templates provide pre-defined configurations for creating alert rules in Kibana.
 
-For more information, refer to the [Elastic documentation](https://www.elastic.co/docs/reference/fleet/alert-templates#alert-templates).
+For more information, refer to the [Elastic documentation](https://www.elastic.co/docs/reference/fleet/alerting-rule-templates).
 
 Alert rule templates require Elastic Stack version 9.2.0 or later.
 


### PR DESCRIPTION
- The [public docs link](https://www.elastic.co/docs/reference/fleet/alerting-rule-templates) is now replaced for Alerting Rule Templates. 
- Updated the link in the links_table and generated the README for the test integration.