### PR TITLE
fix: preserve pipeline format when adding reroute processors from routing_rules.yml

### DIFF
--- a/internal/elasticsearch/ingest/datastream.go
+++ b/internal/elasticsearch/ingest/datastream.go
@@ -7,6 +7,7 @@ package ingest
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/elastic/elastic-package/internal/elasticsearch"
 	"github.com/elastic/elastic-package/internal/files"
+	"github.com/elastic/elastic-package/internal/formatter"
 	"github.com/elastic/elastic-package/internal/packages"
 )
 
@@ -43,10 +45,10 @@ type RoutingRule struct {
 }
 
 type RerouteProcessor struct {
-	Tag       string   `yaml:"tag"`
-	If        string   `yaml:"if"`
-	Dataset   []string `yaml:"dataset"`
-	Namespace []string `yaml:"namespace"`
+	Tag       string   `yaml:"tag" json:"tag"`
+	If        string   `yaml:"if" json:"if"`
+	Dataset   []string `yaml:"dataset" json:"dataset"`
+	Namespace []string `yaml:"namespace" json:"namespace"`
 }
 
 func InstallDataStreamPipelines(ctx context.Context, api *elasticsearch.API, dataStreamRoot string, repositoryRoot *os.Root) (string, []Pipeline, error) {
@@ -109,7 +111,8 @@ func LoadIngestPipelineFiles(dataStreamRoot string, nonce int64, repositoryRoot 
 			return nil, err
 		}
 
-		cWithRerouteProcessors, err := addRerouteProcessors(c, dataStreamRoot, path)
+		format := filepath.Ext(strings.TrimSuffix(path, ".link"))[1:]
+		cWithRerouteProcessors, err := addRerouteProcessors(c, dataStreamRoot, path, format)
 		if err != nil {
 			return nil, err
 		}
@@ -118,7 +121,7 @@ func LoadIngestPipelineFiles(dataStreamRoot string, nonce int64, repositoryRoot 
 		pipelines = append(pipelines, Pipeline{
 			Path:            path,
 			Name:            GetPipelineNameWithNonce(name[:strings.Index(name, ".")], nonce),
-			Format:          filepath.Ext(strings.TrimSuffix(path, ".link"))[1:],
+			Format:          format,
 			Content:         cWithRerouteProcessors,
 			ContentOriginal: c,
 		})
@@ -126,7 +129,7 @@ func LoadIngestPipelineFiles(dataStreamRoot string, nonce int64, repositoryRoot 
 	return pipelines, nil
 }
 
-func addRerouteProcessors(pipeline []byte, dataStreamRoot, pipelinePath string) ([]byte, error) {
+func addRerouteProcessors(pipeline []byte, dataStreamRoot, pipelinePath, format string) ([]byte, error) {
 	// Only attach routing_rules.yml reroute processors after the default pipeline
 	filename := filepath.Base(pipelinePath)
 	if filename != defaultPipelineJSON && filename != defaultPipelineYML &&
@@ -137,20 +140,26 @@ func addRerouteProcessors(pipeline []byte, dataStreamRoot, pipelinePath string) 
 	// Read routing_rules.yml and convert it into reroute processors in ingest pipeline
 	rerouteProcessors, err := loadRoutingRuleFile(dataStreamRoot)
 	if err != nil {
-		return nil, fmt.Errorf("failed loading routing rules: %v", err)
+		return nil, fmt.Errorf("failed loading routing rules: %w", err)
 	}
 	if len(rerouteProcessors) == 0 {
 		return pipeline, nil
 	}
 
-	var yamlPipeline map[string]any
-	err = yaml.Unmarshal(pipeline, &yamlPipeline)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal ingest pipeline YAML data (path: %s): %w", pipelinePath, err)
+	var pipelineMap map[string]any
+	switch format {
+	case "json":
+		if err = formatter.JSONUnmarshalUsingNumber(pipeline, &pipelineMap); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal ingest pipeline JSON data (path: %s): %w", pipelinePath, err)
+		}
+	default:
+		if err = yaml.Unmarshal(pipeline, &pipelineMap); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal ingest pipeline YAML data (path: %s): %w", pipelinePath, err)
+		}
 	}
 
 	var processors []any
-	v, found := yamlPipeline["processors"]
+	v, found := pipelineMap["processors"]
 	if found {
 		list, ok := v.([]any)
 		if !ok {
@@ -161,11 +170,19 @@ func addRerouteProcessors(pipeline []byte, dataStreamRoot, pipelinePath string) 
 	for _, p := range rerouteProcessors {
 		processors = append(processors, p)
 	}
-	yamlPipeline["processors"] = processors
+	pipelineMap["processors"] = processors
 
-	pipeline, err = yaml.Marshal(yamlPipeline)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal modified ingest pipeline YAML data: %v", err)
+	switch format {
+	case "json":
+		pipeline, err = json.Marshal(pipelineMap)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal modified ingest pipeline JSON data: %w", err)
+		}
+	default:
+		pipeline, err = yaml.Marshal(pipelineMap)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal modified ingest pipeline YAML data: %w", err)
+		}
 	}
 
 	return pipeline, nil

--- a/internal/elasticsearch/ingest/datastream.go
+++ b/internal/elasticsearch/ingest/datastream.go
@@ -111,7 +111,10 @@ func LoadIngestPipelineFiles(dataStreamRoot string, nonce int64, repositoryRoot 
 			return nil, err
 		}
 
-		format := filepath.Ext(strings.TrimSuffix(path, ".link"))[1:]
+		format := strings.TrimPrefix(filepath.Ext(strings.TrimSuffix(path, ".link")), ".")
+		if format == "" {
+			return nil, fmt.Errorf("invalid ingest pipeline extension (path: %s)", path)
+		}
 		cWithRerouteProcessors, err := addRerouteProcessors(c, dataStreamRoot, path, format)
 		if err != nil {
 			return nil, err

--- a/internal/elasticsearch/ingest/datastream_test.go
+++ b/internal/elasticsearch/ingest/datastream_test.go
@@ -5,10 +5,28 @@
 package ingest
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestAddRerouteProcessorsJSONPipeline(t *testing.T) {
+	pipeline := []byte(`{"description":"test pipeline","processors":[{"set":{"field":"ecs.version","value":"8.0.0"}}]}`)
+	dataStreamRoot := "../testdata/routing_rules/good/single_rule"
+
+	result, err := addRerouteProcessors(pipeline, dataStreamRoot, defaultPipelineJSON, "json")
+	assert.NoError(t, err)
+
+	var parsed map[string]any
+	err = json.Unmarshal(result, &parsed)
+	assert.NoError(t, err, "output should be valid JSON")
+
+	// Original processor + 3 reroute processors from single_rule routing_rules.yml
+	processors, ok := parsed["processors"].([]any)
+	assert.True(t, ok)
+	assert.Len(t, processors, 4)
+}
 
 func TestLoadRoutingRuleFileGoodSingleRule(t *testing.T) {
 	mockDataStreamPath := "../testdata/routing_rules/good/single_rule"

--- a/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/_dev/test/pipeline/test-cloudtrail.json
+++ b/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/_dev/test/pipeline/test-cloudtrail.json
@@ -1,0 +1,22 @@
+{
+    "events": [
+        {
+            "cloud.region": "us-east-2",
+            "aws.firehose.arn": "arn:aws:firehose:us-east-2:123456:deliverystream/firehose-cloudtrail-logs-to-elastic",
+            "data_stream.namespace": "default",
+            "aws.firehose.subscription_filters": "[cloudtrail-to-firehose]",
+            "message": "{\"eventVersion\":\"1.08\",\"userIdentity\":{\"type\":\"AWSService\",\"invokedBy\":\"cloudtrail.amazonaws.com\"},\"eventTime\":\"2023-07-17T21:02:26Z\",\"eventSource\":\"sts.amazonaws.com\",\"eventName\":\"AssumeRole\",\"awsRegion\":\"sa-east-1\",\"sourceIPAddress\":\"cloudtrail.amazonaws.com\",\"userAgent\":\"cloudtrail.amazonaws.com\",\"requestParameters\":{\"roleArn\":\"arn:aws:iam::123456:role/service-role/aws-cloudtrail-logs-123456-b888baff_Role\",\"roleSessionName\":\"CLOUDWATCH_LOGS_DELIVERY_SESSION\"},\"responseElements\":{\"credentials\":{\"accessKeyId\":\"ASIAZEDJODE3A5LVGLFB\",\"sessionToken\":\"IQoJb3JpZ2luX2VjEGUaCXNhLWVhc3QtMSJHMEUCIHgHmtcrhwDhosJlQVky+C2zsYDKuR99qVlNjGIp8FLWAiEAsJtTDQ3Arq8iXEOHwv0ImEQdGb5tbgc+fLpoK58Enb4q9AII3v//////////ARAEGgw2MjcyODYzNTAxMzQiDN5gNdfO4ZdSqDmmwSrIAicTBYZg+ZXjwiJTN/Bz2YsMWYU6psw5znG3/Gh3EJ1P3RCmB7d79X6XZzFVi2u2xdrnaY/sTKDfp1jdl8OoAsSKYwJiGbzjoQlv59bB6JqPbKfAKUPAmz6JEMWNFgWTtaQL9rNkdPz23u/1msoUSzxCcxR9f3A2dD4yqnVpNJe8ipuhxpBMzQ61vcGL4G5hQEDM/o8sORP2PXbK4O7QAuWOyuryYkHAPwY9RrL0WHfflGBEBQV6XlidGpsRCtIppZVn025n3DQOypDEaL3fKp0gUsMkDH+frFjxop4o4wRYC3CxXe3XRJ5/Te886rQry7RUfXlQtiCfojZO5ohcLB+z6Y/uCK0IHp3zrfl5shKsQIAFt7p0B8W7PK5yHE4W9HHRiktJ9wTtq1YCTaWECpnjW0bISNgumRmDOAJvVHAjSjfkr4yAlJkw4qm8pQY6vwGbBiuf98AfRFrXMy01hVdE3GNTBrIS68zxUJaOjBLgw8l0nEC00L+LPuqaASFWz65Dnq5JAjXaDD9E3iCi4klp4gZFAcj7uGgeBIPkP7Bpr4SvBfnnqCgE2oyFrWke3NnYtqkL5iHLJeGlOTrvI5ND2H4jurQv0KbiqwHt6DmGF3poZOrtf8R3piNcuCCDLU8RvhRVLHy5rKPzsWgNokBc9XXmgltwvB6rIgdZhBJzupzmy/NSoWZcOeH2ooEELw==\",\"expiration\":\"Jul 12, 2023, 10:02:26 PM\"},\"assumedRoleUser\":{\"assumedRoleId\":\"AROAZEDJODE3NLJAH2FZC:CLOUDWATCH_LOGS_DELIVERY_SESSION\",\"arn\":\"arn:aws:sts::123456:assumed-role/aws-cloudtrail-logs-123456-b888baff_Role/CLOUDWATCH_LOGS_DELIVERY_SESSION\"}},\"requestID\":\"041c9e5f-a031-47d2-a4a0-011bc8d5352c\",\"eventID\":\"3096b662-7aa9-43e6-8bee-541a45686745\",\"readOnly\":true,\"resources\":[{\"accountId\":\"123456\",\"type\":\"AWS::IAM::Role\",\"ARN\":\"arn:aws:iam::123456:role/service-role/aws-cloudtrail-logs-123456-b888baff_Role\"}],\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"123456\",\"sharedEventID\":\"a1c94275-884f-4c1f-b8dc-2e1bf4c94d29\",\"eventCategory\":\"Management\"}",
+            "aws.kinesis.type": "deliverystream",
+            "data_stream.type": "logs",
+            "aws.firehose.request_id": "971ae05f-a128-4a7f-b623-30f9bc513e55",
+            "aws.cloudwatch.log_stream": "123456_CloudTrail_us-east-2_3",
+            "cloud.provider": "aws",
+            "@timestamp": "2023-07-25T21:04:35Z",
+            "cloud.account.id": "123456",
+            "data_stream.dataset": "awsfirehose.log_json_pipeline",
+            "aws.kinesis.name": "firehose-cloudtrail-logs-to-elastic",
+            "event.id": "37670326805251200781477669690942747782212394134076063744",
+            "aws.cloudwatch.log_group": "aws-cloudtrail-logs-123456-1c167310"
+        }
+    ]
+}

--- a/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/_dev/test/pipeline/test-cloudtrail.json-expected.json
+++ b/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/_dev/test/pipeline/test-cloudtrail.json-expected.json
@@ -1,0 +1,28 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2023-07-25T21:04:35Z",
+            "aws.cloudwatch.log_group": "aws-cloudtrail-logs-123456-1c167310",
+            "aws.cloudwatch.log_stream": "123456_CloudTrail_us-east-2_3",
+            "aws.firehose.arn": "arn:aws:firehose:us-east-2:123456:deliverystream/firehose-cloudtrail-logs-to-elastic",
+            "aws.firehose.request_id": "971ae05f-a128-4a7f-b623-30f9bc513e55",
+            "aws.firehose.subscription_filters": "[cloudtrail-to-firehose]",
+            "aws.kinesis.name": "firehose-cloudtrail-logs-to-elastic",
+            "aws.kinesis.type": "deliverystream",
+            "cloud": {
+                "provider": "aws"
+            },
+            "cloud.account.id": "123456",
+            "cloud.provider": "aws",
+            "cloud.region": "us-east-2",
+            "data_stream.dataset": "aws.cloudtrail",
+            "data_stream.namespace": "default",
+            "data_stream.type": "logs",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event.id": "37670326805251200781477669690942747782212394134076063744",
+            "message": "{\"eventVersion\":\"1.08\",\"userIdentity\":{\"type\":\"AWSService\",\"invokedBy\":\"cloudtrail.amazonaws.com\"},\"eventTime\":\"2023-07-17T21:02:26Z\",\"eventSource\":\"sts.amazonaws.com\",\"eventName\":\"AssumeRole\",\"awsRegion\":\"sa-east-1\",\"sourceIPAddress\":\"cloudtrail.amazonaws.com\",\"userAgent\":\"cloudtrail.amazonaws.com\",\"requestParameters\":{\"roleArn\":\"arn:aws:iam::123456:role/service-role/aws-cloudtrail-logs-123456-b888baff_Role\",\"roleSessionName\":\"CLOUDWATCH_LOGS_DELIVERY_SESSION\"},\"responseElements\":{\"credentials\":{\"accessKeyId\":\"ASIAZEDJODE3A5LVGLFB\",\"sessionToken\":\"IQoJb3JpZ2luX2VjEGUaCXNhLWVhc3QtMSJHMEUCIHgHmtcrhwDhosJlQVky+C2zsYDKuR99qVlNjGIp8FLWAiEAsJtTDQ3Arq8iXEOHwv0ImEQdGb5tbgc+fLpoK58Enb4q9AII3v//////////ARAEGgw2MjcyODYzNTAxMzQiDN5gNdfO4ZdSqDmmwSrIAicTBYZg+ZXjwiJTN/Bz2YsMWYU6psw5znG3/Gh3EJ1P3RCmB7d79X6XZzFVi2u2xdrnaY/sTKDfp1jdl8OoAsSKYwJiGbzjoQlv59bB6JqPbKfAKUPAmz6JEMWNFgWTtaQL9rNkdPz23u/1msoUSzxCcxR9f3A2dD4yqnVpNJe8ipuhxpBMzQ61vcGL4G5hQEDM/o8sORP2PXbK4O7QAuWOyuryYkHAPwY9RrL0WHfflGBEBQV6XlidGpsRCtIppZVn025n3DQOypDEaL3fKp0gUsMkDH+frFjxop4o4wRYC3CxXe3XRJ5/Te886rQry7RUfXlQtiCfojZO5ohcLB+z6Y/uCK0IHp3zrfl5shKsQIAFt7p0B8W7PK5yHE4W9HHRiktJ9wTtq1YCTaWECpnjW0bISNgumRmDOAJvVHAjSjfkr4yAlJkw4qm8pQY6vwGbBiuf98AfRFrXMy01hVdE3GNTBrIS68zxUJaOjBLgw8l0nEC00L+LPuqaASFWz65Dnq5JAjXaDD9E3iCi4klp4gZFAcj7uGgeBIPkP7Bpr4SvBfnnqCgE2oyFrWke3NnYtqkL5iHLJeGlOTrvI5ND2H4jurQv0KbiqwHt6DmGF3poZOrtf8R3piNcuCCDLU8RvhRVLHy5rKPzsWgNokBc9XXmgltwvB6rIgdZhBJzupzmy/NSoWZcOeH2ooEELw==\",\"expiration\":\"Jul 12, 2023, 10:02:26 PM\"},\"assumedRoleUser\":{\"assumedRoleId\":\"AROAZEDJODE3NLJAH2FZC:CLOUDWATCH_LOGS_DELIVERY_SESSION\",\"arn\":\"arn:aws:sts::123456:assumed-role/aws-cloudtrail-logs-123456-b888baff_Role/CLOUDWATCH_LOGS_DELIVERY_SESSION\"}},\"requestID\":\"041c9e5f-a031-47d2-a4a0-011bc8d5352c\",\"eventID\":\"3096b662-7aa9-43e6-8bee-541a45686745\",\"readOnly\":true,\"resources\":[{\"accountId\":\"123456\",\"type\":\"AWS::IAM::Role\",\"ARN\":\"arn:aws:iam::123456:role/service-role/aws-cloudtrail-logs-123456-b888baff_Role\"}],\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"123456\",\"sharedEventID\":\"a1c94275-884f-4c1f-b8dc-2e1bf4c94d29\",\"eventCategory\":\"Management\"}"
+        }
+    ]
+}

--- a/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/_dev/test/pipeline/test-vpcflow-log.json
+++ b/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/_dev/test/pipeline/test-vpcflow-log.json
@@ -1,0 +1,34 @@
+{
+    "events": [
+        {
+            "cloud": {
+                "region": "us-east-2",
+                "account": {
+                    "id": "428152502467"
+                },
+                "provider": "aws"
+            },
+            "aws": {
+                "firehose": {
+                    "arn": "arn:aws:firehose:us-east-2:428152502467:deliverystream/test-vpcflow-logs",
+                    "request_id": "1cfbed13-d631-4b8b-b20a-b7c5bf8fcd00"
+                },
+                "kinesis": {
+                    "name": "test-vpcflow-logs",
+                    "type": "deliverystream"
+                },
+                "labels": {
+                    "elastic_co/dataset": "mydataset",
+                    "elastic_co/namespace": "mynamespace"
+                }
+            },
+            "data_stream": {
+                "namespace": "default",
+                "type": "logs",
+                "dataset": "generic"
+            },
+            "@timestamp": "2023-08-23T16:47:26Z",
+            "message": "{\"message\":\"2 428152502467 eni-0b584e1c714317ac6 176.111.174.91 10.0.0.102 41536 1135 6 1 40 1692809104 1692809162 REJECT OK\"}\n"
+        }
+    ]
+}

--- a/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/_dev/test/pipeline/test-vpcflow-log.json-expected.json
+++ b/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/_dev/test/pipeline/test-vpcflow-log.json-expected.json
@@ -1,0 +1,37 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2023-08-23T16:47:26Z",
+            "aws": {
+                "firehose": {
+                    "arn": "arn:aws:firehose:us-east-2:428152502467:deliverystream/test-vpcflow-logs",
+                    "request_id": "1cfbed13-d631-4b8b-b20a-b7c5bf8fcd00"
+                },
+                "kinesis": {
+                    "name": "test-vpcflow-logs",
+                    "type": "deliverystream"
+                },
+                "labels": {
+                    "elastic_co/dataset": "mydataset",
+                    "elastic_co/namespace": "mynamespace"
+                }
+            },
+            "cloud": {
+                "account": {
+                    "id": "428152502467"
+                },
+                "provider": "aws",
+                "region": "us-east-2"
+            },
+            "data_stream": {
+                "dataset": "mydataset",
+                "namespace": "mynamespace",
+                "type": "logs"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "message": "{\"message\":\"2 428152502467 eni-0b584e1c714317ac6 176.111.174.91 10.0.0.102 41536 1135 6 1 40 1692809104 1692809162 REJECT OK\"}\n"
+        }
+    ]
+}

--- a/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/elasticsearch/ingest_pipeline/default.json
+++ b/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/elasticsearch/ingest_pipeline/default.json
@@ -1,0 +1,25 @@
+{
+  "description": "Pipeline for rerouting logs streams from Amazon Kinesis Data Firehose.",
+  "processors": [
+    {
+      "set": {
+        "field": "ecs.version",
+        "value": "8.0.0"
+      }
+    },
+    {
+      "set": {
+        "field": "cloud.provider",
+        "value": "aws"
+      }
+    }
+  ],
+  "on_failure": [
+    {
+      "set": {
+        "field": "error.message",
+        "value": "{{ _ingest.on_failure_message }}"
+      }
+    }
+  ]
+}

--- a/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/fields/base-fields.yml
+++ b/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/fields/base-fields.yml
@@ -1,0 +1,23 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: aws
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: aws_logs.generic
+- name: input.type
+  type: keyword
+  description: Type of Filebeat input.

--- a/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/fields/ecs.yml
+++ b/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/fields/ecs.yml
@@ -1,0 +1,10 @@
+- external: ecs
+  name: ecs.version
+- external: ecs
+  name: log.level
+- external: ecs
+  name: message
+- name: event.original
+  external: ecs
+- name: tags
+  external: ecs

--- a/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/fields/fields.yml
+++ b/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/fields/fields.yml
@@ -1,0 +1,49 @@
+- name: aws
+  type: object
+  fields:
+    - name: cloudwatch
+      type: object
+      fields:
+        - name: log_group
+          type: keyword
+          description: |
+            CloudWatch log group name.
+        - name: log_stream
+          type: keyword
+          description: |
+            CloudWatch log stream name.
+    - name: firehose
+      type: object
+      fields:
+        - name: arn
+          type: keyword
+          description: |
+            Firehose ARN.
+        - name: request_id
+          type: keyword
+          description: |
+            Firehose request ID.
+        - name: subscription_filters
+          type: keyword
+          description: |
+            Firehose request ID.
+    - name: kinesis
+      type: object
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Kinesis name.
+        - name: type
+          type: keyword
+          description: |-
+            Kinesis type.
+    - name: labels
+      type: object
+      fields:
+        - name: elastic_co/dataset
+          type: keyword
+          description: Fictional field to test datasets routing rules.
+        - name: elastic_co/namespace
+          type: keyword
+          description: Fictional field to test namespaces routing rules.

--- a/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/manifest.yml
+++ b/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/manifest.yml
@@ -1,0 +1,7 @@
+title: Logs from Amazon Kinesis Data Firehose (JSON pipeline)
+type: logs
+dataset: awsfirehose
+# Ensures agents have permissions to write data to `logs-*-*`
+elasticsearch:
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/routing_rules.yml
+++ b/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/routing_rules.yml
@@ -1,0 +1,11 @@
+- source_dataset: awsfirehose.log_json_pipeline
+  rules:
+    - target_dataset:
+        - "{{aws.labels.elastic_co/dataset}}"
+      namespace:
+        - "{{aws.labels.elastic_co/namespace}}"
+      if: "ctx.aws?.labels != null"
+    - target_dataset: aws.cloudtrail
+      if: ctx['aws.cloudwatch.log_stream'].contains('CloudTrail') == true
+      namespace:
+        - default


### PR DESCRIPTION
Fixes #2861

## Problem

When a data stream uses a JSON-format ingest pipeline (`default.json`) combined with `routing_rules.yml`, `addRerouteProcessors` was always marshaling the modified pipeline back to YAML regardless of the original format. This caused Elasticsearch to reject the pipeline with a `not_x_content_exception` because it received YAML content where JSON was expected.

Additionally, `RerouteProcessor` lacked `json` struct tags, causing field names to be serialized with uppercase initials (e.g., `Tag`, `If`) when converted to JSON, producing invalid processor definitions.

## Changes

- Propagate the pipeline format through `addRerouteProcessors` and use format-appropriate unmarshal/marshal (JSON or YAML).
- Add `json` struct tags to `RerouteProcessor` to ensure correct lowercase field names when serialized to JSON.
- Extract the `format` variable in `LoadIngestPipelineFiles` to avoid computing it twice.
- Add a unit test (`TestAddRerouteProcessorsJSONPipeline`) covering the JSON pipeline + routing rules code path.
- Add a new `log_json_pipeline` data stream to the `awsfirehose` test package with pipeline tests and routing rules to exercise the fix end-to-end.

## Testing

- New unit test verifies the output is valid JSON and contains the expected processors.
- New integration test data (`test-cloudtrail.json`, `test-vpcflow-log.json`) covers the rerouting logic for JSON pipelines.

## Author's checklist

- [x] Validate that keeps working with YAML pipelines and `routing_rules.yml` file.
- [x] Validate that works with JSON pipeline and `routing_rules.yml` file.
- [x] Validate that works with YAML pipelines without `routing_rules.yml` file.
    - Tested with `elastic_package_registry` from integrations repository 
- [x] Validate that works with JSON pipelines without `routing_rules.yml` file.
    - Tested with `mysql` package (data stream `slowlog`) from integrations repository

## How to test this PR locally

This PR can be tested via:
```sh
elastic-package stack up -v -d
elastic-package -C test/packages/parallel/awsfirehose test pipeline -v
elastic-package stack down -v
```

When this is tested with elastic-package version `v0.123.0`, this gives the following error:
```
Error: error running package pipeline tests: could not complete test run: installing ingest pipelines failed: unexpected response status for PutPipeline (400): 400 Bad Request (pipelineName: default-1777987633876933265, path: /home/mariorodriguez/Coding/work/elastic-package/test/packages/parallel/awsfirehose/data_stream/log_json_pipeline/elasticsearch/ingest_pipeline/default.json): elasticsearch error (type=x_content_parse_exception): [1:13] Unrecognized token 'description': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
 at [Source: (byte[])"description: Pipeline for rerouting logs streams from Amazon Kinesis Data Firehose.
on_failure:
    - set:
        field: error.message
        value: '{{ _ingest.on_failure_message }}'
processors:
    - set:
        field: ecs.version
        value: 8.0.0
    - set:
        field: cloud.provider
        value: aws
    - reroute:
        tag: awsfirehose.log_json_pipeline
        if: ctx.aws?.labels != null
        dataset:
            - '{{aws.labels.elastic_co/dataset}}'
        namespace:
   "[truncated 270 bytes]; line: 1, column: 13]
Root cause:
[
  {
    "type": "x_content_parse_exception",
    "reason": "[1:13] Unrecognized token 'description': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n at [Source: (byte[])\"description: Pipeline for rerouting logs streams from Amazon Kinesis Data Firehose.\non_failure:\n    - set:\n        field: error.message\n        value: '{{ _ingest.on_failure_message }}'\nprocessors:\n    - set:\n        field: ecs.version\n        value: 8.0.0\n    - set:\n        field: cloud.provider\n        value: aws\n    - reroute:\n        tag: awsfirehose.log_json_pipeline\n        if: ctx.aws?.labels != null\n        dataset:\n            - '{{aws.labels.elastic_co/dataset}}'\n        namespace:\n   \"[truncated 270 bytes]; line: 1, column: 13]",
    "position": {
      "offset": 0,
      "start": 0,
      "end": 0
    }
  }
]
```

When running the code in this PR, it runs pipeline tests successfully:
```sh
--- Test results for package: awsfirehose - START ---
╭─────────────┬───────────────────┬───────────┬──────────────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE     │ DATA STREAM       │ TEST TYPE │ TEST NAME                                        │ RESULT │ TIME ELAPSED │
├─────────────┼───────────────────┼───────────┼──────────────────────────────────────────────────┼────────┼──────────────┤
│ awsfirehose │ log               │ pipeline  │ (ingest pipeline warnings test-cloudtrail.json)  │ PASS   │ 177.075413ms │
│ awsfirehose │ log               │ pipeline  │ (ingest pipeline warnings test-vpcflow-log.json) │ PASS   │ 181.771697ms │
│ awsfirehose │ log               │ pipeline  │ test-cloudtrail.json                             │ PASS   │  30.685066ms │
│ awsfirehose │ log               │ pipeline  │ test-vpcflow-log.json                            │ PASS   │  28.595604ms │
│ awsfirehose │ log_json_pipeline │ pipeline  │ (ingest pipeline warnings test-cloudtrail.json)  │ PASS   │ 178.171931ms │
│ awsfirehose │ log_json_pipeline │ pipeline  │ (ingest pipeline warnings test-vpcflow-log.json) │ PASS   │ 179.515222ms │
│ awsfirehose │ log_json_pipeline │ pipeline  │ test-cloudtrail.json                             │ PASS   │  28.200119ms │
│ awsfirehose │ log_json_pipeline │ pipeline  │ test-vpcflow-log.json                            │ PASS   │  29.053974ms │
╰─────────────┴───────────────────┴───────────┴──────────────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: awsfirehose - END   ---
Done

```


---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).