### PR TITLE
fix typo in tcp input template

### DIFF
--- a/internal/docs/_static/inputs/tcp.yml
+++ b/internal/docs/_static/inputs/tcp.yml
@@ -156,7 +156,7 @@ documentation: |-
   To enable encrypted connections, configure the following SSL settings:
 
   **SSL Settings:**
-  - Enable SSL*- Toggle to enable SSL/TLS encryption
+  - Enable SSL - Toggle to enable SSL/TLS encryption
   - Certificate - Path to the SSL certificate file (`.crt` or `.pem`)
   - Certificate Key - Path to the private key file (`.key`)
   - Certificate Authorities - Path to CA certificate file for client certificate validation (optional)


### PR DESCRIPTION
There's a typo in TCP input docs template. This PR fixes that.