### PR TITLE
fix(requiredinputs): rewrite {{data_stream.dataset}} to _meta path in bundled templates

### DIFF
--- a/internal/requiredinputs/copy.go
+++ b/internal/requiredinputs/copy.go
@@ -5,6 +5,7 @@
 package requiredinputs
 
 import (
+	"bytes"
 	"fmt"
 	"io/fs"
 	"os"
@@ -53,6 +54,7 @@ func collectAndCopyPolicyTemplateFiles(inputPkgPath, pkgName, destDir string, bu
 			if err != nil {
 				return nil, fmt.Errorf("failed to read template %q from agent/input (declared in manifest): %w", name, err)
 			}
+			content = rewriteDataStreamDatasetVar(content)
 			destName := pkgName + "-" + name
 			if err := buildRoot.MkdirAll(destDir, 0755); err != nil {
 				return nil, fmt.Errorf("failed to create directory %q: %w", destDir, err)
@@ -66,4 +68,21 @@ func collectAndCopyPolicyTemplateFiles(inputPkgPath, pkgName, destDir string, bu
 		}
 	}
 	return copiedNames, nil
+}
+
+// rewriteDataStreamDatasetVar replaces {{data_stream.dataset}} with
+// {{_meta.stream.data_stream.dataset}} in Handlebars template content.
+//
+// For standalone input packages Fleet auto-injects data_stream.dataset as a
+// stream var. For composable (integration-type) packages Fleet does not inject
+// it, so {{data_stream.dataset}} would render as empty. Fleet always injects
+// _meta.stream.data_stream.dataset from package metadata for all package types,
+// and that value is correct for composable packages. Rewriting to the _meta path
+// eliminates the need for a user-visible stream var entirely.
+func rewriteDataStreamDatasetVar(content []byte) []byte {
+	return bytes.ReplaceAll(
+		content,
+		[]byte("{{data_stream.dataset}}"),
+		[]byte("{{_meta.stream.data_stream.dataset}}"),
+	)
 }

--- a/internal/requiredinputs/copy_test.go
+++ b/internal/requiredinputs/copy_test.go
@@ -167,8 +167,8 @@ func TestCollectAndCopyPolicyTemplateFiles_CustomDestDir(t *testing.T) {
 	assert.Error(t, err, "file must not be written to agent/input when a custom destDir is given")
 }
 
-// TestCollectAndCopyPolicyTemplateFiles_FileContentPreserved verifies that the byte content
-// of the template is copied verbatim without modification.
+// TestCollectAndCopyPolicyTemplateFiles_FileContentPreserved verifies that template content
+// without {{data_stream.dataset}} is copied without modification.
 func TestCollectAndCopyPolicyTemplateFiles_FileContentPreserved(t *testing.T) {
 	inputPkgDir := t.TempDir()
 	originalContent := []byte("{{#each processors}}\n- {{this}}\n{{/each}}")
@@ -194,4 +194,73 @@ policy_templates:
 	copied, err := buildRoot.ReadFile(filepath.Join("agent", "input", "sql-input.yml.hbs"))
 	require.NoError(t, err)
 	assert.Equal(t, originalContent, copied)
+}
+
+// TestRewriteDataStreamDatasetVar verifies that rewriteDataStreamDatasetVar
+// replaces every {{data_stream.dataset}} with {{_meta.stream.data_stream.dataset}}
+// and leaves all other content untouched.
+func TestRewriteDataStreamDatasetVar(t *testing.T) {
+	t.Run("no occurrence — content unchanged", func(t *testing.T) {
+		in := []byte("type: logfile\npaths: [/var/log/*.log]")
+		out := rewriteDataStreamDatasetVar(in)
+		assert.Equal(t, in, out)
+	})
+
+	t.Run("single occurrence — rewritten", func(t *testing.T) {
+		in := []byte("dataset: {{data_stream.dataset}}")
+		out := rewriteDataStreamDatasetVar(in)
+		assert.Equal(t, []byte("dataset: {{_meta.stream.data_stream.dataset}}"), out)
+	})
+
+	t.Run("multiple occurrences — all rewritten", func(t *testing.T) {
+		in := []byte("a: {{data_stream.dataset}}\nb: {{data_stream.dataset}}")
+		out := rewriteDataStreamDatasetVar(in)
+		assert.Equal(t, []byte("a: {{_meta.stream.data_stream.dataset}}\nb: {{_meta.stream.data_stream.dataset}}"), out)
+	})
+
+	t.Run("surrounding content preserved", func(t *testing.T) {
+		in := []byte("prefix {{data_stream.dataset}} suffix\nother: value")
+		out := rewriteDataStreamDatasetVar(in)
+		assert.Equal(t, []byte("prefix {{_meta.stream.data_stream.dataset}} suffix\nother: value"), out)
+	})
+
+	t.Run("partial match not replaced", func(t *testing.T) {
+		// data_stream.type and data_stream.namespace must not be affected.
+		in := []byte("type: {{data_stream.type}}\nns: {{data_stream.namespace}}")
+		out := rewriteDataStreamDatasetVar(in)
+		assert.Equal(t, in, out)
+	})
+}
+
+// TestCollectAndCopyPolicyTemplateFiles_DatasetVarRewritten verifies that when an
+// input package template contains {{data_stream.dataset}}, the bundled copy has
+// it rewritten to {{_meta.stream.data_stream.dataset}}.
+func TestCollectAndCopyPolicyTemplateFiles_DatasetVarRewritten(t *testing.T) {
+	inputPkgDir := t.TempDir()
+	originalContent := []byte("dataset: {{data_stream.dataset}}\ntype: {{data_stream.type}}")
+	manifest := []byte(`name: mypkg
+version: 0.1.0
+type: input
+policy_templates:
+  - input: logfile
+    template_path: input.yml.hbs
+`)
+	err := os.WriteFile(filepath.Join(inputPkgDir, "manifest.yml"), manifest, 0644)
+	require.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(inputPkgDir, "agent", "input"), 0755)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(inputPkgDir, "agent", "input", "input.yml.hbs"), originalContent, 0644)
+	require.NoError(t, err)
+
+	buildRoot := buildRootFor(t)
+
+	_, err = collectAndCopyPolicyTemplateFiles(inputPkgDir, "mypkg", "agent/input", buildRoot)
+	require.NoError(t, err)
+
+	copied, err := buildRoot.ReadFile(filepath.Join("agent", "input", "mypkg-input.yml.hbs"))
+	require.NoError(t, err)
+
+	// {{data_stream.dataset}} must be rewritten; other patterns untouched.
+	expected := []byte("dataset: {{_meta.stream.data_stream.dataset}}\ntype: {{data_stream.type}}")
+	assert.Equal(t, expected, copied)
 }

--- a/internal/requiredinputs/variables_test.go
+++ b/internal/requiredinputs/variables_test.go
@@ -760,4 +760,3 @@ func TestMergeVariables_TwoPolicyTemplatesScopedPromotion(t *testing.T) {
 	assert.Equal(t, "encoding", betaStreamVars[1].Name)
 	assert.Equal(t, "timeout", betaStreamVars[2].Name)
 }
-

--- a/internal/requiredinputs/variables_test.go
+++ b/internal/requiredinputs/variables_test.go
@@ -760,3 +760,4 @@ func TestMergeVariables_TwoPolicyTemplatesScopedPromotion(t *testing.T) {
 	assert.Equal(t, "encoding", betaStreamVars[1].Name)
 	assert.Equal(t, "timeout", betaStreamVars[2].Name)
 }
+


### PR DESCRIPTION
## What changed

- When bundling an input package template into a composable integration, rewrite `{{data_stream.dataset}}` → `{{_meta.stream.data_stream.dataset}}` in the copied template content.

## Context

For standalone `type: input` packages, Fleet auto-injects `data_stream.dataset` as a stream var, so `{{data_stream.dataset}}` resolves correctly in `.hbs` templates. For `type: integration` (composable) packages Fleet does **not** inject that var — `{{data_stream.dataset}}` renders empty, which silently breaks routing to the correct index template.

Fleet always injects `_meta.stream.data_stream.dataset` from package metadata for all package types, and that value is correct for composable packages. Rewriting the variable reference at bundle time eliminates the need for composable package authors to add a user-visible `data_stream.dataset` stream var override as a workaround.

## Tests

```
go test ./internal/requiredinputs/...
make format
```

## Reviewer notes

The rewrite is a byte-level `strings.ReplaceAll` on the copied template before it is written to the build root. It only touches `{{data_stream.dataset}}`; `{{data_stream.type}}` and `{{data_stream.namespace}}` are unaffected (covered by the partial-match test case).


Found while working on https://github.com/elastic/integrations/pull/19719 - tested manually with this package