### PR TITLE
internal/testrunner/script: use repository root for RepositoryRoot

### DIFF
--- a/internal/testrunner/script/package.go
+++ b/internal/testrunner/script/package.go
@@ -9,11 +9,11 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/rogpeppe/go-internal/testscript"
 
 	"github.com/elastic/elastic-package/internal/fields"
+	"github.com/elastic/elastic-package/internal/files"
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/resources"
 )
@@ -25,7 +25,7 @@ func addPackage(ts *testscript.TestScript, neg bool, args []string) {
 	if pkgRoot == "" {
 		ts.Fatalf("PACKAGE_ROOT is not set")
 	}
-	root, err := os.OpenRoot(pkgRoot)
+	root, err := files.FindRepositoryRootFrom(pkgRoot)
 	ts.Check(err)
 	pkg := ts.Getenv("PACKAGE_NAME")
 	if pkg == "" {
@@ -82,7 +82,7 @@ func removePackage(ts *testscript.TestScript, neg bool, args []string) {
 	if pkgRoot == "" {
 		ts.Fatalf("PACKAGE_ROOT is not set")
 	}
-	root, err := os.OpenRoot(pkgRoot)
+	root, err := files.FindRepositoryRootFrom(pkgRoot)
 	ts.Check(err)
 	pkg := ts.Getenv("PACKAGE_NAME")
 	if pkg == "" {


### PR DESCRIPTION
## Summary

`addPackage` and `removePackage` used `os.OpenRoot(pkgRoot)` to create the `RepositoryRoot` passed to the package builder. This scoped filesystem access to the package directory, not the repository root. When CI sets `ELASTIC_PACKAGE_REPOSITORY_LICENSE`, the builder tries to read `licenses/Elastic-2.0.txt` via the sandboxed `os.Root`, which cannot traverse above the package directory.

Replace `os.OpenRoot` with `files.FindRepositoryRootFrom`, which walks up from the given path to find `.git` and opens an `os.Root` there.

Fixes #3321

> [!NOTE]
> If a package lives in a git submodule with its own `.git`, the walk would stop at the submodule root rather than the outer repo root, potentially reproducing the bug. This doesn't apply to the integrations repo but could affect other layouts. This is a limitation of `FindRepositoryRootFrom`'s design.

## Test plan

- [ ] CI integration tests pass (specifically script tests that exercise `add_package` / `remove_package`)

Made with [Cursor](https://cursor.com)