### PR TITLE
internal/testrunner/script,internal/registry: add install_package_from_registry command

### DIFF
--- a/docs/howto/script_testing.md
+++ b/docs/howto/script_testing.md
@@ -54,22 +54,23 @@ a stack, starting agents and services and validating results.
 - package commands:
   - `add_package [-profile <profile>] [-timeout <duration>]`: add the current package's assets
   - `remove_package [-profile <profile>] [-timeout <duration>]`: remove assets for the current package
+  - `install_package_from_registry [-profile <profile>] [-timeout <duration>] <name> <version>`: install a published package version from the EPR via Fleet, download and extract its zip so manifests are available locally; registers the package for cleanup
   - `add_package_zip [-profile <profile>] [-timeout <duration>] <path_to_zip>`: add assets from a Zip-packaged integration package
   - `remove_package_zip [-profile <profile>] [-timeout <duration>] <path_to_zip>`: remove assets for Zip-packaged integration package
   - `upgrade_package_latest [-profile <profile>] [-timeout <duration>] [<package_name>]`: upgrade the current package or another named package to the latest version
-  - `add_package_policy [-profile <profile>] [-timeout <duration>] [-policy <policy_name>] <config.yaml> <name_var_label>`: add a package policy, setting the environment variable named in the positional argument
+  - `add_package_policy [-profile <profile>] [-timeout <duration>] [-policy <policy_name>] [-version <version>] <config.yaml> <name_var_label>`: add a package policy, setting the environment variable named in the positional argument; when `-version` is set, reads manifests from the EPR package extracted by a prior `install_package_from_registry` call for that version instead of from `PACKAGE_ROOT`
   - `remove_package_policy [-profile <profile>] [-timeout <duration>] <data_stream_name>`: remove a package policy
-  - `get_docs [-profile <profile>] [-timeout <duration>] [<data_stream>]`: get documents from a data stream
+  - `get_docs [-profile <profile>] [-want <n>] [-size <n>] [-confirm <duration>] [-timeout <duration>] [<data_stream>]`: get documents from a data stream; `-want` sets expected count (-1 means any positive number), `-size` sets query size, `-confirm` sets a duration to hold steady at the expected count
 
 - docker commands:
-  - `docker_up [-profile <profile>] [-timeout <duration>] <dir>`: start a docker service defined in the provided directory
+  - `docker_up [-profile <profile>] [-network <name>] [-timeout <duration>] <dir>`: start a docker service defined in the provided directory
   - `docker_down [-timeout <duration>] <name>`: stop a started docker service and print the docker logs to stdout
   - `docker_signal [-timeout <duration>] <name> <signal>`: send a signal to a running docker service
   - `docker_wait_exit [-timeout <duration>] <name>`: wait for a docker service to exit 
 
 - pipeline commands:
   - `install_pipelines [-profile <profile>] [-timeout <duration>] <path_to_data_stream>`: install ingest pipelines from a path
-  - `simulate [-profile <profile>] [-timeout <duration>] <path_to_data_stream> <pipeline> <path_to_data>`: run a pipeline test, printing the result as pretty-printed JSON to standard output
+  - `simulate [-profile <profile>] [-index <name>] [-timeout <duration>] <path_to_data_stream> <pipeline> <path_to_data>`: run a pipeline test, printing the result as pretty-printed JSON to standard output; `-index` sets the simulate index name (default `index-default`)
   - `uninstall_pipelines [-profile <profile>] [-timeout <duration>] <path_to_data_stream>`: remove installed ingest pipelines
 
 
@@ -87,6 +88,8 @@ a stack, starting agents and services and validating results.
 - `PREVIOUS_VERSION`: the previous version of the package
 - `DATA_STREAM`: the name of the data stream
 - `DATA_STREAM_ROOT`: the path to the root of the data stream
+- `ECS_BASE_SCHEMA_URL`: the ECS base schema URL
+- `PACKAGE_REGISTRY_BASE_URL`: the base URL for the Elastic Package Registry
 - `WORK`: the path to the directory that the script is run in
 
 
@@ -108,6 +111,10 @@ test for changes that are back-ports.
 
 The `has_previous_release` condition indicates whether there is a previous version
 in the changelog file.
+
+The `env:<VAR>` condition is true when the named environment variable is set and
+non-empty. For example, `[!env:LATEST_EPR_VERSION] skip` skips when there is no
+EPR release for the package.
 
 
 ## Example

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 
 	"github.com/elastic/elastic-package/internal/logger"
 )
@@ -63,4 +65,23 @@ func (c *Client) get(resourcePath string) (int, []byte, error) {
 	}
 
 	return resp.StatusCode, body, nil
+}
+
+// DownloadPackage downloads a package zip from the registry and writes it to destDir.
+// It returns the path to the downloaded zip file.
+func (c *Client) DownloadPackage(name, version, destDir string) (string, error) {
+	resourcePath := fmt.Sprintf("/epr/%s/%s-%s.zip", name, name, version)
+	statusCode, body, err := c.get(resourcePath)
+	if err != nil {
+		return "", fmt.Errorf("downloading package %s-%s: %w", name, version, err)
+	}
+	if statusCode != http.StatusOK {
+		return "", fmt.Errorf("downloading package %s-%s: unexpected status code %d", name, version, statusCode)
+	}
+
+	zipPath := filepath.Join(destDir, fmt.Sprintf("%s-%s.zip", name, version))
+	if err := os.WriteFile(zipPath, body, 0o644); err != nil {
+		return "", fmt.Errorf("writing package zip to %s: %w", zipPath, err)
+	}
+	return zipPath, nil
 }

--- a/internal/testrunner/script/data_stream.go
+++ b/internal/testrunner/script/data_stream.go
@@ -56,10 +56,11 @@ func addPackagePolicy(ts *testscript.TestScript, neg bool, args []string) {
 	flg := flag.NewFlagSet("add", flag.ContinueOnError)
 	profName := flg.String("profile", "default", "profile name")
 	polName := flg.String("policy", "", "policy name")
+	version := flg.String("version", "", "package version (reads manifests from EPR package extracted by install_package_from_registry)")
 	timeout := flg.Duration("timeout", 0, "timeout (zero or lower indicates no timeout)")
 	ts.Check(flg.Parse(args))
 	if flg.NArg() != 2 {
-		ts.Fatalf("usage: add_package_policy [-profile <profile>] [-timeout <duration>] [-policy <policy_name>] <config.yaml> <name_var_label>")
+		ts.Fatalf("usage: add_package_policy [-profile <profile>] [-timeout <duration>] [-policy <policy_name>] [-version <version>] <config.yaml> <name_var_label>")
 	}
 
 	cfgPath := ts.MkAbs(flg.Arg(0))
@@ -94,9 +95,23 @@ func addPackagePolicy(ts *testscript.TestScript, neg bool, args []string) {
 		defer cancel()
 	}
 
-	pkgMan, err := packages.ReadPackageManifestFromPackageRoot(pkgRoot)
+	manifestRoot := pkgRoot
+	if *version != "" {
+		regRoots, ok := ts.Value(registryPackageRootsTag{}).(map[string]string)
+		if !ok {
+			ts.Fatalf("no registry package roots registry")
+		}
+		key := fmt.Sprintf("%s-%s", pkg, *version)
+		root, ok := regRoots[key]
+		if !ok {
+			ts.Fatalf("no extracted EPR package for %s (call install_package_from_registry first)", key)
+		}
+		manifestRoot = root
+	}
+
+	pkgMan, err := packages.ReadPackageManifestFromPackageRoot(manifestRoot)
 	ts.Check(decoratedWith("reading package manifest", err))
-	dsMan, err := packages.ReadDataStreamManifestFromPackageRoot(pkgRoot, ds)
+	dsMan, err := packages.ReadDataStreamManifestFromPackageRoot(manifestRoot, ds)
 	ts.Check(decoratedWith("reading data stream manifest", err))
 
 	if *polName == "" {
@@ -106,7 +121,7 @@ func addPackagePolicy(ts *testscript.TestScript, neg bool, args []string) {
 	templ, err := packages.SelectPolicyTemplateByName(pkgMan.PolicyTemplates, *polName)
 	ts.Check(decoratedWith("finding policy template", err))
 
-	policy, dsType, dsDataset, err := system.CreatePackagePolicy(installed.testingPolicy, pkgMan, templ, dsMan, config.Input, config.Vars, config.DataStream.Vars, installed.testingPolicy.Namespace, pkgRoot)
+	policy, dsType, dsDataset, err := system.CreatePackagePolicy(installed.testingPolicy, pkgMan, templ, dsMan, config.Input, config.Vars, config.DataStream.Vars, installed.testingPolicy.Namespace, manifestRoot)
 	ts.Check(decoratedWith("creating package policy", err))
 	_, err = stk.kibana.CreatePackagePolicy(ctx, policy, kibana.PolicyAPIFormatAuto)
 	ts.Check(decoratedWith("adding package policy", err))

--- a/internal/testrunner/script/package.go
+++ b/internal/testrunner/script/package.go
@@ -5,16 +5,23 @@
 package script
 
 import (
+	"archive/zip"
 	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/rogpeppe/go-internal/testscript"
 
 	"github.com/elastic/elastic-package/internal/fields"
 	"github.com/elastic/elastic-package/internal/files"
 	"github.com/elastic/elastic-package/internal/packages"
+	"github.com/elastic/elastic-package/internal/registry"
 	"github.com/elastic/elastic-package/internal/resources"
 )
 
@@ -125,6 +132,136 @@ func removePackage(ts *testscript.TestScript, neg bool, args []string) {
 	ts.Check(decoratedWith("removing package resources", err))
 
 	fmt.Fprintf(ts.Stdout(), "removed package resources for %s\n", pkg)
+}
+
+func installPackageFromRegistry(ts *testscript.TestScript, neg bool, args []string) {
+	clearStdStreams(ts)
+
+	stacks, ok := ts.Value(runningStackTag{}).(map[string]*runningStack)
+	if !ok {
+		ts.Fatalf("no active stacks registry")
+	}
+	regPkgs, ok := ts.Value(registryPackagesTag{}).(map[string][]registryPackage)
+	if !ok {
+		ts.Fatalf("no registry packages registry")
+	}
+	regRoots, ok := ts.Value(registryPackageRootsTag{}).(map[string]string)
+	if !ok {
+		ts.Fatalf("no registry package roots registry")
+	}
+
+	flg := flag.NewFlagSet("install_registry", flag.ContinueOnError)
+	profName := flg.String("profile", "default", "profile name")
+	timeout := flg.Duration("timeout", 0, "timeout (zero or lower indicates no timeout)")
+	ts.Check(flg.Parse(args))
+	if flg.NArg() != 2 {
+		ts.Fatalf("usage: install_package_from_registry [-profile <profile>] [-timeout <duration>] <name> <version>")
+	}
+
+	name := flg.Arg(0)
+	version := flg.Arg(1)
+
+	stk, ok := stacks[*profName]
+	if !ok {
+		ts.Fatalf("no active client for %s", *profName)
+	}
+
+	ctx := context.Background()
+	if *timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *timeout)
+		defer cancel()
+	}
+
+	registryBaseURL := ts.Getenv("PACKAGE_REGISTRY_BASE_URL")
+	if registryBaseURL == "" {
+		ts.Fatalf("PACKAGE_REGISTRY_BASE_URL is not set")
+	}
+
+	_, err := stk.kibana.InstallPackage(ctx, name, version)
+	ts.Check(decoratedWith("installing package from registry", err))
+
+	regPkgs[*profName] = append(regPkgs[*profName], registryPackage{name: name, version: version})
+
+	workDir := ts.MkAbs(".")
+	client := registry.NewClient(registryBaseURL)
+	zipPath, err := client.DownloadPackage(name, version, workDir)
+	ts.Check(decoratedWith("downloading package from registry", err))
+
+	ts.Check(decoratedWith("extracting package zip", extractZip(zipPath, workDir)))
+
+	key := fmt.Sprintf("%s-%s", name, version)
+	eprRoot := filepath.Join(workDir, key)
+	regRoots[key] = eprRoot
+
+	fmt.Fprintf(ts.Stdout(), "installed %s %s from registry\n", name, version)
+}
+
+type registryPackagesTag struct{}
+type registryPackageRootsTag struct{}
+
+type registryPackage struct {
+	name    string
+	version string
+}
+
+// extractZip extracts a zip file to destDir. It validates that
+// the zip contains exactly one top-level directory.
+func extractZip(zipPath, destDir string) error {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return fmt.Errorf("opening zip %s: %w", zipPath, err)
+	}
+	defer r.Close()
+
+	dirs, err := fs.ReadDir(r, ".")
+	if err != nil {
+		return fmt.Errorf("reading zip root: %w", err)
+	}
+	if len(dirs) != 1 || !dirs[0].IsDir() {
+		return fmt.Errorf("expected exactly one top-level directory in zip, got %d entries", len(dirs))
+	}
+
+	for _, f := range r.File {
+		name := strings.TrimSuffix(f.Name, "/")
+		if !fs.ValidPath(name) {
+			return fmt.Errorf("invalid path in zip: %s", f.Name)
+		}
+		if strings.Contains(name, "..") {
+			return fmt.Errorf("path traversal in zip: %s", f.Name)
+		}
+
+		target := filepath.Join(destDir, name)
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("creating directory %s: %w", target, err)
+			}
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("creating parent directory for %s: %w", target, err)
+		}
+
+		src, err := f.Open()
+		if err != nil {
+			return fmt.Errorf("opening zip entry %s: %w", f.Name, err)
+		}
+		dst, err := os.Create(target)
+		if err != nil {
+			src.Close()
+			return fmt.Errorf("creating file %s: %w", target, err)
+		}
+		_, err = io.Copy(dst, src)
+		src.Close()
+		if closeErr := dst.Close(); err == nil {
+			err = closeErr
+		}
+		if err != nil {
+			return fmt.Errorf("writing file %s: %w", target, err)
+		}
+	}
+	return nil
 }
 
 func upgradePackageLatest(ts *testscript.TestScript, neg bool, args []string) {

--- a/internal/testrunner/script/script.go
+++ b/internal/testrunner/script/script.go
@@ -177,6 +177,8 @@ func Run(dst *[]testrunner.TestResult, w io.Writer, opt Options) error {
 		installedAgents:      make(map[string]*installedAgent),
 		installedDataStreams: make(map[string]struct{}),
 		installedPipelines:   make(map[string]installedPipelines),
+		registryPackages:     make(map[string][]registryPackage),
+		registryPackageRoots: make(map[string]string),
 	}
 	if opt.RunPattern != "" {
 		t.run, err = regexp.Compile(opt.RunPattern)
@@ -226,6 +228,32 @@ func Run(dst *[]testrunner.TestResult, w io.Writer, opt Options) error {
 			continue
 		}
 		n++
+		scriptEnv := map[string]string{
+			"PROFILE":                   appConfig.CurrentProfile(),
+			"CONFIG_ROOT":               loc.RootDir(),
+			"CONFIG_PROFILES":           loc.ProfileDir(),
+			"HOME":                      home,
+			"ECS_BASE_SCHEMA_URL":       appConfig.SchemaURLs().ECSBase(),
+			"PACKAGE_REGISTRY_BASE_URL": appConfig.PackageRegistryBaseURL(),
+		}
+		if pkgRoot != "" {
+			scriptEnv["PACKAGE_NAME"] = manifest.Name
+			scriptEnv["PACKAGE_BASE"] = filepath.Base(pkgRoot)
+			scriptEnv["PACKAGE_ROOT"] = pkgRoot
+		}
+		if latestEPRVersion != "" {
+			scriptEnv["LATEST_EPR_VERSION"] = latestEPRVersion
+		}
+		if currVersion != "" {
+			scriptEnv["CURRENT_VERSION"] = currVersion
+		}
+		if prevVersion != "" {
+			scriptEnv["PREVIOUS_VERSION"] = prevVersion
+		}
+		if dsRoot != "" {
+			scriptEnv["DATA_STREAM"] = d
+			scriptEnv["DATA_STREAM_ROOT"] = dsRoot
+		}
 		p := testscript.Params{
 			Dir:             scripts,
 			WorkdirRoot:     workdirRoot,
@@ -233,76 +261,62 @@ func Run(dst *[]testrunner.TestResult, w io.Writer, opt Options) error {
 			ContinueOnError: opt.ContinueOnError,
 			TestWork:        opt.TestWork,
 			Cmds: map[string]func(ts *testscript.TestScript, neg bool, args []string){
-				"sleep":                  sleep,
-				"date":                   date,
-				"GET":                    get,
-				"POST":                   post,
-				"stack_up":               stackUp,
-				"use_stack":              useStack,
-				"stack_down":             stackDown,
-				"docker_up":              dockerUp,
-				"docker_down":            dockerDown,
-				"docker_signal":          dockerSignal,
-				"docker_wait_exit":       dockerWaitExit,
-				"install_pipelines":      installPipelines,
-				"simulate":               simulate,
-				"uninstall_pipelines":    uninstallPipelines,
-				"install_agent":          installAgent,
-				"add_package":            addPackage,
-				"remove_package":         removePackage,
-				"upgrade_package_latest": upgradePackageLatest,
-				"add_package_zip":        addPackageZip,
-				"remove_package_zip":     removePackageZip,
-				"add_package_policy":     addPackagePolicy,
-				"remove_package_policy":  removePackagePolicy,
-				"uninstall_agent":        uninstallAgent,
-				"get_docs":               getDocs,
-				"dump_logs":              dumpLogs,
-				"match_file":             match,
-				"get_policy":             getPolicyCommand,
-				"compile_registry_state": compileRegistryState,
+				"sleep":                         sleep,
+				"date":                          date,
+				"GET":                           get,
+				"POST":                          post,
+				"stack_up":                      stackUp,
+				"use_stack":                     useStack,
+				"stack_down":                    stackDown,
+				"docker_up":                     dockerUp,
+				"docker_down":                   dockerDown,
+				"docker_signal":                 dockerSignal,
+				"docker_wait_exit":              dockerWaitExit,
+				"install_pipelines":             installPipelines,
+				"simulate":                      simulate,
+				"uninstall_pipelines":           uninstallPipelines,
+				"install_agent":                 installAgent,
+				"add_package":                   addPackage,
+				"remove_package":                removePackage,
+				"upgrade_package_latest":        upgradePackageLatest,
+				"add_package_zip":               addPackageZip,
+				"install_package_from_registry": installPackageFromRegistry,
+				"remove_package_zip":            removePackageZip,
+				"add_package_policy":            addPackagePolicy,
+				"remove_package_policy":         removePackagePolicy,
+				"uninstall_agent":               uninstallAgent,
+				"get_docs":                      getDocs,
+				"dump_logs":                     dumpLogs,
+				"match_file":                    match,
+				"get_policy":                    getPolicyCommand,
+				"compile_registry_state":        compileRegistryState,
 			},
 			Setup: func(e *testscript.Env) error {
-				e.Setenv("PROFILE", appConfig.CurrentProfile())
-				e.Setenv("CONFIG_ROOT", loc.RootDir())
-				e.Setenv("CONFIG_PROFILES", loc.ProfileDir())
-				e.Setenv("HOME", home)
-				if pkgRoot != "" {
-					e.Setenv("PACKAGE_NAME", manifest.Name)
-					e.Setenv("PACKAGE_BASE", filepath.Base(pkgRoot))
-					e.Setenv("PACKAGE_ROOT", pkgRoot)
+				for k, v := range scriptEnv {
+					e.Setenv(k, v)
 				}
-				if latestEPRVersion != "" {
-					e.Setenv("LATEST_EPR_VERSION", latestEPRVersion)
-				}
-				if currVersion != "" {
-					e.Setenv("CURRENT_VERSION", currVersion)
-				}
-				if prevVersion != "" {
-					e.Setenv("PREVIOUS_VERSION", prevVersion)
-				}
-				if dsRoot != "" {
-					e.Setenv("DATA_STREAM", d)
-					e.Setenv("DATA_STREAM_ROOT", dsRoot)
-				}
-				e.Setenv("ECS_BASE_SCHEMA_URL", appConfig.SchemaURLs().ECSBase())
 				e.Values[deployedServiceTag{}] = t.deployedService
 				e.Values[runningStackTag{}] = t.runningStack
 				e.Values[installedAgentsTag{}] = t.installedAgents
 				e.Values[installedDataStreamsTag{}] = t.installedDataStreams
 				e.Values[installedPipelinesTag{}] = t.installedPipelines
+				e.Values[registryPackagesTag{}] = t.registryPackages
+				e.Values[registryPackageRootsTag{}] = t.registryPackageRoots
 				return nil
 			},
 			Condition: func(cond string) (bool, error) {
-				switch cond {
-				case "external_stack":
+				switch {
+				case cond == "external_stack":
 					return opt.ExternalStack, nil
-				case "breaking_change":
+				case cond == "breaking_change":
 					return breakingChange, nil
-				case "is_latest_version":
+				case cond == "is_latest_version":
 					return isLatestVersion, nil
-				case "has_previous_release":
+				case cond == "has_previous_release":
 					return prevVersion != "", nil
+				case strings.HasPrefix(cond, "env:"):
+					_, ok := scriptEnv[cond[len("env:"):]]
+					return ok, nil
 				default:
 					return false, fmt.Errorf("unknown condition: %s", cond)
 				}
@@ -328,6 +342,7 @@ func Run(dst *[]testrunner.TestResult, w io.Writer, opt Options) error {
 			t.installedDataStreams,
 			t.installedAgents,
 			t.installedPipelines,
+			t.registryPackages,
 			t.runningStack,
 		)
 		if err != nil {
@@ -340,13 +355,13 @@ func Run(dst *[]testrunner.TestResult, w io.Writer, opt Options) error {
 	return nil
 }
 
-func cleanUp(ctx context.Context, pkgRoot string, srvs map[string]servicedeployer.DeployedService, streams map[string]struct{}, agents map[string]*installedAgent, pipes map[string]installedPipelines, stacks map[string]*runningStack) error {
+func cleanUp(ctx context.Context, pkgRoot string, srvs map[string]servicedeployer.DeployedService, streams map[string]struct{}, agents map[string]*installedAgent, pipes map[string]installedPipelines, regPkgs map[string][]registryPackage, stacks map[string]*runningStack) error {
 	// We most likely have only one stack, but just iterate over
 	// all if there is more than one. What could possibly go wrong?
 	// If this _is_ problematic, we'll need to record the stack that
 	// was used for each item when it's created.
 	var errs []error
-	for _, stk := range stacks {
+	for prof, stk := range stacks {
 		for _, pipe := range pipes {
 			ingest.UninstallPipelines(ctx, stk.es.API, pipe.pipes)
 		}
@@ -367,6 +382,13 @@ func cleanUp(ctx context.Context, pkgRoot string, srvs map[string]servicedeploye
 			deletePolicies(ctx, stk.kibana, installed)
 		}
 
+		for _, pkg := range regPkgs[prof] {
+			_, err := stk.kibana.RemovePackage(ctx, pkg.name, pkg.version)
+			if err != nil && !strings.Contains(err.Error(), "status code = 404") && !strings.Contains(err.Error(), "is not installed") {
+				errs = append(errs, fmt.Errorf("removing registry package %s-%s: %w", pkg.name, pkg.version, err))
+			}
+		}
+
 		m := resources.NewManager()
 		m.RegisterProvider(resources.DefaultKibanaProviderName, &resources.KibanaProvider{Client: stk.kibana})
 		_, err := m.ApplyCtx(ctx, resources.Resources{&resources.FleetPackage{
@@ -374,7 +396,7 @@ func cleanUp(ctx context.Context, pkgRoot string, srvs map[string]servicedeploye
 			Absent:      true,
 			Force:       true,
 		}})
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), "is not installed") {
 			errs = append(errs, err)
 		}
 
@@ -509,6 +531,8 @@ type T struct {
 	installedAgents      map[string]*installedAgent
 	installedDataStreams map[string]struct{}
 	installedPipelines   map[string]installedPipelines
+	registryPackages     map[string][]registryPackage
+	registryPackageRoots map[string]string
 }
 
 // clearRegistries prevents tests within a directory from communicating
@@ -520,6 +544,8 @@ func (t *T) clearRegistries() {
 	clear(t.installedDataStreams)
 	clear(t.installedAgents)
 	clear(t.runningStack)
+	clear(t.registryPackages)
+	clear(t.registryPackageRoots)
 }
 
 func (t *T) Skip(is ...any) {

--- a/test/packages/other/with_script/data_stream/first/_dev/test/scripts/upgrade_from_registry.txt
+++ b/test/packages/other/with_script/data_stream/first/_dev/test/scripts/upgrade_from_registry.txt
@@ -1,0 +1,9 @@
+# The with_script package has no EPR release, so this test validates the
+# skip path and documents the intended upgrade test pattern.
+[!env:LATEST_EPR_VERSION] skip 'no EPR release to upgrade from'
+
+# If the skip condition is not met (unexpected), fail explicitly.
+cmp stdout note
+
+-- note --
+This should fail if it does not skip.


### PR DESCRIPTION
Add a new script test command that installs a published package version from the EPR via Fleet and downloads/extracts its zip so the real manifests are available locally. A new -version flag on add_package_policy reads manifests from the extracted EPR package instead of PACKAGE_ROOT, so the policy is built from the EPR version's actual schema rather than the dev version's.

Registry-installed packages are tracked for cleanup, with 404 errors ignored since the package may have been replaced by a subsequent add_package call.

Also backfills missing flags in docs/howto/script_testing.md (get_docs -want/-size/-confirm, docker_up -network, simulate -index) and adds the ECS_BASE_SCHEMA_URL and PACKAGE_REGISTRY_BASE_URL env vars.

Closes #3334

The test in the testing package does not test the substantive change since that depends on packages in the EPR. To test this locally, check out the change in elastic/integrations#17892 and apply (with a version number that is greater than the EPR latest):
```diff
diff --git a/packages/o365/changelog.yml b/packages/o365/changelog.yml
index ab2510bc8e..0c60eb2411 100644
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.8.1"
+  changes:
+    - description: Mock update.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9001
 - version: "3.8.0"
   changes:
     - description: Increase field limits to avoid unindexed ECS fields.
diff --git a/packages/o365/manifest.yml b/packages/o365/manifest.yml
index bd17279e9c..36de2bf191 100644
--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "3.8.0"
+version: "3.8.1"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.2.3"
```
and then run the script test in the o365 package with
```
elastic-package test script --verbose-scripts --run upgrade
```