### PR TITLE
update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
+* @elastic/ecosystem
+
 /go.mod @elastic/ecosystem
 /.buildkite/ @elastic/ecosystem
 /.github/ @elastic/ecosystem
@@ -13,4 +15,4 @@ internal/registry/gpgkey/fetch/ @elastic/ecosystem
 internal/registry/gpgkey_test.go @elastic/ecosystem
 
 # LLM based functionality owned by integration-experience
-internal/llmagent/ @elastic/integration-experience
+internal/llmagent/ @elastic/integration-experience @elastic/ecosystem

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,4 +15,4 @@ internal/registry/gpgkey/fetch/ @elastic/ecosystem
 internal/registry/gpgkey_test.go @elastic/ecosystem
 
 # LLM based functionality owned by integration-experience
-internal/llmagent/ @elastic/integration-experience @elastic/ecosystem
+internal/llmagent/ @elastic/integration-experience


### PR DESCRIPTION
This pull request updates the `CODEOWNERS` configuration to clarify and expand ownership assignments. The most important changes are:

Ownership updates:

* Added a global assignment so that all files are now owned by the `@elastic/ecosystem` team.
* The `internal/llmagent/` directory remains owned solely by `@elastic/integration-experience`.