### PR TITLE
Add opt-in ignored fields doc-values query

### DIFF
--- a/docs/howto/system_testing.md
+++ b/docs/howto/system_testing.md
@@ -1007,6 +1007,9 @@ In this case, `elastic-package test system` will fail with an error and print a 
 skip_ignored_fields:
   - field.to.ignore
 ```
+
+For targeted verification runs, set `ELASTIC_PACKAGE_IGNORED_FIELDS_USE_DOC_VALUES=true` to read `_ignored` from doc values. This stricter lookup can surface ignored fields that the default `_fields` lookup misses.
+
 ### Kibana policy overrides
 
 If you need to test a system test with a Kibana policy override you can do that by setting the environment variable `ELASTIC_PACKAGE_KIBANA_POLICY_OVERRIDES` to be a path to a yaml file that contains the policy override.  For example:

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -43,7 +43,13 @@ import (
 	"github.com/elastic/elastic-package/internal/wait"
 )
 
-const FieldsQuery = `{
+const (
+	ignoredFieldsUseDocValuesEnvVar = "ELASTIC_PACKAGE_IGNORED_FIELDS_USE_DOC_VALUES"
+
+	storedFieldsIgnoredFieldsScript = "for (def v : params['_fields']._ignored.values) { emit(v); }"
+	docValuesIgnoredFieldsScript    = "for (def v : doc['_ignored']) { emit(v); }"
+
+	fieldsQueryTemplate = `{
   "fields": [
     "*"
   ],
@@ -51,7 +57,7 @@ const FieldsQuery = `{
     "my_ignored": {
       "type": "keyword",
       "script": {
-        "source": "for (def v : doc['_ignored']) { emit(v); }"
+        "source": %q
       }
     }
   },
@@ -78,6 +84,23 @@ const FieldsQuery = `{
     }
   }
 }`
+)
+
+// FieldsQuery is the default query body used by callers that don't opt in to
+// stricter _ignored doc-values detection.
+var FieldsQuery = fieldsQuery(false)
+
+func fieldsQuery(useDocValues bool) string {
+	script := storedFieldsIgnoredFieldsScript
+	if useDocValues {
+		script = docValuesIgnoredFieldsScript
+	}
+	return fmt.Sprintf(fieldsQueryTemplate, script)
+}
+
+func ignoredFieldsUseDocValues() bool {
+	return strings.EqualFold(os.Getenv(ignoredFieldsUseDocValuesEnvVar), "true")
+}
 
 // doNotSkipDeferCleanup is the value for tearDownTest's skipDeferCleanup parameter
 // when the caller wants to keep the defer-cleanup wait (e.g. setup/teardown-only paths).
@@ -835,14 +858,14 @@ func (h hits) size() int {
 	return len(h.Source)
 }
 
-func (r *tester) getDocs(ctx context.Context, dataStream string) (*hits, error) {
+func (r *tester) getDocs(ctx context.Context, dataStream string, useDocValuesForIgnoredFields bool) (*hits, error) {
 	resp, err := r.esAPI.Search(
 		r.esAPI.Search.WithContext(ctx),
 		r.esAPI.Search.WithIndex(dataStream),
 		r.esAPI.Search.WithSort("@timestamp:asc"),
 		r.esAPI.Search.WithSize(elasticsearchQuerySize),
 		r.esAPI.Search.WithSource("true"),
-		r.esAPI.Search.WithBody(strings.NewReader(FieldsQuery)),
+		r.esAPI.Search.WithBody(strings.NewReader(fieldsQuery(useDocValuesForIgnoredFields))),
 		r.esAPI.Search.WithIgnoreUnavailable(true),
 	)
 	if err != nil {
@@ -1840,7 +1863,7 @@ func (r *tester) waitForDocs(ctx context.Context, config *testConfig, dataStream
 	var missingFields []string
 	passed, waitErr := wait.UntilTrue(ctx, func(ctx context.Context) (bool, error) {
 		var err error
-		hits, err = r.getDocs(ctx, dataStream)
+		hits, err = r.getDocs(ctx, dataStream, ignoredFieldsUseDocValues())
 		if err != nil {
 			return false, err
 		}

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -1861,9 +1861,10 @@ func (r *tester) waitForDocs(ctx context.Context, config *testConfig, dataStream
 	oldHits := 0
 	foundFields := map[string]any{}
 	var missingFields []string
+	useDocValuesForIgnoredFields := ignoredFieldsUseDocValues()
 	passed, waitErr := wait.UntilTrue(ctx, func(ctx context.Context) (bool, error) {
 		var err error
-		hits, err = r.getDocs(ctx, dataStream, ignoredFieldsUseDocValues())
+		hits, err = r.getDocs(ctx, dataStream, useDocValuesForIgnoredFields)
 		if err != nil {
 			return false, err
 		}

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -51,7 +51,7 @@ const FieldsQuery = `{
     "my_ignored": {
       "type": "keyword",
       "script": {
-        "source": "for (def v : params['_fields']._ignored.values) { emit(v); }"
+        "source": "for (def v : doc['_ignored']) { emit(v); }"
       }
     }
   },

--- a/internal/testrunner/runners/system/tester_test.go
+++ b/internal/testrunner/runners/system/tester_test.go
@@ -27,18 +27,54 @@ import (
 	"github.com/elastic/elastic-package/internal/testrunner"
 )
 
-func TestFieldsQueryReadsIgnoredFromDocValues(t *testing.T) {
-	var query struct {
-		RuntimeMappings map[string]struct {
-			Script struct {
-				Source string `json:"source"`
-			} `json:"script"`
-		} `json:"runtime_mappings"`
-	}
+func TestFieldsQueryIgnoredFieldsScript(t *testing.T) {
+	assert.Equal(t, fieldsQuery(false), FieldsQuery)
 
-	require.NoError(t, json.Unmarshal([]byte(FieldsQuery), &query))
-	assert.Equal(t, "for (def v : doc['_ignored']) { emit(v); }", query.RuntimeMappings["my_ignored"].Script.Source)
-	assert.NotContains(t, FieldsQuery, "params['_fields']")
+	for _, tc := range []struct {
+		name         string
+		useDocValues bool
+		expected     string
+		notExpected  string
+	}{
+		{
+			name:        "default keeps stored fields lookup",
+			expected:    storedFieldsIgnoredFieldsScript,
+			notExpected: docValuesIgnoredFieldsScript,
+		},
+		{
+			name:         "opt in reads ignored from doc values",
+			useDocValues: true,
+			expected:     docValuesIgnoredFieldsScript,
+			notExpected:  storedFieldsIgnoredFieldsScript,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			queryBody := fieldsQuery(tc.useDocValues)
+			var query struct {
+				RuntimeMappings map[string]struct {
+					Script struct {
+						Source string `json:"source"`
+					} `json:"script"`
+				} `json:"runtime_mappings"`
+			}
+
+			require.NoError(t, json.Unmarshal([]byte(queryBody), &query))
+			assert.Equal(t, tc.expected, query.RuntimeMappings["my_ignored"].Script.Source)
+			assert.NotContains(t, queryBody, tc.notExpected)
+		})
+	}
+}
+
+func TestIgnoredFieldsUseDocValues(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		t.Setenv(ignoredFieldsUseDocValuesEnvVar, "")
+		assert.False(t, ignoredFieldsUseDocValues())
+	})
+
+	t.Run("enabled by environment", func(t *testing.T) {
+		t.Setenv(ignoredFieldsUseDocValuesEnvVar, "true")
+		assert.True(t, ignoredFieldsUseDocValues())
+	})
 }
 
 func TestFindPolicyTemplateForInput(t *testing.T) {

--- a/internal/testrunner/runners/system/tester_test.go
+++ b/internal/testrunner/runners/system/tester_test.go
@@ -5,6 +5,7 @@
 package system
 
 import (
+	"encoding/json"
 	"fmt"
 	"maps"
 	"os"
@@ -25,6 +26,20 @@ import (
 	"github.com/elastic/elastic-package/internal/stack"
 	"github.com/elastic/elastic-package/internal/testrunner"
 )
+
+func TestFieldsQueryReadsIgnoredFromDocValues(t *testing.T) {
+	var query struct {
+		RuntimeMappings map[string]struct {
+			Script struct {
+				Source string `json:"source"`
+			} `json:"script"`
+		} `json:"runtime_mappings"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(FieldsQuery), &query))
+	assert.Equal(t, "for (def v : doc['_ignored']) { emit(v); }", query.RuntimeMappings["my_ignored"].Script.Source)
+	assert.NotContains(t, FieldsQuery, "params['_fields']")
+}
 
 func TestFindPolicyTemplateForInput(t *testing.T) {
 	const policyTemplateName = "my_policy_template"


### PR DESCRIPTION
Refs #3524

## What changed
- Keep the default ignored-fields query on the existing `_fields` lookup to avoid changing every system test at once.
- Add `ELASTIC_PACKAGE_IGNORED_FIELDS_USE_DOC_VALUES=true` as a targeted opt-in for stricter doc-values based `_ignored` detection.
- Cover both query modes, the default exported query body, and the env switch with regression tests.

## Tests
- `CGO_ENABLED=0 go test ./internal/testrunner/runners/system -run 'Test(FieldsQueryIgnoredFieldsScript|IgnoredFieldsUseDocValues|NewConfig)$'`
- `CGO_ENABLED=0 go test ./internal/testrunner/runners/system ./internal/testrunner/script`
- `CGO_ENABLED=0 go test ./internal/testrunner/...`
- `make format`
- `git diff --check`