### PR TITLE
docs/_static/inputs: fix input name capitalisations

### DIFF
--- a/internal/docs/_static/inputs/http_endpoint.yml
+++ b/internal/docs/_static/inputs/http_endpoint.yml
@@ -198,11 +198,11 @@ vars:
 documentation: |-
   ## Setup
 
-  For more details about the Http endpoint input settings, check the [Filebeat documentation](https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-http_endpoint).
+  For more details about the HTTP Endpoint input settings, check the [Filebeat documentation](https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-http_endpoint).
 
-  ### Collecting logs from Http Endpoint
+  ### Collecting logs from HTTP Endpoint
 
-  To collect logs via Http Endpoint, select **Collect logs via Http Endpoint** and configure the following parameters:
+  To collect logs via HTTP Endpoint, select **Collect logs via HTTP Endpoint** and configure the following parameters:
 
   - Listen Address: Bind address for the HTTP listener. Use 0.0.0.0 to listen on all interfaces.
   - Listen port: Bind port for the listener.

--- a/internal/docs/_static/inputs/httpjson.yml
+++ b/internal/docs/_static/inputs/httpjson.yml
@@ -2,10 +2,10 @@ name: httpjson
 documentation: |-
   ## Setup
 
-  For more details about the Http Json input settings, check the [Filebeat documentation](https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-httpjson).
+  For more details about the HTTP JSON input settings, check the [Filebeat documentation](https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-httpjson).
 
-  ### Collecting logs from Http Json
+  ### Collecting logs from HTTP JSON
 
-  To collect logs via http json, select **Collect logs via API** and configure the following parameter:
+  To collect logs via HTTP JSON, select **Collect logs via API** and configure the following parameter:
 
   - API url: The API URL without the path.

--- a/test/packages/parallel/apache/docs/README.md
+++ b/test/packages/parallel/apache/docs/README.md
@@ -697,11 +697,11 @@ These inputs can be used with this integration:
 
 ## Setup
 
-For more details about the Http Json input settings, check the [Filebeat documentation](https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-httpjson).
+For more details about the HTTP JSON input settings, check the [Filebeat documentation](https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-httpjson).
 
-### Collecting logs from Http Json
+### Collecting logs from HTTP JSON
 
-To collect logs via http json, select **Collect logs via API** and configure the following parameter:
+To collect logs via HTTP JSON, select **Collect logs via API** and configure the following parameter:
 
 - API url: The API URL without the path.
 </details>


### PR DESCRIPTION
See title.