### PR TITLE
fix: remove duplicate event.kind field from fields.yml

### DIFF
--- a/test/packages/parallel/ti_anomali/elasticsearch/transform/latest_ioc/fields/fields.yml
+++ b/test/packages/parallel/ti_anomali/elasticsearch/transform/latest_ioc/fields/fields.yml
@@ -107,12 +107,6 @@
     When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events.
   name: ecs.version
   type: keyword
-- description: |-
-    This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy.
-    `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events.
-    The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not.
-  name: event.kind
-  type: keyword
 - description: The date and time when intelligence source first reported sighting this indicator.
   name: threat.indicator.first_seen
   type: date


### PR DESCRIPTION
When updating `package-spec` to 3.5.5 found error for validating test packages https://github.com/elastic/elastic-package/pull/3176.

This PR changes the test package transform file so `event.kind` field comes from the ecs fields from the shared file