### PR TITLE
Allow constant_keyword to keyword field overrides

### DIFF
--- a/internal/fields/dependency_manager.go
+++ b/internal/fields/dependency_manager.go
@@ -309,6 +309,7 @@ func allowedTypeOverride(fromType, toType string) bool {
 	}{
 		// Support the case of setting the value already in the mappings.
 		{"keyword", "constant_keyword"},
+		{"constant_keyword", "keyword"},
 
 		// Support objects in ECS where the developer must decide if using
 		// a group or nested object.

--- a/internal/fields/dependency_manager_test.go
+++ b/internal/fields/dependency_manager_test.go
@@ -83,6 +83,25 @@ func TestDependencyManagerInjectExternalFields(t *testing.T) {
 			valid:   true,
 		},
 		{
+			title: "constant_keyword to keyword override",
+			defs: []common.MapStr{
+				{
+					"name":     "data_stream.namespace",
+					"type":     "keyword",
+					"external": "test",
+				},
+			},
+			result: []common.MapStr{
+				{
+					"name":        "data_stream.namespace",
+					"type":        "keyword",
+					"description": "Data stream namespace.",
+				},
+			},
+			changed: true,
+			valid:   true,
+		},
+		{
 			title: "external dimension",
 			defs: []common.MapStr{
 				{
@@ -519,6 +538,11 @@ func TestDependencyManagerInjectExternalFields(t *testing.T) {
 		{
 			Name:        "data_stream.dataset",
 			Description: "Data stream dataset.",
+			Type:        "constant_keyword",
+		},
+		{
+			Name:        "data_stream.namespace",
+			Description: "Data stream namespace.",
 			Type:        "constant_keyword",
 		},
 		{


### PR DESCRIPTION
## Summary
- allow external field imports to override `constant_keyword` fields to `keyword`
- keep the override allowlist narrow instead of allowing arbitrary type changes
- add regression coverage for `data_stream.namespace`

Fixes #3583

## Validation
- go test ./internal/fields
- git diff --check