### PR TITLE
[System tests] Avoid waiting to defer cleanup in skipped tests

### DIFF
--- a/internal/testrunner/runners/pipeline/tester.go
+++ b/internal/testrunner/runners/pipeline/tester.go
@@ -331,8 +331,8 @@ func (r *tester) runTestCase(ctx context.Context, testCaseFile string, dsPath st
 	rc.Name = tc.name
 
 	if skip := testrunner.AnySkipConfig(tc.config.Skip, r.globalTestConfig.Skip); skip != nil {
-		logger.Warnf("skipping %s test for %s/%s: %s (details: %s)",
-			TestType, r.testFolder.Package, r.testFolder.DataStream,
+		logger.Warnf("skipping %s %s test for %s/%s: %s (details: %s)",
+			tc.name, TestType, r.testFolder.Package, r.testFolder.DataStream,
 			skip.Reason, skip.Link)
 		results, _ := rc.WithSkip(skip)
 		return results, nil

--- a/internal/testrunner/runners/policy/tester.go
+++ b/internal/testrunner/runners/policy/tester.go
@@ -104,8 +104,8 @@ func (r *tester) runTest(ctx context.Context, manager *resources.Manager, testPa
 	testName := testNameFromPath(testPath)
 
 	if skip := testrunner.AnySkipConfig(testConfig.Skip, r.globalTestConfig.Skip); skip != nil {
-		logger.Warnf("skipping %s test for %s/%s: %s (details: %s)",
-			TestType, r.testFolder.Package, r.testFolder.DataStream,
+		logger.Warnf("skipping %s %s test for %s/%s: %s (details: %s)",
+			testName, TestType, r.testFolder.Package, r.testFolder.DataStream,
 			skip.Reason, skip.Link)
 		return result.WithSkip(skip)
 	}

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -1832,8 +1832,8 @@ func (r *tester) runTest(ctx context.Context, config *testConfig, stackConfig st
 	result := r.newResult(config.Name())
 
 	if skip := testrunner.AnySkipConfig(config.Skip, r.globalTestConfig.Skip); skip != nil {
-		logger.Warnf("skipping %s test for %s/%s: %s (details: %s)",
-			TestType, r.testFolder.Package, r.testFolder.DataStream,
+		logger.Warnf("skipping %s %s test for %s/%s: %s (details: %s)",
+			config.Name(), TestType, r.testFolder.Package, r.testFolder.DataStream,
 			skip.Reason, skip.Link)
 		return result.WithSkip(skip)
 	}


### PR DESCRIPTION
This PR avoids waiting to defer the cleanup process in those tests that have been marked as skipped.

For instance, currently running system tests for a package that contains a skipped test, `elastic-package` was also defering the cleanup process for those skipped tests:

```
2026/03/06 16:22:55 DEBUG Running tests sequentially
2026/03/06 16:22:55 DEBUG Using config: "filelog"
2026/03/06 16:22:55  WARN skipping system test for filelog_otel/: Test is skipped. (details: https://github.com/elastic/elastic-package/issues/1)
2026/03/06 16:22:55 DEBUG waiting for 10m0s before tearing down..
``` 

With the changes in this PR:
```
2026/03/06 16:23:29 DEBUG Running tests sequentially
2026/03/06 16:23:29 DEBUG Using config: "filelog"
2026/03/06 16:23:29  WARN skipping filelog system test for filelog_otel/: Test is skipped. (details: https://github.com/elastic/elastic-package/issues/1)
2026/03/06 16:23:29 DEBUG Test skipped, avoid checking agent logs
2026/03/06 16:23:29 DEBUG Using config: "filelog-multiline"
2026/03/06 16:23:29  WARN skipping filelog-multiline system test for filelog_otel/: Test is skipped. (details: https://github.com/elastic/elastic-package/issues/1)
2026/03/06 16:23:29 DEBUG Test skipped, avoid checking agent logs
2026/03/06 16:23:29 DEBUG Using config: "filelog-custom-dataset"
2026/03/06 16:23:29  WARN skipping filelog-custom-dataset system test for filelog_otel/: Test is skipped. (details: https://github.com/elastic/elastic-package/issues/1)
2026/03/06 16:23:29 DEBUG Test skipped, avoid checking agent logs
```

It also updates the skip message in the output to include the test name:
- Before
> skipping system test for filelog_otel/: Test is skipped. (details: https://github.com/elastic/elastic-package/issues/1)
- After
> skipping filelog system test for filelog_otel/: Test is skipped. (details: https://github.com/elastic/elastic-package/issues/1)


### How to test this PR locally

```
elastic-package stack up -v -d

cd test/packages/other/skipped_tests
elastic-package test system -v --defer-cleanup 10m

elastic-package stack down -v
```

---
Generated with the assistance of Cursor/Copilot
