### PR TITLE
[CI] Include policy tests in serverless mode

### DIFF
--- a/scripts/test-check-packages.sh
+++ b/scripts/test-check-packages.sh
@@ -93,9 +93,10 @@ run_serverless_tests() {
   # skip system tests
   elastic-package test asset -C "$package_path" $test_options $coverage_options
   elastic-package test static -C "$package_path" $test_options $coverage_options
-  # FIXME: adding test-coverage for serverless results in errors like this:
+  # FIXME: adding test-coverage in pipeline tests for serverless results in errors like this:
   # Error: error running package pipeline tests: could not complete test run: error calculating pipeline coverage: error fetching pipeline stats for code coverage calculations: need exactly one ES node in stats response (got 4)
   elastic-package test pipeline -C "$package_path" $test_options
+  elastic-package test policy -C "$package_path" $test_options $coverage_options
 }
 
 run_pipeline_benchmark() {


### PR DESCRIPTION
Include policy tests when running tests in Serverless mode.


## Author's checklist
- [x] Trigger and validate that policy tests run in serverless pipeline https://buildkite.com/elastic/elastic-package-test-serverless/builds/726
- [x] Validate that serverless pipelines in integrations repository is executing policy tests ([link](https://github.com/elastic/integrations/blob/a35602144fac113b01d74e985af3de0ea3a2f401/.buildkite/scripts/common.sh#L909))