### PR TITLE
Reformat failed test output with per-test details

### DIFF
--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -983,7 +983,7 @@ func processResults(results []testrunner.TestResult, testType testrunner.TestTyp
 			continue
 		}
 		var b strings.Builder
-		b.WriteString("--- FAIL : ")
+		b.WriteString("FAIL: ")
 		if r.Package != "" {
 			b.WriteString(r.Package)
 		}
@@ -1011,7 +1011,7 @@ func processResults(results []testrunner.TestResult, testType testrunner.TestTyp
 		failures = append(failures, b.String())
 	}
 	if len(failures) > 0 {
-		return fmt.Errorf("%d test case(s) failed:\n\n%s", len(failures), strings.Join(failures, "\n\n"))
+		return fmt.Errorf("--- %d test case(s) failed:\n\n%s", len(failures), strings.Join(failures, "\n\n"))
 	}
 	return nil
 }

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -1011,7 +1011,7 @@ func processResults(results []testrunner.TestResult, testType testrunner.TestTyp
 		failures = append(failures, b.String())
 	}
 	if len(failures) > 0 {
-		return fmt.Errorf("%d test case(s) failed:\n\n--- %s", len(failures), strings.Join(failures, "\n\n"))
+		return fmt.Errorf("\n--- %d test case(s) failed:\n\n%s", len(failures), strings.Join(failures, "\n\n"))
 	}
 	return nil
 }

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -1011,7 +1011,7 @@ func processResults(results []testrunner.TestResult, testType testrunner.TestTyp
 		failures = append(failures, b.String())
 	}
 	if len(failures) > 0 {
-		return fmt.Errorf("--- %d test case(s) failed:\n\n%s", len(failures), strings.Join(failures, "\n\n"))
+		return fmt.Errorf("%d test case(s) failed:\n\n--- %s", len(failures), strings.Join(failures, "\n\n"))
 	}
 	return nil
 }

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -1011,7 +1011,7 @@ func processResults(results []testrunner.TestResult, testType testrunner.TestTyp
 		failures = append(failures, b.String())
 	}
 	if len(failures) > 0 {
-		return fmt.Errorf("\n--- %d test case(s) failed:\n\n%s", len(failures), strings.Join(failures, "\n\n"))
+		return fmt.Errorf("%d test case(s) failed:\n\n%s", len(failures), strings.Join(failures, "\n\n"))
 	}
 	return nil
 }

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -983,7 +983,7 @@ func processResults(results []testrunner.TestResult, testType testrunner.TestTyp
 			continue
 		}
 		var b strings.Builder
-		b.WriteString("--- FAIL: ")
+		b.WriteString("--- FAIL : ")
 		if r.Package != "" {
 			b.WriteString(r.Package)
 		}

--- a/scripts/test-check-false-positives.sh
+++ b/scripts/test-check-false-positives.sh
@@ -55,7 +55,7 @@ function check_expected_errors() {
   rm -f ${result_tests}
   elastic-package test -C "$package_root" -v --report-format xUnit --report-output file --test-coverage --coverage-format=generic --defer-cleanup 1s || true
 
-  echo "--- Validate expected errors: ${package_name}"
+  echo "--- Validate expected errors: ${package_root}"
   cat ${result_tests} | tr -d '\n' > ${results_no_spaces}
 
   # check number of expected errors
@@ -96,7 +96,7 @@ function check_build_output() {
   mkdir -p "$(dirname "$output_file")"
   elastic-package build -C "$package_root" 2>&1 | tee "$output_file" || true # Ignore errors here
 
-  echo "--- Validate build output: ${package_name}"
+  echo "--- Validate build output: ${package_root}"
   diff -w -u "$expected_build_output" "$output_file" || (
     echo "Error: Build output has differences with expected output"
     exit 1

--- a/scripts/test-check-false-positives.sh
+++ b/scripts/test-check-false-positives.sh
@@ -55,6 +55,7 @@ function check_expected_errors() {
   rm -f ${result_tests}
   elastic-package test -C "$package_root" -v --report-format xUnit --report-output file --test-coverage --coverage-format=generic --defer-cleanup 1s || true
 
+  echo "--- Validate expected errors: ${package_name}"
   cat ${result_tests} | tr -d '\n' > ${results_no_spaces}
 
   # check number of expected errors
@@ -95,6 +96,7 @@ function check_build_output() {
   mkdir -p "$(dirname "$output_file")"
   elastic-package build -C "$package_root" 2>&1 | tee "$output_file" || true # Ignore errors here
 
+  echo "--- Validate build output: ${package_name}"
   diff -w -u "$expected_build_output" "$output_file" || (
     echo "Error: Build output has differences with expected output"
     exit 1


### PR DESCRIPTION
## What does this PR do?

Follow-up of #3594.

When `elastic-package test` encounters failing test cases, the error message now
includes a formatted summary listing each failing test case with its package,
data stream, name, test type, and the specific failure/error messages.

Previously, the error was a single generic message:

```
Error: one or more test cases failed
```

In #3594, this output was changed to be:
```
Error: N test case(s) failed:

--- FAIL: package/datastream/testname (pipeline)
    <failure message>
    error: <error message>
```
creating collapsible sections in the Buildkite output due to the `---` string.

Now it shows:

```
Error: N test case(s) failed:

FAIL: package/datastream/testname (pipeline)
    <failure message>
    error: <error message>
```

The error output deliberately avoids using `---` as a prefix to prevent
coupling the `elastic-package` output format with Buildkite's log rendering,
where `---` is a special marker that starts a collapsible section.

Additionally, Buildkite collapsible section markers have been added explicitly
to `scripts/test-check-false-positives.sh` to separate the `elastic-package
test` output (which contains intentional, expected failures) from the validation
logic that checks counts and patterns against the expected errors file.


## Screenshots

- Before ([buildkite build](https://buildkite.com/elastic/integrations/builds/43498/list?sid=019e6365-139e-4ec8-bdd7-9abcc30b441b&tab=output))
<img width="1022" height="284" alt="collapsed failures" src="https://github.com/user-attachments/assets/584846c2-84f8-491d-88d1-94434594fe51" />

- Now ([buildkite build](https://buildkite.com/elastic/integrations/builds/43540/list?sid=019e64c5-7ea8-4127-8236-660f68c46a17&tab=output)):
    - All test failures show at the end of the test section.
    - CI scripts ensure that if this section fails, it is kept opened to make it easy to find the failures.

<img width="1941" height="1157" alt="without collapsed sections" src="https://github.com/user-attachments/assets/55196f61-a8d3-46ae-a66c-8c522442e610" />
