### PR TITLE
Enable errorlint and some gocritic checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,8 +3,7 @@ version: "2"
 linters:
   enable:
     - contextcheck
-    # TODO: enable errorlint to detect issues with error comparisons, wrapping and so on.
-    #- errorlint
+    - errorlint
     - exhaustive
     - gocognit
     - gocritic
@@ -25,6 +24,10 @@ linters:
       # TODO: Enable more checks, it is detecting actual potential issues.
       disable-all: true
       enabled-checks:
+        - appendAssign
+        - offBy1
+
+        # Enabled for the custom rules below.
         - ruleguard
       settings:
         ruleguard:

--- a/cmd/export_ingest_pipelines.go
+++ b/cmd/export_ingest_pipelines.go
@@ -86,7 +86,8 @@ func exportIngestPipelinesCmd(cmd *cobra.Command, args []string) error {
 		ParentPath: packageRoot,
 	}
 
-	pipelineWriteLocations := append(dataStreamDirs, rootWriteLocation)
+	pipelineWriteLocations := append([]export.PipelineWriteLocation{}, dataStreamDirs...)
+	pipelineWriteLocations = append(pipelineWriteLocations, rootWriteLocation)
 
 	pipelineWriteAssignments, err := promptWriteLocations(pipelineIDs, pipelineWriteLocations)
 	if err != nil {

--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -158,7 +158,7 @@ User profiles can be configured with a "config.yml" file in the profile director
 
 			_, err := profile.LoadProfile(profileName)
 			if err != nil {
-				return fmt.Errorf("cannot use profile %q: %v", profileName, err)
+				return fmt.Errorf("cannot use profile %q: %w", profileName, err)
 			}
 
 			location, err := locations.NewLocationManager()

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -763,7 +763,7 @@ func testRunnerScriptCommandAction(cmd *cobra.Command, args []string) error {
 
 	pkgRoot, err := packages.FindPackageRoot()
 	if err != nil {
-		if err == packages.ErrPackageRootNotFound {
+		if errors.Is(err, packages.ErrPackageRootNotFound) {
 			return errors.New("package root not found")
 		}
 		return fmt.Errorf("locating package root failed: %w", err)

--- a/internal/benchrunner/runners/rally/runner.go
+++ b/internal/benchrunner/runners/rally/runner.go
@@ -690,7 +690,7 @@ func (r *runner) runGenerator(destDir string) (uint64, error) {
 	var corpusDocsCount uint64
 	for {
 		err := r.generator.Emit(buf)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 
@@ -1101,7 +1101,7 @@ func (r *runner) bulkMetrics(ctx context.Context, indexName string, sr searchRes
 		r.options.ESAPI.Scroll.WithScroll(time.Minute),
 	)
 	if err != nil {
-		return fmt.Errorf("error executing scroll: %s", err)
+		return fmt.Errorf("error executing scroll: %w", err)
 	}
 	defer resp.Body.Close()
 

--- a/internal/benchrunner/runners/system/runner.go
+++ b/internal/benchrunner/runners/system/runner.go
@@ -652,7 +652,7 @@ func (r *runner) runGenerator(destDir string) error {
 	var corpusDocsCount uint64
 	for {
 		err := r.generator.Emit(buf)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 
@@ -957,7 +957,7 @@ func (r *runner) bulkMetrics(ctx context.Context, indexName string, sr searchRes
 		r.options.ESAPI.Scroll.WithScroll(time.Minute),
 	)
 	if err != nil {
-		return fmt.Errorf("error executing scroll: %s", err)
+		return fmt.Errorf("error executing scroll: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.IsError() {

--- a/internal/builder/dashboards.go
+++ b/internal/builder/dashboards.go
@@ -6,6 +6,7 @@ package builder
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -109,7 +110,7 @@ func encodeObjectMapStr(object common.MapStr) (common.MapStr, bool, error) {
 
 func encodeEmbeddedPanels(object common.MapStr) (common.MapStr, bool, error) {
 	embeddedPanelsValue, err := object.GetValue(panelsAttribute)
-	if err == common.ErrKeyNotFound {
+	if errors.Is(err, common.ErrKeyNotFound) {
 		return object, false, nil
 	}
 	if err != nil {

--- a/internal/builder/packages.go
+++ b/internal/builder/packages.go
@@ -94,7 +94,7 @@ func BuildPackagesDirectory(packageRoot string, buildDir string) (string, error)
 			return "", fmt.Errorf("can't check build directory: %w", err)
 		}
 		if !info.IsDir() {
-			return "", fmt.Errorf("build path (%s) expected to be a directory", err)
+			return "", fmt.Errorf("build path (%s) expected to be a directory", buildDir)
 		}
 		d := filepath.Join(buildDir, builtPackagesDir)
 		err = os.MkdirAll(d, 0755)

--- a/internal/elasticsearch/ingest/datastream.go
+++ b/internal/elasticsearch/ingest/datastream.go
@@ -115,9 +115,10 @@ func LoadIngestPipelineFiles(dataStreamRoot string, nonce int64, repositoryRoot 
 		}
 
 		name := filepath.Base(path)
+		baseName, _, _ := strings.Cut(name, ".")
 		pipelines = append(pipelines, Pipeline{
 			Path:            path,
-			Name:            GetPipelineNameWithNonce(name[:strings.Index(name, ".")], nonce),
+			Name:            GetPipelineNameWithNonce(baseName, nonce),
 			Format:          filepath.Ext(strings.TrimSuffix(path, ".link"))[1:],
 			Content:         cWithRerouteProcessors,
 			ContentOriginal: c,
@@ -137,7 +138,7 @@ func addRerouteProcessors(pipeline []byte, dataStreamRoot, pipelinePath string) 
 	// Read routing_rules.yml and convert it into reroute processors in ingest pipeline
 	rerouteProcessors, err := loadRoutingRuleFile(dataStreamRoot)
 	if err != nil {
-		return nil, fmt.Errorf("failed loading routing rules: %v", err)
+		return nil, fmt.Errorf("failed loading routing rules: %w", err)
 	}
 	if len(rerouteProcessors) == 0 {
 		return pipeline, nil
@@ -165,7 +166,7 @@ func addRerouteProcessors(pipeline []byte, dataStreamRoot, pipelinePath string) 
 
 	pipeline, err = yaml.Marshal(yamlPipeline)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal modified ingest pipeline YAML data: %v", err)
+		return nil, fmt.Errorf("failed to marshal modified ingest pipeline YAML data: %w", err)
 	}
 
 	return pipeline, nil

--- a/internal/elasticsearch/ingest/processors.go
+++ b/internal/elasticsearch/ingest/processors.go
@@ -102,7 +102,7 @@ func getProcessorLastLine(idx int, processors []yaml.Node, currentProcessor Proc
 func nextProcessorOrEndOfPipeline(content []byte) (int, error) {
 	var root yaml.Node
 	if err := yaml.Unmarshal(content, &root); err != nil {
-		return 0, fmt.Errorf("error unmarshaling YAML: %v", err)
+		return 0, fmt.Errorf("error unmarshaling YAML: %w", err)
 	}
 
 	var nodes []*yaml.Node

--- a/internal/export/tags.go
+++ b/internal/export/tags.go
@@ -5,6 +5,7 @@
 package export
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -27,7 +28,7 @@ func removeFleetTags(ctx *transformationContext, object common.MapStr) (common.M
 
 func removeTagReferences(ctx *transformationContext, object common.MapStr) (common.MapStr, error) {
 	references, err := object.GetValue("references")
-	if err == common.ErrKeyNotFound {
+	if errors.Is(err, common.ErrKeyNotFound) {
 		return object, nil
 	}
 
@@ -55,7 +56,7 @@ func removeTagReferences(ctx *transformationContext, object common.MapStr) (comm
 
 func removeTagObjects(ctx *transformationContext, object common.MapStr) (common.MapStr, error) {
 	aId, err := object.GetValue("id")
-	if err == common.ErrKeyNotFound {
+	if errors.Is(err, common.ErrKeyNotFound) {
 		return object, nil
 	}
 

--- a/internal/export/transform_decode.go
+++ b/internal/export/transform_decode.go
@@ -6,6 +6,7 @@ package export
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/elastic/elastic-package/internal/common"
@@ -31,7 +32,7 @@ var encodedFields = []string{
 func decodeObject(ctx *transformationContext, object common.MapStr) (common.MapStr, error) {
 	for _, fieldToDecode := range encodedFields {
 		v, err := object.GetValue(fieldToDecode)
-		if err == common.ErrKeyNotFound {
+		if errors.Is(err, common.ErrKeyNotFound) {
 			continue
 		} else if err != nil {
 			return nil, fmt.Errorf("retrieving value failed (key: %s): %w", fieldToDecode, err)
@@ -66,7 +67,7 @@ func decodeObject(ctx *transformationContext, object common.MapStr) (common.MapS
 
 func decodeEmbeddedPanels(ctx *transformationContext, object common.MapStr) (common.MapStr, error) {
 	embeddedPanelsValue, err := object.GetValue(panelsAttribute)
-	if err == common.ErrKeyNotFound {
+	if errors.Is(err, common.ErrKeyNotFound) {
 		return object, nil
 	}
 	if err != nil {

--- a/internal/export/transform_standardize.go
+++ b/internal/export/transform_standardize.go
@@ -5,6 +5,7 @@
 package export
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -24,7 +25,7 @@ func standardizeObjectID(ctx *transformationContext, object common.MapStr) (comm
 
 	// Adjust references
 	references, err := object.GetValue("references")
-	if err != nil && err != common.ErrKeyNotFound {
+	if err != nil && !errors.Is(err, common.ErrKeyNotFound) {
 		return nil, fmt.Errorf("retrieving object references failed: %w", err)
 	}
 

--- a/internal/export/transform_strip.go
+++ b/internal/export/transform_strip.go
@@ -5,6 +5,7 @@
 package export
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/elastic/elastic-package/internal/common"
@@ -12,22 +13,22 @@ import (
 
 func stripObjectProperties(ctx *transformationContext, object common.MapStr) (common.MapStr, error) {
 	err := object.Delete("namespaces")
-	if err != nil && err != common.ErrKeyNotFound {
+	if err != nil && !errors.Is(err, common.ErrKeyNotFound) {
 		return nil, fmt.Errorf("removing field \"namespaces\" failed: %w", err)
 	}
 
 	err = object.Delete("updated_at")
-	if err != nil && err != common.ErrKeyNotFound {
+	if err != nil && !errors.Is(err, common.ErrKeyNotFound) {
 		return nil, fmt.Errorf("removing field \"updated_at\" failed: %w", err)
 	}
 
 	err = object.Delete("version")
-	if err != nil && err != common.ErrKeyNotFound {
+	if err != nil && !errors.Is(err, common.ErrKeyNotFound) {
 		return nil, fmt.Errorf("removing field \"version\" failed: %w", err)
 	}
 
 	err = object.Delete("managed")
-	if err != nil && err != common.ErrKeyNotFound {
+	if err != nil && !errors.Is(err, common.ErrKeyNotFound) {
 		return nil, fmt.Errorf("removing field \"managed\" failed: %w", err)
 	}
 

--- a/internal/fields/validate.go
+++ b/internal/fields/validate.go
@@ -174,7 +174,7 @@ func WithSpecVersion(version string) ValidatorOption {
 	return func(v *Validator) error {
 		sv, err := semver.NewVersion(version)
 		if err != nil {
-			return fmt.Errorf("invalid version %q: %v", version, err)
+			return fmt.Errorf("invalid version %q: %w", version, err)
 		}
 		v.specVersion = *sv
 		return nil

--- a/internal/fields/validate_test.go
+++ b/internal/fields/validate_test.go
@@ -688,7 +688,8 @@ func Test_parseElementValue(t *testing.T) {
 			specVersion: *semver3_0_1,
 			fail:        true,
 			assertError: func(t *testing.T, err error) {
-				errs := err.(multierror.Error)
+				var errs multierror.Error
+				require.ErrorAs(t, err, &errs)
 				if assert.Len(t, errs, 1) {
 					assert.Contains(t, errs[0].Error(), `"details.hostname" is undefined`)
 				}
@@ -716,7 +717,8 @@ func Test_parseElementValue(t *testing.T) {
 			specVersion: *semver3_0_1,
 			fail:        true,
 			assertError: func(t *testing.T, err error) {
-				errs := err.(multierror.Error)
+				var errs multierror.Error
+				require.ErrorAs(t, err, &errs)
 				if assert.Len(t, errs, 1) {
 					assert.Contains(t, errs[0].Error(), `"nested.hostname" is undefined`)
 				}

--- a/internal/kibana/dashboards.go
+++ b/internal/kibana/dashboards.go
@@ -83,7 +83,7 @@ func (c *Client) exportWithDashboardsAPI(ctx context.Context, dashboardIDs []str
 			multiErr = append(multiErr, errors.New(errMsg.(string)))
 			continue
 		}
-		if err != nil && err != common.ErrKeyNotFound {
+		if err != nil && !errors.Is(err, common.ErrKeyNotFound) {
 			multiErr = append(multiErr, err)
 		}
 	}

--- a/internal/kubectl/kubectl_apply.go
+++ b/internal/kubectl/kubectl_apply.go
@@ -179,12 +179,11 @@ func createResourceInfo(r resource) (*kresource.Info, error) {
 	var group string
 	var version string
 
-	if !strings.Contains(r.APIVersion, "/") {
-		version = r.APIVersion
+	if g, v, ok := strings.Cut(r.APIVersion, "/"); ok {
+		group = g
+		version = v
 	} else {
-		i := strings.Index(r.APIVersion, "/")
-		group = r.APIVersion[:i]
-		version = r.APIVersion[i+1:]
+		version = r.APIVersion
 	}
 
 	resInfo := &kresource.Info{

--- a/internal/packages/installer/factory.go
+++ b/internal/packages/installer/factory.go
@@ -102,7 +102,7 @@ func NewForPackage(options Options) (Installer, error) {
 		RequiredInputsResolver: options.RequiredInputsResolver,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to build package: %v", err)
+		return nil, fmt.Errorf("failed to build package: %w", err)
 	}
 
 	if supportsUploadZip {

--- a/internal/stack/config.go
+++ b/internal/stack/config.go
@@ -92,7 +92,7 @@ func storeConfig(profile *profile.Profile, config Config) error {
 
 	err = os.WriteFile(configPath(profile), d, 0644)
 	if err != nil {
-		return fmt.Errorf("failed to write stack config: %s", err)
+		return fmt.Errorf("failed to write stack config: %w", err)
 	}
 
 	return nil

--- a/internal/stack/dump.go
+++ b/internal/stack/dump.go
@@ -98,7 +98,7 @@ func dumpStackLogs(ctx context.Context, options DumpOptions) ([]DumpResult, erro
 
 		content, err := dockerComposeLogsSince(ctx, serviceName, options.Profile, options.Since)
 		if err != nil {
-			containerErrors = errors.Join(containerErrors, fmt.Errorf("can't fetch service logs (service: %s): %v", serviceName, err))
+			containerErrors = errors.Join(containerErrors, fmt.Errorf("can't fetch service logs (service: %s): %w", serviceName, err))
 			continue
 		}
 		if options.Output == "" {
@@ -144,7 +144,7 @@ func writeLogFiles(logsPath, serviceName string, content []byte) (string, error)
 	logPath := filepath.Join(logsPath, serviceName+".log")
 	err := os.WriteFile(logPath, content, 0644)
 	if err != nil {
-		return "", fmt.Errorf("can't write service logs (service: %s): %v", serviceName, err)
+		return "", fmt.Errorf("can't write service logs (service: %s): %w", serviceName, err)
 	}
 
 	return logPath, nil

--- a/internal/stack/environment.go
+++ b/internal/stack/environment.go
@@ -238,7 +238,7 @@ func (p *environmentProvider) TearDown(ctx context.Context, options Options) err
 	}
 	err = deleteAgentPolicy(ctx, kibanaClient)
 	if err != nil {
-		return fmt.Errorf("failed to delete agent policy: %v", err)
+		return fmt.Errorf("failed to delete agent policy: %w", err)
 	}
 
 	config, err := LoadConfig(options.Profile)
@@ -260,7 +260,7 @@ func (p *environmentProvider) TearDown(ctx context.Context, options Options) err
 	if config.OutputID != "" {
 		err := kibanaClient.RemoveFleetOutput(ctx, config.OutputID)
 		if err != nil {
-			return fmt.Errorf("failed to delete %s output: %s", config.OutputID, err)
+			return fmt.Errorf("failed to delete %s output: %w", config.OutputID, err)
 		}
 	}
 

--- a/internal/stack/serverless.go
+++ b/internal/stack/serverless.go
@@ -316,10 +316,8 @@ func (sp *serverlessProvider) BootUp(ctx context.Context, options Options) error
 
 	isNewProject := false
 	project, err = sp.currentProject(ctx, config)
-	switch err {
-	default:
-		return err
-	case serverless.ErrProjectNotExist:
+	switch {
+	case errors.Is(err, serverless.ErrProjectNotExist):
 		logger.Infof("Creating %s project: %q", settings.Type, settings.Name)
 		config, err = sp.createProject(ctx, settings, options)
 		if err != nil {
@@ -340,7 +338,9 @@ func (sp *serverlessProvider) BootUp(ctx context.Context, options Options) error
 
 		// TODO: Ensuring a specific GeoIP database would make tests reproducible
 		// Currently geo ip files would be ignored when running pipeline tests
-	case nil:
+	case err != nil:
+		return err
+	default:
 		logger.Debugf("%s project existed: %s", project.Type, project.Name)
 		printUserConfig(options.Printer, config)
 	}

--- a/internal/testrunner/coverage.go
+++ b/internal/testrunner/coverage.go
@@ -155,7 +155,7 @@ func generateBaseCoberturaFileCoverageReport(root *os.Root, packageName, path st
 
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open file: %v", err)
+		return nil, fmt.Errorf("failed to open file: %w", err)
 	}
 	defer f.Close()
 
@@ -199,7 +199,7 @@ func generateBaseGenericFileCoverageReport(root *os.Root, _, path string, covere
 
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open file: %v", err)
+		return nil, fmt.Errorf("failed to open file: %w", err)
 	}
 	defer f.Close()
 

--- a/internal/testrunner/runners/pipeline/tester.go
+++ b/internal/testrunner/runners/pipeline/tester.go
@@ -446,7 +446,8 @@ func (r *tester) verifyResults(testCaseFile string, config *testConfig, result *
 	// TODO: temporary workaround until other approach for deterministic geoip in serverless can be implemented.
 	if r.runCompareResults {
 		err = compareResults(testCasePath, config, result, *specVersion)
-		if _, ok := err.(testrunner.ErrTestCaseFailed); ok {
+		var testErr testrunner.ErrTestCaseFailed
+		if errors.As(err, &testErr) {
 			return err
 		}
 		if err != nil {
@@ -496,7 +497,7 @@ func verifyDynamicFields(result *testResult, config *testConfig) error {
 
 		for key, pattern := range config.DynamicFields {
 			val, err := m.GetValue(key)
-			if err != nil && err != common.ErrKeyNotFound {
+			if err != nil && !errors.Is(err, common.ErrKeyNotFound) {
 				return fmt.Errorf("can't remove dynamic field: %w", err)
 			}
 

--- a/internal/testrunner/runners/pipeline/testresult.go
+++ b/internal/testrunner/runners/pipeline/testresult.go
@@ -7,6 +7,7 @@ package pipeline
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -180,7 +181,7 @@ func adjustTestResult(result *testResult, config *testConfig) (*testResult, erro
 			// Strip dynamic fields from test result
 			for key := range config.DynamicFields {
 				err := m.Delete(key)
-				if err != nil && err != common.ErrKeyNotFound {
+				if err != nil && !errors.Is(err, common.ErrKeyNotFound) {
 					return nil, fmt.Errorf("can't remove dynamic field: %w", err)
 				}
 			}

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -2698,23 +2698,24 @@ func (r *tester) checkNewAgentLogs(ctx context.Context, agent agentdeployer.Depl
 
 		outputBytes, err := agent.Logs(ctx, startTesting)
 		if err != nil {
-			return nil, fmt.Errorf("check log messages failed: %s", err)
+			return nil, fmt.Errorf("check log messages failed: %w", err)
 		}
 		_, err = f.Write(outputBytes)
 		if err != nil {
-			return nil, fmt.Errorf("write log messages failed: %s", err)
+			return nil, fmt.Errorf("write log messages failed: %w", err)
 		}
 
 		err = r.anyErrorMessages(f.Name(), startTesting, patternsContainer.patterns)
-		if e, ok := err.(testrunner.ErrTestCaseFailed); ok {
+		var testErrLogs testrunner.ErrTestCaseFailed
+		if errors.As(err, &testErrLogs) {
 			tr := testrunner.TestResult{
 				TestType:   TestType,
 				Name:       fmt.Sprintf("(%s logs - %s)", patternsContainer.containerName, configName),
 				Package:    r.testFolder.Package,
 				DataStream: r.testFolder.DataStream,
 			}
-			tr.FailureMsg = e.Error()
-			tr.FailureDetails = e.Details
+			tr.FailureMsg = testErrLogs.Error()
+			tr.FailureDetails = testErrLogs.Details
 			tr.TimeElapsed = time.Since(startTime)
 			results = append(results, tr)
 			// Just check elastic-agent
@@ -2722,7 +2723,7 @@ func (r *tester) checkNewAgentLogs(ctx context.Context, agent agentdeployer.Depl
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("check log messages failed: %s", err)
+			return nil, fmt.Errorf("check log messages failed: %w", err)
 		}
 		// Just check elastic-agent
 		break
@@ -2743,22 +2744,23 @@ func (r *tester) checkAgentLogs(dump []stack.DumpResult, startTesting time.Time,
 		serviceLogsFile := dump[serviceDumpIndex].LogsFile
 
 		err = r.anyErrorMessages(serviceLogsFile, startTesting, patternsContainer.patterns)
-		if e, ok := err.(testrunner.ErrTestCaseFailed); ok {
+		var testErrSvcLogs testrunner.ErrTestCaseFailed
+		if errors.As(err, &testErrSvcLogs) {
 			tr := testrunner.TestResult{
 				TestType:   TestType,
 				Name:       fmt.Sprintf("(%s logs)", patternsContainer.containerName),
 				Package:    r.testFolder.Package,
 				DataStream: r.testFolder.DataStream,
 			}
-			tr.FailureMsg = e.Error()
-			tr.FailureDetails = e.Details
+			tr.FailureMsg = testErrSvcLogs.Error()
+			tr.FailureDetails = testErrSvcLogs.Details
 			tr.TimeElapsed = time.Since(startTime)
 			results = append(results, tr)
 			continue
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("check log messages failed: %s", err)
+			return nil, fmt.Errorf("check log messages failed: %w", err)
 		}
 	}
 	return results, nil

--- a/internal/testrunner/script/debugging.go
+++ b/internal/testrunner/script/debugging.go
@@ -64,10 +64,10 @@ func getPolicyCommand(ts *testscript.TestScript, neg bool, args []string) {
 	if *timeout < 0 {
 		// Single check.
 		pol, err := getPolicy(ctx, stk.es.API, policyName)
-		switch err {
-		case nil:
+		switch {
+		case err == nil:
 			fmt.Fprint(ts.Stdout(), pol)
-		case errPolicyNotFound:
+		case errors.Is(err, errPolicyNotFound):
 			fmt.Fprint(ts.Stdout(), "not found")
 		default:
 			fmt.Fprint(ts.Stdout(), err)
@@ -78,11 +78,11 @@ func getPolicyCommand(ts *testscript.TestScript, neg bool, args []string) {
 	for {
 		// Check until found or timeout.
 		pol, err := getPolicy(ctx, stk.es.API, policyName)
-		switch err {
-		case nil:
+		switch {
+		case err == nil:
 			fmt.Fprint(ts.Stdout(), pol)
 			return
-		case errPolicyNotFound:
+		case errors.Is(err, errPolicyNotFound):
 			time.Sleep(time.Second)
 			continue
 		default:

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -78,8 +78,8 @@ func fsFromPackageZip(fsys fs.FS) (fs.FS, error) {
 }
 
 func filterErrors(allErrors error, fsys fs.FS) (specerrors.FilterResult, error) {
-	errs, ok := allErrors.(specerrors.ValidationErrors)
-	if !ok {
+	var errs specerrors.ValidationErrors
+	if !errors.As(allErrors, &errs) {
 		return specerrors.FilterResult{Processed: allErrors, Removed: nil}, nil
 	}
 


### PR DESCRIPTION
Enable some additional linter checks that can prevent potential bugs:
* `errorlint`:
  * Ensure `errors.Is`/`As` is used for code handling specific types of errors.  
  * Ensure wrapping is used when formatting errors.
* `gocritic`:
  * `appendAssign` ensures `append` result is not assigned to a different variable, to avoid issues depending on the capacity of the modified slice.
  * `offBy1` avoids unsafe uses of indexes in slices.

Part of https://github.com/elastic/elastic-package/issues/3443.