### PR TITLE
Add permission to use extra_metadata_labels in otel collector

### DIFF
--- a/internal/agentdeployer/_static/elastic-agent-managed.yaml.tmpl
+++ b/internal/agentdeployer/_static/elastic-agent-managed.yaml.tmpl
@@ -222,6 +222,14 @@ rules:
       - nodes/stats
     verbs:
       - get
+  - apiGroups:
+      - ""
+    resources:
+      # Needed if you are using extra_metadata_labels or
+      # are collecting the request/limit utilization metrics via OTel Collector
+      - nodes/proxy
+    verbs:
+      - get
   - apiGroups: [ "batch" ]
     resources:
       - jobs


### PR DESCRIPTION
Relates https://github.com/elastic/integrations/pull/17159/

This PR adds the permission required for `nodes/proxy` resources in the ClusterRole resource to be able to define `extra_metadata_labels` or request/limit utilization metrics in the OTel collector.

Related documentation:
https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver#role-based-access-control

## Author's Checklist
-  [x] Test `kubernetes` package in integrations repository: [Buildkite build](https://buildkite.com/elastic/integrations/builds/37730#019c434c-86a1-48e0-a671-9db67ff259a8)