### PR TITLE
[system tests] Fail when no data streams remain after APM rollup filtering

### DIFF
--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -1471,6 +1471,9 @@ func (r *tester) buildDataStreamScenarios(ctx context.Context, dsType, dsDataset
 			return nil, err
 		}
 		discovered = filterOtelAPMRollupDataStreams(discovered)
+		if len(discovered) == 0 {
+			return nil, testrunner.ErrTestCaseFailed{Reason: fmt.Sprintf("no data streams matching %s remained after filtering", strings.Join(patterns, ","))}
+		}
 		scenarios := make([]scenarioDataStream, len(discovered))
 		for i, dsd := range discovered {
 			scenarios[i] = scenarioDataStream{


### PR DESCRIPTION
## Summary

Follow-up to #3442, which introduced `filterOtelAPMRollupDataStreams` to
skip APM connector-generated rollup data streams during dynamic discovery
in OTel system tests.

### Problem

After `filterOtelAPMRollupDataStreams` removes matched streams, the
resulting slice can be empty with no error returned. The caller
(`buildDataStreamScenarios`) then iterates over an empty slice and silently
skips all data stream verification — producing a false-positive test result.

### Fix

Add a guard in `buildDataStreamScenarios` immediately after filtering:
if no data streams remain, return `ErrTestCaseFailed` with a descriptive
message instead of silently succeeding.

```go
if len(discovered) == 0 {
    return nil, testrunner.ErrTestCaseFailed{Reason: fmt.Sprintf(
        "no data streams matching %s remained after filtering",
        strings.Join(patterns, ","),
    )}
}
```

If forced in filter function to remove all data streams as:
```go
func filterOtelAPMRollupDataStreams(streams []discoveredDataStream) []discoveredDataStream {
	return slices.DeleteFunc(streams, func(s discoveredDataStream) bool {
		logger.Infof("Skipping APM connector-generated data stream %q", s.name)
		return true
	})
}
```
System tests finish successfully but they shouldn't.
```
2026/04/24 17:55:16 DEBUG Waiting for data streams matching *-*-62686 (timeout: 10m0s, or results are stable for: 1m30s)...
2026/04/24 17:57:40 DEBUG Discovery finished; found 5 data stream(s) matching *-*-62686: logs-zipkinreceiver.otel-62686, metrics-service_summary.1m.otel-62686, metrics-service_transaction.1m.otel-62686, metrics-transaction.1m.otel-62686, traces-zipkinreceiver.otel-62686
2026/04/24 17:57:40  INFO Skipping APM connector-generated data stream "logs-zipkinreceiver.otel-62686"
2026/04/24 17:57:40  INFO Skipping APM connector-generated data stream "metrics-service_summary.1m.otel-62686"
2026/04/24 17:57:40  INFO Skipping APM connector-generated data stream "metrics-service_transaction.1m.otel-62686"
2026/04/24 17:57:40  INFO Skipping APM connector-generated data stream "metrics-transaction.1m.otel-62686"
2026/04/24 17:57:40  INFO Skipping APM connector-generated data stream "traces-zipkinreceiver.otel-62686"
2026/04/24 17:57:40 DEBUG Testing 0 data stream(s): 
2026/04/24 17:57:40  INFO Validating test case...
2026/04/24 17:57:40  WARN Validation for packages using OpenTelemetry Collector input is experimental
```

## Author's Checklist

- [x] Validate that this change works by forcing to filter all data streams.

Including the fix, if no data streams are found after the filtering, test fails:
```
╭───────────────────┬─────────────┬───────────┬────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────┬─────────────────╮
│ PACKAGE           │ DATA STREAM │ TEST TYPE │ TEST NAME              │ RESULT                                                                              │    TIME ELAPSED │
├───────────────────┼─────────────┼───────────┼────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────┼─────────────────┤
│ zipkin_input_otel │             │ system    │ default                │ FAIL: test case failed: no data streams matching *-*-77698 remained after filtering │ 3m15.916796234s │
│ zipkin_input_otel │             │ system    │ default-custom-dataset │ SKIPPED:                                                                            │        24.437µs │
╰───────────────────┴─────────────┴───────────┴────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────┴─────────────────╯
```

## Related issues
- Relates #3434
---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).