### PR TITLE
Fix policy tests failing on 9.4.0+ due to beatsauth OTel fields injected by Fleet

### DIFF
--- a/internal/testrunner/runners/policy/policy.go
+++ b/internal/testrunner/runners/policy/policy.go
@@ -162,6 +162,8 @@ var policyEntryFilters = []policyEntryFilter{
 			regexp:  regexp.MustCompile(`^https?://.*$`),
 			replace: "https://elasticsearch:9200",
 		}},
+		// auth is injected by Fleet since 9.4.0 and may appear in any exporter, not just
+		// elasticsearch. Removed for backwards compatibility with older stacks.
 		{name: "auth"},
 	}},
 

--- a/internal/testrunner/runners/policy/policy.go
+++ b/internal/testrunner/runners/policy/policy.go
@@ -118,6 +118,9 @@ type policyEntryReplace struct {
 	replace string
 }
 
+// beatsauthPattern matches OTel component IDs for the beatsauth extension injected by Fleet.
+var beatsauthPattern = regexp.MustCompile(`^beatsauth/`)
+
 // policyEntryFilter includes a list of filters to do to the policy. These filters
 // are used to remove or control fields whose content is not relevant for the package
 // test.
@@ -163,9 +166,9 @@ var policyEntryFilters = []policyEntryFilter{
 	}},
 
 	// Fields injected by Fleet into OTel policies since 9.4.0 (beatsauth extension).
-	{name: "extensions", deletePattern: regexp.MustCompile(`^beatsauth/`)},
+	{name: "extensions", deletePattern: beatsauthPattern},
 	{name: "extensions", onlyIfEmpty: true},
-	{name: "service.extensions", deletePattern: regexp.MustCompile(`^beatsauth/`)},
+	{name: "service.extensions", deletePattern: beatsauthPattern},
 	{name: "service.extensions", onlyIfEmpty: true},
 
 	// Signatures that change from installation to installation.

--- a/internal/testrunner/runners/policy/policy.go
+++ b/internal/testrunner/runners/policy/policy.go
@@ -108,6 +108,7 @@ type policyEntryFilter struct {
 	mapValues          []policyEntryFilter
 	memberReplace      *policyEntryReplace
 	stringValueReplace *policyEntryReplace
+	deletePattern      *regexp.Regexp
 	onlyIfEmpty        bool
 	ignoreValues       []any
 }
@@ -158,7 +159,13 @@ var policyEntryFilters = []policyEntryFilter{
 			regexp:  regexp.MustCompile(`^https?://.*$`),
 			replace: "https://elasticsearch:9200",
 		}},
+		{name: "auth"},
 	}},
+
+	// Fields injected by Fleet into OTel policies since 9.4.0 (beatsauth extension).
+	{name: "extensions", deletePattern: regexp.MustCompile(`^beatsauth/`)},
+	{name: "extensions", onlyIfEmpty: true},
+	{name: "service.extensions", deletePattern: regexp.MustCompile(`^beatsauth/`)},
 
 	// Signatures that change from installation to installation.
 	{name: "agent.protection.uninstall_token_hash"},
@@ -468,6 +475,33 @@ func cleanPolicyMap(policyMap common.MapStr, entries []policyEntryFilter) (commo
 			if regexp.MatchString(vStr) {
 				value := regexp.ReplaceAllString(vStr, replacement)
 				policyMap.Put(entry.name, value)
+			}
+		case entry.deletePattern != nil:
+			switch val := v.(type) {
+			case common.MapStr:
+				for k := range val {
+					if entry.deletePattern.MatchString(k) {
+						delete(val, k)
+					}
+				}
+			case []any:
+				filtered := val[:0]
+				for _, elem := range val {
+					elemStr, ok := elem.(string)
+					if !ok {
+						return nil, fmt.Errorf("expected string array element, found %T", elem)
+					}
+					if !entry.deletePattern.MatchString(elemStr) {
+						filtered = append(filtered, elemStr)
+					}
+				}
+				policyMap.Delete(entry.name)
+				_, err := policyMap.Put(entry.name, filtered)
+				if err != nil {
+					return nil, err
+				}
+			default:
+				return nil, fmt.Errorf("expected map or array for deletePattern, found %T", v)
 			}
 		default:
 			if entry.onlyIfEmpty && !isEmpty(v, entry.ignoreValues) {

--- a/internal/testrunner/runners/policy/policy.go
+++ b/internal/testrunner/runners/policy/policy.go
@@ -166,6 +166,7 @@ var policyEntryFilters = []policyEntryFilter{
 	{name: "extensions", deletePattern: regexp.MustCompile(`^beatsauth/`)},
 	{name: "extensions", onlyIfEmpty: true},
 	{name: "service.extensions", deletePattern: regexp.MustCompile(`^beatsauth/`)},
+	{name: "service.extensions", onlyIfEmpty: true},
 
 	// Signatures that change from installation to installation.
 	{name: "agent.protection.uninstall_token_hash"},

--- a/internal/testrunner/runners/policy/policy_test.go
+++ b/internal/testrunner/runners/policy/policy_test.go
@@ -118,10 +118,36 @@ service:
     extensions:
         - beatsauth/default
         - health_check/default
+    pipelines:
+        logs/default:
+            receivers:
+                - otlp/default
 `,
 			expected: `service:
     extensions:
         - health_check/default
+    pipelines:
+        logs/componentid-0:
+            receivers:
+                - otlp/default
+`,
+		},
+		{
+			title: "remove service.extensions entirely when only beatsauth entries remain",
+			policy: `
+service:
+    extensions:
+        - beatsauth/default
+    pipelines:
+        logs/default:
+            receivers:
+                - otlp/default
+`,
+			expected: `service:
+    pipelines:
+        logs/componentid-0:
+            receivers:
+                - otlp/default
 `,
 		},
 		{

--- a/internal/testrunner/runners/policy/policy_test.go
+++ b/internal/testrunner/runners/policy/policy_test.go
@@ -68,6 +68,94 @@ exporters:
             - https://elasticsearch:9200
 `,
 		},
+		// beatsauth fields injected by Fleet in OTel policies since 9.4.0.
+		{
+			title: "strip auth from exporter, keep endpoints",
+			policy: `
+exporters:
+    elasticsearch/default:
+        endpoints:
+            - https://abc123def.elastic.cloud:443
+        auth:
+            authenticator: beatsauth/default
+`,
+			expected: `exporters:
+    elasticsearch/componentid-0:
+        endpoints:
+            - https://elasticsearch:9200
+`,
+		},
+		{
+			title: "strip beatsauth entries from extensions, keep non-beatsauth",
+			policy: `
+extensions:
+    beatsauth/default:
+        ssl:
+            ca_trusted_fingerprint: abc123
+    health_check/default:
+        endpoint: 0.0.0.0:13133
+`,
+			expected: `extensions:
+    health_check/componentid-0:
+        endpoint: 0.0.0.0:13133
+`,
+		},
+		{
+			title: "remove extensions entirely when only beatsauth entries remain",
+			policy: `
+extensions:
+    beatsauth/default:
+        ssl:
+            ca_trusted_fingerprint: abc123
+`,
+			expected: `{}
+`,
+		},
+		{
+			title: "strip beatsauth entries from service.extensions, keep others",
+			policy: `
+service:
+    extensions:
+        - beatsauth/default
+        - health_check/default
+`,
+			expected: `service:
+    extensions:
+        - health_check/default
+`,
+		},
+		{
+			title: "strip all beatsauth fields injected by Fleet on 9.4.0+",
+			policy: `
+exporters:
+    elasticsearch/default:
+        endpoints:
+            - https://abc123def.elastic.cloud:443
+        auth:
+            authenticator: beatsauth/default
+extensions:
+    beatsauth/default:
+        ssl:
+            ca_trusted_fingerprint: abc123
+    health_check/default:
+        endpoint: 0.0.0.0:13133
+service:
+    extensions:
+        - beatsauth/default
+        - health_check/default
+`,
+			expected: `exporters:
+    elasticsearch/componentid-0:
+        endpoints:
+            - https://elasticsearch:9200
+extensions:
+    health_check/componentid-0:
+        endpoint: 0.0.0.0:13133
+service:
+    extensions:
+        - health_check/componentid-0
+`,
+		},
 	}
 
 	for _, c := range cases {

--- a/test/packages/parallel/sql_server_input_otel/_dev/test/system/test-all-signals-config.yml
+++ b/test/packages/parallel/sql_server_input_otel/_dev/test/system/test-all-signals-config.yml
@@ -1,6 +1,3 @@
-skip:
-  reason: Broken after change in Kibana, to be fixed after https://github.com/elastic/kibana/pull/262000
-  link: https://github.com/elastic/elastic-package/pull/3433
 service: sql_server_input_otel
 signal_types:
   - logs

--- a/test/packages/parallel/sql_server_input_otel/_dev/test/system/test-default-config.yml
+++ b/test/packages/parallel/sql_server_input_otel/_dev/test/system/test-default-config.yml
@@ -1,6 +1,3 @@
-skip:
-  reason: Broken after change in Kibana, to be fixed after https://github.com/elastic/kibana/pull/262000
-  link: https://github.com/elastic/elastic-package/pull/3433
 service: sql_server_input_otel
 vars:
   server: "{{Hostname}}"

--- a/test/packages/parallel/sql_server_input_otel/_dev/test/system/test-logs-config.yml
+++ b/test/packages/parallel/sql_server_input_otel/_dev/test/system/test-logs-config.yml
@@ -1,6 +1,3 @@
-skip:
-  reason: Broken after change in Kibana, to be fixed after https://github.com/elastic/kibana/pull/262000
-  link: https://github.com/elastic/elastic-package/pull/3433
 service: sql_server_input_otel
 signal_types:
   - logs

--- a/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default-custom-dataset.expected
+++ b/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default-custom-dataset.expected
@@ -21,7 +21,7 @@ output_permissions:
                     - auto_configure
                     - create_doc
                 - names:
-                    - logs-generic.otel-*
+                    - logs-zipkin.custom-*
                   privileges:
                     - auto_configure
                     - create_doc
@@ -47,6 +47,7 @@ processors:
             - context: spanevent
               statements:
                 - set(attributes["data_stream.type"], "logs")
+                - set(attributes["data_stream.dataset"], "zipkin.custom")
                 - set(attributes["data_stream.namespace"], "ep")
 receivers:
     zipkin/componentid-0:

--- a/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default-custom-dataset.yml
+++ b/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default-custom-dataset.yml
@@ -1,6 +1,3 @@
-skip:
-  reason: Broken after change in Kibana, to be fixed after https://github.com/elastic/kibana/pull/262000
-  link: https://github.com/elastic/elastic-package/pull/3433
 vars:
   endpoint: "0.0.0.0:9411"
   parse_string_tags: true

--- a/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default-disable-use-apm.expected
+++ b/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default-disable-use-apm.expected
@@ -20,7 +20,7 @@ output_permissions:
                     - auto_configure
                     - create_doc
                 - names:
-                    - logs-generic.otel-*
+                    - logs-zipkinreceiver-*
                   privileges:
                     - auto_configure
                     - create_doc
@@ -35,6 +35,7 @@ processors:
             - context: spanevent
               statements:
                 - set(attributes["data_stream.type"], "logs")
+                - set(attributes["data_stream.dataset"], "zipkinreceiver")
                 - set(attributes["data_stream.namespace"], "ep")
 receivers:
     zipkin/componentid-0:

--- a/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default-disable-use-apm.yml
+++ b/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default-disable-use-apm.yml
@@ -1,6 +1,3 @@
-skip:
-  reason: Broken after change in Kibana, to be fixed after https://github.com/elastic/kibana/pull/262000
-  link: https://github.com/elastic/elastic-package/pull/3433
 vars:
   endpoint: "0.0.0.0:9411"
   parse_string_tags: true

--- a/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default-use-apm.expected
+++ b/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default-use-apm.expected
@@ -21,7 +21,7 @@ output_permissions:
                     - auto_configure
                     - create_doc
                 - names:
-                    - logs-generic.otel-*
+                    - logs-zipkinreceiver-*
                   privileges:
                     - auto_configure
                     - create_doc
@@ -47,6 +47,7 @@ processors:
             - context: spanevent
               statements:
                 - set(attributes["data_stream.type"], "logs")
+                - set(attributes["data_stream.dataset"], "zipkinreceiver")
                 - set(attributes["data_stream.namespace"], "ep")
 receivers:
     zipkin/componentid-0:

--- a/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default-use-apm.yml
+++ b/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default-use-apm.yml
@@ -1,6 +1,3 @@
-skip:
-  reason: Broken after change in Kibana, to be fixed after https://github.com/elastic/kibana/pull/262000
-  link: https://github.com/elastic/elastic-package/pull/3433
 vars:
   endpoint: "0.0.0.0:9411"
   parse_string_tags: true

--- a/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default-vars.expected
+++ b/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default-vars.expected
@@ -21,7 +21,7 @@ output_permissions:
                     - auto_configure
                     - create_doc
                 - names:
-                    - logs-generic.otel-*
+                    - logs-zipkinreceiver-*
                   privileges:
                     - auto_configure
                     - create_doc
@@ -47,6 +47,7 @@ processors:
             - context: spanevent
               statements:
                 - set(attributes["data_stream.type"], "logs")
+                - set(attributes["data_stream.dataset"], "zipkinreceiver")
                 - set(attributes["data_stream.namespace"], "ep")
 receivers:
     zipkin/componentid-0:

--- a/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default-vars.yml
+++ b/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default-vars.yml
@@ -1,4 +1,1 @@
-skip:
-  reason: Broken after change in Kibana, to be fixed after https://github.com/elastic/kibana/pull/262000
-  link: https://github.com/elastic/elastic-package/pull/3433
 vars: ~

--- a/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default.expected
+++ b/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default.expected
@@ -21,7 +21,7 @@ output_permissions:
                     - auto_configure
                     - create_doc
                 - names:
-                    - logs-generic.otel-*
+                    - logs-zipkinreceiver-*
                   privileges:
                     - auto_configure
                     - create_doc
@@ -47,6 +47,7 @@ processors:
             - context: spanevent
               statements:
                 - set(attributes["data_stream.type"], "logs")
+                - set(attributes["data_stream.dataset"], "zipkinreceiver")
                 - set(attributes["data_stream.namespace"], "ep")
 receivers:
     zipkin/componentid-0:

--- a/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default.yml
+++ b/test/packages/parallel/zipkin_input_otel/_dev/test/policy/test-default.yml
@@ -1,6 +1,3 @@
-skip:
-  reason: Broken after change in Kibana, to be fixed after https://github.com/elastic/kibana/pull/262000
-  link: https://github.com/elastic/elastic-package/pull/3433
 vars:
   endpoint: "0.0.0.0:9411"
   parse_string_tags: true

--- a/test/packages/parallel/zipkin_input_otel/_dev/test/system/test-default-config.yml
+++ b/test/packages/parallel/zipkin_input_otel/_dev/test/system/test-default-config.yml
@@ -1,6 +1,3 @@
-skip:
-  reason: Broken after change in Kibana, to be fixed after https://github.com/elastic/kibana/pull/262000
-  link: https://github.com/elastic/elastic-package/pull/3433
 service: backend
 vars:
   endpoint: "0.0.0.0:9411"


### PR DESCRIPTION
Since https://github.com/elastic/kibana/pull/259308 (present in 9.4.0+), Fleet injects a `beatsauth` authentication extension into every OTel policy that uses an Elasticsearch output. This caused policy tests to fail when run against a 9.4.0+ stack because the downloaded policy contains fields that existing fixtures don't include.

The three new fields injected are:

- `exporters[*].auth` — authentication reference added to each exporter
- `extensions[beatsauth/*]` — new top-level extension with deployment-specific SSL data (dynamic `ca_trusted_fingerprint`)
- `service.extensions` entries matching `beatsauth/*` — extension registered in the service block

These fields are deployment-specific and should be stripped by `cleanPolicy` before comparison, following the existing pattern in `policyEntryFilters`.

### Changes

- Added a new `deletePattern *regexp.Regexp` field to `policyEntryFilter` to support removing map entries by key pattern and list entries by value pattern
- Extended the existing `exporters` filter to strip `auth` (present in any exporter since 9.4.0, removed for backwards compatibility)
- Added filters to strip `beatsauth/*` entries from `extensions` and `service.extensions`, and to remove those keys entirely when left empty
- Re-enabled previously skipped policy and system tests for `zipkin_input_otel` and `sql_server_input_otel` (also broken by the same Kibana change)
- Updated `zipkin_input_otel` policy fixtures to reflect the new `data_stream.dataset` processor statements introduced in 9.4.0

## Related issues

- Closes #3463

## Author's Checklist

- [x] Verified that policy tests pass on a 9.4.0+ stack
    - Tested in https://buildkite.com/elastic/integrations-test-stack/builds/65
    - Failing packages are not related to this issue, and they are already reported as flaky tests. 
- [x] Verified that policy tests on an older stack (e.g. 9.2.0) still pass — fixtures created before 9.4.0 should not require regeneration
- [x] Tested a package that requires a minimum stack version of 9.2.0 (e.g. `filelog_otel`) against a 9.4.0 stack to confirm policy tests no longer fail due to beatsauth fields
- [x] Confirmed that `zipkin_input_otel` and `sql_server_input_otel` tests are no longer skipped and pass correctly

---

> _This PR was created with the assistance of [Claude](https://claude.ai)._
