### PR TITLE
Wire --defer-cleanup and --metrics-collection-interval flags to rally benchmark runner

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -267,6 +267,16 @@ func rallyCommandAction(cmd *cobra.Command, args []string) error {
 		return cobraext.FlagParsingError(err, cobraext.BenchNameFlagName)
 	}
 
+	deferCleanup, err := cmd.Flags().GetDuration(cobraext.DeferCleanupFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.DeferCleanupFlagName)
+	}
+
+	metricsInterval, err := cmd.Flags().GetDuration(cobraext.BenchMetricsIntervalFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.BenchMetricsIntervalFlagName)
+	}
+
 	dataReindex, err := cmd.Flags().GetBool(cobraext.BenchReindexToMetricstoreFlagName)
 	if err != nil {
 		return cobraext.FlagParsingError(err, cobraext.BenchReindexToMetricstoreFlagName)
@@ -348,6 +358,8 @@ func rallyCommandAction(cmd *cobra.Command, args []string) error {
 	withOpts := []rally.OptionFunc{
 		rally.WithVariant(variant),
 		rally.WithBenchmarkName(benchName),
+		rally.WithDeferCleanup(deferCleanup),
+		rally.WithMetricsInterval(metricsInterval),
 		rally.WithDataReindexing(dataReindex),
 		rally.WithPackageRoot(packageRoot),
 		rally.WithESAPI(esClient.API),

--- a/internal/benchrunner/runners/rally/options.go
+++ b/internal/benchrunner/runners/rally/options.go
@@ -86,6 +86,18 @@ func WithESMetricsAPI(api *elasticsearch.API) OptionFunc {
 	}
 }
 
+func WithDeferCleanup(d time.Duration) OptionFunc {
+	return func(opts *Options) {
+		opts.DeferCleanup = d
+	}
+}
+
+func WithMetricsInterval(d time.Duration) OptionFunc {
+	return func(opts *Options) {
+		opts.MetricsInterval = d
+	}
+}
+
 func WithVariant(name string) OptionFunc {
 	return func(opts *Options) {
 		opts.Variant = name

--- a/internal/benchrunner/runners/rally/options_test.go
+++ b/internal/benchrunner/runners/rally/options_test.go
@@ -1,0 +1,65 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package rally
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("defaults_are_zero", func(t *testing.T) {
+		t.Parallel()
+		opts := NewOptions()
+		assert.Zero(t, opts.DeferCleanup)
+		assert.Zero(t, opts.MetricsInterval)
+		assert.Empty(t, opts.BenchName)
+		assert.Empty(t, opts.Variant)
+		assert.False(t, opts.ReindexData)
+	})
+
+	t.Run("with_defer_cleanup", func(t *testing.T) {
+		t.Parallel()
+		opts := NewOptions(WithDeferCleanup(30 * time.Minute))
+		assert.Equal(t, 30*time.Minute, opts.DeferCleanup)
+	})
+
+	t.Run("with_metrics_interval", func(t *testing.T) {
+		t.Parallel()
+		opts := NewOptions(WithMetricsInterval(5 * time.Second))
+		assert.Equal(t, 5*time.Second, opts.MetricsInterval)
+	})
+
+	t.Run("combined_options", func(t *testing.T) {
+		t.Parallel()
+		opts := NewOptions(
+			WithBenchmarkName("my-bench"),
+			WithVariant("default"),
+			WithDeferCleanup(10*time.Minute),
+			WithMetricsInterval(2*time.Second),
+			WithDataReindexing(true),
+			WithRallyDryRun(true),
+		)
+		assert.Equal(t, "my-bench", opts.BenchName)
+		assert.Equal(t, "default", opts.Variant)
+		assert.Equal(t, 10*time.Minute, opts.DeferCleanup)
+		assert.Equal(t, 2*time.Second, opts.MetricsInterval)
+		assert.True(t, opts.ReindexData)
+		assert.True(t, opts.DryRun)
+	})
+
+	t.Run("last_option_wins", func(t *testing.T) {
+		t.Parallel()
+		opts := NewOptions(
+			WithDeferCleanup(5*time.Minute),
+			WithDeferCleanup(20*time.Minute),
+		)
+		assert.Equal(t, 20*time.Minute, opts.DeferCleanup)
+	})
+}


### PR DESCRIPTION
```
Wire --defer-cleanup and --metrics-collection-interval flags to rally benchmark runner

The two flags were registered on the rally subcommand but never
extracted in rallyCommandAction or passed to the runner options.
The rally runner already checked DeferCleanup and MetricsInterval
in TearDown and startMetricsColletion, so they silently did nothing.

Add WithDeferCleanup and WithMetricsInterval option helpers to the
rally package, read both flags in rallyCommandAction, and thread them
into the options slice — matching how benchmark system already wires
them.

Fixes #3591
```

Closes #3591