### PR TITLE
Add policy tests forcing legacy policy_api_format

### DIFF
--- a/test/packages/other/with_legacy_policy_api/data_stream/indicator/_dev/test/policy/test-default.expected
+++ b/test/packages/other/with_legacy_policy_api/data_stream/indicator/_dev/test/policy/test-default.expected
@@ -1,0 +1,37 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: with_legacy_policy_api
+      name: test-default-with_legacy_policy_api
+      streams:
+        - data_stream:
+            dataset: with_legacy_policy_api.indicator
+          exclude_files:
+            - .gz$
+          paths:
+            - /var/log/prod-*.log
+          processors:
+            - add_locale: null
+            - add_tags:
+                tags:
+                    - revoked_true
+                    - env_production
+      type: logfile
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-with_legacy_policy_api.indicator-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/test/packages/other/with_legacy_policy_api/data_stream/indicator/_dev/test/policy/test-default.yml
+++ b/test/packages/other/with_legacy_policy_api/data_stream/indicator/_dev/test/policy/test-default.yml
@@ -1,0 +1,9 @@
+# policy_api_format: legacy is required because this package has a select variable
+# (revoked) with "false" as an option value. Fleet's simplified API coerces the
+# string "false" to boolean false before validation, causing a 400 error.
+policy_api_format: legacy
+data_stream:
+  vars:
+    revoked: "true"
+    paths:
+      - /var/log/prod-*.log

--- a/test/packages/other/with_legacy_policy_api/data_stream/indicator/_dev/test/policy/test-staging.expected
+++ b/test/packages/other/with_legacy_policy_api/data_stream/indicator/_dev/test/policy/test-staging.expected
@@ -1,0 +1,37 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: with_legacy_policy_api
+      name: test-staging-with_legacy_policy_api
+      streams:
+        - data_stream:
+            dataset: with_legacy_policy_api.indicator
+          exclude_files:
+            - .gz$
+          paths:
+            - /var/log/stag-*.log
+          processors:
+            - add_locale: null
+            - add_tags:
+                tags:
+                    - revoked_false
+                    - env_staging
+      type: logfile
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-with_legacy_policy_api.indicator-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/test/packages/other/with_legacy_policy_api/data_stream/indicator/_dev/test/policy/test-staging.yml
+++ b/test/packages/other/with_legacy_policy_api/data_stream/indicator/_dev/test/policy/test-staging.yml
@@ -1,0 +1,11 @@
+# policy_api_format: legacy is required because this package has a select variable
+# (revoked) with "false" as an option value. Fleet's simplified API coerces the
+# string "false" to boolean false before validation, causing a 400 error.
+policy_api_format: legacy
+vars:
+  revoked: "false"
+  environment: "staging"
+data_stream:
+  vars:
+    paths:
+      - /var/log/stag-*.log


### PR DESCRIPTION
These tests were originally included in https://github.com/elastic/elastic-package/pull/3307, but removed because the required setting was not available in the Package Spec version.

See https://github.com/elastic/elastic-package/pull/3307#discussion_r2890046922.