### PR TITLE
Support custom data_stream.type in system and policy tests

### DIFF
--- a/docs/howto/policy_testing.md
+++ b/docs/howto/policy_testing.md
@@ -82,6 +82,7 @@ In these configuration files it is possible to define:
 - Values for the variables of the data stream manifests (only used for
   integration packages).
 - Input to use, for packages supporting multiple input types.
+- Overrides for the data stream routing (only used for input packages). See [Overriding data stream type and dataset for input packages](./system_testing.md#overriding-data-stream-type-and-dataset-for-input-packages) in the system testing documentation.
 
 For example, the following configuration tells Fleet to create a policy using an
 specific input, and some variables at the package level:

--- a/docs/howto/system_testing.md
+++ b/docs/howto/system_testing.md
@@ -554,7 +554,7 @@ override the data stream routing set by Fleet:
   Requires Kibana 8.18.3 / 8.19.0 / 9.1.0 or later (Fleet PR [#214216](https://github.com/elastic/kibana/pull/214216)).
   Because the Kibana simplified Fleet API does not yet accept `data_stream.type` as a
   stream-level variable (it rejects unknown vars), tests that use this override must also
-  set `policy_api_format: legacy` until a Kibana fix is available.
+  set `policy_api_format: legacy` until a Kibana fix is available ([#266321](https://github.com/elastic/kibana/issues/266321)).
 
 ```yaml
 policy_api_format: legacy

--- a/docs/howto/system_testing.md
+++ b/docs/howto/system_testing.md
@@ -543,6 +543,30 @@ for system tests.
 | wait_for_data_timeout | duration |  | Amount of time to wait for data to be present in Elasticsearch. Defaults to 10m. |
 | wait_for_dynamic_streams_stable | duration |  | For packages with dynamic data streams (e.g. `dynamic_signal_types`), minimum time the discovered data stream count must stay unchanged after the first stream appears before discovery completes. Defaults to 10s. |
 
+#### Overriding data stream type and dataset for input packages
+
+For **input packages**, the top-level `vars` field also accepts two special variables that
+override the data stream routing set by Fleet:
+
+- `data_stream.dataset` — overrides the dataset portion of the data stream name
+  (e.g. `sql_input.test` instead of the default `sql_input.sql_query`).
+- `data_stream.type` — overrides the signal type (`logs`, `metrics`, or `traces`).
+  Requires Kibana 8.18.3 / 8.19.0 / 9.1.0 or later (Fleet PR [#214216](https://github.com/elastic/kibana/pull/214216)).
+
+```yaml
+vars:
+  hosts:
+    - root:test@tcp({{Hostname}}:{{Port}})/
+  sql_query: "SHOW GLOBAL STATUS LIKE 'Innodb_data%';"
+  data_stream.type: logs
+  data_stream.dataset: sql_input.test
+```
+
+When `data_stream.type` is set, `elastic-package` passes it to Fleet as a stream-level variable
+and uses it when computing the expected Elasticsearch data stream name
+(`<type>-<dataset>-<namespace>`). Without this override, the type defaults to the `type` field
+of the policy template in the package manifest.
+
 For example, the `apache/access` data stream's `test-access-log-config.yml` is
 shown below.
 

--- a/docs/howto/system_testing.md
+++ b/docs/howto/system_testing.md
@@ -552,8 +552,12 @@ override the data stream routing set by Fleet:
   (e.g. `sql_input.test` instead of the default `sql_input.sql_query`).
 - `data_stream.type` — overrides the signal type (`logs`, `metrics`, or `traces`).
   Requires Kibana 8.18.3 / 8.19.0 / 9.1.0 or later (Fleet PR [#214216](https://github.com/elastic/kibana/pull/214216)).
+  Because the Kibana simplified Fleet API does not yet accept `data_stream.type` as a
+  stream-level variable (it rejects unknown vars), tests that use this override must also
+  set `policy_api_format: legacy` until a Kibana fix is available.
 
 ```yaml
+policy_api_format: legacy
 vars:
   hosts:
     - root:test@tcp({{Hostname}}:{{Port}})/

--- a/internal/kibana/packagepolicy.go
+++ b/internal/kibana/packagepolicy.go
@@ -165,10 +165,17 @@ func BuildInputPackagePolicy(
 
 	vars := SetKibanaVariables(policyTemplate.Vars, varValues)
 	ensureDatasetVar(vars, policyTemplate, varValues)
+	ensureDataStreamTypeVar(vars, varValues)
 	// For otelcol, data_stream.dataset is the base name only (do not include a ".otel" suffix).
 	// Elastic Agent appends ".otel" at ingest; Fleet and this builder do not.
 	if policyTemplate.Input == "otelcol" {
 		ensureUseAPMVar(vars, varValues)
+	}
+	dsType := policyTemplate.Type
+	if v, found := vars["data_stream.type"]; found && v.fromUser {
+		if s, ok := v.Value.Value().(string); ok && s != "" {
+			dsType = s
+		}
 	}
 	inputEntry := PackagePolicyInput{
 		Enabled: enabled,
@@ -178,9 +185,7 @@ func BuildInputPackagePolicy(
 				Vars:              vars.ToMapStr(),
 				legacyVars:        vars,
 				dataStreamDataset: streamDataset,
-				// dataStreamType is intentionally empty: input packages
-				// require Kibana >= 7.16 (simplified API), so legacy
-				// conversion is not needed.
+				dataStreamType:    dsType,
 			},
 		},
 		inputType:      streamInput,
@@ -277,6 +282,23 @@ func ensureUseAPMVar(vars Vars, varValues common.MapStr) {
 	if val.Value() != nil {
 		setVarFromUser(vars, "use_apm", "boolean", val)
 	}
+}
+
+// ensureDataStreamTypeVar injects data_stream.type into vars with fromUser=true so
+// that the simplified API includes it, overriding the default from policy_template.type.
+// Only applies when the user explicitly provides a value in varValues; when absent,
+// Fleet uses policy_template.type as the default (no injection needed).
+// This mirrors the override introduced in Kibana PR #214216 for input packages.
+func ensureDataStreamTypeVar(vars Vars, varValues common.MapStr) {
+	raw, err := varValues.GetValue("data_stream.type")
+	if err != nil {
+		return
+	}
+	var val packages.VarValue
+	if err := val.Unpack(raw); err != nil {
+		return
+	}
+	setVarFromUser(vars, "data_stream.type", "text", val)
 }
 
 // setVarFromUser sets vars[name] with fromUser=true so that the variable is included

--- a/internal/kibana/packagepolicy_test.go
+++ b/internal/kibana/packagepolicy_test.go
@@ -230,6 +230,21 @@ func TestBuildInputPackagePolicy(t *testing.T) {
 			goldenLegacy:     "testdata/log_custom_logs_legacy.json",
 		},
 		{
+			// Override data_stream.type from the default "logs" to "metrics".
+			// Mirrors the Kibana Fleet feature (PR #214216) for input packages.
+			name:               "log_custom_logs_metrics_type",
+			packageRoot:        "testdata/packages/log_input",
+			policyTemplateName: "logs",
+			policyName:         "log-logs-test",
+			varValues: common.MapStr{
+				"paths":               []string{"/tmp/test.log"},
+				"data_stream.dataset": "log.custom",
+				"data_stream.type":    "metrics",
+			},
+			goldenSimplified: "testdata/log_custom_logs_metrics_type.json",
+			goldenLegacy:     "testdata/log_custom_logs_metrics_type_legacy.json",
+		},
+		{
 			name:               "sql_input_custom_dataset",
 			packageRoot:        "../../test/packages/parallel/sql_input",
 			policyTemplateName: "sql_query",

--- a/internal/kibana/testdata/input_with_pkg_vars_legacy.json
+++ b/internal/kibana/testdata/input_with_pkg_vars_legacy.json
@@ -30,7 +30,7 @@
         {
           "enabled": true,
           "data_stream": {
-            "type": "",
+            "type": "logs",
             "dataset": "input_with_pkg_vars.logs"
           },
           "vars": {

--- a/internal/kibana/testdata/log_custom_logs_metrics_type.json
+++ b/internal/kibana/testdata/log_custom_logs_metrics_type.json
@@ -1,0 +1,28 @@
+{
+  "name": "log-logs-test",
+  "description": "",
+  "namespace": "test",
+  "policy_id": "test-policy-id",
+  "package": {
+    "name": "log",
+    "version": "2.4.4"
+  },
+  "inputs": {
+    "logs-logfile": {
+      "enabled": true,
+      "streams": {
+        "log.logs": {
+          "enabled": true,
+          "vars": {
+            "data_stream.dataset": "log.custom",
+            "data_stream.type": "metrics",
+            "paths": [
+              "/tmp/test.log"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "force": false
+}

--- a/internal/kibana/testdata/log_custom_logs_metrics_type_legacy.json
+++ b/internal/kibana/testdata/log_custom_logs_metrics_type_legacy.json
@@ -23,6 +23,10 @@
           "value": "log.custom",
           "type": "text"
         },
+        "data_stream.type": {
+          "value": "metrics",
+          "type": "text"
+        },
         "exclude_files": {
           "value": [],
           "type": "text"
@@ -46,7 +50,7 @@
         {
           "enabled": true,
           "data_stream": {
-            "type": "logs",
+            "type": "metrics",
             "dataset": "log.logs"
           },
           "vars": {
@@ -56,6 +60,10 @@
             },
             "data_stream.dataset": {
               "value": "log.custom",
+              "type": "text"
+            },
+            "data_stream.type": {
+              "value": "metrics",
               "type": "text"
             },
             "exclude_files": {

--- a/internal/kibana/testdata/otel_traces_use_apm_legacy.json
+++ b/internal/kibana/testdata/otel_traces_use_apm_legacy.json
@@ -32,7 +32,7 @@
         {
           "enabled": true,
           "data_stream": {
-            "type": "",
+            "type": "traces",
             "dataset": "otel_traces_input.receiver"
           },
           "vars": {

--- a/internal/kibana/testdata/sql_input_custom_dataset_legacy.json
+++ b/internal/kibana/testdata/sql_input_custom_dataset_legacy.json
@@ -42,7 +42,7 @@
         {
           "enabled": true,
           "data_stream": {
-            "type": "",
+            "type": "metrics",
             "dataset": "sql_input.sql_query"
           },
           "vars": {

--- a/internal/kibana/testdata/sql_input_default_dataset_legacy.json
+++ b/internal/kibana/testdata/sql_input_default_dataset_legacy.json
@@ -42,7 +42,7 @@
         {
           "enabled": true,
           "data_stream": {
-            "type": "",
+            "type": "metrics",
             "dataset": "sql_input.sql_query"
           },
           "vars": {

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -2171,7 +2171,7 @@ func CreatePackagePolicy(
 			*pkg, policyTemplate, cfgVars, true,
 		)
 		fallbackDataset := fmt.Sprintf("%s.%s", pkg.Name, policyTemplate.Name)
-		return p, policyTemplate.Type, datasetFromPolicy(p, fallbackDataset), nil
+		return p, dataStreamTypeFromPolicy(p, policyTemplate.Type), datasetFromPolicy(p, fallbackDataset), nil
 	}
 	if ds == nil {
 		return kibana.PackagePolicy{}, "", "", fmt.Errorf("data stream manifest is required for integration packages")
@@ -2224,6 +2224,32 @@ func datasetFromPolicy(policy kibana.PackagePolicy, fallback string) string {
 			}
 
 			return ds
+		}
+	}
+
+	return fallback
+}
+
+// dataStreamTypeFromPolicy returns the data stream type stored in the enabled stream's
+// data_stream.type var (set when the user overrides it via the test config). Falls back
+// to the supplied fallback (normally policyTemplate.Type) when not explicitly set.
+func dataStreamTypeFromPolicy(policy kibana.PackagePolicy, fallback string) string {
+	for _, input := range policy.Inputs {
+		if !input.Enabled {
+			continue
+		}
+		for _, stream := range input.Streams {
+			if !stream.Enabled {
+				continue
+			}
+
+			v, _ := common.MapStr(stream.Vars).GetValue("data_stream.type")
+			t, _ := v.(string)
+			if t == "" {
+				continue
+			}
+
+			return t
 		}
 	}
 

--- a/internal/testrunner/runners/system/tester_test.go
+++ b/internal/testrunner/runners/system/tester_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/elastic/elastic-package/internal/common"
 	estest "github.com/elastic/elastic-package/internal/elasticsearch/test"
+	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/stack"
 	"github.com/elastic/elastic-package/internal/testrunner"
@@ -900,6 +901,86 @@ func TestPipelineErrorMessage(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := pipelineErrorMessage(tc.doc)
 			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestDataStreamTypeFromPolicy(t *testing.T) {
+	cases := []struct {
+		title    string
+		policy   kibana.PackagePolicy
+		fallback string
+		expected string
+	}{
+		{
+			title:    "no enabled input: returns fallback",
+			policy:   kibana.PackagePolicy{},
+			fallback: "logs",
+			expected: "logs",
+		},
+		{
+			title: "enabled stream without data_stream.type var: returns fallback",
+			policy: kibana.PackagePolicy{
+				Inputs: map[string]kibana.PackagePolicyInput{
+					"logs-logfile": {
+						Enabled: true,
+						Streams: map[string]kibana.PackagePolicyStream{
+							"log.logs": {
+								Enabled: true,
+								Vars:    map[string]any{"data_stream.dataset": "log.custom"},
+							},
+						},
+					},
+				},
+			},
+			fallback: "logs",
+			expected: "logs",
+		},
+		{
+			title: "enabled stream with data_stream.type var overrides fallback",
+			policy: kibana.PackagePolicy{
+				Inputs: map[string]kibana.PackagePolicyInput{
+					"logs-logfile": {
+						Enabled: true,
+						Streams: map[string]kibana.PackagePolicyStream{
+							"log.logs": {
+								Enabled: true,
+								Vars: map[string]any{
+									"data_stream.dataset": "log.custom",
+									"data_stream.type":    "metrics",
+								},
+							},
+						},
+					},
+				},
+			},
+			fallback: "logs",
+			expected: "metrics",
+		},
+		{
+			title: "disabled input is skipped: returns fallback",
+			policy: kibana.PackagePolicy{
+				Inputs: map[string]kibana.PackagePolicyInput{
+					"logs-logfile": {
+						Enabled: false,
+						Streams: map[string]kibana.PackagePolicyStream{
+							"log.logs": {
+								Enabled: true,
+								Vars:    map[string]any{"data_stream.type": "metrics"},
+							},
+						},
+					},
+				},
+			},
+			fallback: "logs",
+			expected: "logs",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			got := dataStreamTypeFromPolicy(c.policy, c.fallback)
+			assert.Equal(t, c.expected, got)
 		})
 	}
 }

--- a/test/packages/parallel/sql_input/_dev/test/policy/test-mysql-logs-type.expected
+++ b/test/packages/parallel/sql_input/_dev/test/policy/test-mysql-logs-type.expected
@@ -1,0 +1,36 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: sql_input
+      name: test-mysql-logs-type-sql_input
+      streams:
+        - data_stream:
+            dataset: sql_query
+            type: logs
+          driver: mysql
+          hosts:
+            - root:test@tcp(localhost:3306)/
+          metricsets:
+            - query
+          period: 10s
+          sql_query: SHOW GLOBAL STATUS LIKE 'Innodb_%';
+          sql_response_format: variables
+      type: sql/metrics
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-*-*
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/test/packages/parallel/sql_input/_dev/test/policy/test-mysql-logs-type.yml
+++ b/test/packages/parallel/sql_input/_dev/test/policy/test-mysql-logs-type.yml
@@ -1,0 +1,5 @@
+vars:
+  hosts:
+    - root:test@tcp(localhost:3306)/
+  sql_query: "SHOW GLOBAL STATUS LIKE 'Innodb_%';"
+  data_stream.type: logs

--- a/test/packages/parallel/sql_input/_dev/test/policy/test-mysql-logs-type.yml
+++ b/test/packages/parallel/sql_input/_dev/test/policy/test-mysql-logs-type.yml
@@ -1,6 +1,7 @@
 # The simplified Fleet API rejects data_stream.type because it is not declared
 # as a variable in the package manifest. Use the legacy API until Kibana's
 # simplified_package_policy_helper handles data_stream.type like data_stream.dataset.
+# https://github.com/elastic/kibana/issues/266321
 policy_api_format: legacy
 vars:
   hosts:

--- a/test/packages/parallel/sql_input/_dev/test/policy/test-mysql-logs-type.yml
+++ b/test/packages/parallel/sql_input/_dev/test/policy/test-mysql-logs-type.yml
@@ -1,3 +1,7 @@
+# The simplified Fleet API rejects data_stream.type because it is not declared
+# as a variable in the package manifest. Use the legacy API until Kibana's
+# simplified_package_policy_helper handles data_stream.type like data_stream.dataset.
+policy_api_format: legacy
 vars:
   hosts:
     - root:test@tcp(localhost:3306)/

--- a/test/packages/parallel/sql_input/_dev/test/system/test-logs-type-config.yml
+++ b/test/packages/parallel/sql_input/_dev/test/system/test-logs-type-config.yml
@@ -1,0 +1,9 @@
+vars:
+  hosts:
+    - root:test@tcp({{Hostname}}:{{Port}})/
+  sql_query: "SHOW GLOBAL STATUS LIKE 'Innodb_data%';"
+
+  # This test overrides data_stream.type from the default "metrics" to "logs".
+  # Requires Kibana >= 8.18.3 / 8.19.0 / 9.1.0.
+  data_stream.type: logs
+  data_stream.dataset: sql_input.test

--- a/test/packages/parallel/sql_input/_dev/test/system/test-logs-type-config.yml
+++ b/test/packages/parallel/sql_input/_dev/test/system/test-logs-type-config.yml
@@ -1,3 +1,7 @@
+# The simplified Fleet API rejects data_stream.type because it is not declared
+# as a variable in the package manifest. Use the legacy API until Kibana's
+# simplified_package_policy_helper handles data_stream.type like data_stream.dataset.
+policy_api_format: legacy
 vars:
   hosts:
     - root:test@tcp({{Hostname}}:{{Port}})/

--- a/test/packages/parallel/sql_input/_dev/test/system/test-logs-type-config.yml
+++ b/test/packages/parallel/sql_input/_dev/test/system/test-logs-type-config.yml
@@ -1,6 +1,7 @@
 # The simplified Fleet API rejects data_stream.type because it is not declared
 # as a variable in the package manifest. Use the legacy API until Kibana's
 # simplified_package_policy_helper handles data_stream.type like data_stream.dataset.
+# https://github.com/elastic/kibana/issues/266321
 policy_api_format: legacy
 vars:
   hosts:


### PR DESCRIPTION
https://github.com/elastic/package-spec/issues/849 introduced a way to override the data stream type for input packages. Users can use this toggle to decide the data stream to use for data collected with generic input packages.

Allow to override the data stream type using the `data_stream.type` variable in system and policy tests.