### PR TITLE
Revert breaking change in inputDocs

### DIFF
--- a/internal/docs/input_docs.go
+++ b/internal/docs/input_docs.go
@@ -44,8 +44,7 @@ func renderInputDocs(packageRoot string) (string, error) {
 
 	sort.Strings(inputs)
 	var renderedDocs strings.Builder
-	renderedDocs.WriteString("### Inputs used\n")
-	renderedDocs.WriteString("\nThese inputs can be used with this integration:\n")
+	renderedDocs.WriteString("These inputs can be used with this integration:\n")
 	for _, input := range inputs {
 		for _, inputDef := range inputDefs {
 			if inputDef.Name == input {

--- a/internal/packages/archetype/_static/package-docs-readme.md.tmpl
+++ b/internal/packages/archetype/_static/package-docs-readme.md.tmpl
@@ -106,6 +106,7 @@ To include a sample event from `sample_event.json`, uncomment and use:
 */}}
 {{ transform }}
 
+### Inputs used
 {{/* All inputs used by this package will be automatically listed here. */}}
 {{ inputDocs }}
 

--- a/test/packages/parallel/apache/_dev/build/docs/README.md
+++ b/test/packages/parallel/apache/_dev/build/docs/README.md
@@ -128,6 +128,8 @@ For more information on architectures that can be used for scaling this integrat
 
 {{event "status"}}
 
+### Inputs used
+
 {{ inputDocs }}
 
 ### API usage


### PR DESCRIPTION
Revert breaking change in inputDocs introduced in https://github.com/elastic/elastic-package/pull/3221.

This change would require updating READMEs in many packages, as found in https://buildkite.com/elastic/integrations/builds/39189.