### PR TITLE
fix: update template syntax for conditional statements in dataStream-…

### DIFF
--- a/internal/packages/archetype/_static/dataStream-agent-stream.yml.tmpl
+++ b/internal/packages/archetype/_static/dataStream-agent-stream.yml.tmpl
@@ -1,14 +1,14 @@
-{{if eq .Manifest.Type "logs"}}paths:
+{[if eq .Manifest.Type "logs"]}paths:
 {{ "{{#each paths as |path i|}}" }}
   - {{ "{{path}}" }}
 {{ "{{/each}}" }}
 exclude_files: [".gz$"]
 processors:
   - add_locale: ~
-{{else}}metricsets: ["sample_metricset"]
+{[else]}metricsets: ["sample_metricset"]
 hosts:
 {{ "{{#each hosts}}" }}
   - {{ "{{this}}" }}
 {{ "{{/each}}" }}
 period: {{ "{{period}}" }}
-{{end}}
+{[end]}


### PR DESCRIPTION
When creating test scenarios with the go templates, the syntax representing go-templates should be with the [delim `{[` and `]}` ](https://github.com/elastic/elastic-package/blob/380813f626f083ae5d4b75cc18845ea705b064ab/internal/packages/archetype/archetype.go#L24)

This was spotted after implementing hbs validation at package-spec. The test packages where being rendered as `hbs` files with go-template syntax.

- Related to https://github.com/elastic/elastic-package/pull/3176