### PR TITLE
testrunner/runners/system: fall back to packageRoot in CreatePackagePolicy when built tree is unavailable

### DIFF
--- a/internal/builder/packages.go
+++ b/internal/builder/packages.go
@@ -112,27 +112,16 @@ func BuildPackagesDirectory(packageRoot string, buildDir string) (string, error)
 
 // ReadBuiltPackageManifest locates the built package directory for packageRoot
 // and reads its manifest. Returns the built root path and parsed manifest.
-//
-// When the built directory does not exist or does not contain a valid manifest,
-// packageRoot is used directly. This handles two cases:
-//   - EPR-extracted packages passed via add_package_policy -version, where the
-//     built tree contains a different version than the one being installed.
-//   - Execution outside a Git repository (e.g. temp directories) where no
-//     build/ directory can be found.
 func ReadBuiltPackageManifest(packageRoot string) (string, *packages.PackageManifest, error) {
 	builtRoot, err := BuildPackagesDirectory(packageRoot, "")
-	if err == nil {
-		builtPkg, readErr := packages.ReadPackageManifestFromPackageRoot(builtRoot)
-		if readErr == nil {
-			return builtRoot, builtPkg, nil
-		}
-	}
-	// Built tree unavailable or incomplete; fall back to packageRoot.
-	pkg, err := packages.ReadPackageManifestFromPackageRoot(packageRoot)
 	if err != nil {
-		return "", nil, fmt.Errorf("reading package manifest from %s: %w", packageRoot, err)
+		return "", nil, err
 	}
-	return packageRoot, pkg, nil
+	builtPkg, err := packages.ReadPackageManifestFromPackageRoot(builtRoot)
+	if err != nil {
+		return "", nil, err
+	}
+	return builtRoot, builtPkg, nil
 }
 
 // buildPackagesZipPath function returns the path to zipped built package.

--- a/internal/builder/packages.go
+++ b/internal/builder/packages.go
@@ -112,16 +112,27 @@ func BuildPackagesDirectory(packageRoot string, buildDir string) (string, error)
 
 // ReadBuiltPackageManifest locates the built package directory for packageRoot
 // and reads its manifest. Returns the built root path and parsed manifest.
+//
+// When the built directory does not exist or does not contain a valid manifest,
+// packageRoot is used directly. This handles two cases:
+//   - EPR-extracted packages passed via add_package_policy -version, where the
+//     built tree contains a different version than the one being installed.
+//   - Execution outside a Git repository (e.g. temp directories) where no
+//     build/ directory can be found.
 func ReadBuiltPackageManifest(packageRoot string) (string, *packages.PackageManifest, error) {
 	builtRoot, err := BuildPackagesDirectory(packageRoot, "")
-	if err != nil {
-		return "", nil, err
+	if err == nil {
+		builtPkg, readErr := packages.ReadPackageManifestFromPackageRoot(builtRoot)
+		if readErr == nil {
+			return builtRoot, builtPkg, nil
+		}
 	}
-	builtPkg, err := packages.ReadPackageManifestFromPackageRoot(builtRoot)
+	// Built tree unavailable or incomplete; fall back to packageRoot.
+	pkg, err := packages.ReadPackageManifestFromPackageRoot(packageRoot)
 	if err != nil {
-		return "", nil, err
+		return "", nil, fmt.Errorf("reading package manifest from %s: %w", packageRoot, err)
 	}
-	return builtRoot, builtPkg, nil
+	return packageRoot, pkg, nil
 }
 
 // buildPackagesZipPath function returns the path to zipped built package.

--- a/internal/builder/packages_test.go
+++ b/internal/builder/packages_test.go
@@ -5,6 +5,7 @@
 package builder
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -161,4 +162,99 @@ func TestCopyLicenseTextFile_UsesExistingLicenseFile(t *testing.T) {
 		assert.ErrorIs(t, err, os.ErrNotExist)
 	})
 
+}
+
+const testManifestTemplate = `name: %s
+title: Test Package
+version: %s
+type: integration
+format_version: 3.0.0
+`
+
+func writeTestManifest(t *testing.T, dir, name, version string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "manifest.yml"),
+		[]byte(fmt.Sprintf(testManifestTemplate, name, version)),
+		0o644,
+	))
+}
+
+func TestReadBuiltPackageManifest(t *testing.T) {
+	const pkgName = "testpkg"
+
+	t.Run("PreferBuiltTree", func(t *testing.T) {
+		// Simulate a repo layout where both the source packageRoot and the
+		// built tree exist under a common ancestor with a build/ directory.
+		root := t.TempDir()
+		t.Chdir(root)
+
+		srcVersion := "1.2.3"
+		packageRoot := filepath.Join(root, "packages", pkgName)
+		writeTestManifest(t, packageRoot, pkgName, srcVersion)
+
+		builtRoot := filepath.Join(root, "build", "packages", pkgName, srcVersion)
+		writeTestManifest(t, builtRoot, pkgName, srcVersion)
+
+		gotRoot, gotPkg, err := ReadBuiltPackageManifest(packageRoot)
+		require.NoError(t, err)
+		assert.Equal(t, builtRoot, gotRoot)
+		assert.Equal(t, pkgName, gotPkg.Name)
+		assert.Equal(t, srcVersion, gotPkg.Version)
+	})
+
+	t.Run("FallbackWhenBuiltTreeMissing", func(t *testing.T) {
+		// No build/ directory exists, simulating an EPR-extracted package
+		// or execution outside a Git repository.
+		root := t.TempDir()
+		t.Chdir(root)
+
+		eprVersion := "1.0.0"
+		packageRoot := filepath.Join(root, "epr", pkgName, eprVersion)
+		writeTestManifest(t, packageRoot, pkgName, eprVersion)
+
+		gotRoot, gotPkg, err := ReadBuiltPackageManifest(packageRoot)
+		require.NoError(t, err)
+		assert.Equal(t, packageRoot, gotRoot)
+		assert.Equal(t, pkgName, gotPkg.Name)
+		assert.Equal(t, eprVersion, gotPkg.Version)
+	})
+
+	t.Run("FallbackWhenBuiltTreeHasDifferentVersion", func(t *testing.T) {
+		// The built tree exists but contains a different version (the dev
+		// version) than the EPR package being installed. The function must
+		// fall back to packageRoot.
+		root := t.TempDir()
+		t.Chdir(root)
+
+		devVersion := "1.2.3"
+		eprVersion := "1.1.0"
+		packageRoot := filepath.Join(root, "epr", pkgName, eprVersion)
+		writeTestManifest(t, packageRoot, pkgName, eprVersion)
+
+		// Built tree has the dev version, not the EPR version.
+		builtDev := filepath.Join(root, "build", "packages", pkgName, devVersion)
+		writeTestManifest(t, builtDev, pkgName, devVersion)
+
+		// BuildPackagesDirectory resolves to <build>/packages/<name>/<eprVersion>,
+		// which does not exist (only devVersion was built), triggering fallback.
+		gotRoot, gotPkg, err := ReadBuiltPackageManifest(packageRoot)
+		require.NoError(t, err)
+		assert.Equal(t, packageRoot, gotRoot)
+		assert.Equal(t, pkgName, gotPkg.Name)
+		assert.Equal(t, eprVersion, gotPkg.Version)
+	})
+
+	t.Run("ErrorWhenNoManifestAnywhere", func(t *testing.T) {
+		root := t.TempDir()
+		t.Chdir(root)
+
+		packageRoot := filepath.Join(root, "empty")
+		require.NoError(t, os.MkdirAll(packageRoot, 0o755))
+
+		_, _, err := ReadBuiltPackageManifest(packageRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), packageRoot)
+	})
 }

--- a/internal/builder/packages_test.go
+++ b/internal/builder/packages_test.go
@@ -178,9 +178,7 @@ func writeTestManifest(t *testing.T, dir, version string) {
 
 func TestReadBuiltPackageManifest(t *testing.T) {
 
-	t.Run("PreferBuiltTree", func(t *testing.T) {
-		// Simulate a repo layout where both the source packageRoot and the
-		// built tree exist under a common ancestor with a build/ directory.
+	t.Run("ReturnsBuiltTree", func(t *testing.T) {
 		root := t.TempDir()
 		t.Chdir(root)
 
@@ -198,57 +196,30 @@ func TestReadBuiltPackageManifest(t *testing.T) {
 		assert.Equal(t, srcVersion, gotPkg.Version)
 	})
 
-	t.Run("FallbackWhenBuiltTreeMissing", func(t *testing.T) {
-		// No build/ directory exists, simulating an EPR-extracted package
-		// or execution outside a Git repository.
+	t.Run("ErrorWhenBuiltTreeMissing", func(t *testing.T) {
+		// No build/ directory and no .git — strict mode must fail.
 		root := t.TempDir()
 		t.Chdir(root)
 
-		eprVersion := "1.0.0"
-		packageRoot := filepath.Join(root, "epr", pkgName, eprVersion)
-		writeTestManifest(t, packageRoot, eprVersion)
-
-		gotRoot, gotPkg, err := ReadBuiltPackageManifest(packageRoot)
-		require.NoError(t, err)
-		assert.Equal(t, packageRoot, gotRoot)
-		assert.Equal(t, pkgName, gotPkg.Name)
-		assert.Equal(t, eprVersion, gotPkg.Version)
-	})
-
-	t.Run("FallbackWhenBuiltTreeHasDifferentVersion", func(t *testing.T) {
-		// The built tree exists but contains a different version (the dev
-		// version) than the EPR package being installed. The function must
-		// fall back to packageRoot.
-		root := t.TempDir()
-		t.Chdir(root)
-
-		devVersion := "1.2.3"
-		eprVersion := "1.1.0"
-		packageRoot := filepath.Join(root, "epr", pkgName, eprVersion)
-		writeTestManifest(t, packageRoot, eprVersion)
-
-		// Built tree has the dev version, not the EPR version.
-		builtDev := filepath.Join(root, "build", "packages", pkgName, devVersion)
-		writeTestManifest(t, builtDev, devVersion)
-
-		// BuildPackagesDirectory resolves to <build>/packages/<name>/<eprVersion>,
-		// which does not exist (only devVersion was built), triggering fallback.
-		gotRoot, gotPkg, err := ReadBuiltPackageManifest(packageRoot)
-		require.NoError(t, err)
-		assert.Equal(t, packageRoot, gotRoot)
-		assert.Equal(t, pkgName, gotPkg.Name)
-		assert.Equal(t, eprVersion, gotPkg.Version)
-	})
-
-	t.Run("ErrorWhenNoManifestAnywhere", func(t *testing.T) {
-		root := t.TempDir()
-		t.Chdir(root)
-
-		packageRoot := filepath.Join(root, "empty")
-		require.NoError(t, os.MkdirAll(packageRoot, 0o755))
+		packageRoot := filepath.Join(root, "epr", pkgName, "1.0.0")
+		writeTestManifest(t, packageRoot, "1.0.0")
 
 		_, _, err := ReadBuiltPackageManifest(packageRoot)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), packageRoot)
+	})
+
+	t.Run("ErrorWhenBuiltVersionDiffers", func(t *testing.T) {
+		// Built tree exists but for a different version — strict mode must fail.
+		root := t.TempDir()
+		t.Chdir(root)
+
+		packageRoot := filepath.Join(root, "epr", pkgName, "1.1.0")
+		writeTestManifest(t, packageRoot, "1.1.0")
+
+		builtDev := filepath.Join(root, "build", "packages", pkgName, "1.2.3")
+		writeTestManifest(t, builtDev, "1.2.3")
+
+		_, _, err := ReadBuiltPackageManifest(packageRoot)
+		require.Error(t, err)
 	})
 }

--- a/internal/builder/packages_test.go
+++ b/internal/builder/packages_test.go
@@ -164,25 +164,19 @@ func TestCopyLicenseTextFile_UsesExistingLicenseFile(t *testing.T) {
 
 }
 
-const testManifestTemplate = `name: %s
-title: Test Package
-version: %s
-type: integration
-format_version: 3.0.0
-`
+const pkgName = "testpkg"
 
-func writeTestManifest(t *testing.T, dir, name, version string) {
+func writeTestManifest(t *testing.T, dir, version string) {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(dir, 0o755))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, "manifest.yml"),
-		[]byte(fmt.Sprintf(testManifestTemplate, name, version)),
+		[]byte(fmt.Sprintf("name: %s\ntitle: Test Package\nversion: %s\ntype: integration\nformat_version: 3.0.0\n", pkgName, version)),
 		0o644,
 	))
 }
 
 func TestReadBuiltPackageManifest(t *testing.T) {
-	const pkgName = "testpkg"
 
 	t.Run("PreferBuiltTree", func(t *testing.T) {
 		// Simulate a repo layout where both the source packageRoot and the
@@ -192,10 +186,10 @@ func TestReadBuiltPackageManifest(t *testing.T) {
 
 		srcVersion := "1.2.3"
 		packageRoot := filepath.Join(root, "packages", pkgName)
-		writeTestManifest(t, packageRoot, pkgName, srcVersion)
+		writeTestManifest(t, packageRoot, srcVersion)
 
 		builtRoot := filepath.Join(root, "build", "packages", pkgName, srcVersion)
-		writeTestManifest(t, builtRoot, pkgName, srcVersion)
+		writeTestManifest(t, builtRoot, srcVersion)
 
 		gotRoot, gotPkg, err := ReadBuiltPackageManifest(packageRoot)
 		require.NoError(t, err)
@@ -212,7 +206,7 @@ func TestReadBuiltPackageManifest(t *testing.T) {
 
 		eprVersion := "1.0.0"
 		packageRoot := filepath.Join(root, "epr", pkgName, eprVersion)
-		writeTestManifest(t, packageRoot, pkgName, eprVersion)
+		writeTestManifest(t, packageRoot, eprVersion)
 
 		gotRoot, gotPkg, err := ReadBuiltPackageManifest(packageRoot)
 		require.NoError(t, err)
@@ -231,11 +225,11 @@ func TestReadBuiltPackageManifest(t *testing.T) {
 		devVersion := "1.2.3"
 		eprVersion := "1.1.0"
 		packageRoot := filepath.Join(root, "epr", pkgName, eprVersion)
-		writeTestManifest(t, packageRoot, pkgName, eprVersion)
+		writeTestManifest(t, packageRoot, eprVersion)
 
 		// Built tree has the dev version, not the EPR version.
 		builtDev := filepath.Join(root, "build", "packages", pkgName, devVersion)
-		writeTestManifest(t, builtDev, pkgName, devVersion)
+		writeTestManifest(t, builtDev, devVersion)
 
 		// BuildPackagesDirectory resolves to <build>/packages/<name>/<eprVersion>,
 		// which does not exist (only devVersion was built), triggering fallback.

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -2268,12 +2268,21 @@ func CreatePackagePolicy(
 	}
 
 	// Prefer the built tree so RequiredInputsResolver has already materialized
-	// package: references into concrete input types. ReadBuiltPackageManifest
-	// falls back to packageRoot when no built tree is available (e.g. EPR
-	// packages or execution outside a Git repository).
+	// package: references into concrete input types.
+	//
+	// When the built tree is unavailable — for example an EPR-extracted package
+	// passed via add_package_policy -version, or execution outside a Git
+	// repository — fall back to reading manifests directly from packageRoot.
+	// An EPR package is already fully resolved (no package: references), so
+	// the source manifest is accurate enough to build a correct policy.
 	builtRoot, builtPkg, err := builder.ReadBuiltPackageManifest(packageRoot)
 	if err != nil {
-		return kibana.PackagePolicy{}, "", "", fmt.Errorf("reading built package manifest: %w", err)
+		logger.Debugf("built tree unavailable for %s, falling back to packageRoot: %v", packageRoot, err)
+		builtRoot = packageRoot
+		builtPkg, err = packages.ReadPackageManifestFromPackageRoot(packageRoot)
+		if err != nil {
+			return kibana.PackagePolicy{}, "", "", fmt.Errorf("reading package manifest from %s: %w", packageRoot, err)
+		}
 	}
 
 	builtPolicyTemplate, err := packages.SelectPolicyTemplateByName(builtPkg.PolicyTemplates, policyTemplateName)

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -2267,8 +2267,10 @@ func CreatePackagePolicy(
 		return kibana.PackagePolicy{}, "", "", fmt.Errorf("package root is required")
 	}
 
-	// Always resolve against the built tree so that RequiredInputsResolver has already
-	// materialized package: references into concrete input types.
+	// Prefer the built tree so RequiredInputsResolver has already materialized
+	// package: references into concrete input types. ReadBuiltPackageManifest
+	// falls back to packageRoot when no built tree is available (e.g. EPR
+	// packages or execution outside a Git repository).
 	builtRoot, builtPkg, err := builder.ReadBuiltPackageManifest(packageRoot)
 	if err != nil {
 		return kibana.PackagePolicy{}, "", "", fmt.Errorf("reading built package manifest: %w", err)

--- a/internal/testrunner/runners/system/tester_test.go
+++ b/internal/testrunner/runners/system/tester_test.go
@@ -1055,3 +1055,129 @@ func TestDataStreamTypeFromPolicy(t *testing.T) {
 		})
 	}
 }
+
+// TestCreatePackagePolicyFallbackStreams verifies that CreatePackagePolicy
+// populates streams from the packageRoot (e.g. an EPR-extracted package) when
+// the built tree contains a different version. Before the fix, the built tree
+// would resolve to a non-existent directory, ReadAllDataStreamManifests would
+// silently return nil, and the resulting policy would have empty Streams —
+// causing Fleet to reject the request because required vars had no defaults.
+func TestCreatePackagePolicyFallbackStreams(t *testing.T) {
+	const pkgName = "testpkg"
+	const eprVersion = "1.0.0"
+	const devVersion = "2.0.0"
+	const dsName = "audit"
+	const policyTemplateName = "default"
+	const inputType = "cel"
+
+	root := t.TempDir()
+	t.Chdir(root)
+
+	// Simulate an EPR-extracted package at a path outside the built tree.
+	eprRoot := filepath.Join(root, "epr", pkgName, eprVersion)
+	writeManifest(t, eprRoot, "manifest.yml", fmt.Sprintf(`
+format_version: "3.0.0"
+name: %s
+title: Test Package
+version: %s
+type: integration
+policy_templates:
+  - name: %s
+    title: Default
+    inputs:
+      - type: %s
+        title: Collect audit logs
+`, pkgName, eprVersion, policyTemplateName, inputType))
+
+	dsDir := filepath.Join(eprRoot, "data_stream", dsName)
+	writeManifest(t, dsDir, "manifest.yml", fmt.Sprintf(`
+title: Audit logs
+type: logs
+streams:
+  - input: %s
+    title: Audit log stream
+    vars:
+      - name: tenant_id
+        type: text
+        title: Tenant ID
+        required: true
+      - name: client_id
+        type: text
+        title: Client ID
+        required: true
+`, inputType))
+
+	// Built tree has the dev version only — no eprVersion directory exists.
+	builtDev := filepath.Join(root, "build", "packages", pkgName, devVersion)
+	writeManifest(t, builtDev, "manifest.yml", fmt.Sprintf(`
+format_version: "3.0.0"
+name: %s
+title: Test Package
+version: %s
+type: integration
+policy_templates:
+  - name: %s
+    title: Default
+    inputs:
+      - type: %s
+        title: Collect audit logs
+`, pkgName, devVersion, policyTemplateName, inputType))
+
+	devDSDir := filepath.Join(builtDev, "data_stream", dsName)
+	writeManifest(t, devDSDir, "manifest.yml", fmt.Sprintf(`
+title: Audit logs
+type: logs
+streams:
+  - input: %s
+    title: Audit log stream
+    vars:
+      - name: tenant_id
+        type: text
+        title: Tenant ID
+        required: true
+      - name: client_id
+        type: text
+        title: Client ID
+        required: true
+`, inputType))
+
+	testPolicy := &kibana.Policy{ID: "test-policy-id", Namespace: "test"}
+	dsVars := common.MapStr{
+		"tenant_id": "my-tenant",
+		"client_id": "my-client",
+	}
+
+	policy, dsType, dsDataset, err := CreatePackagePolicy(
+		testPolicy, policyTemplateName, dsName,
+		inputType, common.MapStr{}, dsVars,
+		testPolicy.Namespace, eprRoot,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "logs", dsType)
+	assert.Equal(t, fmt.Sprintf("%s.%s", pkgName, dsName), dsDataset)
+
+	// The enabled input must have a non-empty Streams map — this is the
+	// exact symptom the bug produced: empty Streams causing Fleet to reject
+	// the policy because required vars (tenant_id, client_id) were missing.
+	inputKey := fmt.Sprintf("%s-%s", policyTemplateName, inputType)
+	require.Contains(t, policy.Inputs, inputKey, "policy must contain the target input")
+	input := policy.Inputs[inputKey]
+	assert.True(t, input.Enabled)
+	require.NotEmpty(t, input.Streams, "enabled input must have non-empty Streams (bug: Fleet rejects empty streams when required vars have no defaults)")
+
+	streamKey := fmt.Sprintf("%s.%s", pkgName, dsName)
+	require.Contains(t, input.Streams, streamKey, "streams must contain the data stream key")
+	stream := input.Streams[streamKey]
+	assert.True(t, stream.Enabled)
+
+	// Verify user-provided vars are present in the stream.
+	require.NotNil(t, stream.Vars, "stream vars must not be nil")
+	assert.Contains(t, stream.Vars, "tenant_id")
+	assert.Contains(t, stream.Vars, "client_id")
+}
+
+func writeManifest(t *testing.T, dir, filename, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, filename), []byte(content), 0o644))
+}

--- a/internal/testrunner/runners/system/tester_test.go
+++ b/internal/testrunner/runners/system/tester_test.go
@@ -1075,7 +1075,7 @@ func TestCreatePackagePolicyFallbackStreams(t *testing.T) {
 
 	// Simulate an EPR-extracted package at a path outside the built tree.
 	eprRoot := filepath.Join(root, "epr", pkgName, eprVersion)
-	writeManifest(t, eprRoot, "manifest.yml", fmt.Sprintf(`
+	writeManifest(t, eprRoot, fmt.Sprintf(`
 format_version: "3.0.0"
 name: %s
 title: Test Package
@@ -1090,7 +1090,7 @@ policy_templates:
 `, pkgName, eprVersion, policyTemplateName, inputType))
 
 	dsDir := filepath.Join(eprRoot, "data_stream", dsName)
-	writeManifest(t, dsDir, "manifest.yml", fmt.Sprintf(`
+	writeManifest(t, dsDir, fmt.Sprintf(`
 title: Audit logs
 type: logs
 streams:
@@ -1109,7 +1109,7 @@ streams:
 
 	// Built tree has the dev version only — no eprVersion directory exists.
 	builtDev := filepath.Join(root, "build", "packages", pkgName, devVersion)
-	writeManifest(t, builtDev, "manifest.yml", fmt.Sprintf(`
+	writeManifest(t, builtDev, fmt.Sprintf(`
 format_version: "3.0.0"
 name: %s
 title: Test Package
@@ -1124,7 +1124,7 @@ policy_templates:
 `, pkgName, devVersion, policyTemplateName, inputType))
 
 	devDSDir := filepath.Join(builtDev, "data_stream", dsName)
-	writeManifest(t, devDSDir, "manifest.yml", fmt.Sprintf(`
+	writeManifest(t, devDSDir, fmt.Sprintf(`
 title: Audit logs
 type: logs
 streams:
@@ -1176,8 +1176,8 @@ streams:
 	assert.Contains(t, stream.Vars, "client_id")
 }
 
-func writeManifest(t *testing.T, dir, filename, content string) {
+func writeManifest(t *testing.T, dir, content string) {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(dir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, filename), []byte(content), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.yml"), []byte(content), 0o644))
 }


### PR DESCRIPTION
```
testrunner/runners/system: fall back to packageRoot in CreatePackagePolicy when built tree is unavailable

CreatePackagePolicy called ReadBuiltPackageManifest unconditionally,
which assumed the built package directory always exists and is reachable
from a Git repository. This fails when packageRoot is an EPR-extracted
package (add_package_policy -version) because the built tree contains a
different version, or when running outside a Git repository where no
build/ ancestor exists.

ReadAllDataStreamManifests silently returned nil for the non-existent
built path, producing an empty Streams map that Fleet rejected because
required variables had no defaults.

The fix is in CreatePackagePolicy: when ReadBuiltPackageManifest fails,
fall back to reading manifests directly from packageRoot. This keeps
ReadBuiltPackageManifest strict — callers that genuinely need the built
tree (composable integrations) still get a hard error if the build is
missing. An EPR package is already fully resolved (no package:
references), so the source manifest is accurate enough.

The fallback is logged at debug level so it appears in verbose output
without masking real build failures.

Fixes #3552

Assisted-by Cursor (claude-opus-4.6)
```