### PR TITLE
Add some tests for EPR_PROXY_TO overrided in profile

### DIFF
--- a/internal/configuration/locations/locations_internal_test.go
+++ b/internal/configuration/locations/locations_internal_test.go
@@ -36,22 +36,18 @@ func Test_configurationDirError(t *testing.T) {
 	default:
 		env = "HOME"
 	}
-	homeEnv := os.Getenv(env)
-	os.Unsetenv(env)
+	t.Setenv(env, "")
 
 	_, err := configurationDir()
 	assert.Error(t, err)
-
-	os.Setenv(env, homeEnv)
 }
 
 func Test_configurationDirOverride(t *testing.T) {
 	expected := "/tmp/foobar"
-	os.Setenv(elasticPackageDataHome, expected)
+	t.Setenv(elasticPackageDataHome, expected)
 
 	actual, err := configurationDir()
 	assert.Nil(t, err)
 
 	assert.Equal(t, expected, actual)
-	os.Setenv(elasticPackageDataHome, "")
 }

--- a/internal/stack/resources.go
+++ b/internal/stack/resources.go
@@ -29,6 +29,9 @@ const (
 	// ComposeFile is the docker compose file.
 	ComposeFile = "docker-compose.yml"
 
+	// DockerfilePackageRegistryFile is the dockerfile for package-registry container.
+	DockerfilePackageRegistryFile = "Dockerfile.package-registry"
+
 	// ElasticsearchConfigFile is the elasticsearch config file.
 	ElasticsearchConfigFile = "elasticsearch.yml"
 
@@ -77,7 +80,7 @@ var (
 	staticSource   = resource.NewSourceFS(static).WithTemplateFuncs(templateFuncs)
 	stackResources = []resource.Resource{
 		&resource.File{
-			Path:    "Dockerfile.package-registry",
+			Path:    DockerfilePackageRegistryFile,
 			Content: staticSource.Template("_static/Dockerfile.package-registry.tmpl"),
 		},
 		&resource.File{


### PR DESCRIPTION
Relates #3113 

Added tests for overriding EPR_PROXY_TO via profile setting.

Update tests to avoid using `os.Setenv` in favor of `t.Setenv`.