### PR TITLE
Add LogsDB Columnar support for system tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,8 +840,9 @@ The following settings are available per profile:
   with `index.mode: logsdb_columnar` and forces `doc_values: true` on fields that would
   otherwise fail under columnar mode (including ECS `event.original` and package fields
   declared with `doc_values: false`). It also strips explicit `subobjects` mapping
-  parameters from `@package` templates, which columnar mode rejects (the mode already
-  disables subobjects). These overrides are a test-only workaround: `logsdb_columnar`
+  parameters from all logs `@package` templates in the package (including sibling
+  streams not under test), which columnar mode rejects (the mode already disables
+  subobjects). These overrides are a test-only workaround: `logsdb_columnar`
   reconstructs `_source` from doc values, and ECS / package mappings still need a
   product solution for this mode.
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the

--- a/README.md
+++ b/README.md
@@ -842,11 +842,13 @@ The following settings are available per profile:
   and package fields declared with `doc_values: false`). It also strips explicit
   `subobjects` mapping parameters from all logs `@package` templates in the package
   (including sibling streams not under test), which columnar mode rejects (the mode
-  already disables subobjects). Global `logs@custom` is never modified, so other
-  installed packages (for example `elastic_agent`) are unaffected. Metrics-only
-  packages skip this path. These overrides are a test-only workaround:
-  `logsdb_columnar` reconstructs `_source` from doc values, and ECS / package
-  mappings still need a product solution for this mode.
+  already disables subobjects). For input packages, datasets are taken from policy
+  template defaults and system test `data_stream.dataset` overrides. Global
+  `logs@custom` is never modified, so other installed packages (for example
+  `elastic_agent`) are unaffected. Metrics-only packages skip this path. These
+  overrides are a test-only workaround: `logsdb_columnar` reconstructs `_source`
+  from doc values, and ECS / package mappings still need a product solution for
+  this mode.
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.

--- a/README.md
+++ b/README.md
@@ -835,12 +835,13 @@ The following settings are available per profile:
   enables logs index mode in all data streams that support it. Defaults to false.
 * `stack.logsdb_columnar_enabled` can be set to true to activate LogsDB Columnar support in
   Elasticsearch for logs data streams. Defaults to false.
-  When system tests run with `--logsdb-columnar`, elastic-package configures dataset
-  `@custom` component templates after package install with `index.mode: logsdb_columnar`
-  and forces `doc_values: true` on fields that would otherwise fail under columnar mode
-  (including ECS `event.original` and package fields declared with `doc_values: false`).
-  That override is a test-only workaround: `logsdb_columnar` reconstructs `_source`
-  from doc values, and ECS still needs a product solution for this mode.
+  When this profile setting is true, or when system tests run with `--logsdb-columnar`,
+  elastic-package configures dataset `@custom` component templates after package install
+  with `index.mode: logsdb_columnar` and forces `doc_values: true` on fields that would
+  otherwise fail under columnar mode (including ECS `event.original` and package fields
+  declared with `doc_values: false`). That override is a test-only workaround:
+  `logsdb_columnar` reconstructs `_source` from doc values, and ECS still needs a product
+  solution for this mode.
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.

--- a/README.md
+++ b/README.md
@@ -833,6 +833,8 @@ The following settings are available per profile:
   kibana that support it. Defaults to true.
 * `stack.logsdb_enabled` can be set to true to activate the feature flag in Elasticsearch that
   enables logs index mode in all data streams that support it. Defaults to false.
+* `stack.logsdb_columnar_enabled` can be set to true to activate LogsDB Columnar support in
+  Elasticsearch for logs data streams. Defaults to false.
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.

--- a/README.md
+++ b/README.md
@@ -836,15 +836,17 @@ The following settings are available per profile:
 * `stack.logsdb_columnar_enabled` can be set to true to activate LogsDB Columnar support in
   Elasticsearch for logs data streams. Defaults to false.
   When this profile setting is true, or when system tests run with `--logsdb-columnar`,
-  elastic-package configures dataset `@custom` component templates after package install
-  with `index.mode: logsdb_columnar` and forces `doc_values: true` on fields that would
-  otherwise fail under columnar mode (including ECS `event.original` and package fields
-  declared with `doc_values: false`). It also strips explicit `subobjects` mapping
-  parameters from all logs `@package` templates in the package (including sibling
-  streams not under test), which columnar mode rejects (the mode already disables
-  subobjects). These overrides are a test-only workaround: `logsdb_columnar`
-  reconstructs `_source` from doc values, and ECS / package mappings still need a
-  product solution for this mode.
+  elastic-package configures each selected logs dataset `@custom` component template
+  after package install with `index.mode: logsdb_columnar` and forces `doc_values: true`
+  on fields that would otherwise fail under columnar mode (including ECS `event.original`
+  and package fields declared with `doc_values: false`). It also strips explicit
+  `subobjects` mapping parameters from all logs `@package` templates in the package
+  (including sibling streams not under test), which columnar mode rejects (the mode
+  already disables subobjects). Global `logs@custom` is never modified, so other
+  installed packages (for example `elastic_agent`) are unaffected. Metrics-only
+  packages skip this path. These overrides are a test-only workaround:
+  `logsdb_columnar` reconstructs `_source` from doc values, and ECS / package
+  mappings still need a product solution for this mode.
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.

--- a/README.md
+++ b/README.md
@@ -839,9 +839,11 @@ The following settings are available per profile:
   elastic-package configures dataset `@custom` component templates after package install
   with `index.mode: logsdb_columnar` and forces `doc_values: true` on fields that would
   otherwise fail under columnar mode (including ECS `event.original` and package fields
-  declared with `doc_values: false`). That override is a test-only workaround:
-  `logsdb_columnar` reconstructs `_source` from doc values, and ECS still needs a product
-  solution for this mode.
+  declared with `doc_values: false`). It also strips explicit `subobjects` mapping
+  parameters from `@package` templates, which columnar mode rejects (the mode already
+  disables subobjects). These overrides are a test-only workaround: `logsdb_columnar`
+  reconstructs `_source` from doc values, and ECS / package mappings still need a
+  product solution for this mode.
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.

--- a/README.md
+++ b/README.md
@@ -835,6 +835,12 @@ The following settings are available per profile:
   enables logs index mode in all data streams that support it. Defaults to false.
 * `stack.logsdb_columnar_enabled` can be set to true to activate LogsDB Columnar support in
   Elasticsearch for logs data streams. Defaults to false.
+  When system tests run with `--logsdb-columnar`, elastic-package configures dataset
+  `@custom` component templates after package install with `index.mode: logsdb_columnar`
+  and forces `doc_values: true` on fields that would otherwise fail under columnar mode
+  (including ECS `event.original` and package fields declared with `doc_values: false`).
+  That override is a test-only workaround: `logsdb_columnar` reconstructs `_source`
+  from doc values, and ECS still needs a product solution for this mode.
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -483,6 +483,7 @@ func getTestRunnerSystemCommand() *cobra.Command {
 	cmd.Flags().Bool(cobraext.TearDownFlagName, false, cobraext.TearDownFlagDescription)
 	cmd.Flags().Bool(cobraext.NoProvisionFlagName, false, cobraext.NoProvisionFlagDescription)
 	cmd.Flags().String(cobraext.AgentVersionFlagName, "", cobraext.AgentVersionFlagDescription)
+	cmd.Flags().Bool(cobraext.LogsDBColumnarFlagName, false, cobraext.LogsDBColumnarFlagDescription)
 
 	cmd.MarkFlagsMutuallyExclusive(cobraext.SetupFlagName, cobraext.TearDownFlagName, cobraext.NoProvisionFlagName)
 	cmd.MarkFlagsRequiredTogether(cobraext.ConfigFileFlagName, cobraext.SetupFlagName)
@@ -610,6 +611,11 @@ func testRunnerSystemCommandAction(cmd *cobra.Command, args []string) error {
 		return cobraext.FlagParsingError(err, cobraext.AgentVersionFlagName)
 	}
 
+	logsDBColumnar, err := cmd.Flags().GetBool(cobraext.LogsDBColumnarFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.LogsDBColumnarFlagName)
+	}
+
 	esClient, err := stack.NewElasticsearchClientFromProfile(profile)
 	if err != nil {
 		return fmt.Errorf("can't create Elasticsearch client: %w", err)
@@ -683,6 +689,7 @@ func testRunnerSystemCommandAction(cmd *cobra.Command, args []string) error {
 		RepositoryRoot:         repositoryRoot,
 		OverrideAgentVersion:   agentVersion,
 		RequiredInputsResolver: requiredInputsResolver,
+		LogsDBColumnar:         logsDBColumnar,
 	})
 
 	logger.Debugf("Running suite...")

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -91,6 +91,8 @@ func setupTestCommand() *cobraext.Command {
 	// Just used in pipeline and system tests
 	// Keep it here for backwards compatibility
 	cmd.PersistentFlags().DurationP(cobraext.DeferCleanupFlagName, "", 0, cobraext.DeferCleanupFlagDescription)
+	// System tests only; persistent so `elastic-package test --logsdb-columnar` works in CI.
+	cmd.PersistentFlags().Bool(cobraext.LogsDBColumnarFlagName, false, cobraext.LogsDBColumnarFlagDescription)
 
 	assetCmd := getTestRunnerAssetCommand()
 	cmd.AddCommand(assetCmd)
@@ -483,7 +485,6 @@ func getTestRunnerSystemCommand() *cobra.Command {
 	cmd.Flags().Bool(cobraext.TearDownFlagName, false, cobraext.TearDownFlagDescription)
 	cmd.Flags().Bool(cobraext.NoProvisionFlagName, false, cobraext.NoProvisionFlagDescription)
 	cmd.Flags().String(cobraext.AgentVersionFlagName, "", cobraext.AgentVersionFlagDescription)
-	cmd.Flags().Bool(cobraext.LogsDBColumnarFlagName, false, cobraext.LogsDBColumnarFlagDescription)
 
 	cmd.MarkFlagsMutuallyExclusive(cobraext.SetupFlagName, cobraext.TearDownFlagName, cobraext.NoProvisionFlagName)
 	cmd.MarkFlagsRequiredTogether(cobraext.ConfigFileFlagName, cobraext.SetupFlagName)
@@ -614,6 +615,12 @@ func testRunnerSystemCommandAction(cmd *cobra.Command, args []string) error {
 	logsDBColumnar, err := cmd.Flags().GetBool(cobraext.LogsDBColumnarFlagName)
 	if err != nil {
 		return cobraext.FlagParsingError(err, cobraext.LogsDBColumnarFlagName)
+	}
+	// CI enables columnar via stack profile (-U stack.logsdb_columnar_enabled=true) without
+	// always passing --logsdb-columnar. Follow the profile so doc_values overrides still apply.
+	if !logsDBColumnar && profile.Config("stack.logsdb_columnar_enabled", "false") == "true" {
+		logger.Info("Enabling LogsDB Columnar system-test overrides (stack.logsdb_columnar_enabled=true)")
+		logsDBColumnar = true
 	}
 
 	esClient, err := stack.NewElasticsearchClientFromProfile(profile)

--- a/internal/agentdeployer/agent.go
+++ b/internal/agentdeployer/agent.go
@@ -450,6 +450,23 @@ func (s *dockerComposeDeployedAgent) Logs(ctx context.Context, t time.Time) ([]b
 	return p.Logs(ctx, opts)
 }
 
+const agentInternalLogsPath = "/usr/share/elastic-agent/state/data/logs/"
+
+// CopyInternalLogs copies Elastic Agent internal NDJSON logs into destDir.
+// destDir should not already exist; docker cp creates it.
+func (s *dockerComposeDeployedAgent) CopyInternalLogs(destDir string) error {
+	p, err := compose.NewProject(s.project, s.ymlPaths...)
+	if err != nil {
+		return fmt.Errorf("could not create Docker Compose project for agent: %w", err)
+	}
+
+	containerName := p.ContainerName(s.agentInfo.Name)
+	if err := docker.Copy(containerName, agentInternalLogsPath, destDir); err != nil {
+		return fmt.Errorf("copy agent internal logs from %s: %w", containerName, err)
+	}
+	return nil
+}
+
 // TearDown tears down the agent.
 func (s *dockerComposeDeployedAgent) TearDown(ctx context.Context) error {
 	logger.Debugf("tearing down agent using Docker Compose runner")

--- a/internal/agentdeployer/deployed_agent.go
+++ b/internal/agentdeployer/deployed_agent.go
@@ -28,4 +28,9 @@ type DeployedAgent interface {
 
 	// Logs returns the logs from the agent starting at the given time
 	Logs(ctx context.Context, t time.Time) ([]byte, error)
+
+	// CopyInternalLogs copies Elastic Agent internal NDJSON logs from
+	// /usr/share/elastic-agent/state/data/logs/ into destDir.
+	// Returns ErrNotSupported when the agent runtime cannot expose those logs.
+	CopyInternalLogs(destDir string) error
 }

--- a/internal/agentdeployer/kubernetes.go
+++ b/internal/agentdeployer/kubernetes.go
@@ -88,6 +88,11 @@ func (s *kubernetesDeployedAgent) Logs(ctx context.Context, t time.Time) ([]byte
 	return nil, nil
 }
 
+// CopyInternalLogs is not supported for Kubernetes agents.
+func (s *kubernetesDeployedAgent) CopyInternalLogs(destDir string) error {
+	return ErrNotSupported
+}
+
 var _ DeployedAgent = new(kubernetesDeployedAgent)
 
 // NewKubernetesAgentDeployer function creates a new instance of KubernetesAgentDeployer.

--- a/internal/cobraext/flags.go
+++ b/internal/cobraext/flags.go
@@ -200,6 +200,9 @@ const (
 	GenerateTestResultFlagName        = "generate"
 	GenerateTestResultFlagDescription = "generate test result file"
 
+	LogsDBColumnarFlagName        = "logsdb-columnar"
+	LogsDBColumnarFlagDescription = "enable LogsDB Columnar mode for system tests"
+
 	PackagesFlagName        = "packages"
 	PackagesFlagDescription = "whether to return packages names or complete paths for the linked files found"
 

--- a/internal/cobraext/flags.go
+++ b/internal/cobraext/flags.go
@@ -201,7 +201,7 @@ const (
 	GenerateTestResultFlagDescription = "generate test result file"
 
 	LogsDBColumnarFlagName        = "logsdb-columnar"
-	LogsDBColumnarFlagDescription = "enable LogsDB Columnar mode for system tests"
+	LogsDBColumnarFlagDescription = "enable LogsDB Columnar mode for system tests (also forces doc_values on fields that would fail under columnar mode; test-only workaround)"
 
 	PackagesFlagName        = "packages"
 	PackagesFlagDescription = "whether to return packages names or complete paths for the linked files found"

--- a/internal/fields/mappings.go
+++ b/internal/fields/mappings.go
@@ -428,6 +428,11 @@ func validateConstantKeywordField(path string, preview, actual map[string]any) (
 func (v *MappingValidator) compareMappings(path string, couldBeParametersDefinition bool, preview, actual map[string]any, dynamicTemplates []map[string]any) multierror.Error {
 	var errs multierror.Error
 
+	if path == "" && !couldBeParametersDefinition {
+		preview = normalizeDottedMappingProperties(preview)
+		actual = normalizeDottedMappingProperties(actual)
+	}
+
 	isConstantKeywordType, err := validateConstantKeywordField(path, preview, actual)
 	if err != nil {
 		return multierror.Error{err}
@@ -605,6 +610,101 @@ func (v *MappingValidator) validateMappingsNotInPreview(currentPath string, chil
 		}
 	}
 	return errs.Unique()
+}
+
+func normalizeDottedMappingProperties(properties map[string]any) map[string]any {
+	normalized := make(map[string]any, len(properties))
+	for key, value := range properties {
+		value = normalizeMappingValue(value)
+		if strings.Contains(key, ".") {
+			insertDottedMappingProperty(normalized, strings.Split(key, "."), value)
+			continue
+		}
+		normalized[key] = mergeMappingValues(normalized[key], value)
+	}
+	return normalized
+}
+
+func normalizeMappingValue(value any) any {
+	mapping, ok := value.(map[string]any)
+	if !ok {
+		return value
+	}
+
+	normalized := make(map[string]any, len(mapping))
+	for k, v := range mapping {
+		normalized[k] = v
+	}
+	if props, ok := mapping["properties"].(map[string]any); ok {
+		normalized["properties"] = normalizeDottedMappingProperties(props)
+	}
+	return normalized
+}
+
+func insertDottedMappingProperty(properties map[string]any, path []string, value any) {
+	if len(path) == 0 {
+		return
+	}
+	if len(path) == 1 {
+		properties[path[0]] = mergeMappingValues(properties[path[0]], value)
+		return
+	}
+
+	parent, ok := properties[path[0]].(map[string]any)
+	if !ok {
+		parent = map[string]any{
+			"properties": map[string]any{},
+		}
+		properties[path[0]] = parent
+	}
+
+	childProperties, ok := parent["properties"].(map[string]any)
+	if !ok {
+		childProperties = map[string]any{}
+		parent["properties"] = childProperties
+	}
+
+	insertDottedMappingProperty(childProperties, path[1:], value)
+}
+
+func mergeMappingValues(existing, incoming any) any {
+	if existing == nil {
+		return incoming
+	}
+
+	existingMapping, existingOK := existing.(map[string]any)
+	incomingMapping, incomingOK := incoming.(map[string]any)
+	if !existingOK || !incomingOK {
+		return incoming
+	}
+
+	merged := make(map[string]any, len(existingMapping)+len(incomingMapping))
+	for key, value := range existingMapping {
+		merged[key] = value
+	}
+	for key, value := range incomingMapping {
+		if key == "properties" {
+			existingProperties, existingHasProperties := merged[key].(map[string]any)
+			incomingProperties, incomingHasProperties := value.(map[string]any)
+			if existingHasProperties && incomingHasProperties {
+				merged[key] = mergeMappingProperties(existingProperties, incomingProperties)
+				continue
+			}
+		}
+		merged[key] = value
+	}
+	return merged
+}
+
+func mergeMappingProperties(existing, incoming map[string]any) map[string]any {
+	merged := make(map[string]any, len(existing)+len(incoming))
+	for key, value := range existing {
+		merged[key] = value
+	}
+	for key, value := range incoming {
+		merged[key] = mergeMappingValues(merged[key], value)
+	}
+	return merged
 }
 
 // matchingWithDynamicTemplates validates a given definition (currentPath) with a set of dynamic templates.

--- a/internal/fields/mappings_test.go
+++ b/internal/fields/mappings_test.go
@@ -83,6 +83,49 @@ func TestComparingMappings(t *testing.T) {
 			expectedErrors: []string{},
 		},
 		{
+			title: "same logical mappings with dotted actual fields",
+			preview: map[string]any{
+				"data_stream": map[string]any{
+					"properties": map[string]any{
+						"dataset": map[string]any{
+							"type": "constant_keyword",
+						},
+					},
+				},
+				"prisma_access": map[string]any{
+					"properties": map[string]any{
+						"event": map[string]any{
+							"properties": map[string]any{
+								"access_point_name": map[string]any{
+									"type": "keyword",
+								},
+								"agent": map[string]any{
+									"properties": map[string]any{
+										"id": map[string]any{
+											"type": "keyword",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			actual: map[string]any{
+				"data_stream.dataset": map[string]any{
+					"type": "constant_keyword",
+				},
+				"prisma_access.event.access_point_name": map[string]any{
+					"type": "keyword",
+				},
+				"prisma_access.event.agent.id": map[string]any{
+					"type": "keyword",
+				},
+			},
+			schema:         []FieldDefinition{},
+			expectedErrors: []string{},
+		},
+		{
 			title: "validate fields with ECS",
 			preview: map[string]any{
 				"foo": map[string]any{

--- a/internal/profile/_static/config.yml.example
+++ b/internal/profile/_static/config.yml.example
@@ -4,6 +4,9 @@
 #
 # Flag to enable the logs index mode in logs data stream.
 # stack.logsdb_enabled: true
+#
+# Flag to enable the logsdb_columnar index mode in logs data streams.
+# stack.logsdb_columnar_enabled: true
 
 ## Elastic Cloud
 # Host URL

--- a/internal/stack/_static/docker-compose-stack.yml.tmpl
+++ b/internal/stack/_static/docker-compose-stack.yml.tmpl
@@ -2,6 +2,7 @@
 {{- $password := fact "password" -}}
 {{- $apm_enabled := fact "apm_enabled" -}}
 {{- $version := fact "kibana_version" -}}
+{{- $logsdb_columnar_enabled := fact "logsdb_columnar_enabled" -}}
 
 {{- $fleet_healthcheck_success_checks := 3 -}}
 {{- $fleet_healthcheck_waiting_time := 1 -}}
@@ -17,7 +18,7 @@ services:
       start_period: 300s
       interval: 5s
     environment:
-      - "ES_JAVA_OPTS=-Xms1g -Xmx1g {{ if not (semverLessThan $version "8.15.0-SNAPSHOT") -}}-Des.failure_store_feature_flag_enabled=true{{- end -}}"
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g {{ if not (semverLessThan $version "8.15.0-SNAPSHOT") -}}-Des.failure_store_feature_flag_enabled=true {{- end -}}{{ if (and (eq $logsdb_columnar_enabled "true") (not (semverLessThan $version "9.5.0-SNAPSHOT"))) -}}-Des.columnar_index_mode_feature_flag_enabled=true{{- end -}}"
       - "ELASTIC_PASSWORD={{ $password }}"
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml"

--- a/internal/stack/_static/elasticsearch.yml.tmpl
+++ b/internal/stack/_static/elasticsearch.yml.tmpl
@@ -16,8 +16,12 @@ ingest.geoip.downloader.enabled: false
 
 {{- $version := fact "elasticsearch_version" -}}
 {{- $logsdb_enabled := fact "logsdb_enabled" -}}
+{{- $logsdb_columnar_enabled := fact "logsdb_columnar_enabled" -}}
 {{ if (and (eq $logsdb_enabled "true") (not (semverLessThan $version "8.15.0-SNAPSHOT"))) }}
 cluster.logsdb.enabled: true
+{{- end -}}
+{{ if (and (eq $logsdb_columnar_enabled "true") (not (semverLessThan $version "9.5.0-SNAPSHOT"))) }}
+cluster.logsdb_columnar.enabled: true
 {{- end -}}
 
 {{ if semverLessThan $version "8.0.0" }}

--- a/internal/stack/parselogs.go
+++ b/internal/stack/parselogs.go
@@ -7,26 +7,33 @@ package stack
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/elastic/elastic-package/internal/logger"
 )
 
+// ParseLogsOptions configures log parsing.
 type ParseLogsOptions struct {
 	LogsFilePath string
 	StartTime    time.Time
 }
 
+// LogLine is a parsed Elastic Agent / stack log entry.
 type LogLine struct {
-	LogLevel  string    `json:"log.level"`
-	Timestamp time.Time `json:"@timestamp"`
-	Logger    string    `json:"log.logger"`
-	Message   string    `json:"message"`
+	LogLevel    string    `json:"log.level"`
+	Timestamp   time.Time `json:"@timestamp"`
+	Logger      string    `json:"log.logger"`
+	Message     string    `json:"message"`
+	ErrorReason string    `json:"error.reason"`
+	ErrorType   string    `json:"error.type"`
 }
 
+// LogLineWithType is an alternate Elasticsearch-style log format.
 type LogLineWithType struct {
 	LogLevel  string    `json:"level"`
 	Timestamp time.Time `json:"timestamp"`
@@ -34,7 +41,19 @@ type LogLineWithType struct {
 	Message   string    `json:"message"`
 }
 
-// ParseLogs returns all the logs for a given service name
+// FormatError returns a human-readable description of the log line,
+// including error.reason and error.type when present.
+func (l LogLine) FormatError() string {
+	if l.ErrorReason == "" {
+		return l.Message
+	}
+	if l.ErrorType != "" {
+		return fmt.Sprintf("%s: %s (%s)", l.Message, l.ErrorReason, l.ErrorType)
+	}
+	return fmt.Sprintf("%s: %s", l.Message, l.ErrorReason)
+}
+
+// ParseLogs returns all the logs for a given docker-compose service log file.
 func ParseLogs(options ParseLogsOptions, process func(log LogLine) error) error {
 	file, err := os.Open(options.LogsFilePath)
 	if err != nil {
@@ -45,10 +64,14 @@ func ParseLogs(options ParseLogsOptions, process func(log LogLine) error) error 
 	return ParseLogsFromReader(file, options, process)
 }
 
+// ParseLogsFromReader parses docker-compose formatted logs ("service | {json}").
 func ParseLogsFromReader(reader io.Reader, options ParseLogsOptions, process func(log LogLine) error) error {
 	startProcessing := false
 
 	scanner := bufio.NewScanner(reader)
+	// Agent indexing-failure lines can be large; raise the default 64KiB token limit.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
 	for scanner.Scan() {
 		line := scanner.Text()
 
@@ -58,20 +81,7 @@ func ParseLogsFromReader(reader io.Reader, options ParseLogsOptions, process fun
 			continue
 		}
 
-		var log LogLine
-		err := json.Unmarshal([]byte(messageLog), &log)
-		if err != nil {
-			log.Message = strings.TrimSpace(messageLog)
-		} else if log.Timestamp.IsZero() {
-			// this means that no log was unmarshalled, let's try with another format
-			var logWithType LogLineWithType
-			if err := json.Unmarshal([]byte(messageLog), &logWithType); err == nil {
-				log.Message = logWithType.Message
-				log.LogLevel = logWithType.LogLevel
-				log.Logger = logWithType.Component
-				log.Timestamp = logWithType.Timestamp
-			}
-		}
+		log := unmarshalLogLine(strings.TrimSpace(messageLog))
 
 		// There could be valid messages with just plain text without timestamp
 		// and therefore not processed, cannot be ensured in which timestamp they
@@ -81,11 +91,88 @@ func ParseLogsFromReader(reader io.Reader, options ParseLogsOptions, process fun
 		}
 		startProcessing = true
 
-		err = process(log)
-		if err != nil {
+		if err := process(log); err != nil {
 			return err
 		}
 	}
 
-	return nil
+	return scanner.Err()
+}
+
+// ParseNDJSONLogs parses a raw Elastic Agent NDJSON log file (no docker-compose prefix).
+func ParseNDJSONLogs(options ParseLogsOptions, process func(log LogLine) error) error {
+	file, err := os.Open(options.LogsFilePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return ParseNDJSONLogsFromReader(file, options, process)
+}
+
+// ParseNDJSONLogsFromReader parses raw NDJSON agent log lines.
+func ParseNDJSONLogsFromReader(reader io.Reader, options ParseLogsOptions, process func(log LogLine) error) error {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		log := unmarshalLogLine(line)
+		if !log.Timestamp.IsZero() && log.Timestamp.UTC().Before(options.StartTime.UTC()) {
+			continue
+		}
+
+		if err := process(log); err != nil {
+			return err
+		}
+	}
+
+	return scanner.Err()
+}
+
+// ParseNDJSONLogsDir walks dir for *.ndjson / *.json files and parses each.
+func ParseNDJSONLogsDir(dir string, startTime time.Time, process func(log LogLine) error) error {
+	return filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".ndjson") && !strings.HasSuffix(name, ".json") {
+			return nil
+		}
+		if err := ParseNDJSONLogs(ParseLogsOptions{
+			LogsFilePath: path,
+			StartTime:    startTime,
+		}, process); err != nil {
+			return fmt.Errorf("parse %s: %w", path, err)
+		}
+		return nil
+	})
+}
+
+func unmarshalLogLine(raw string) LogLine {
+	var log LogLine
+	err := json.Unmarshal([]byte(raw), &log)
+	if err != nil {
+		log.Message = strings.TrimSpace(raw)
+		return log
+	}
+	if log.Timestamp.IsZero() {
+		// Try the alternate Elasticsearch server log format.
+		var logWithType LogLineWithType
+		if err := json.Unmarshal([]byte(raw), &logWithType); err == nil {
+			log.Message = logWithType.Message
+			log.LogLevel = logWithType.LogLevel
+			log.Logger = logWithType.Component
+			log.Timestamp = logWithType.Timestamp
+		}
+	}
+	return log
 }

--- a/internal/stack/parselogs_test.go
+++ b/internal/stack/parselogs_test.go
@@ -5,9 +5,13 @@
 package stack
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,6 +44,114 @@ func TestParseLogsFromReader(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedParsedLogCount, redLogLines)
+		})
+	}
+}
+
+const sampleFailedToIndexDocument = `{"log.level":"error","@timestamp":"2026-07-01T17:34:35.220Z","message":"failed to index document","http.response.status_code":400,"error.type":"illegal_argument_exception","error.reason":"field [event.original] cannot reconstruct _source from doc values; every field must be reconstructable from doc values in index using [logsdb_columnar] index mode","ecs.version":"1.6.0"}`
+
+func TestParseNDJSONLogsFromReader_IndexingFailure(t *testing.T) {
+	start, err := time.Parse(time.RFC3339Nano, "2026-07-01T17:00:00.000Z")
+	require.NoError(t, err, "parse start time")
+
+	var logs []LogLine
+	err = ParseNDJSONLogsFromReader(strings.NewReader(sampleFailedToIndexDocument+"\n"), ParseLogsOptions{
+		StartTime: start,
+	}, func(log LogLine) error {
+		logs = append(logs, log)
+		return nil
+	})
+	require.NoError(t, err, "parse NDJSON")
+	require.Len(t, logs, 1, "expected one log line")
+
+	assert.Equal(t, "failed to index document", logs[0].Message, "message")
+	assert.Equal(t, "illegal_argument_exception", logs[0].ErrorType, "error.type")
+	assert.Contains(t, logs[0].ErrorReason, "logsdb_columnar", "error.reason should mention logsdb_columnar")
+	assert.Equal(t,
+		"failed to index document: field [event.original] cannot reconstruct _source from doc values; every field must be reconstructable from doc values in index using [logsdb_columnar] index mode (illegal_argument_exception)",
+		logs[0].FormatError(),
+		"FormatError should include message, reason, and type",
+	)
+}
+
+func TestParseNDJSONLogsFromReader_FiltersByStartTime(t *testing.T) {
+	start, err := time.Parse(time.RFC3339Nano, "2026-07-01T18:00:00.000Z")
+	require.NoError(t, err, "parse start time")
+
+	var count int
+	err = ParseNDJSONLogsFromReader(strings.NewReader(sampleFailedToIndexDocument+"\n"), ParseLogsOptions{
+		StartTime: start,
+	}, func(log LogLine) error {
+		count++
+		return nil
+	})
+	require.NoError(t, err, "parse NDJSON")
+	assert.Equal(t, 0, count, "log before start time should be skipped")
+}
+
+func TestParseLogsFromReader_PreservesErrorFields(t *testing.T) {
+	line := "elastic-agent-1  | " + sampleFailedToIndexDocument + "\n"
+	start, err := time.Parse(time.RFC3339Nano, "2026-07-01T17:00:00.000Z")
+	require.NoError(t, err, "parse start time")
+
+	var logs []LogLine
+	err = ParseLogsFromReader(strings.NewReader(line), ParseLogsOptions{StartTime: start}, func(log LogLine) error {
+		logs = append(logs, log)
+		return nil
+	})
+	require.NoError(t, err, "parse docker-compose logs")
+	require.Len(t, logs, 1, "expected one log line")
+	assert.Equal(t, "failed to index document", logs[0].Message, "message")
+	assert.Contains(t, logs[0].ErrorReason, "event.original", "error.reason")
+}
+
+func TestParseNDJSONLogsDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "elastic-agent-20260701.ndjson")
+	require.NoError(t, os.WriteFile(path, []byte(sampleFailedToIndexDocument+"\n"), 0o644), "write fixture")
+
+	start, err := time.Parse(time.RFC3339Nano, "2026-07-01T17:00:00.000Z")
+	require.NoError(t, err, "parse start time")
+
+	var logs []LogLine
+	err = ParseNDJSONLogsDir(dir, start, func(log LogLine) error {
+		logs = append(logs, log)
+		return nil
+	})
+	require.NoError(t, err, "parse NDJSON dir")
+	require.Len(t, logs, 1, "expected one log from dir")
+	assert.Equal(t, "failed to index document", logs[0].Message, "message")
+}
+
+func TestLogLineFormatError(t *testing.T) {
+	tests := []struct {
+		name string
+		log  LogLine
+		want string
+	}{
+		{
+			name: "message only",
+			log:  LogLine{Message: "something failed"},
+			want: "something failed",
+		},
+		{
+			name: "message and reason",
+			log:  LogLine{Message: "failed to index document", ErrorReason: "bad mapping"},
+			want: "failed to index document: bad mapping",
+		},
+		{
+			name: "message reason and type",
+			log: LogLine{
+				Message:     "failed to index document",
+				ErrorReason: "bad mapping",
+				ErrorType:   "illegal_argument_exception",
+			},
+			want: "failed to index document: bad mapping (illegal_argument_exception)",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.log.FormatError())
 		})
 	}
 }

--- a/internal/stack/resources.go
+++ b/internal/stack/resources.go
@@ -70,6 +70,7 @@ const (
 	configGeoIPDir                               = "stack.geoip_dir"
 	configKibanaHTTP2Enabled                     = "stack.kibana_http2_enabled"
 	configLogsDBEnabled                          = "stack.logsdb_enabled"
+	configLogsDBColumnarEnabled                  = "stack.logsdb_columnar_enabled"
 	configLogstashEnabled                        = "stack.logstash_enabled"
 	configSelfMonitorEnabled                     = "stack.self_monitor_enabled"
 	configElasticEPRProxyTo                      = "stack.epr.proxy_to"
@@ -205,6 +206,7 @@ func applyResources(profile *profile.Profile, appConfig *install.ApplicationConf
 		"geoip_dir":                                   profile.Config(configGeoIPDir, "./ingest-geoip"),
 		"kibana_http2_enabled":                        profile.Config(configKibanaHTTP2Enabled, "true"),
 		"logsdb_enabled":                              profile.Config(configLogsDBEnabled, "false"),
+		"logsdb_columnar_enabled":                     profile.Config(configLogsDBColumnarEnabled, "false"),
 		"logstash_enabled":                            profile.Config(configLogstashEnabled, "false"),
 		"self_monitor_enabled":                        profile.Config(configSelfMonitorEnabled, "false"),
 		"epr_proxy_to":                                packageRegistryProxyToURL(profile, appConfig),

--- a/internal/stack/resources_test.go
+++ b/internal/stack/resources_test.go
@@ -82,6 +82,75 @@ func TestApplyResourcesWithCustomGeoipDir(t *testing.T) {
 	assert.Contains(t, volumes, expectedVolume)
 }
 
+func TestApplyResourcesWithLogsDBColumnarEnabled(t *testing.T) {
+	cases := []struct {
+		name                 string
+		stackVersion         string
+		expectClusterSetting bool
+		expectFeatureFlag    bool
+	}{
+		{
+			name:                 "columnar disabled in older stack versions",
+			stackVersion:         "9.4.0-SNAPSHOT",
+			expectClusterSetting: false,
+			expectFeatureFlag:    false,
+		},
+		{
+			name:                 "columnar enabled in supported stack versions",
+			stackVersion:         "9.5.0-SNAPSHOT",
+			expectClusterSetting: true,
+			expectFeatureFlag:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			const profileName = "logsdb_columnar"
+
+			elasticPackagePath := t.TempDir()
+			profilesPath := filepath.Join(elasticPackagePath, "profiles")
+
+			t.Setenv("ELASTIC_PACKAGE_DATA_HOME", elasticPackagePath)
+
+			err := profile.CreateProfile(profile.Options{
+				ProfilesDirPath: profilesPath,
+				Name:            profileName,
+			})
+			require.NoError(t, err)
+
+			configPath := filepath.Join(profilesPath, profileName, profile.PackageProfileConfigFile)
+			config := "stack.logsdb_enabled: true\nstack.logsdb_columnar_enabled: true\n"
+			err = os.WriteFile(configPath, []byte(config), 0644)
+			require.NoError(t, err)
+
+			p, err := profile.LoadProfile(profileName)
+			require.NoError(t, err)
+
+			appConfig, err := install.Configuration()
+			require.NoError(t, err)
+
+			err = applyResources(p, appConfig, tc.stackVersion, tc.stackVersion)
+			require.NoError(t, err)
+
+			esConfig, err := os.ReadFile(p.Path(ProfileStackPath, ElasticsearchConfigFile))
+			require.NoError(t, err)
+			if tc.expectClusterSetting {
+				assert.Contains(t, string(esConfig), "cluster.logsdb_columnar.enabled: true")
+			} else {
+				assert.NotContains(t, string(esConfig), "cluster.logsdb_columnar.enabled: true")
+			}
+
+			composeConfig, err := os.ReadFile(p.Path(ProfileStackPath, ComposeFile))
+			require.NoError(t, err)
+			if tc.expectFeatureFlag {
+				assert.Contains(t, string(composeConfig), "-Des.columnar_index_mode_feature_flag_enabled=true")
+			} else {
+				assert.NotContains(t, string(composeConfig), "-Des.columnar_index_mode_feature_flag_enabled=true")
+			}
+		})
+	}
+}
+
 func TestApplyResourcesWithPackageRegistryConfigurations(t *testing.T) {
 	cases := []struct {
 		name                  string

--- a/internal/testrunner/runners/system/agent_diagnostics.go
+++ b/internal/testrunner/runners/system/agent_diagnostics.go
@@ -1,0 +1,186 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package system
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"time"
+
+	"github.com/elastic/elastic-package/internal/agentdeployer"
+	"github.com/elastic/elastic-package/internal/logger"
+	"github.com/elastic/elastic-package/internal/multierror"
+	"github.com/elastic/elastic-package/internal/stack"
+	"github.com/elastic/elastic-package/internal/testrunner"
+)
+
+// maxAgentDiagnosticErrors caps unique indexing/agent errors attached to a
+// missing-hits failure so Buildkite junit annotations stay within size limits.
+const maxAgentDiagnosticErrors = 5
+
+// indexingErrorPatterns matches Elasticsearch indexing failures in agent logs.
+// These are a subset of errorPatterns focused on explaining zero-hit failures.
+var indexingErrorPatterns = []logsRegexp{
+	{
+		includes: regexp.MustCompile(`^Cannot index event publisher.Event`),
+		excludes: []*regexp.Regexp{
+			regexp.MustCompile(`action \[indices:data\/write\/bulk\[s\]\] is unauthorized for API key id \[.*\] of user \[.*\] on indices \[.*\], this action is granted by the index privileges \[.*\]`),
+		},
+	},
+	{
+		includes: regexp.MustCompile(`^failed to index document`),
+	},
+}
+
+// enrichWithAgentDiagnostics attaches agent indexing-failure details to an
+// ErrTestCaseFailed when an independent agent is still available. Best-effort:
+// collection failures leave the original error unchanged.
+func (r *tester) enrichWithAgentDiagnostics(ctx context.Context, scenario *scenarioTest, err error) error {
+	var testErr testrunner.ErrTestCaseFailed
+	if !errors.As(err, &testErr) {
+		return err
+	}
+	if scenario == nil || scenario.agent == nil {
+		return err
+	}
+
+	details := r.collectAgentIndexingDiagnostics(ctx, scenario.agent, scenario.startTestTime)
+	if details == "" {
+		return err
+	}
+	if testErr.Details != "" {
+		testErr.Details = testErr.Details + "\n" + details
+	} else {
+		testErr.Details = details
+	}
+	return testErr
+}
+
+// collectAgentIndexingDiagnostics scrapes independent-agent logs for indexing
+// failures. Prefers internal NDJSON logs; falls back to docker-compose stdout.
+func (r *tester) collectAgentIndexingDiagnostics(ctx context.Context, agent agentdeployer.DeployedAgent, startTime time.Time) string {
+	var matched []stack.LogLine
+
+	collect := func(log stack.LogLine) error {
+		if matchLogPatterns(log, indexingErrorPatterns) {
+			matched = append(matched, log)
+		}
+		return nil
+	}
+
+	internalErr := r.collectFromInternalLogs(agent, startTime, collect)
+	if internalErr != nil {
+		logger.Debugf("agent internal log diagnostics unavailable: %v", internalErr)
+	}
+	if internalErr != nil || len(matched) == 0 {
+		if err := r.collectFromComposeLogs(ctx, agent, startTime, collect); err != nil {
+			logger.Debugf("agent compose log diagnostics unavailable: %v", err)
+		}
+	}
+
+	return formatDiagnosticErrors(matched, maxAgentDiagnosticErrors)
+}
+
+func (r *tester) collectFromInternalLogs(agent agentdeployer.DeployedAgent, startTime time.Time, process func(stack.LogLine) error) error {
+	tmpParent, err := os.MkdirTemp("", "elastic-agent-internal-logs-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpParent)
+
+	destDir := filepath.Join(tmpParent, "logs")
+	if err := agent.CopyInternalLogs(destDir); err != nil {
+		return err
+	}
+
+	// docker cp of a directory may nest an extra folder when the destination
+	// parent exists, or place files directly in destDir.
+	logDir := destDir
+	if entries, err := os.ReadDir(destDir); err == nil {
+		if len(entries) == 1 && entries[0].IsDir() {
+			logDir = filepath.Join(destDir, entries[0].Name())
+		}
+	}
+
+	return stack.ParseNDJSONLogsDir(logDir, startTime, process)
+}
+
+func (r *tester) collectFromComposeLogs(ctx context.Context, agent agentdeployer.DeployedAgent, startTime time.Time, process func(stack.LogLine) error) error {
+	output, err := agent.Logs(ctx, startTime)
+	if err != nil {
+		return err
+	}
+	if len(output) == 0 {
+		return nil
+	}
+
+	f, err := os.CreateTemp("", "elastic-agent.compose.logs")
+	if err != nil {
+		return err
+	}
+	path := f.Name()
+	defer os.Remove(path)
+
+	if _, err := f.Write(output); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	return stack.ParseLogs(stack.ParseLogsOptions{
+		LogsFilePath: path,
+		StartTime:    startTime,
+	}, process)
+}
+
+func matchLogPatterns(log stack.LogLine, patterns []logsRegexp) bool {
+	for _, pattern := range patterns {
+		if !pattern.includes.MatchString(log.Message) {
+			continue
+		}
+		excluded := false
+		for _, excludes := range pattern.excludes {
+			if excludes.MatchString(log.Message) {
+				excluded = true
+				break
+			}
+		}
+		if !excluded {
+			return true
+		}
+	}
+	return false
+}
+
+func formatDiagnosticErrors(logs []stack.LogLine, maxUnique int) string {
+	if len(logs) == 0 {
+		return ""
+	}
+
+	var multiErr multierror.Error
+	seen := make(map[string]struct{})
+	for _, log := range logs {
+		formatted := log.FormatError()
+		dedupeKey := log.ErrorReason
+		if dedupeKey == "" {
+			dedupeKey = formatted
+		}
+		if _, ok := seen[dedupeKey]; ok {
+			continue
+		}
+		seen[dedupeKey] = struct{}{}
+		multiErr = append(multiErr, fmt.Errorf("%s", formatted))
+		if len(multiErr) >= maxUnique {
+			break
+		}
+	}
+	return multiErr.Error()
+}

--- a/internal/testrunner/runners/system/agent_diagnostics.go
+++ b/internal/testrunner/runners/system/agent_diagnostics.go
@@ -24,8 +24,9 @@ import (
 // missing-hits failure so Buildkite junit annotations stay within size limits.
 const maxAgentDiagnosticErrors = 5
 
-// indexingErrorPatterns matches Elasticsearch indexing failures in agent logs.
-// These are a subset of errorPatterns focused on explaining zero-hit failures.
+// indexingErrorPatterns matches agent log lines that explain zero-hit failures.
+// Includes Elasticsearch indexing rejections and permanent input/component
+// failures (for example an unreachable mock service).
 var indexingErrorPatterns = []logsRegexp{
 	{
 		includes: regexp.MustCompile(`^Cannot index event publisher.Event`),
@@ -35,6 +36,16 @@ var indexingErrorPatterns = []logsRegexp{
 	},
 	{
 		includes: regexp.MustCompile(`^failed to index document`),
+	},
+	{
+		// Permanent input startup/runtime failures (e.g. mock service API mismatch).
+		includes: regexp.MustCompile(`^Input '.*' failed with:`),
+	},
+	{
+		includes: regexp.MustCompile(`(STARTING|HEALTHY|DEGRADED)->FAILED\)`),
+		excludes: []*regexp.Regexp{
+			regexp.MustCompile(`Component state changed .* \(HEALTHY->DEGRADED\): Degraded: pid .* missed .* check-in`),
+		},
 	},
 }
 

--- a/internal/testrunner/runners/system/agent_diagnostics.go
+++ b/internal/testrunner/runners/system/agent_diagnostics.go
@@ -92,7 +92,7 @@ func (r *tester) collectFromInternalLogs(agent agentdeployer.DeployedAgent, star
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tmpParent)
+	defer os.RemoveAll(tmpParent) //nolint:errcheck // best-effort cleanup of temp dir
 
 	destDir := filepath.Join(tmpParent, "logs")
 	if err := agent.CopyInternalLogs(destDir); err != nil {
@@ -125,7 +125,7 @@ func (r *tester) collectFromComposeLogs(ctx context.Context, agent agentdeployer
 		return err
 	}
 	path := f.Name()
-	defer os.Remove(path)
+	defer os.Remove(path) //nolint:errcheck // best-effort cleanup of temp file
 
 	if _, err := f.Write(output); err != nil {
 		f.Close()

--- a/internal/testrunner/runners/system/agent_diagnostics_test.go
+++ b/internal/testrunner/runners/system/agent_diagnostics_test.go
@@ -104,6 +104,14 @@ func TestMatchLogPatterns_FailedToIndexDocument(t *testing.T) {
 	assert.True(t, matchLogPatterns(log, errorPatterns[0].patterns), "should match shared errorPatterns")
 }
 
+func TestMatchLogPatterns_InputFailed(t *testing.T) {
+	log := stack.LogLine{Message: "Input 'azure-blob-storage' failed with: GET http://svc:10000/... RESPONSE 400"}
+	assert.True(t, matchLogPatterns(log, indexingErrorPatterns), "should match permanent input failures")
+
+	failed := stack.LogLine{Message: "Component state changed azure-blob-storage-default (STARTING->FAILED): Permanent: failed to fetch next page"}
+	assert.True(t, matchLogPatterns(failed, indexingErrorPatterns), "should match STARTING->FAILED")
+}
+
 func TestCollectAgentIndexingDiagnostics_FromInternalLogs(t *testing.T) {
 	r := &tester{}
 	agent := &stubAgent{

--- a/internal/testrunner/runners/system/agent_diagnostics_test.go
+++ b/internal/testrunner/runners/system/agent_diagnostics_test.go
@@ -1,0 +1,226 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package system
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-package/internal/agentdeployer"
+	"github.com/elastic/elastic-package/internal/stack"
+	"github.com/elastic/elastic-package/internal/testrunner"
+)
+
+const sampleOTelIndexingFailure = `{"log.level":"error","@timestamp":"2026-07-01T17:34:35.220Z","message":"failed to index document","http.response.status_code":400,"error.type":"illegal_argument_exception","error.reason":"field [event.original] cannot reconstruct _source from doc values; every field must be reconstructable from doc values in index using [logsdb_columnar] index mode","ecs.version":"1.6.0"}`
+
+type stubAgent struct {
+	internalLogs map[string]string
+	composeLogs  []byte
+	copyErr      error
+	logsErr      error
+}
+
+func (s *stubAgent) TearDown(context.Context) error  { return nil }
+func (s *stubAgent) Info() agentdeployer.AgentInfo   { return agentdeployer.AgentInfo{} }
+func (s *stubAgent) SetInfo(agentdeployer.AgentInfo) {}
+func (s *stubAgent) ExitCode(context.Context) (bool, int, error) {
+	return false, 0, agentdeployer.ErrNotSupported
+}
+func (s *stubAgent) Logs(context.Context, time.Time) ([]byte, error) {
+	if s.logsErr != nil {
+		return nil, s.logsErr
+	}
+	return s.composeLogs, nil
+}
+func (s *stubAgent) CopyInternalLogs(destDir string) error {
+	if s.copyErr != nil {
+		return s.copyErr
+	}
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return err
+	}
+	for name, content := range s.internalLogs {
+		if err := os.WriteFile(filepath.Join(destDir, name), []byte(content), 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestFormatDiagnosticErrors(t *testing.T) {
+	logs := []stack.LogLine{
+		{
+			Message:     "failed to index document",
+			ErrorReason: "field [event.original] cannot reconstruct _source from doc values; every field must be reconstructable from doc values in index using [logsdb_columnar] index mode",
+			ErrorType:   "illegal_argument_exception",
+		},
+		{
+			Message:     "failed to index document",
+			ErrorReason: "field [event.original] cannot reconstruct _source from doc values; every field must be reconstructable from doc values in index using [logsdb_columnar] index mode",
+			ErrorType:   "illegal_argument_exception",
+		},
+		{
+			Message:     "failed to index document",
+			ErrorReason: "field [other.field] cannot reconstruct _source from doc values",
+			ErrorType:   "illegal_argument_exception",
+		},
+	}
+
+	got := formatDiagnosticErrors(logs, 5)
+	assert.Contains(t, got, "[0] failed to index document: field [event.original]", "first unique reason")
+	assert.Contains(t, got, "[1] failed to index document: field [other.field]", "second unique reason")
+	assert.NotContains(t, got, "[2]", "duplicates should be capped out of listing")
+}
+
+func TestFormatDiagnosticErrors_CapsUnique(t *testing.T) {
+	var logs []stack.LogLine
+	for i := 0; i < 10; i++ {
+		logs = append(logs, stack.LogLine{
+			Message:     "failed to index document",
+			ErrorReason: fmt.Sprintf("reason-%d", i),
+			ErrorType:   "illegal_argument_exception",
+		})
+	}
+	got := formatDiagnosticErrors(logs, 3)
+	assert.Contains(t, got, "[0]", "first entry")
+	assert.Contains(t, got, "[2]", "third entry")
+	assert.NotContains(t, got, "[3]", "should cap at maxUnique")
+}
+
+func TestMatchLogPatterns_FailedToIndexDocument(t *testing.T) {
+	log := stack.LogLine{Message: "failed to index document"}
+	assert.True(t, matchLogPatterns(log, indexingErrorPatterns), "should match failed to index document")
+	assert.True(t, matchLogPatterns(log, errorPatterns[0].patterns), "should match shared errorPatterns")
+}
+
+func TestCollectAgentIndexingDiagnostics_FromInternalLogs(t *testing.T) {
+	r := &tester{}
+	agent := &stubAgent{
+		internalLogs: map[string]string{
+			"elastic-agent-20260701.ndjson": sampleOTelIndexingFailure + "\n",
+		},
+	}
+	start, err := time.Parse(time.RFC3339Nano, "2026-07-01T17:00:00.000Z")
+	require.NoError(t, err, "parse start time")
+
+	details := r.collectAgentIndexingDiagnostics(context.Background(), agent, start)
+	require.NotEmpty(t, details, "expected diagnostics from internal logs")
+	assert.Contains(t, details, "failed to index document", "message")
+	assert.Contains(t, details, "logsdb_columnar", "error.reason")
+	assert.Contains(t, details, "illegal_argument_exception", "error.type")
+}
+
+func TestCollectAgentIndexingDiagnostics_FallsBackToComposeLogs(t *testing.T) {
+	r := &tester{}
+	composeLine := "elastic-agent-1  | " + sampleOTelIndexingFailure + "\n"
+	agent := &stubAgent{
+		copyErr:     errors.New("docker cp failed"),
+		composeLogs: []byte(composeLine),
+	}
+	start, err := time.Parse(time.RFC3339Nano, "2026-07-01T17:00:00.000Z")
+	require.NoError(t, err, "parse start time")
+
+	details := r.collectAgentIndexingDiagnostics(context.Background(), agent, start)
+	require.NotEmpty(t, details, "expected diagnostics from compose logs fallback")
+	assert.Contains(t, details, "event.original", "error.reason from compose logs")
+}
+
+func TestEnrichWithAgentDiagnostics(t *testing.T) {
+	r := &tester{}
+	agent := &stubAgent{
+		internalLogs: map[string]string{
+			"elastic-agent-20260701.ndjson": sampleOTelIndexingFailure + "\n",
+		},
+	}
+	start, err := time.Parse(time.RFC3339Nano, "2026-07-01T17:00:00.000Z")
+	require.NoError(t, err, "parse start time")
+
+	scenario := &scenarioTest{
+		agent:         agent,
+		startTestTime: start,
+	}
+	orig := testrunner.ErrTestCaseFailed{
+		Reason: "could not find the expected hits in logs-hashicorp_vault.audit-43464 data stream",
+	}
+
+	got := r.enrichWithAgentDiagnostics(context.Background(), scenario, orig)
+	var testErr testrunner.ErrTestCaseFailed
+	require.True(t, errors.As(got, &testErr), "should remain ErrTestCaseFailed")
+	assert.Equal(t, orig.Reason, testErr.Reason, "reason preserved")
+	assert.Contains(t, testErr.Details, "logsdb_columnar", "details include indexing reason")
+	assert.Equal(t, "test case failed: "+orig.Reason, testErr.Error(), "Error() uses Reason only")
+}
+
+func TestEnrichWithAgentDiagnostics_NonTestFailureUnchanged(t *testing.T) {
+	r := &tester{}
+	orig := errors.New("setup exploded")
+	got := r.enrichWithAgentDiagnostics(context.Background(), &scenarioTest{}, orig)
+	assert.Equal(t, orig, got, "non-test failures must pass through")
+}
+
+func TestXUnitFailureBodyIncludesAgentDiagnostics(t *testing.T) {
+	r := &tester{}
+	agent := &stubAgent{
+		internalLogs: map[string]string{
+			"elastic-agent-20260701.ndjson": sampleOTelIndexingFailure + "\n",
+		},
+	}
+	start, err := time.Parse(time.RFC3339Nano, "2026-07-01T17:00:00.000Z")
+	require.NoError(t, err, "parse start time")
+
+	enriched := r.enrichWithAgentDiagnostics(context.Background(), &scenarioTest{
+		agent:         agent,
+		startTestTime: start,
+	}, testrunner.ErrTestCaseFailed{
+		Reason: "could not find the expected hits in logs-zeek.intel-68376 data stream",
+	})
+
+	composer := testrunner.NewResultComposer(testrunner.TestResult{
+		TestType:   "system",
+		Name:       "default",
+		Package:    "zeek",
+		DataStream: "intel",
+	})
+	results, err := composer.WithError(enriched)
+	require.NoError(t, err, "WithError should treat ErrTestCaseFailed as a failure, not a runner error")
+	require.Len(t, results, 1, "one test result")
+
+	// Mirrors reporters/formats/xunit.go failure body construction.
+	failure := results[0].FailureMsg
+	if results[0].FailureDetails != "" {
+		failure += ": " + results[0].FailureDetails
+	}
+
+	assert.Contains(t, failure, "could not find the expected hits in logs-zeek.intel-68376 data stream", "reason in body")
+	assert.Contains(t, failure, "failed to index document", "indexing message in body")
+	assert.Contains(t, failure, "logsdb_columnar", "rejection reason in body for Buildkite annotation")
+}
+
+func TestIndexingErrorPatterns_ExcludesUnauthorizedBulk(t *testing.T) {
+	log := stack.LogLine{
+		Message: `Cannot index event publisher.Event..., error: fail to execute the bulk action: {...} action [indices:data/write/bulk[s]] is unauthorized for API key id [abc] of user [xyz] on indices [logs-system.auth-default], this action is granted by the index privileges [create_doc,create,index,all]`,
+	}
+	assert.False(t, matchLogPatterns(log, indexingErrorPatterns), "unauthorized bulk noise should be excluded")
+}
+
+func TestFailedToIndexDocumentPatternInErrorPatterns(t *testing.T) {
+	found := false
+	for _, p := range errorPatterns[0].patterns {
+		if p.includes.String() == regexp.MustCompile(`^failed to index document`).String() {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "errorPatterns must include failed to index document")
+}

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -64,6 +64,7 @@ var logsDBColumnarDocValuesDynamicTemplates = []map[string]any{
 
 type logsDBColumnarTemplateState struct {
 	Templates         map[string]logsDBColumnarTemplateSnapshot `json:"templates,omitempty"`
+	PackageTemplates  map[string]logsDBColumnarTemplateSnapshot `json:"package_templates,omitempty"`
 	Existed           bool                                      `json:"existed,omitempty"`
 	ComponentTemplate json.RawMessage                           `json:"component_template,omitempty"`
 }
@@ -260,7 +261,8 @@ func (r *runner) ensureLogsDBColumnarTemplate(ctx context.Context) error {
 	}
 
 	state = &logsDBColumnarTemplateState{
-		Templates: make(map[string]logsDBColumnarTemplateSnapshot, len(templateNames)),
+		Templates:        make(map[string]logsDBColumnarTemplateSnapshot, len(templateNames)),
+		PackageTemplates: make(map[string]logsDBColumnarTemplateSnapshot),
 	}
 	for _, templateName := range templateNames {
 		currentTemplate, exists, err := r.getComponentTemplate(ctx, templateName)
@@ -276,6 +278,24 @@ func (r *runner) ensureLogsDBColumnarTemplate(ctx context.Context) error {
 				return err
 			}
 			if packageExists {
+				// Columnar mode rejects explicit subobjects mapping params (it implies
+				// subobjects disabled). Strip them from @package before enabling mode.
+				strippedPackageTemplate, stripped, err := stripSubobjectsFromComponentTemplate(packageTemplate)
+				if err != nil {
+					return fmt.Errorf("failed to strip subobjects from %q: %w", packageTemplateName, err)
+				}
+				if stripped {
+					if err := r.putComponentTemplate(ctx, packageTemplateName, strippedPackageTemplate); err != nil {
+						return err
+					}
+					state.PackageTemplates[packageTemplateName] = logsDBColumnarTemplateSnapshot{
+						Existed:           true,
+						ComponentTemplate: packageTemplate,
+					}
+					logger.Debugf("Stripped subobjects from %s for logsdb_columnar testing", packageTemplateName)
+					packageTemplate = strippedPackageTemplate
+				}
+
 				for path, mapping := range collectDocValuesDisabledFieldOverrides(packageTemplate) {
 					overrides[path] = mapping
 				}
@@ -312,6 +332,7 @@ func (r *runner) restoreLogsDBColumnarTemplate(ctx context.Context) error {
 		return nil
 	}
 
+	// Remove columnar mode from @custom first so @package can regain subobjects.
 	for templateName, snapshot := range state.Templates {
 		if snapshot.Existed {
 			if err := r.putComponentTemplate(ctx, templateName, snapshot.ComponentTemplate); err != nil {
@@ -324,6 +345,13 @@ func (r *runner) restoreLogsDBColumnarTemplate(ctx context.Context) error {
 			}
 			logger.Debugf("Removed temporary %s component template", templateName)
 		}
+	}
+
+	for templateName, snapshot := range state.PackageTemplates {
+		if err := r.putComponentTemplate(ctx, templateName, snapshot.ComponentTemplate); err != nil {
+			return err
+		}
+		logger.Debugf("Restored previous %s component template", templateName)
 	}
 
 	r.logsDBColumnarState = nil
@@ -638,6 +666,70 @@ func collectDocValuesDisabledFieldOverrides(componentTemplate json.RawMessage) m
 		return nil
 	}
 	return collectDocValuesDisabledFields(template.Template.Mappings.Properties, "")
+}
+
+// stripSubobjectsFromComponentTemplate removes explicit subobjects mapping
+// parameters. logsdb_columnar rejects them because the mode already disables
+// subobjects. Returns the (possibly unchanged) template and whether anything
+// was removed.
+func stripSubobjectsFromComponentTemplate(componentTemplate json.RawMessage) ([]byte, bool, error) {
+	template := map[string]any{}
+	if err := json.Unmarshal(componentTemplate, &template); err != nil {
+		return nil, false, fmt.Errorf("failed to decode component template: %w", err)
+	}
+
+	templateSection, ok := template["template"].(map[string]any)
+	if !ok {
+		return componentTemplate, false, nil
+	}
+	mappingsSection, ok := templateSection["mappings"].(map[string]any)
+	if !ok {
+		return componentTemplate, false, nil
+	}
+
+	if !stripSubobjectsFromMappings(mappingsSection) {
+		return componentTemplate, false, nil
+	}
+
+	payload, err := json.Marshal(template)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to encode component template without subobjects: %w", err)
+	}
+	return payload, true, nil
+}
+
+func stripSubobjectsFromMappings(mappings map[string]any) bool {
+	changed := false
+	if _, ok := mappings["subobjects"]; ok {
+		delete(mappings, "subobjects")
+		changed = true
+	}
+	if properties, ok := mappings["properties"].(map[string]any); ok {
+		if stripSubobjectsFromProperties(properties) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+func stripSubobjectsFromProperties(properties map[string]any) bool {
+	changed := false
+	for _, raw := range properties {
+		prop, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, ok := prop["subobjects"]; ok {
+			delete(prop, "subobjects")
+			changed = true
+		}
+		if nested, ok := prop["properties"].(map[string]any); ok {
+			if stripSubobjectsFromProperties(nested) {
+				changed = true
+			}
+		}
+	}
+	return changed
 }
 
 func collectDocValuesDisabledFields(properties map[string]any, prefix string) map[string]map[string]any {

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -568,9 +568,10 @@ func (r *runner) logsDBColumnarPackageTemplateNames() ([]string, error) {
 
 func (r *runner) logsDBColumnarCustomTemplateNames(selectedOnly bool) ([]string, error) {
 	if r.packageRoot == "" {
-		if selectedOnly {
-			return []string{defaultLogsDBColumnarComponentTemplateName}, nil
-		}
+		// Without a package root there is no per-dataset @custom to configure.
+		// Never fall back to global logs@custom: putting index.mode there breaks
+		// every logs index template that still has explicit subobjects (for example
+		// elastic_agent.*) when templates are merged.
 		return nil, nil
 	}
 
@@ -612,9 +613,6 @@ func (r *runner) logsDBColumnarCustomTemplateNames(selectedOnly bool) ([]string,
 		templateNames = append(templateNames, "logs-"+dataset+"@custom")
 	}
 
-	if selectedOnly && len(templateNames) == 0 {
-		return []string{defaultLogsDBColumnarComponentTemplateName}, nil
-	}
 	return templateNames, nil
 }
 

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -448,6 +448,11 @@ func (r *runner) getComponentTemplate(ctx context.Context, templateName string) 
 }
 
 func (r *runner) putComponentTemplate(ctx context.Context, templateName string, payload []byte) error {
+	payload, err := sanitizeComponentTemplateForPut(payload)
+	if err != nil {
+		return fmt.Errorf("failed to prepare component template %q for put: %w", templateName, err)
+	}
+
 	resp, err := r.esAPI.Cluster.PutComponentTemplate(
 		templateName,
 		bytes.NewReader(payload),
@@ -696,6 +701,32 @@ func stripSubobjectsFromComponentTemplate(componentTemplate json.RawMessage) ([]
 		return nil, false, fmt.Errorf("failed to encode component template without subobjects: %w", err)
 	}
 	return payload, true, nil
+}
+
+// sanitizeComponentTemplateForPut removes GET-only system fields that
+// Elasticsearch rejects on PutComponentTemplate.
+func sanitizeComponentTemplateForPut(componentTemplate []byte) ([]byte, error) {
+	template := map[string]any{}
+	if err := json.Unmarshal(componentTemplate, &template); err != nil {
+		return nil, fmt.Errorf("failed to decode component template: %w", err)
+	}
+
+	changed := false
+	for _, key := range []string{"created_date_millis", "modified_date_millis", "created_date", "modified_date"} {
+		if _, ok := template[key]; ok {
+			delete(template, key)
+			changed = true
+		}
+	}
+	if !changed {
+		return componentTemplate, nil
+	}
+
+	payload, err := json.Marshal(template)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode sanitized component template: %w", err)
+	}
+	return payload, nil
 }
 
 func stripSubobjectsFromMappings(mappings map[string]any) bool {

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -264,6 +264,43 @@ func (r *runner) ensureLogsDBColumnarTemplate(ctx context.Context) error {
 		Templates:        make(map[string]logsDBColumnarTemplateSnapshot, len(templateNames)),
 		PackageTemplates: make(map[string]logsDBColumnarTemplateSnapshot),
 	}
+
+	// Strip subobjects from every logs @package template in the package, not only
+	// selected streams. Sibling streams can still be created under
+	// cluster.logsdb_columnar.enabled even when only one stream is under test.
+	packageTemplateNames, err := r.logsDBColumnarPackageTemplateNames()
+	if err != nil {
+		return err
+	}
+	packageTemplates := make(map[string]json.RawMessage, len(packageTemplateNames))
+	for _, packageTemplateName := range packageTemplateNames {
+		packageTemplate, packageExists, err := r.getComponentTemplate(ctx, packageTemplateName)
+		if err != nil {
+			return err
+		}
+		if !packageExists {
+			continue
+		}
+		// Columnar mode rejects explicit subobjects mapping params (it implies
+		// subobjects disabled). Strip them from @package before enabling mode.
+		strippedPackageTemplate, stripped, err := stripSubobjectsFromComponentTemplate(packageTemplate)
+		if err != nil {
+			return fmt.Errorf("failed to strip subobjects from %q: %w", packageTemplateName, err)
+		}
+		if stripped {
+			if err := r.putComponentTemplate(ctx, packageTemplateName, strippedPackageTemplate); err != nil {
+				return err
+			}
+			state.PackageTemplates[packageTemplateName] = logsDBColumnarTemplateSnapshot{
+				Existed:           true,
+				ComponentTemplate: packageTemplate,
+			}
+			logger.Debugf("Stripped subobjects from %s for logsdb_columnar testing", packageTemplateName)
+			packageTemplate = strippedPackageTemplate
+		}
+		packageTemplates[packageTemplateName] = packageTemplate
+	}
+
 	for _, templateName := range templateNames {
 		currentTemplate, exists, err := r.getComponentTemplate(ctx, templateName)
 		if err != nil {
@@ -272,33 +309,9 @@ func (r *runner) ensureLogsDBColumnarTemplate(ctx context.Context) error {
 
 		overrides := logsDBColumnarPropertyOverrides()
 		packageTemplateName := packageComponentTemplateName(templateName)
-		if packageTemplateName != "" {
-			packageTemplate, packageExists, err := r.getComponentTemplate(ctx, packageTemplateName)
-			if err != nil {
-				return err
-			}
-			if packageExists {
-				// Columnar mode rejects explicit subobjects mapping params (it implies
-				// subobjects disabled). Strip them from @package before enabling mode.
-				strippedPackageTemplate, stripped, err := stripSubobjectsFromComponentTemplate(packageTemplate)
-				if err != nil {
-					return fmt.Errorf("failed to strip subobjects from %q: %w", packageTemplateName, err)
-				}
-				if stripped {
-					if err := r.putComponentTemplate(ctx, packageTemplateName, strippedPackageTemplate); err != nil {
-						return err
-					}
-					state.PackageTemplates[packageTemplateName] = logsDBColumnarTemplateSnapshot{
-						Existed:           true,
-						ComponentTemplate: packageTemplate,
-					}
-					logger.Debugf("Stripped subobjects from %s for logsdb_columnar testing", packageTemplateName)
-					packageTemplate = strippedPackageTemplate
-				}
-
-				for path, mapping := range collectDocValuesDisabledFieldOverrides(packageTemplate) {
-					overrides[path] = mapping
-				}
+		if packageTemplate, ok := packageTemplates[packageTemplateName]; ok {
+			for path, mapping := range collectDocValuesDisabledFieldOverrides(packageTemplate) {
+				overrides[path] = mapping
 			}
 		}
 
@@ -534,8 +547,31 @@ func (r *runner) saveLogsDBColumnarState(state *logsDBColumnarTemplateState) err
 }
 
 func (r *runner) logsDBColumnarTemplateNames() ([]string, error) {
+	return r.logsDBColumnarCustomTemplateNames(true)
+}
+
+// logsDBColumnarPackageTemplateNames returns @package component template names
+// for every logs data stream in the package.
+func (r *runner) logsDBColumnarPackageTemplateNames() ([]string, error) {
+	customNames, err := r.logsDBColumnarCustomTemplateNames(false)
+	if err != nil {
+		return nil, err
+	}
+	packageNames := make([]string, 0, len(customNames))
+	for _, customName := range customNames {
+		if packageName := packageComponentTemplateName(customName); packageName != "" {
+			packageNames = append(packageNames, packageName)
+		}
+	}
+	return packageNames, nil
+}
+
+func (r *runner) logsDBColumnarCustomTemplateNames(selectedOnly bool) ([]string, error) {
 	if r.packageRoot == "" {
-		return []string{defaultLogsDBColumnarComponentTemplateName}, nil
+		if selectedOnly {
+			return []string{defaultLogsDBColumnarComponentTemplateName}, nil
+		}
+		return nil, nil
 	}
 
 	packageManifest, err := packages.ReadPackageManifestFromPackageRoot(r.packageRoot)
@@ -547,18 +583,20 @@ func (r *runner) logsDBColumnarTemplateNames() ([]string, error) {
 		return nil, fmt.Errorf("reading data stream manifests failed (path: %s): %w", r.packageRoot, err)
 	}
 
-	selectedDataStreams, err := r.selectedDataStreamsForRun()
-	if err != nil {
-		return nil, err
-	}
 	selectedSet := map[string]struct{}{}
-	for _, dataStream := range selectedDataStreams {
-		selectedSet[dataStream] = struct{}{}
+	if selectedOnly {
+		selectedDataStreams, err := r.selectedDataStreamsForRun()
+		if err != nil {
+			return nil, err
+		}
+		for _, dataStream := range selectedDataStreams {
+			selectedSet[dataStream] = struct{}{}
+		}
 	}
 
 	templateNames := make([]string, 0, len(dataStreamManifests))
 	for _, dataStreamManifest := range dataStreamManifests {
-		if len(selectedSet) > 0 {
+		if selectedOnly && len(selectedSet) > 0 {
 			if _, found := selectedSet[dataStreamManifest.Name]; !found {
 				continue
 			}
@@ -574,7 +612,7 @@ func (r *runner) logsDBColumnarTemplateNames() ([]string, error) {
 		templateNames = append(templateNames, "logs-"+dataset+"@custom")
 	}
 
-	if len(templateNames) == 0 {
+	if selectedOnly && len(templateNames) == 0 {
 		return []string{defaultLogsDBColumnarComponentTemplateName}, nil
 	}
 	return templateNames, nil

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -34,6 +35,32 @@ const (
 	logsDBColumnarIndexMode                    = "logsdb_columnar"
 	logsDBColumnarStateFileName                = "logsdb-columnar-template.json"
 )
+
+// logsDBColumnarDocValuesDynamicTemplates are prepended to @custom so they match
+// before ecs@mappings templates that set doc_values:false. This is a test-only
+// workaround; ECS still needs a product solution for logsdb_columnar.
+var logsDBColumnarDocValuesDynamicTemplates = []map[string]any{
+	{
+		"event_original_logsdb_columnar_workaround": map[string]any{
+			"path_match": []any{"event.original", "*event.original", "*gen_ai.agent.description"},
+			"mapping": map[string]any{
+				"type":       "keyword",
+				"index":      false,
+				"doc_values": true,
+			},
+		},
+	},
+	{
+		"x509_public_key_exponent_logsdb_columnar_workaround": map[string]any{
+			"path_match": "*.x509.public_key_exponent",
+			"mapping": map[string]any{
+				"type":       "long",
+				"index":      false,
+				"doc_values": true,
+			},
+		},
+	},
+}
 
 type logsDBColumnarTemplateState struct {
 	Templates         map[string]logsDBColumnarTemplateSnapshot `json:"templates,omitempty"`
@@ -154,12 +181,6 @@ func (r *runner) SetupRunner(ctx context.Context) error {
 		return nil
 	}
 
-	if r.logsDBColumnar {
-		if err := r.ensureLogsDBColumnarTemplate(ctx); err != nil {
-			return err
-		}
-	}
-
 	// Install the package before creating the policy, so we control exactly what is being
 	// installed.
 	logger.Info("Installing package...")
@@ -170,6 +191,15 @@ func (r *runner) SetupRunner(ctx context.Context) error {
 	_, err := r.resourcesManager.ApplyCtx(ctx, r.resources(resourcesOptions))
 	if err != nil {
 		return fmt.Errorf("can't install the package: %w", err)
+	}
+
+	// Configure logsdb_columnar after install so @package mappings exist. Mode and
+	// doc_values overrides must be applied together: ES rejects columnar mode when
+	// composed mappings still contain doc_values:false fields.
+	if r.logsDBColumnar {
+		if err := r.ensureLogsDBColumnarTemplate(ctx); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -237,7 +267,22 @@ func (r *runner) ensureLogsDBColumnarTemplate(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		payload, err := buildLogsDBColumnarTemplatePayload(currentTemplate, exists)
+
+		overrides := logsDBColumnarPropertyOverrides()
+		packageTemplateName := packageComponentTemplateName(templateName)
+		if packageTemplateName != "" {
+			packageTemplate, packageExists, err := r.getComponentTemplate(ctx, packageTemplateName)
+			if err != nil {
+				return err
+			}
+			if packageExists {
+				for path, mapping := range collectDocValuesDisabledFieldOverrides(packageTemplate) {
+					overrides[path] = mapping
+				}
+			}
+		}
+
+		payload, err := buildLogsDBColumnarTemplatePayload(currentTemplate, exists, overrides, logsDBColumnarDocValuesDynamicTemplates)
 		if err != nil {
 			return err
 		}
@@ -248,7 +293,7 @@ func (r *runner) ensureLogsDBColumnarTemplate(ctx context.Context) error {
 			Existed:           exists,
 			ComponentTemplate: currentTemplate,
 		}
-		logger.Debugf("Configured %s with index.mode=%s for system tests", templateName, logsDBColumnarIndexMode)
+		logger.Debugf("Configured %s with index.mode=%s and %d doc_values overrides for system tests", templateName, logsDBColumnarIndexMode, len(overrides))
 	}
 
 	if err := r.saveLogsDBColumnarState(state); err != nil {
@@ -286,6 +331,24 @@ func (r *runner) restoreLogsDBColumnarTemplate(ctx context.Context) error {
 		return fmt.Errorf("failed to remove logsdb columnar state file: %w", err)
 	}
 	return nil
+}
+
+func logsDBColumnarPropertyOverrides() map[string]map[string]any {
+	return map[string]map[string]any{
+		// ECS dynamic templates leave event.original without doc values.
+		"event.original": {
+			"type":       "keyword",
+			"index":      false,
+			"doc_values": true,
+		},
+	}
+}
+
+func packageComponentTemplateName(customTemplateName string) string {
+	if !strings.HasSuffix(customTemplateName, "@custom") {
+		return ""
+	}
+	return strings.TrimSuffix(customTemplateName, "@custom") + "@package"
 }
 
 func (r *runner) hasColumnarIndexModeCapability(ctx context.Context) (bool, error) {
@@ -510,7 +573,7 @@ func (r *runner) selectedDataStreamsForRun() ([]string, error) {
 	return nil, nil
 }
 
-func buildLogsDBColumnarTemplatePayload(currentTemplate json.RawMessage, exists bool) ([]byte, error) {
+func buildLogsDBColumnarTemplatePayload(currentTemplate json.RawMessage, exists bool, propertyOverrides map[string]map[string]any, dynamicTemplates []map[string]any) ([]byte, error) {
 	template := map[string]any{}
 	if exists {
 		if err := json.Unmarshal(currentTemplate, &template); err != nil {
@@ -535,11 +598,157 @@ func buildLogsDBColumnarTemplatePayload(currentTemplate json.RawMessage, exists 
 	}
 	indexSection["mode"] = logsDBColumnarIndexMode
 
+	if len(propertyOverrides) > 0 || len(dynamicTemplates) > 0 {
+		mappingsSection, ok := templateSection["mappings"].(map[string]any)
+		if !ok {
+			mappingsSection = map[string]any{}
+			templateSection["mappings"] = mappingsSection
+		}
+
+		if len(propertyOverrides) > 0 {
+			propertiesSection, ok := mappingsSection["properties"].(map[string]any)
+			if !ok {
+				propertiesSection = map[string]any{}
+				mappingsSection["properties"] = propertiesSection
+			}
+			mergeMappingProperties(propertiesSection, nestFieldMappingOverrides(propertyOverrides))
+		}
+
+		if len(dynamicTemplates) > 0 {
+			mappingsSection["dynamic_templates"] = prependDynamicTemplates(mappingsSection["dynamic_templates"], dynamicTemplates)
+		}
+	}
+
 	payload, err := json.Marshal(template)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode logsdb columnar component template payload: %w", err)
 	}
 	return payload, nil
+}
+
+func collectDocValuesDisabledFieldOverrides(componentTemplate json.RawMessage) map[string]map[string]any {
+	var template struct {
+		Template struct {
+			Mappings struct {
+				Properties map[string]any `json:"properties"`
+			} `json:"mappings"`
+		} `json:"template"`
+	}
+	if err := json.Unmarshal(componentTemplate, &template); err != nil {
+		return nil
+	}
+	return collectDocValuesDisabledFields(template.Template.Mappings.Properties, "")
+}
+
+func collectDocValuesDisabledFields(properties map[string]any, prefix string) map[string]map[string]any {
+	if len(properties) == 0 {
+		return nil
+	}
+
+	overrides := map[string]map[string]any{}
+	for name, raw := range properties {
+		prop, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		path := name
+		if prefix != "" {
+			path = prefix + "." + name
+		}
+
+		if nested, ok := prop["properties"].(map[string]any); ok {
+			for nestedPath, mapping := range collectDocValuesDisabledFields(nested, path) {
+				overrides[nestedPath] = mapping
+			}
+			continue
+		}
+
+		docValues, hasDocValues := prop["doc_values"].(bool)
+		if !hasDocValues || docValues {
+			continue
+		}
+
+		override := maps.Clone(prop)
+		override["doc_values"] = true
+		overrides[path] = override
+	}
+	return overrides
+}
+
+func nestFieldMappingOverrides(flat map[string]map[string]any) map[string]any {
+	root := map[string]any{}
+	for path, mapping := range flat {
+		parts := strings.Split(path, ".")
+		current := root
+		for i, part := range parts {
+			if i == len(parts)-1 {
+				current[part] = mapping
+				break
+			}
+			child, ok := current[part].(map[string]any)
+			if !ok {
+				child = map[string]any{}
+				current[part] = child
+			}
+			props, ok := child["properties"].(map[string]any)
+			if !ok {
+				props = map[string]any{}
+				child["properties"] = props
+			}
+			current = props
+		}
+	}
+	return root
+}
+
+func mergeMappingProperties(dst, src map[string]any) {
+	for key, srcValue := range src {
+		srcMap, srcIsMap := srcValue.(map[string]any)
+		if !srcIsMap {
+			dst[key] = srcValue
+			continue
+		}
+
+		dstValue, exists := dst[key]
+		if !exists {
+			dst[key] = srcValue
+			continue
+		}
+		dstMap, dstIsMap := dstValue.(map[string]any)
+		if !dstIsMap {
+			dst[key] = srcValue
+			continue
+		}
+
+		srcProps, srcHasProps := srcMap["properties"].(map[string]any)
+		if !srcHasProps {
+			dst[key] = srcValue
+			continue
+		}
+
+		dstProps, ok := dstMap["properties"].(map[string]any)
+		if !ok {
+			dstProps = map[string]any{}
+			dstMap["properties"] = dstProps
+		}
+		mergeMappingProperties(dstProps, srcProps)
+	}
+}
+
+func prependDynamicTemplates(existing any, templates []map[string]any) []any {
+	result := make([]any, 0, len(templates)+8)
+	for _, template := range templates {
+		result = append(result, template)
+	}
+	switch current := existing.(type) {
+	case []any:
+		result = append(result, current...)
+	case nil:
+		// nothing
+	default:
+		// Unexpected shape from JSON decode; keep only our workarounds.
+	}
+	return result
 }
 
 func (r *runner) GetTests(ctx context.Context) ([]testrunner.Tester, error) {

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -28,6 +28,8 @@ import (
 	"github.com/elastic/elastic-package/internal/resources"
 	"github.com/elastic/elastic-package/internal/servicedeployer"
 	"github.com/elastic/elastic-package/internal/testrunner"
+
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -595,7 +597,20 @@ func (r *runner) logsDBColumnarCustomTemplateNames(selectedOnly bool) ([]string,
 		}
 	}
 
+	seen := map[string]struct{}{}
 	templateNames := make([]string, 0, len(dataStreamManifests))
+	addTemplate := func(dataset string) {
+		if dataset == "" {
+			return
+		}
+		name := "logs-" + dataset + "@custom"
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		templateNames = append(templateNames, name)
+	}
+
 	for _, dataStreamManifest := range dataStreamManifests {
 		if selectedOnly && len(selectedSet) > 0 {
 			if _, found := selectedSet[dataStreamManifest.Name]; !found {
@@ -610,10 +625,101 @@ func (r *runner) logsDBColumnarCustomTemplateNames(selectedOnly bool) ([]string,
 		if dataset == "" {
 			dataset = packageManifest.Name + "." + dataStreamManifest.Name
 		}
-		templateNames = append(templateNames, "logs-"+dataset+"@custom")
+		addTemplate(dataset)
+	}
+
+	// Input packages have no data_stream manifests. Cluster logsdb_columnar can
+	// still force columnar mode on their datasets, so configure per-dataset
+	// @custom from policy defaults and system test configs.
+	if packageManifest.Type == "input" {
+		datasets, err := inputPackageLogsDatasets(r.packageRoot, packageManifest)
+		if err != nil {
+			return nil, err
+		}
+		for _, dataset := range datasets {
+			addTemplate(dataset)
+		}
 	}
 
 	return templateNames, nil
+}
+
+// inputPackageLogsDatasets returns datasets used by an input package's logs
+// policy templates: defaults from the manifest plus overrides from system test
+// configs under _dev/test/system.
+func inputPackageLogsDatasets(packageRoot string, packageManifest *packages.PackageManifest) ([]string, error) {
+	seen := map[string]struct{}{}
+	var datasets []string
+	add := func(dataset string) {
+		dataset = strings.TrimSpace(dataset)
+		if dataset == "" {
+			return
+		}
+		if _, ok := seen[dataset]; ok {
+			return
+		}
+		seen[dataset] = struct{}{}
+		datasets = append(datasets, dataset)
+	}
+
+	for _, policyTemplate := range packageManifest.PolicyTemplates {
+		if policyTemplate.Type != "" && policyTemplate.Type != "logs" {
+			continue
+		}
+		for _, variable := range policyTemplate.Vars {
+			if variable.Name != "data_stream.dataset" || variable.Default == nil {
+				continue
+			}
+			if dataset, ok := variable.Default.Value().(string); ok {
+				add(dataset)
+			}
+		}
+	}
+
+	systemTestDir := filepath.Join(packageRoot, "_dev", "test", "system")
+	configFiles, err := listConfigFiles(systemTestDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return datasets, nil
+		}
+		return nil, fmt.Errorf("listing system test configs failed: %w", err)
+	}
+	for _, configFile := range configFiles {
+		dataset, err := datasetFromSystemTestConfigFile(filepath.Join(systemTestDir, configFile))
+		if err != nil {
+			return nil, err
+		}
+		add(dataset)
+	}
+
+	return datasets, nil
+}
+
+func datasetFromSystemTestConfigFile(path string) (string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading system test config %q failed: %w", path, err)
+	}
+
+	var probe struct {
+		Vars       map[string]any `yaml:"vars"`
+		DataStream struct {
+			Vars map[string]any `yaml:"vars"`
+		} `yaml:"data_stream"`
+	}
+	if err := yaml.Unmarshal(content, &probe); err != nil {
+		return "", fmt.Errorf("parsing system test config %q failed: %w", path, err)
+	}
+
+	for _, vars := range []map[string]any{probe.Vars, probe.DataStream.Vars} {
+		if vars == nil {
+			continue
+		}
+		if dataset, ok := vars["data_stream.dataset"].(string); ok {
+			return dataset, nil
+		}
+	}
+	return "", nil
 }
 
 func (r *runner) selectedDataStreamsForRun() ([]string, error) {

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -17,8 +17,6 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/elastic/elastic-package/internal/elasticsearch"
 	"github.com/elastic/elastic-package/internal/fields"
 	"github.com/elastic/elastic-package/internal/kibana"
@@ -623,20 +621,8 @@ func (r *runner) GetTests(ctx context.Context) ([]testrunner.Tester, error) {
 		}
 	}
 
-	columnarSkipReasons := map[string]string{}
-	if r.logsDBColumnar {
-		columnarSkipReasons, err = r.skipReasonsForLogsDBColumnar(folders)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	var testers []testrunner.Tester
 	for _, t := range folders {
-		if reason, shouldSkip := columnarSkipReasons[t.Path]; shouldSkip {
-			testers = append(testers, newSkippedSystemTester(t, reason))
-			continue
-		}
 		folderTesters, err := r.createTestersForFolder(t, serviceState)
 		if err != nil {
 			return nil, err
@@ -700,127 +686,6 @@ func (r *runner) createTestersForFolder(testFolder testrunner.TestFolder, servic
 	}
 
 	return testers, nil
-}
-
-func (r *runner) skipReasonsForLogsDBColumnar(folders []testrunner.TestFolder) (map[string]string, error) {
-	reasons := map[string]string{}
-
-	for _, folder := range folders {
-		if folder.DataStream == "" {
-			continue
-		}
-
-		manifest, err := packages.ReadDataStreamManifestFromPackageRoot(r.packageRoot, folder.DataStream)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read manifest for data stream %q: %w", folder.DataStream, err)
-		}
-		if manifest.Type != "logs" {
-			continue
-		}
-
-		hasNested, err := hasNestedFieldsInDataStream(r.packageRoot, folder.DataStream)
-		if err != nil {
-			return nil, err
-		}
-		if hasNested {
-			reasons[folder.Path] = "LogsDB Columnar does not support nested mappings for logs data streams"
-		}
-	}
-
-	return reasons, nil
-}
-
-type skippedSystemTester struct {
-	testFolder testrunner.TestFolder
-	reason     string
-}
-
-func newSkippedSystemTester(testFolder testrunner.TestFolder, reason string) *skippedSystemTester {
-	return &skippedSystemTester{
-		testFolder: testFolder,
-		reason:     reason,
-	}
-}
-
-func (s *skippedSystemTester) Type() testrunner.TestType {
-	return TestType
-}
-
-func (s *skippedSystemTester) String() string {
-	return "system"
-}
-
-func (s *skippedSystemTester) Run(ctx context.Context) ([]testrunner.TestResult, error) {
-	logger.Warnf(
-		"skipping system test for %s/%s: %s",
-		s.testFolder.Package,
-		s.testFolder.DataStream,
-		s.reason,
-	)
-	result := testrunner.NewResultComposer(testrunner.TestResult{
-		TestType:   TestType,
-		Name:       "logsdb-columnar compatibility",
-		Package:    s.testFolder.Package,
-		DataStream: s.testFolder.DataStream,
-	})
-	return result.WithSkip(&testrunner.SkipConfig{Reason: s.reason})
-}
-
-func (s *skippedSystemTester) TearDown(ctx context.Context) error {
-	return nil
-}
-
-func (s *skippedSystemTester) Parallel() bool {
-	return true
-}
-
-func hasNestedFieldsInDataStream(packageRoot, dataStreamName string) (bool, error) {
-	fieldsDir := filepath.Join(packageRoot, "data_stream", dataStreamName, "fields")
-	info, err := os.Stat(fieldsDir)
-	switch {
-	case errors.Is(err, os.ErrNotExist):
-		return false, nil
-	case err != nil:
-		return false, fmt.Errorf("failed to inspect fields directory for data stream %q: %w", dataStreamName, err)
-	case !info.IsDir():
-		return false, nil
-	}
-
-	fieldFiles, err := filepath.Glob(filepath.Join(fieldsDir, "*.yml"))
-	if err != nil {
-		return false, fmt.Errorf("failed to list field files for data stream %q: %w", dataStreamName, err)
-	}
-
-	for _, fieldFile := range fieldFiles {
-		content, err := os.ReadFile(fieldFile)
-		if err != nil {
-			return false, fmt.Errorf("failed to read field file %q: %w", fieldFile, err)
-		}
-		var definitions fields.FieldDefinitions
-		if err := yaml.Unmarshal(content, &definitions); err != nil {
-			return false, fmt.Errorf("failed to parse field file %q: %w", fieldFile, err)
-		}
-		if hasNestedFieldDefinitions(definitions) {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-func hasNestedFieldDefinitions(definitions []fields.FieldDefinition) bool {
-	for _, definition := range definitions {
-		if definition.Type == "nested" {
-			return true
-		}
-		if hasNestedFieldDefinitions(definition.Fields) {
-			return true
-		}
-		if hasNestedFieldDefinitions(definition.MultiFields) {
-			return true
-		}
-	}
-	return false
 }
 
 // Type returns the type of test that can be run by this test runner.

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -5,13 +5,19 @@
 package system
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/elastic-package/internal/elasticsearch"
 	"github.com/elastic/elastic-package/internal/fields"
@@ -24,6 +30,23 @@ import (
 	"github.com/elastic/elastic-package/internal/servicedeployer"
 	"github.com/elastic/elastic-package/internal/testrunner"
 )
+
+const (
+	defaultLogsDBColumnarComponentTemplateName = "logs@custom"
+	logsDBColumnarIndexMode                    = "logsdb_columnar"
+	logsDBColumnarStateFileName                = "logsdb-columnar-template.json"
+)
+
+type logsDBColumnarTemplateState struct {
+	Templates         map[string]logsDBColumnarTemplateSnapshot `json:"templates,omitempty"`
+	Existed           bool                                      `json:"existed,omitempty"`
+	ComponentTemplate json.RawMessage                           `json:"component_template,omitempty"`
+}
+
+type logsDBColumnarTemplateSnapshot struct {
+	Existed           bool            `json:"existed"`
+	ComponentTemplate json.RawMessage `json:"component_template,omitempty"`
+}
 
 type runner struct {
 	profile        *profile.Profile
@@ -44,15 +67,18 @@ type runner struct {
 	generateTestResult bool
 	withCoverage       bool
 	coverageType       string
+	logsDBColumnar     bool
 
 	configFilePath string
 	runSetup       bool
 	runTearDown    bool
 	runTestsOnly   bool
 
-	resourcesManager       *resources.Manager
-	serviceStateFilePath   string
-	requiredInputsResolver requiredinputs.Resolver
+	resourcesManager        *resources.Manager
+	serviceStateFilePath    string
+	logsDBColumnarState     *logsDBColumnarTemplateState
+	logsDBColumnarStatePath string
+	requiredInputsResolver  requiredinputs.Resolver
 }
 
 // Ensures that runner implements testrunner.TestRunner interface
@@ -86,6 +112,7 @@ type SystemTestRunnerOptions struct {
 	WithCoverage           bool
 	CoverageType           string
 	RequiredInputsResolver requiredinputs.Resolver
+	LogsDBColumnar         bool
 }
 
 func NewSystemTestRunner(options SystemTestRunnerOptions) *runner {
@@ -108,6 +135,7 @@ func NewSystemTestRunner(options SystemTestRunnerOptions) *runner {
 		globalTestConfig:       options.GlobalTestConfig,
 		withCoverage:           options.WithCoverage,
 		coverageType:           options.CoverageType,
+		logsDBColumnar:         options.LogsDBColumnar,
 		repositoryRoot:         options.RepositoryRoot,
 		overrideAgentVersion:   options.OverrideAgentVersion,
 		requiredInputsResolver: options.RequiredInputsResolver,
@@ -117,6 +145,7 @@ func NewSystemTestRunner(options SystemTestRunnerOptions) *runner {
 	r.resourcesManager.RegisterProvider(resources.DefaultKibanaProviderName, &resources.KibanaProvider{Client: r.kibanaClient})
 
 	r.serviceStateFilePath = filepath.Join(stateFolderPath(r.profile.ProfilePath), serviceStateFileName)
+	r.logsDBColumnarStatePath = filepath.Join(stateFolderPath(r.profile.ProfilePath), logsDBColumnarStateFileName)
 	return &r
 }
 
@@ -125,6 +154,12 @@ func (r *runner) SetupRunner(ctx context.Context) error {
 	if r.runTearDown {
 		logger.Debug("Skip installing package")
 		return nil
+	}
+
+	if r.logsDBColumnar {
+		if err := r.ensureLogsDBColumnarTemplate(ctx); err != nil {
+			return err
+		}
 	}
 
 	// Install the package before creating the policy, so we control exactly what is being
@@ -150,11 +185,363 @@ func (r *runner) TearDownRunner(ctx context.Context) error {
 		// Keep it installed only if we were running setup, or tests only.
 		installedPackage: r.runSetup || r.runTestsOnly,
 	}
-	_, err := r.resourcesManager.ApplyCtx(ctx, r.resources(resourcesOptions))
+	_, resourceErr := r.resourcesManager.ApplyCtx(ctx, r.resources(resourcesOptions))
+
+	var templateErr error
+	if r.logsDBColumnar && !r.runSetup && !r.runTestsOnly {
+		templateErr = r.restoreLogsDBColumnarTemplate(ctx)
+	}
+
+	if resourceErr != nil && templateErr != nil {
+		return fmt.Errorf("failed to clean system runner resources: %w", errors.Join(resourceErr, templateErr))
+	}
+	if resourceErr != nil {
+		return resourceErr
+	}
+	if templateErr != nil {
+		return templateErr
+	}
+	return nil
+}
+
+func (r *runner) ensureLogsDBColumnarTemplate(ctx context.Context) error {
+	state, err := r.loadLogsDBColumnarState()
 	if err != nil {
 		return err
 	}
+	if state != nil {
+		logger.Debug("LogsDB Columnar component template already configured in prior setup")
+		return nil
+	}
+
+	supported, err := r.hasColumnarIndexModeCapability(ctx)
+	if err != nil {
+		return err
+	}
+	if !supported {
+		return fmt.Errorf("logsdb columnar is not supported by this cluster: required create-index capability %q is unavailable", "columnar_index_modes")
+	}
+
+	templateNames, err := r.logsDBColumnarTemplateNames()
+	if err != nil {
+		return err
+	}
+	if len(templateNames) == 0 {
+		logger.Debug("No logs data streams selected for LogsDB Columnar")
+		return nil
+	}
+
+	state = &logsDBColumnarTemplateState{
+		Templates: make(map[string]logsDBColumnarTemplateSnapshot, len(templateNames)),
+	}
+	for _, templateName := range templateNames {
+		currentTemplate, exists, err := r.getComponentTemplate(ctx, templateName)
+		if err != nil {
+			return err
+		}
+		payload, err := buildLogsDBColumnarTemplatePayload(currentTemplate, exists)
+		if err != nil {
+			return err
+		}
+		if err := r.putComponentTemplate(ctx, templateName, payload); err != nil {
+			return err
+		}
+		state.Templates[templateName] = logsDBColumnarTemplateSnapshot{
+			Existed:           exists,
+			ComponentTemplate: currentTemplate,
+		}
+		logger.Debugf("Configured %s with index.mode=%s for system tests", templateName, logsDBColumnarIndexMode)
+	}
+
+	if err := r.saveLogsDBColumnarState(state); err != nil {
+		return err
+	}
+	r.logsDBColumnarState = state
 	return nil
+}
+
+func (r *runner) restoreLogsDBColumnarTemplate(ctx context.Context) error {
+	state, err := r.loadLogsDBColumnarState()
+	if err != nil {
+		return err
+	}
+	if state == nil {
+		return nil
+	}
+
+	for templateName, snapshot := range state.Templates {
+		if snapshot.Existed {
+			if err := r.putComponentTemplate(ctx, templateName, snapshot.ComponentTemplate); err != nil {
+				return err
+			}
+			logger.Debugf("Restored previous %s component template", templateName)
+		} else {
+			if err := r.deleteComponentTemplate(ctx, templateName); err != nil {
+				return err
+			}
+			logger.Debugf("Removed temporary %s component template", templateName)
+		}
+	}
+
+	r.logsDBColumnarState = nil
+	if err := os.Remove(r.logsDBColumnarStatePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to remove logsdb columnar state file: %w", err)
+	}
+	return nil
+}
+
+func (r *runner) hasColumnarIndexModeCapability(ctx context.Context) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/_capabilities", nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to create capabilities request: %w", err)
+	}
+
+	query := req.URL.Query()
+	query.Set("method", http.MethodPut)
+	query.Set("path", "/{index}")
+	query.Set("capabilities", "columnar_index_modes")
+	req.URL.RawQuery = query.Encode()
+
+	resp, err := r.esClient.Transport.Perform(req)
+	if err != nil {
+		return false, fmt.Errorf("failed to query Elasticsearch capabilities: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode/100 == 4 {
+		return false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return false, fmt.Errorf("unexpected status querying Elasticsearch capabilities: %d: %s", resp.StatusCode, string(body))
+	}
+
+	var response struct {
+		Supported bool `json:"supported"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return false, fmt.Errorf("failed to decode Elasticsearch capabilities response: %w", err)
+	}
+	return response.Supported, nil
+}
+
+func (r *runner) getComponentTemplate(ctx context.Context, templateName string) (json.RawMessage, bool, error) {
+	resp, err := r.esAPI.Cluster.GetComponentTemplate(
+		r.esAPI.Cluster.GetComponentTemplate.WithContext(ctx),
+		r.esAPI.Cluster.GetComponentTemplate.WithName(templateName),
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to query component template %q: %w", templateName, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, false, nil
+	}
+	if resp.IsError() {
+		return nil, false, fmt.Errorf("failed to query component template %q: %s", templateName, resp.String())
+	}
+
+	var response struct {
+		ComponentTemplates []struct {
+			Name              string          `json:"name"`
+			ComponentTemplate json.RawMessage `json:"component_template"`
+		} `json:"component_templates"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, false, fmt.Errorf("failed to decode component template %q response: %w", templateName, err)
+	}
+
+	if len(response.ComponentTemplates) == 0 {
+		return nil, false, nil
+	}
+	return response.ComponentTemplates[0].ComponentTemplate, true, nil
+}
+
+func (r *runner) putComponentTemplate(ctx context.Context, templateName string, payload []byte) error {
+	resp, err := r.esAPI.Cluster.PutComponentTemplate(
+		templateName,
+		bytes.NewReader(payload),
+		r.esAPI.Cluster.PutComponentTemplate.WithContext(ctx),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to put component template %q: %w", templateName, err)
+	}
+	defer resp.Body.Close()
+	if resp.IsError() {
+		return fmt.Errorf("failed to put component template %q: %s", templateName, resp.String())
+	}
+	return nil
+}
+
+func (r *runner) deleteComponentTemplate(ctx context.Context, templateName string) error {
+	resp, err := r.esAPI.Cluster.DeleteComponentTemplate(
+		templateName,
+		r.esAPI.Cluster.DeleteComponentTemplate.WithContext(ctx),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to delete component template %q: %w", templateName, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if resp.IsError() {
+		return fmt.Errorf("failed to delete component template %q: %s", templateName, resp.String())
+	}
+	return nil
+}
+
+func (r *runner) loadLogsDBColumnarState() (*logsDBColumnarTemplateState, error) {
+	if r.logsDBColumnarState != nil {
+		return r.logsDBColumnarState, nil
+	}
+
+	content, err := os.ReadFile(r.logsDBColumnarStatePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read logsdb columnar state file: %w", err)
+	}
+
+	var state logsDBColumnarTemplateState
+	if err := json.Unmarshal(content, &state); err != nil {
+		return nil, fmt.Errorf("failed to decode logsdb columnar state file: %w", err)
+	}
+	if len(state.Templates) == 0 {
+		if state.Existed || len(state.ComponentTemplate) > 0 {
+			state.Templates = map[string]logsDBColumnarTemplateSnapshot{
+				defaultLogsDBColumnarComponentTemplateName: {
+					Existed:           state.Existed,
+					ComponentTemplate: state.ComponentTemplate,
+				},
+			}
+		}
+	}
+	r.logsDBColumnarState = &state
+	return &state, nil
+}
+
+func (r *runner) saveLogsDBColumnarState(state *logsDBColumnarTemplateState) error {
+	if err := os.MkdirAll(filepath.Dir(r.logsDBColumnarStatePath), 0755); err != nil {
+		return fmt.Errorf("failed to create logsdb columnar state directory: %w", err)
+	}
+
+	content, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("failed to encode logsdb columnar state: %w", err)
+	}
+	if err := os.WriteFile(r.logsDBColumnarStatePath, content, 0644); err != nil {
+		return fmt.Errorf("failed to persist logsdb columnar state: %w", err)
+	}
+	return nil
+}
+
+func (r *runner) logsDBColumnarTemplateNames() ([]string, error) {
+	if r.packageRoot == "" {
+		return []string{defaultLogsDBColumnarComponentTemplateName}, nil
+	}
+
+	packageManifest, err := packages.ReadPackageManifestFromPackageRoot(r.packageRoot)
+	if err != nil {
+		return nil, fmt.Errorf("reading package manifest failed (path: %s): %w", r.packageRoot, err)
+	}
+	dataStreamManifests, err := packages.ReadAllDataStreamManifests(r.packageRoot)
+	if err != nil {
+		return nil, fmt.Errorf("reading data stream manifests failed (path: %s): %w", r.packageRoot, err)
+	}
+
+	selectedDataStreams, err := r.selectedDataStreamsForRun()
+	if err != nil {
+		return nil, err
+	}
+	selectedSet := map[string]struct{}{}
+	for _, dataStream := range selectedDataStreams {
+		selectedSet[dataStream] = struct{}{}
+	}
+
+	templateNames := make([]string, 0, len(dataStreamManifests))
+	for _, dataStreamManifest := range dataStreamManifests {
+		if len(selectedSet) > 0 {
+			if _, found := selectedSet[dataStreamManifest.Name]; !found {
+				continue
+			}
+		}
+		if dataStreamManifest.Type != "logs" {
+			continue
+		}
+
+		dataset := dataStreamManifest.Dataset
+		if dataset == "" {
+			dataset = packageManifest.Name + "." + dataStreamManifest.Name
+		}
+		templateNames = append(templateNames, "logs-"+dataset+"@custom")
+	}
+
+	if len(templateNames) == 0 {
+		return []string{defaultLogsDBColumnarComponentTemplateName}, nil
+	}
+	return templateNames, nil
+}
+
+func (r *runner) selectedDataStreamsForRun() ([]string, error) {
+	if r.runSetup || r.runTearDown || r.runTestsOnly {
+		configFilePath := r.configFilePath
+		if r.runTearDown || r.runTestsOnly {
+			serviceState, err := readServiceStateData(r.serviceStateFilePath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read service state: %w", err)
+			}
+			configFilePath = serviceState.ConfigFilePath
+		}
+		if configFilePath == "" {
+			return nil, nil
+		}
+		dataStream := testrunner.ExtractDataStreamFromPath(configFilePath, r.packageRoot)
+		if dataStream == "" {
+			return nil, nil
+		}
+		return []string{dataStream}, nil
+	}
+
+	if len(r.dataStreams) > 0 {
+		return r.dataStreams, nil
+	}
+	return nil, nil
+}
+
+func buildLogsDBColumnarTemplatePayload(currentTemplate json.RawMessage, exists bool) ([]byte, error) {
+	template := map[string]any{}
+	if exists {
+		if err := json.Unmarshal(currentTemplate, &template); err != nil {
+			return nil, fmt.Errorf("failed to decode existing component template: %w", err)
+		}
+	}
+
+	templateSection, ok := template["template"].(map[string]any)
+	if !ok {
+		templateSection = map[string]any{}
+		template["template"] = templateSection
+	}
+	settingsSection, ok := templateSection["settings"].(map[string]any)
+	if !ok {
+		settingsSection = map[string]any{}
+		templateSection["settings"] = settingsSection
+	}
+	indexSection, ok := settingsSection["index"].(map[string]any)
+	if !ok {
+		indexSection = map[string]any{}
+		settingsSection["index"] = indexSection
+	}
+	indexSection["mode"] = logsDBColumnarIndexMode
+
+	payload, err := json.Marshal(template)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode logsdb columnar component template payload: %w", err)
+	}
+	return payload, nil
 }
 
 func (r *runner) GetTests(ctx context.Context) ([]testrunner.Tester, error) {
@@ -236,59 +623,204 @@ func (r *runner) GetTests(ctx context.Context) ([]testrunner.Tester, error) {
 		}
 	}
 
-	var testers []testrunner.Tester
-	for _, t := range folders {
-		var variants []string
-		var cfgFiles []string
-
-		if r.runTestsOnly || r.runTearDown {
-			variants = []string{serviceState.VariantName}
-			cfgFiles = []string{filepath.Base(serviceState.ConfigFilePath)}
-		} else {
-			variants, err = r.getAllVariants(t)
-			if err != nil {
-				return nil, fmt.Errorf("failed to retrieve variants from %s: %w", t.Path, err)
-			}
-
-			cfgFiles, err = r.getAllConfigFiles(t)
-			if err != nil {
-				return nil, fmt.Errorf("failed to retrieve config files from %s: %w", t.Path, err)
-			}
-		}
-
-		for _, variant := range variants {
-			for _, config := range cfgFiles {
-				logger.Debugf("System runner: data stream %q config file %q variant %q", t.DataStream, config, variant)
-				tester, err := NewSystemTester(SystemTesterOptions{
-					Profile:              r.profile,
-					PackageRoot:          r.packageRoot,
-					KibanaClient:         r.kibanaClient,
-					API:                  r.esAPI,
-					ESClient:             r.esClient,
-					SchemaURLs:           r.schemaURLs,
-					TestFolder:           t,
-					ServiceVariant:       variant,
-					GenerateTestResult:   r.generateTestResult,
-					DeferCleanup:         r.deferCleanup,
-					RunSetup:             r.runSetup,
-					RunTestsOnly:         r.runTestsOnly,
-					RunTearDown:          r.runTearDown,
-					ConfigFileName:       config,
-					GlobalTestConfig:     r.globalTestConfig,
-					WithCoverage:         r.withCoverage,
-					CoverageType:         r.coverageType,
-					OverrideAgentVersion: r.overrideAgentVersion,
-				})
-				if err != nil {
-					return nil, fmt.Errorf(
-						"failed to create system runner for sdata stream %q variant %q config file %q: %w",
-						t.DataStream, variant, config, err)
-				}
-				testers = append(testers, tester)
-			}
+	columnarSkipReasons := map[string]string{}
+	if r.logsDBColumnar {
+		columnarSkipReasons, err = r.skipReasonsForLogsDBColumnar(folders)
+		if err != nil {
+			return nil, err
 		}
 	}
+
+	var testers []testrunner.Tester
+	for _, t := range folders {
+		if reason, shouldSkip := columnarSkipReasons[t.Path]; shouldSkip {
+			testers = append(testers, newSkippedSystemTester(t, reason))
+			continue
+		}
+		folderTesters, err := r.createTestersForFolder(t, serviceState)
+		if err != nil {
+			return nil, err
+		}
+		testers = append(testers, folderTesters...)
+	}
 	return testers, nil
+}
+
+func (r *runner) createTestersForFolder(testFolder testrunner.TestFolder, serviceState ServiceState) ([]testrunner.Tester, error) {
+	var variants []string
+	var cfgFiles []string
+	var err error
+
+	if r.runTestsOnly || r.runTearDown {
+		variants = []string{serviceState.VariantName}
+		cfgFiles = []string{filepath.Base(serviceState.ConfigFilePath)}
+	} else {
+		variants, err = r.getAllVariants(testFolder)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve variants from %s: %w", testFolder.Path, err)
+		}
+
+		cfgFiles, err = r.getAllConfigFiles(testFolder)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve config files from %s: %w", testFolder.Path, err)
+		}
+	}
+
+	testers := make([]testrunner.Tester, 0, len(variants)*len(cfgFiles))
+	for _, variant := range variants {
+		for _, config := range cfgFiles {
+			logger.Debugf("System runner: data stream %q config file %q variant %q", testFolder.DataStream, config, variant)
+			tester, err := NewSystemTester(SystemTesterOptions{
+				Profile:              r.profile,
+				PackageRoot:          r.packageRoot,
+				KibanaClient:         r.kibanaClient,
+				API:                  r.esAPI,
+				ESClient:             r.esClient,
+				SchemaURLs:           r.schemaURLs,
+				TestFolder:           testFolder,
+				ServiceVariant:       variant,
+				GenerateTestResult:   r.generateTestResult,
+				DeferCleanup:         r.deferCleanup,
+				RunSetup:             r.runSetup,
+				RunTestsOnly:         r.runTestsOnly,
+				RunTearDown:          r.runTearDown,
+				ConfigFileName:       config,
+				GlobalTestConfig:     r.globalTestConfig,
+				WithCoverage:         r.withCoverage,
+				CoverageType:         r.coverageType,
+				OverrideAgentVersion: r.overrideAgentVersion,
+			})
+			if err != nil {
+				return nil, fmt.Errorf(
+					"failed to create system runner for sdata stream %q variant %q config file %q: %w",
+					testFolder.DataStream, variant, config, err)
+			}
+			testers = append(testers, tester)
+		}
+	}
+
+	return testers, nil
+}
+
+func (r *runner) skipReasonsForLogsDBColumnar(folders []testrunner.TestFolder) (map[string]string, error) {
+	reasons := map[string]string{}
+
+	for _, folder := range folders {
+		if folder.DataStream == "" {
+			continue
+		}
+
+		manifest, err := packages.ReadDataStreamManifestFromPackageRoot(r.packageRoot, folder.DataStream)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read manifest for data stream %q: %w", folder.DataStream, err)
+		}
+		if manifest.Type != "logs" {
+			continue
+		}
+
+		hasNested, err := hasNestedFieldsInDataStream(r.packageRoot, folder.DataStream)
+		if err != nil {
+			return nil, err
+		}
+		if hasNested {
+			reasons[folder.Path] = "LogsDB Columnar does not support nested mappings for logs data streams"
+		}
+	}
+
+	return reasons, nil
+}
+
+type skippedSystemTester struct {
+	testFolder testrunner.TestFolder
+	reason     string
+}
+
+func newSkippedSystemTester(testFolder testrunner.TestFolder, reason string) *skippedSystemTester {
+	return &skippedSystemTester{
+		testFolder: testFolder,
+		reason:     reason,
+	}
+}
+
+func (s *skippedSystemTester) Type() testrunner.TestType {
+	return TestType
+}
+
+func (s *skippedSystemTester) String() string {
+	return "system"
+}
+
+func (s *skippedSystemTester) Run(ctx context.Context) ([]testrunner.TestResult, error) {
+	logger.Warnf(
+		"skipping system test for %s/%s: %s",
+		s.testFolder.Package,
+		s.testFolder.DataStream,
+		s.reason,
+	)
+	result := testrunner.NewResultComposer(testrunner.TestResult{
+		TestType:   TestType,
+		Name:       "logsdb-columnar compatibility",
+		Package:    s.testFolder.Package,
+		DataStream: s.testFolder.DataStream,
+	})
+	return result.WithSkip(&testrunner.SkipConfig{Reason: s.reason})
+}
+
+func (s *skippedSystemTester) TearDown(ctx context.Context) error {
+	return nil
+}
+
+func (s *skippedSystemTester) Parallel() bool {
+	return true
+}
+
+func hasNestedFieldsInDataStream(packageRoot, dataStreamName string) (bool, error) {
+	fieldsDir := filepath.Join(packageRoot, "data_stream", dataStreamName, "fields")
+	info, err := os.Stat(fieldsDir)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return false, nil
+	case err != nil:
+		return false, fmt.Errorf("failed to inspect fields directory for data stream %q: %w", dataStreamName, err)
+	case !info.IsDir():
+		return false, nil
+	}
+
+	fieldFiles, err := filepath.Glob(filepath.Join(fieldsDir, "*.yml"))
+	if err != nil {
+		return false, fmt.Errorf("failed to list field files for data stream %q: %w", dataStreamName, err)
+	}
+
+	for _, fieldFile := range fieldFiles {
+		content, err := os.ReadFile(fieldFile)
+		if err != nil {
+			return false, fmt.Errorf("failed to read field file %q: %w", fieldFile, err)
+		}
+		var definitions fields.FieldDefinitions
+		if err := yaml.Unmarshal(content, &definitions); err != nil {
+			return false, fmt.Errorf("failed to parse field file %q: %w", fieldFile, err)
+		}
+		if hasNestedFieldDefinitions(definitions) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func hasNestedFieldDefinitions(definitions []fields.FieldDefinition) bool {
+	for _, definition := range definitions {
+		if definition.Type == "nested" {
+			return true
+		}
+		if hasNestedFieldDefinitions(definition.Fields) {
+			return true
+		}
+		if hasNestedFieldDefinitions(definition.MultiFields) {
+			return true
+		}
+	}
+	return false
 }
 
 // Type returns the type of test that can be run by this test runner.

--- a/internal/testrunner/runners/system/runner_test.go
+++ b/internal/testrunner/runners/system/runner_test.go
@@ -166,6 +166,7 @@ func TestPackageComponentTemplateName(t *testing.T) {
 func TestEnsureAndRestoreLogsDBColumnarTemplateWithoutExistingTemplate(t *testing.T) {
 	var putBodies [][]byte
 	deleteCount := 0
+	customName := "logs-testpkg.stream@custom"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("X-Elastic-Product", "Elasticsearch")
 		switch {
@@ -176,18 +177,18 @@ func TestEnsureAndRestoreLogsDBColumnarTemplateWithoutExistingTemplate(t *testin
 			assert.Equal(t, "/{index}", req.URL.Query().Get("path"))
 			assert.Equal(t, "columnar_index_modes", req.URL.Query().Get("capabilities"))
 			_, _ = io.WriteString(w, `{"supported":true}`)
-		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/logs@custom":
+		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/"+customName:
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = io.WriteString(w, `{"status":404}`)
-		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/logs@package":
+		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/logs-testpkg.stream@package":
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = io.WriteString(w, `{"status":404}`)
-		case req.Method == http.MethodPut && req.URL.Path == "/_component_template/logs@custom":
+		case req.Method == http.MethodPut && req.URL.Path == "/_component_template/"+customName:
 			body, err := io.ReadAll(req.Body)
 			require.NoError(t, err)
 			putBodies = append(putBodies, body)
 			_, _ = io.WriteString(w, `{"acknowledged":true}`)
-		case req.Method == http.MethodDelete && req.URL.Path == "/_component_template/logs@custom":
+		case req.Method == http.MethodDelete && req.URL.Path == "/_component_template/"+customName:
 			deleteCount++
 			_, _ = io.WriteString(w, `{"acknowledged":true}`)
 		default:
@@ -203,6 +204,8 @@ func TestEnsureAndRestoreLogsDBColumnarTemplateWithoutExistingTemplate(t *testin
 	r := &runner{
 		esAPI:                   client.API,
 		esClient:                client,
+		packageRoot:             writeLogsPackageRoot(t, "testpkg", "stream"),
+		dataStreams:             []string{"stream"},
 		logsDBColumnarStatePath: statePath,
 	}
 
@@ -224,6 +227,7 @@ func TestEnsureAndRestoreLogsDBColumnarTemplateWithoutExistingTemplate(t *testin
 func TestEnsureAndRestoreLogsDBColumnarTemplateWithExistingTemplate(t *testing.T) {
 	originalTemplate := `{"template":{"settings":{"index":{"number_of_shards":"2"}}}}`
 	var putBodies [][]byte
+	customName := "logs-testpkg.stream@custom"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("X-Elastic-Product", "Elasticsearch")
 		switch {
@@ -231,16 +235,16 @@ func TestEnsureAndRestoreLogsDBColumnarTemplateWithExistingTemplate(t *testing.T
 			_, _ = io.WriteString(w, `{"version":{"number":"9.5.0-SNAPSHOT"}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/_capabilities":
 			_, _ = io.WriteString(w, `{"supported":true}`)
-		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/logs@custom":
+		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/"+customName:
 			_, _ = io.WriteString(w, fmt.Sprintf(`{
 				"component_templates":[
-					{"name":"logs@custom","component_template":%s}
+					{"name":%q,"component_template":%s}
 				]
-			}`, originalTemplate))
-		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/logs@package":
+			}`, customName, originalTemplate))
+		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/logs-testpkg.stream@package":
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = io.WriteString(w, `{"status":404}`)
-		case req.Method == http.MethodPut && req.URL.Path == "/_component_template/logs@custom":
+		case req.Method == http.MethodPut && req.URL.Path == "/_component_template/"+customName:
 			body, err := io.ReadAll(req.Body)
 			require.NoError(t, err)
 			putBodies = append(putBodies, body)
@@ -257,6 +261,8 @@ func TestEnsureAndRestoreLogsDBColumnarTemplateWithExistingTemplate(t *testing.T
 	r := &runner{
 		esAPI:                   client.API,
 		esClient:                client,
+		packageRoot:             writeLogsPackageRoot(t, "testpkg", "stream"),
+		dataStreams:             []string{"stream"},
 		logsDBColumnarStatePath: filepath.Join(t.TempDir(), "logsdb-columnar-state.json"),
 	}
 
@@ -277,6 +283,82 @@ func TestEnsureAndRestoreLogsDBColumnarTemplateWithExistingTemplate(t *testing.T
 	assert.Equal(t, "2", index["number_of_shards"])
 	_, hasMode := index["mode"]
 	assert.False(t, hasMode)
+}
+
+func TestEnsureLogsDBColumnarTemplateSkipsMetricsOnlyPackage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/":
+			_, _ = io.WriteString(w, `{"version":{"number":"9.5.0-SNAPSHOT"}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/_capabilities":
+			_, _ = io.WriteString(w, `{"supported":true}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := elasticsearch.NewClient(elasticsearch.OptionWithAddress(server.URL))
+	require.NoError(t, err)
+
+	packageRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(packageRoot, "manifest.yml"), []byte(`
+format_version: 3.3.2
+name: airflow
+title: Airflow
+version: 0.0.1
+description: test
+type: integration
+conditions:
+  kibana:
+    version: "^8.0.0"
+owner:
+  github: elastic/obs-infraobs-integrations
+`), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(packageRoot, "data_stream", "statsd"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(packageRoot, "data_stream", "statsd", "manifest.yml"), []byte(`
+title: Statsd
+type: metrics
+`), 0o644))
+
+	statePath := filepath.Join(t.TempDir(), "logsdb-columnar-state.json")
+	r := &runner{
+		esAPI:                   client.API,
+		esClient:                client,
+		packageRoot:             packageRoot,
+		dataStreams:             []string{"statsd"},
+		logsDBColumnarStatePath: statePath,
+	}
+
+	err = r.ensureLogsDBColumnarTemplate(t.Context())
+	require.NoError(t, err)
+	_, err = os.Stat(statePath)
+	require.ErrorIs(t, err, os.ErrNotExist, "metrics-only packages must not configure logs@custom")
+}
+
+func writeLogsPackageRoot(t *testing.T, packageName, streamName string) string {
+	t.Helper()
+	packageRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(packageRoot, "manifest.yml"), []byte(fmt.Sprintf(`
+format_version: 3.3.2
+name: %s
+title: Test
+version: 0.0.1
+description: test
+type: integration
+conditions:
+  kibana:
+    version: "^8.0.0"
+owner:
+  github: elastic/test
+`, packageName)), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(packageRoot, "data_stream", streamName), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(packageRoot, "data_stream", streamName, "manifest.yml"), []byte(fmt.Sprintf(`
+title: %s
+type: logs
+`, streamName)), 0o644))
+	return packageRoot
 }
 
 func TestEnsureLogsDBColumnarTemplateWithPackageDocValuesOverrides(t *testing.T) {

--- a/internal/testrunner/runners/system/runner_test.go
+++ b/internal/testrunner/runners/system/runner_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -453,7 +454,7 @@ func TestEnsureLogsDBColumnarTemplateStripsPackageSubobjects(t *testing.T) {
 		"created_date_millis":1784647677960,
 		"modified_date_millis":1784647677960
 	}`
-	var packagePuts [][]byte
+	packagePuts := map[string][][]byte{}
 	var customPuts [][]byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("X-Elastic-Product", "Elasticsearch")
@@ -465,17 +466,21 @@ func TestEnsureLogsDBColumnarTemplateStripsPackageSubobjects(t *testing.T) {
 		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/logs-doppler.activity@custom":
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = io.WriteString(w, `{"status":404}`)
-		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/logs-doppler.activity@package":
+		case req.Method == http.MethodGet && (req.URL.Path == "/_component_template/logs-doppler.activity@package" ||
+			req.URL.Path == "/_component_template/logs-doppler.secret_read@package"):
+			name := strings.TrimPrefix(req.URL.Path, "/_component_template/")
 			_, _ = io.WriteString(w, fmt.Sprintf(`{
 				"component_templates":[{
-					"name":"logs-doppler.activity@package",
+					"name":%q,
 					"component_template":%s
 				}]
-			}`, originalPackage))
-		case req.Method == http.MethodPut && req.URL.Path == "/_component_template/logs-doppler.activity@package":
+			}`, name, originalPackage))
+		case req.Method == http.MethodPut && (req.URL.Path == "/_component_template/logs-doppler.activity@package" ||
+			req.URL.Path == "/_component_template/logs-doppler.secret_read@package"):
+			name := strings.TrimPrefix(req.URL.Path, "/_component_template/")
 			body, err := io.ReadAll(req.Body)
 			require.NoError(t, err)
-			packagePuts = append(packagePuts, body)
+			packagePuts[name] = append(packagePuts[name], body)
 			_, _ = io.WriteString(w, `{"acknowledged":true}`)
 		case req.Method == http.MethodPut && req.URL.Path == "/_component_template/logs-doppler.activity@custom":
 			body, err := io.ReadAll(req.Body)
@@ -507,11 +512,13 @@ conditions:
 owner:
   github: elastic/security-service-integrations
 `), 0o644))
-	require.NoError(t, os.MkdirAll(filepath.Join(packageRoot, "data_stream", "activity"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(packageRoot, "data_stream", "activity", "manifest.yml"), []byte(`
-title: Activity
+	for _, stream := range []string{"activity", "secret_read"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(packageRoot, "data_stream", stream), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(packageRoot, "data_stream", stream, "manifest.yml"), []byte(fmt.Sprintf(`
+title: %s
 type: logs
-`), 0o644))
+`, stream)), 0o644))
+	}
 
 	r := &runner{
 		esAPI:                   client.API,
@@ -523,29 +530,35 @@ type: logs
 
 	err = r.ensureLogsDBColumnarTemplate(t.Context())
 	require.NoError(t, err)
-	require.Len(t, packagePuts, 1, "package template should be rewritten without subobjects")
-	require.Len(t, customPuts, 1)
+	require.Len(t, packagePuts["logs-doppler.activity@package"], 1, "selected stream package template should be rewritten")
+	require.Len(t, packagePuts["logs-doppler.secret_read@package"], 1, "sibling stream package template should also be stripped")
+	require.Len(t, customPuts, 1, "columnar @custom should only be configured for the selected stream")
 
-	strippedPackage := map[string]any{}
-	require.NoError(t, json.Unmarshal(packagePuts[0], &strippedPackage))
-	mappings := strippedPackage["template"].(map[string]any)["mappings"].(map[string]any)
-	_, hasSubobjects := mappings["subobjects"]
-	assert.False(t, hasSubobjects, "subobjects should be stripped before enabling columnar mode")
-	_, hasCreatedMillis := strippedPackage["created_date_millis"]
-	_, hasModifiedMillis := strippedPackage["modified_date_millis"]
-	assert.False(t, hasCreatedMillis, "system-managed created_date_millis must not be sent on put")
-	assert.False(t, hasModifiedMillis, "system-managed modified_date_millis must not be sent on put")
+	for name, puts := range packagePuts {
+		strippedPackage := map[string]any{}
+		require.NoError(t, json.Unmarshal(puts[0], &strippedPackage), name)
+		mappings := strippedPackage["template"].(map[string]any)["mappings"].(map[string]any)
+		_, hasSubobjects := mappings["subobjects"]
+		assert.False(t, hasSubobjects, "%s: subobjects should be stripped before enabling columnar mode", name)
+		_, hasCreatedMillis := strippedPackage["created_date_millis"]
+		_, hasModifiedMillis := strippedPackage["modified_date_millis"]
+		assert.False(t, hasCreatedMillis, "%s: system-managed created_date_millis must not be sent on put", name)
+		assert.False(t, hasModifiedMillis, "%s: system-managed modified_date_millis must not be sent on put", name)
+	}
 
 	err = r.restoreLogsDBColumnarTemplate(t.Context())
 	require.NoError(t, err)
-	require.Len(t, packagePuts, 2, "original package template should be restored after custom")
-	restoredPackage := map[string]any{}
-	require.NoError(t, json.Unmarshal(packagePuts[1], &restoredPackage))
-	assert.Equal(t, false, restoredPackage["template"].(map[string]any)["mappings"].(map[string]any)["subobjects"])
-	_, hasCreatedMillis = restoredPackage["created_date_millis"]
-	_, hasModifiedMillis = restoredPackage["modified_date_millis"]
-	assert.False(t, hasCreatedMillis)
-	assert.False(t, hasModifiedMillis)
+	require.Len(t, packagePuts["logs-doppler.activity@package"], 2, "original activity package template should be restored after custom")
+	require.Len(t, packagePuts["logs-doppler.secret_read@package"], 2, "original sibling package template should be restored")
+	for name, puts := range packagePuts {
+		restoredPackage := map[string]any{}
+		require.NoError(t, json.Unmarshal(puts[1], &restoredPackage), name)
+		assert.Equal(t, false, restoredPackage["template"].(map[string]any)["mappings"].(map[string]any)["subobjects"], name)
+		_, hasCreatedMillis := restoredPackage["created_date_millis"]
+		_, hasModifiedMillis := restoredPackage["modified_date_millis"]
+		assert.False(t, hasCreatedMillis, name)
+		assert.False(t, hasModifiedMillis, name)
+	}
 }
 
 func indexModeFromPayload(t *testing.T, payload []byte) string {

--- a/internal/testrunner/runners/system/runner_test.go
+++ b/internal/testrunner/runners/system/runner_test.go
@@ -379,6 +379,35 @@ type: logs
 	assert.True(t, ok)
 }
 
+func TestSanitizeComponentTemplateForPut(t *testing.T) {
+	original := []byte(`{
+		"template": {"mappings": {"subobjects": false}},
+		"_meta": {"managed": true},
+		"version": 1,
+		"created_date_millis": 1784647677960,
+		"modified_date_millis": 1784647677960,
+		"created_date": "2026-01-01T00:00:00.000Z",
+		"modified_date": "2026-01-01T00:00:00.000Z"
+	}`)
+
+	sanitized, err := sanitizeComponentTemplateForPut(original)
+	require.NoError(t, err)
+
+	decoded := map[string]any{}
+	require.NoError(t, json.Unmarshal(sanitized, &decoded))
+	assert.Equal(t, false, decoded["template"].(map[string]any)["mappings"].(map[string]any)["subobjects"])
+	assert.Equal(t, map[string]any{"managed": true}, decoded["_meta"])
+	assert.EqualValues(t, 1, decoded["version"])
+	_, hasCreatedMillis := decoded["created_date_millis"]
+	_, hasModifiedMillis := decoded["modified_date_millis"]
+	_, hasCreated := decoded["created_date"]
+	_, hasModified := decoded["modified_date"]
+	assert.False(t, hasCreatedMillis)
+	assert.False(t, hasModifiedMillis)
+	assert.False(t, hasCreated)
+	assert.False(t, hasModified)
+}
+
 func TestStripSubobjectsFromComponentTemplate(t *testing.T) {
 	original := []byte(`{
 		"template": {
@@ -419,7 +448,11 @@ func TestStripSubobjectsFromComponentTemplate(t *testing.T) {
 }
 
 func TestEnsureLogsDBColumnarTemplateStripsPackageSubobjects(t *testing.T) {
-	originalPackage := `{"template":{"mappings":{"subobjects":false,"properties":{"message":{"type":"keyword"}}}}}`
+	originalPackage := `{
+		"template":{"mappings":{"subobjects":false,"properties":{"message":{"type":"keyword"}}}},
+		"created_date_millis":1784647677960,
+		"modified_date_millis":1784647677960
+	}`
 	var packagePuts [][]byte
 	var customPuts [][]byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -498,11 +531,21 @@ type: logs
 	mappings := strippedPackage["template"].(map[string]any)["mappings"].(map[string]any)
 	_, hasSubobjects := mappings["subobjects"]
 	assert.False(t, hasSubobjects, "subobjects should be stripped before enabling columnar mode")
+	_, hasCreatedMillis := strippedPackage["created_date_millis"]
+	_, hasModifiedMillis := strippedPackage["modified_date_millis"]
+	assert.False(t, hasCreatedMillis, "system-managed created_date_millis must not be sent on put")
+	assert.False(t, hasModifiedMillis, "system-managed modified_date_millis must not be sent on put")
 
 	err = r.restoreLogsDBColumnarTemplate(t.Context())
 	require.NoError(t, err)
 	require.Len(t, packagePuts, 2, "original package template should be restored after custom")
-	assert.JSONEq(t, originalPackage, string(packagePuts[1]))
+	restoredPackage := map[string]any{}
+	require.NoError(t, json.Unmarshal(packagePuts[1], &restoredPackage))
+	assert.Equal(t, false, restoredPackage["template"].(map[string]any)["mappings"].(map[string]any)["subobjects"])
+	_, hasCreatedMillis = restoredPackage["created_date_millis"]
+	_, hasModifiedMillis = restoredPackage["modified_date_millis"]
+	assert.False(t, hasCreatedMillis)
+	assert.False(t, hasModifiedMillis)
 }
 
 func indexModeFromPayload(t *testing.T, payload []byte) string {

--- a/internal/testrunner/runners/system/runner_test.go
+++ b/internal/testrunner/runners/system/runner_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-package/internal/elasticsearch"
-	"github.com/elastic/elastic-package/internal/testrunner"
 )
 
 func TestBuildLogsDBColumnarTemplatePayload(t *testing.T) {
@@ -166,59 +165,6 @@ func TestEnsureAndRestoreLogsDBColumnarTemplateWithExistingTemplate(t *testing.T
 	assert.False(t, hasMode)
 }
 
-func TestHasNestedFieldsInDataStream(t *testing.T) {
-	packageRoot := t.TempDir()
-
-	err := writeFile(filepath.Join(packageRoot, "data_stream", "with_nested", "fields", "fields.yml"), `
-- name: dns.answers
-  type: nested
-`)
-	require.NoError(t, err)
-
-	err = writeFile(filepath.Join(packageRoot, "data_stream", "without_nested", "fields", "fields.yml"), `
-- name: message
-  type: keyword
-`)
-	require.NoError(t, err)
-
-	nested, err := hasNestedFieldsInDataStream(packageRoot, "with_nested")
-	require.NoError(t, err)
-	assert.True(t, nested)
-
-	nested, err = hasNestedFieldsInDataStream(packageRoot, "without_nested")
-	require.NoError(t, err)
-	assert.False(t, nested)
-
-	nested, err = hasNestedFieldsInDataStream(packageRoot, "missing")
-	require.NoError(t, err)
-	assert.False(t, nested)
-}
-
-func TestSkipReasonsForLogsDBColumnar(t *testing.T) {
-	packageRoot := t.TempDir()
-	require.NoError(t, writeFile(filepath.Join(packageRoot, "data_stream", "logs_stream", "manifest.yml"), "title: Logs\ntype: logs\n"))
-	require.NoError(t, writeFile(filepath.Join(packageRoot, "data_stream", "logs_stream", "fields", "fields.yml"), `
-- name: dns.answers
-  type: nested
-`))
-	require.NoError(t, writeFile(filepath.Join(packageRoot, "data_stream", "metrics_stream", "manifest.yml"), "title: Metrics\ntype: metrics\n"))
-	require.NoError(t, writeFile(filepath.Join(packageRoot, "data_stream", "metrics_stream", "fields", "fields.yml"), `
-- name: host.name
-  type: keyword
-`))
-
-	r := &runner{packageRoot: packageRoot}
-	folders := []testrunner.TestFolder{
-		{Path: "/tmp/logs", Package: "demo", DataStream: "logs_stream"},
-		{Path: "/tmp/metrics", Package: "demo", DataStream: "metrics_stream"},
-	}
-
-	reasons, err := r.skipReasonsForLogsDBColumnar(folders)
-	require.NoError(t, err)
-	require.Len(t, reasons, 1)
-	assert.Contains(t, reasons["/tmp/logs"], "does not support nested mappings")
-}
-
 func indexModeFromPayload(t *testing.T, payload []byte) string {
 	t.Helper()
 	decoded := map[string]any{}
@@ -227,11 +173,4 @@ func indexModeFromPayload(t *testing.T, payload []byte) string {
 	settings := template["settings"].(map[string]any)
 	index := settings["index"].(map[string]any)
 	return index["mode"].(string)
-}
-
-func writeFile(path string, content string) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return err
-	}
-	return os.WriteFile(path, []byte(content), 0644)
 }

--- a/internal/testrunner/runners/system/runner_test.go
+++ b/internal/testrunner/runners/system/runner_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-package/internal/elasticsearch"
+	"github.com/elastic/elastic-package/internal/packages"
 )
 
 func TestBuildLogsDBColumnarTemplatePayload(t *testing.T) {
@@ -283,6 +284,63 @@ func TestEnsureAndRestoreLogsDBColumnarTemplateWithExistingTemplate(t *testing.T
 	assert.Equal(t, "2", index["number_of_shards"])
 	_, hasMode := index["mode"]
 	assert.False(t, hasMode)
+}
+
+func TestInputPackageLogsDatasets(t *testing.T) {
+	packageRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(packageRoot, "manifest.yml"), []byte(`
+format_version: 3.1.5
+name: filestream
+title: Filestream
+version: 0.0.1
+description: test
+type: input
+conditions:
+  kibana:
+    version: "^8.0.0"
+owner:
+  github: elastic/test
+policy_templates:
+  - name: filestream
+    type: logs
+    title: Filestream
+    description: test
+    input: filestream
+    vars:
+      - name: data_stream.dataset
+        type: text
+        default: filestream.generic
+`), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(packageRoot, "_dev", "test", "system"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(packageRoot, "_dev", "test", "system", "test-default-config.yml"), []byte(`
+input: filestream
+vars:
+  data_stream.dataset: filestream.generic
+  paths:
+    - "{{SERVICE_LOGS_DIR}}/test.log"
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(packageRoot, "_dev", "test", "system", "test-custom-dataset-config.yml"), []byte(`
+input: filestream
+vars:
+  data_stream.dataset: elastic_agent.test
+  paths:
+    - "{{SERVICE_LOGS_DIR}}/test.log"
+`), 0o644))
+
+	packageManifest, err := packages.ReadPackageManifestFromPackageRoot(packageRoot)
+	require.NoError(t, err)
+
+	datasets, err := inputPackageLogsDatasets(packageRoot, packageManifest)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"filestream.generic", "elastic_agent.test"}, datasets)
+
+	r := &runner{packageRoot: packageRoot}
+	names, err := r.logsDBColumnarCustomTemplateNames(true)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		"logs-filestream.generic@custom",
+		"logs-elastic_agent.test@custom",
+	}, names)
 }
 
 func TestEnsureLogsDBColumnarTemplateSkipsMetricsOnlyPackage(t *testing.T) {

--- a/internal/testrunner/runners/system/runner_test.go
+++ b/internal/testrunner/runners/system/runner_test.go
@@ -1,0 +1,237 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package system
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-package/internal/elasticsearch"
+	"github.com/elastic/elastic-package/internal/testrunner"
+)
+
+func TestBuildLogsDBColumnarTemplatePayload(t *testing.T) {
+	t.Run("creates payload when template is missing", func(t *testing.T) {
+		payload, err := buildLogsDBColumnarTemplatePayload(nil, false)
+		require.NoError(t, err)
+
+		mode := indexModeFromPayload(t, payload)
+		assert.Equal(t, logsDBColumnarIndexMode, mode)
+	})
+
+	t.Run("merges with existing template settings", func(t *testing.T) {
+		current := []byte(`{
+			"template": {
+				"settings": {
+					"index": {
+						"number_of_shards": "2"
+					}
+				}
+			},
+			"_meta": {
+				"managed_by": "test"
+			}
+		}`)
+		payload, err := buildLogsDBColumnarTemplatePayload(current, true)
+		require.NoError(t, err)
+
+		decoded := map[string]any{}
+		require.NoError(t, json.Unmarshal(payload, &decoded))
+		template := decoded["template"].(map[string]any)
+		settings := template["settings"].(map[string]any)
+		index := settings["index"].(map[string]any)
+		assert.Equal(t, logsDBColumnarIndexMode, index["mode"])
+		assert.Equal(t, "2", index["number_of_shards"])
+		assert.Equal(t, "test", decoded["_meta"].(map[string]any)["managed_by"])
+	})
+}
+
+func TestEnsureAndRestoreLogsDBColumnarTemplateWithoutExistingTemplate(t *testing.T) {
+	var putBodies [][]byte
+	deleteCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/":
+			_, _ = io.WriteString(w, `{"version":{"number":"9.5.0-SNAPSHOT"}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/_capabilities":
+			assert.Equal(t, http.MethodPut, req.URL.Query().Get("method"))
+			assert.Equal(t, "/{index}", req.URL.Query().Get("path"))
+			assert.Equal(t, "columnar_index_modes", req.URL.Query().Get("capabilities"))
+			_, _ = io.WriteString(w, `{"supported":true}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/logs@custom":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"status":404}`)
+		case req.Method == http.MethodPut && req.URL.Path == "/_component_template/logs@custom":
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			putBodies = append(putBodies, body)
+			_, _ = io.WriteString(w, `{"acknowledged":true}`)
+		case req.Method == http.MethodDelete && req.URL.Path == "/_component_template/logs@custom":
+			deleteCount++
+			_, _ = io.WriteString(w, `{"acknowledged":true}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := elasticsearch.NewClient(elasticsearch.OptionWithAddress(server.URL))
+	require.NoError(t, err)
+
+	statePath := filepath.Join(t.TempDir(), "logsdb-columnar-state.json")
+	r := &runner{
+		esAPI:                   client.API,
+		esClient:                client,
+		logsDBColumnarStatePath: statePath,
+	}
+
+	err = r.ensureLogsDBColumnarTemplate(t.Context())
+	require.NoError(t, err)
+	require.Len(t, putBodies, 1)
+	assert.Equal(t, logsDBColumnarIndexMode, indexModeFromPayload(t, putBodies[0]))
+	_, err = os.Stat(statePath)
+	require.NoError(t, err)
+
+	err = r.restoreLogsDBColumnarTemplate(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleteCount)
+	_, err = os.Stat(statePath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestEnsureAndRestoreLogsDBColumnarTemplateWithExistingTemplate(t *testing.T) {
+	originalTemplate := `{"template":{"settings":{"index":{"number_of_shards":"2"}}}}`
+	var putBodies [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/":
+			_, _ = io.WriteString(w, `{"version":{"number":"9.5.0-SNAPSHOT"}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/_capabilities":
+			_, _ = io.WriteString(w, `{"supported":true}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/logs@custom":
+			_, _ = io.WriteString(w, fmt.Sprintf(`{
+				"component_templates":[
+					{"name":"logs@custom","component_template":%s}
+				]
+			}`, originalTemplate))
+		case req.Method == http.MethodPut && req.URL.Path == "/_component_template/logs@custom":
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			putBodies = append(putBodies, body)
+			_, _ = io.WriteString(w, `{"acknowledged":true}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := elasticsearch.NewClient(elasticsearch.OptionWithAddress(server.URL))
+	require.NoError(t, err)
+
+	r := &runner{
+		esAPI:                   client.API,
+		esClient:                client,
+		logsDBColumnarStatePath: filepath.Join(t.TempDir(), "logsdb-columnar-state.json"),
+	}
+
+	err = r.ensureLogsDBColumnarTemplate(context.Background())
+	require.NoError(t, err)
+	require.Len(t, putBodies, 1)
+	assert.Equal(t, logsDBColumnarIndexMode, indexModeFromPayload(t, putBodies[0]))
+
+	err = r.restoreLogsDBColumnarTemplate(context.Background())
+	require.NoError(t, err)
+	require.Len(t, putBodies, 2)
+
+	restored := map[string]any{}
+	require.NoError(t, json.Unmarshal(putBodies[1], &restored))
+	settings := restored["template"].(map[string]any)["settings"].(map[string]any)
+	index := settings["index"].(map[string]any)
+	assert.Equal(t, "2", index["number_of_shards"])
+	_, hasMode := index["mode"]
+	assert.False(t, hasMode)
+}
+
+func TestHasNestedFieldsInDataStream(t *testing.T) {
+	packageRoot := t.TempDir()
+
+	err := writeFile(filepath.Join(packageRoot, "data_stream", "with_nested", "fields", "fields.yml"), `
+- name: dns.answers
+  type: nested
+`)
+	require.NoError(t, err)
+
+	err = writeFile(filepath.Join(packageRoot, "data_stream", "without_nested", "fields", "fields.yml"), `
+- name: message
+  type: keyword
+`)
+	require.NoError(t, err)
+
+	nested, err := hasNestedFieldsInDataStream(packageRoot, "with_nested")
+	require.NoError(t, err)
+	assert.True(t, nested)
+
+	nested, err = hasNestedFieldsInDataStream(packageRoot, "without_nested")
+	require.NoError(t, err)
+	assert.False(t, nested)
+
+	nested, err = hasNestedFieldsInDataStream(packageRoot, "missing")
+	require.NoError(t, err)
+	assert.False(t, nested)
+}
+
+func TestSkipReasonsForLogsDBColumnar(t *testing.T) {
+	packageRoot := t.TempDir()
+	require.NoError(t, writeFile(filepath.Join(packageRoot, "data_stream", "logs_stream", "manifest.yml"), "title: Logs\ntype: logs\n"))
+	require.NoError(t, writeFile(filepath.Join(packageRoot, "data_stream", "logs_stream", "fields", "fields.yml"), `
+- name: dns.answers
+  type: nested
+`))
+	require.NoError(t, writeFile(filepath.Join(packageRoot, "data_stream", "metrics_stream", "manifest.yml"), "title: Metrics\ntype: metrics\n"))
+	require.NoError(t, writeFile(filepath.Join(packageRoot, "data_stream", "metrics_stream", "fields", "fields.yml"), `
+- name: host.name
+  type: keyword
+`))
+
+	r := &runner{packageRoot: packageRoot}
+	folders := []testrunner.TestFolder{
+		{Path: "/tmp/logs", Package: "demo", DataStream: "logs_stream"},
+		{Path: "/tmp/metrics", Package: "demo", DataStream: "metrics_stream"},
+	}
+
+	reasons, err := r.skipReasonsForLogsDBColumnar(folders)
+	require.NoError(t, err)
+	require.Len(t, reasons, 1)
+	assert.Contains(t, reasons["/tmp/logs"], "does not support nested mappings")
+}
+
+func indexModeFromPayload(t *testing.T, payload []byte) string {
+	t.Helper()
+	decoded := map[string]any{}
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+	template := decoded["template"].(map[string]any)
+	settings := template["settings"].(map[string]any)
+	index := settings["index"].(map[string]any)
+	return index["mode"].(string)
+}
+
+func writeFile(path string, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0644)
+}

--- a/internal/testrunner/runners/system/runner_test.go
+++ b/internal/testrunner/runners/system/runner_test.go
@@ -379,6 +379,132 @@ type: logs
 	assert.True(t, ok)
 }
 
+func TestStripSubobjectsFromComponentTemplate(t *testing.T) {
+	original := []byte(`{
+		"template": {
+			"mappings": {
+				"subobjects": false,
+				"properties": {
+					"host": {
+						"type": "object",
+						"subobjects": false,
+						"properties": {
+							"name": {"type": "keyword"}
+						}
+					},
+					"message": {"type": "match_only_text"}
+				}
+			}
+		}
+	}`)
+
+	stripped, changed, err := stripSubobjectsFromComponentTemplate(original)
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	decoded := map[string]any{}
+	require.NoError(t, json.Unmarshal(stripped, &decoded))
+	mappings := decoded["template"].(map[string]any)["mappings"].(map[string]any)
+	_, hasRootSubobjects := mappings["subobjects"]
+	assert.False(t, hasRootSubobjects)
+	host := mappings["properties"].(map[string]any)["host"].(map[string]any)
+	_, hasHostSubobjects := host["subobjects"]
+	assert.False(t, hasHostSubobjects)
+	assert.Equal(t, "keyword", host["properties"].(map[string]any)["name"].(map[string]any)["type"])
+
+	unchanged, changedAgain, err := stripSubobjectsFromComponentTemplate(stripped)
+	require.NoError(t, err)
+	assert.False(t, changedAgain)
+	assert.JSONEq(t, string(stripped), string(unchanged))
+}
+
+func TestEnsureLogsDBColumnarTemplateStripsPackageSubobjects(t *testing.T) {
+	originalPackage := `{"template":{"mappings":{"subobjects":false,"properties":{"message":{"type":"keyword"}}}}}`
+	var packagePuts [][]byte
+	var customPuts [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/":
+			_, _ = io.WriteString(w, `{"version":{"number":"9.5.0-SNAPSHOT"}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/_capabilities":
+			_, _ = io.WriteString(w, `{"supported":true}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/logs-doppler.activity@custom":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"status":404}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/logs-doppler.activity@package":
+			_, _ = io.WriteString(w, fmt.Sprintf(`{
+				"component_templates":[{
+					"name":"logs-doppler.activity@package",
+					"component_template":%s
+				}]
+			}`, originalPackage))
+		case req.Method == http.MethodPut && req.URL.Path == "/_component_template/logs-doppler.activity@package":
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			packagePuts = append(packagePuts, body)
+			_, _ = io.WriteString(w, `{"acknowledged":true}`)
+		case req.Method == http.MethodPut && req.URL.Path == "/_component_template/logs-doppler.activity@custom":
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			customPuts = append(customPuts, body)
+			_, _ = io.WriteString(w, `{"acknowledged":true}`)
+		case req.Method == http.MethodDelete && req.URL.Path == "/_component_template/logs-doppler.activity@custom":
+			_, _ = io.WriteString(w, `{"acknowledged":true}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := elasticsearch.NewClient(elasticsearch.OptionWithAddress(server.URL))
+	require.NoError(t, err)
+
+	packageRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(packageRoot, "manifest.yml"), []byte(`
+format_version: 3.3.2
+name: doppler
+title: Doppler
+version: 0.0.1
+description: test
+type: integration
+conditions:
+  kibana:
+    version: "^8.0.0"
+owner:
+  github: elastic/security-service-integrations
+`), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(packageRoot, "data_stream", "activity"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(packageRoot, "data_stream", "activity", "manifest.yml"), []byte(`
+title: Activity
+type: logs
+`), 0o644))
+
+	r := &runner{
+		esAPI:                   client.API,
+		esClient:                client,
+		packageRoot:             packageRoot,
+		dataStreams:             []string{"activity"},
+		logsDBColumnarStatePath: filepath.Join(t.TempDir(), "logsdb-columnar-state.json"),
+	}
+
+	err = r.ensureLogsDBColumnarTemplate(t.Context())
+	require.NoError(t, err)
+	require.Len(t, packagePuts, 1, "package template should be rewritten without subobjects")
+	require.Len(t, customPuts, 1)
+
+	strippedPackage := map[string]any{}
+	require.NoError(t, json.Unmarshal(packagePuts[0], &strippedPackage))
+	mappings := strippedPackage["template"].(map[string]any)["mappings"].(map[string]any)
+	_, hasSubobjects := mappings["subobjects"]
+	assert.False(t, hasSubobjects, "subobjects should be stripped before enabling columnar mode")
+
+	err = r.restoreLogsDBColumnarTemplate(t.Context())
+	require.NoError(t, err)
+	require.Len(t, packagePuts, 2, "original package template should be restored after custom")
+	assert.JSONEq(t, originalPackage, string(packagePuts[1]))
+}
+
 func indexModeFromPayload(t *testing.T, payload []byte) string {
 	t.Helper()
 	decoded := map[string]any{}

--- a/internal/testrunner/runners/system/runner_test.go
+++ b/internal/testrunner/runners/system/runner_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestBuildLogsDBColumnarTemplatePayload(t *testing.T) {
 	t.Run("creates payload when template is missing", func(t *testing.T) {
-		payload, err := buildLogsDBColumnarTemplatePayload(nil, false)
+		payload, err := buildLogsDBColumnarTemplatePayload(nil, false, nil, nil)
 		require.NoError(t, err)
 
 		mode := indexModeFromPayload(t, payload)
@@ -43,7 +43,7 @@ func TestBuildLogsDBColumnarTemplatePayload(t *testing.T) {
 				"managed_by": "test"
 			}
 		}`)
-		payload, err := buildLogsDBColumnarTemplatePayload(current, true)
+		payload, err := buildLogsDBColumnarTemplatePayload(current, true, nil, nil)
 		require.NoError(t, err)
 
 		decoded := map[string]any{}
@@ -55,6 +55,111 @@ func TestBuildLogsDBColumnarTemplatePayload(t *testing.T) {
 		assert.Equal(t, "2", index["number_of_shards"])
 		assert.Equal(t, "test", decoded["_meta"].(map[string]any)["managed_by"])
 	})
+
+	t.Run("merges doc_values property overrides and dynamic templates", func(t *testing.T) {
+		current := []byte(`{
+			"template": {
+				"settings": {
+					"index": {
+						"mode": "logsdb_columnar"
+					}
+				},
+				"mappings": {
+					"dynamic_templates": [
+						{"existing": {"path_match": "foo", "mapping": {"type": "keyword"}}}
+					]
+				}
+			}
+		}`)
+		overrides := map[string]map[string]any{
+			"event.original": {
+				"type":       "keyword",
+				"index":      false,
+				"doc_values": true,
+			},
+			"doppel.darkweb.cred_leaks_password": {
+				"type":       "keyword",
+				"index":      false,
+				"doc_values": true,
+			},
+		}
+		payload, err := buildLogsDBColumnarTemplatePayload(current, true, overrides, logsDBColumnarDocValuesDynamicTemplates)
+		require.NoError(t, err)
+
+		decoded := map[string]any{}
+		require.NoError(t, json.Unmarshal(payload, &decoded))
+		mappings := decoded["template"].(map[string]any)["mappings"].(map[string]any)
+
+		properties := mappings["properties"].(map[string]any)
+		event := properties["event"].(map[string]any)["properties"].(map[string]any)
+		original := event["original"].(map[string]any)
+		assert.Equal(t, true, original["doc_values"])
+		assert.Equal(t, false, original["index"])
+
+		doppel := properties["doppel"].(map[string]any)["properties"].(map[string]any)
+		darkweb := doppel["darkweb"].(map[string]any)["properties"].(map[string]any)
+		password := darkweb["cred_leaks_password"].(map[string]any)
+		assert.Equal(t, true, password["doc_values"])
+
+		dynamicTemplates := mappings["dynamic_templates"].([]any)
+		require.GreaterOrEqual(t, len(dynamicTemplates), 3)
+		first := dynamicTemplates[0].(map[string]any)
+		_, hasWorkaround := first["event_original_logsdb_columnar_workaround"]
+		assert.True(t, hasWorkaround, "workaround dynamic template should be prepended")
+		last := dynamicTemplates[len(dynamicTemplates)-1].(map[string]any)
+		_, hasExisting := last["existing"]
+		assert.True(t, hasExisting, "existing dynamic templates should be preserved after workarounds")
+	})
+}
+
+func TestCollectDocValuesDisabledFieldOverrides(t *testing.T) {
+	packageTemplate := []byte(`{
+		"template": {
+			"mappings": {
+				"properties": {
+					"event": {
+						"properties": {
+							"original": {
+								"type": "keyword",
+								"index": false,
+								"doc_values": false
+							},
+							"category": {
+								"type": "keyword"
+							}
+						}
+					},
+					"doppel": {
+						"properties": {
+							"darkweb": {
+								"properties": {
+									"cred_leaks_password": {
+										"type": "keyword",
+										"index": false,
+										"doc_values": false
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}`)
+
+	overrides := collectDocValuesDisabledFieldOverrides(packageTemplate)
+	require.Len(t, overrides, 2)
+	assert.Equal(t, true, overrides["event.original"]["doc_values"])
+	assert.Equal(t, false, overrides["event.original"]["index"])
+	assert.Equal(t, true, overrides["doppel.darkweb.cred_leaks_password"]["doc_values"])
+	_, hasCategory := overrides["event.category"]
+	assert.False(t, hasCategory, "fields without doc_values:false should not be overridden")
+}
+
+func TestPackageComponentTemplateName(t *testing.T) {
+	assert.Equal(t, "logs-doppel.alerts@package", packageComponentTemplateName("logs-doppel.alerts@custom"))
+	assert.Equal(t, "logs@package", packageComponentTemplateName("logs@custom"))
+	assert.Equal(t, "", packageComponentTemplateName("logs-foo"))
 }
 
 func TestEnsureAndRestoreLogsDBColumnarTemplateWithoutExistingTemplate(t *testing.T) {
@@ -71,6 +176,9 @@ func TestEnsureAndRestoreLogsDBColumnarTemplateWithoutExistingTemplate(t *testin
 			assert.Equal(t, "columnar_index_modes", req.URL.Query().Get("capabilities"))
 			_, _ = io.WriteString(w, `{"supported":true}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/logs@custom":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"status":404}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/logs@package":
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = io.WriteString(w, `{"status":404}`)
 		case req.Method == http.MethodPut && req.URL.Path == "/_component_template/logs@custom":
@@ -101,6 +209,7 @@ func TestEnsureAndRestoreLogsDBColumnarTemplateWithoutExistingTemplate(t *testin
 	require.NoError(t, err)
 	require.Len(t, putBodies, 1)
 	assert.Equal(t, logsDBColumnarIndexMode, indexModeFromPayload(t, putBodies[0]))
+	assert.Equal(t, true, eventOriginalDocValuesFromPayload(t, putBodies[0]))
 	_, err = os.Stat(statePath)
 	require.NoError(t, err)
 
@@ -127,6 +236,9 @@ func TestEnsureAndRestoreLogsDBColumnarTemplateWithExistingTemplate(t *testing.T
 					{"name":"logs@custom","component_template":%s}
 				]
 			}`, originalTemplate))
+		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/logs@package":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"status":404}`)
 		case req.Method == http.MethodPut && req.URL.Path == "/_component_template/logs@custom":
 			body, err := io.ReadAll(req.Body)
 			require.NoError(t, err)
@@ -151,6 +263,7 @@ func TestEnsureAndRestoreLogsDBColumnarTemplateWithExistingTemplate(t *testing.T
 	require.NoError(t, err)
 	require.Len(t, putBodies, 1)
 	assert.Equal(t, logsDBColumnarIndexMode, indexModeFromPayload(t, putBodies[0]))
+	assert.Equal(t, true, eventOriginalDocValuesFromPayload(t, putBodies[0]))
 
 	err = r.restoreLogsDBColumnarTemplate(context.Background())
 	require.NoError(t, err)
@@ -165,6 +278,107 @@ func TestEnsureAndRestoreLogsDBColumnarTemplateWithExistingTemplate(t *testing.T
 	assert.False(t, hasMode)
 }
 
+func TestEnsureLogsDBColumnarTemplateWithPackageDocValuesOverrides(t *testing.T) {
+	var putBodies [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/":
+			_, _ = io.WriteString(w, `{"version":{"number":"9.5.0-SNAPSHOT"}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/_capabilities":
+			_, _ = io.WriteString(w, `{"supported":true}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/logs-doppel.alerts@custom":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"status":404}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/_component_template/logs-doppel.alerts@package":
+			_, _ = io.WriteString(w, `{
+				"component_templates":[{
+					"name":"logs-doppel.alerts@package",
+					"component_template":{
+						"template":{
+							"mappings":{
+								"properties":{
+									"doppel":{
+										"properties":{
+											"darkweb":{
+												"properties":{
+													"cred_leaks_password":{
+														"type":"keyword",
+														"index":false,
+														"doc_values":false
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}]
+			}`)
+		case req.Method == http.MethodPut && req.URL.Path == "/_component_template/logs-doppel.alerts@custom":
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			putBodies = append(putBodies, body)
+			_, _ = io.WriteString(w, `{"acknowledged":true}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := elasticsearch.NewClient(elasticsearch.OptionWithAddress(server.URL))
+	require.NoError(t, err)
+
+	packageRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(packageRoot, "manifest.yml"), []byte(`
+format_version: 3.3.2
+name: doppel
+title: Doppel
+version: 0.0.1
+description: test
+type: integration
+conditions:
+  kibana:
+    version: "^8.0.0"
+owner:
+  github: elastic/security-service-integrations
+`), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(packageRoot, "data_stream", "alerts"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(packageRoot, "data_stream", "alerts", "manifest.yml"), []byte(`
+title: Alerts
+type: logs
+`), 0o644))
+
+	r := &runner{
+		esAPI:                   client.API,
+		esClient:                client,
+		packageRoot:             packageRoot,
+		dataStreams:             []string{"alerts"},
+		logsDBColumnarStatePath: filepath.Join(t.TempDir(), "logsdb-columnar-state.json"),
+	}
+
+	err = r.ensureLogsDBColumnarTemplate(t.Context())
+	require.NoError(t, err)
+	require.Len(t, putBodies, 1)
+
+	decoded := map[string]any{}
+	require.NoError(t, json.Unmarshal(putBodies[0], &decoded))
+	assert.Equal(t, logsDBColumnarIndexMode, indexModeFromPayload(t, putBodies[0]))
+	assert.Equal(t, true, eventOriginalDocValuesFromPayload(t, putBodies[0]))
+
+	properties := decoded["template"].(map[string]any)["mappings"].(map[string]any)["properties"].(map[string]any)
+	password := properties["doppel"].(map[string]any)["properties"].(map[string]any)["darkweb"].(map[string]any)["properties"].(map[string]any)["cred_leaks_password"].(map[string]any)
+	assert.Equal(t, true, password["doc_values"])
+
+	dynamicTemplates := decoded["template"].(map[string]any)["mappings"].(map[string]any)["dynamic_templates"].([]any)
+	require.NotEmpty(t, dynamicTemplates)
+	first := dynamicTemplates[0].(map[string]any)
+	_, ok := first["event_original_logsdb_columnar_workaround"]
+	assert.True(t, ok)
+}
+
 func indexModeFromPayload(t *testing.T, payload []byte) string {
 	t.Helper()
 	decoded := map[string]any{}
@@ -173,4 +387,12 @@ func indexModeFromPayload(t *testing.T, payload []byte) string {
 	settings := template["settings"].(map[string]any)
 	index := settings["index"].(map[string]any)
 	return index["mode"].(string)
+}
+
+func eventOriginalDocValuesFromPayload(t *testing.T, payload []byte) bool {
+	t.Helper()
+	decoded := map[string]any{}
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+	properties := decoded["template"].(map[string]any)["mappings"].(map[string]any)["properties"].(map[string]any)
+	return properties["event"].(map[string]any)["properties"].(map[string]any)["original"].(map[string]any)["doc_values"].(bool)
 }

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -159,6 +159,10 @@ var (
 					},
 				},
 				{
+					// OTel Elasticsearch exporter indexing failure (e.g. logsdb_columnar rejection).
+					includes: regexp.MustCompile(`^failed to index document`),
+				},
+				{
 					includes: regexp.MustCompile("->(FAILED|DEGRADED)"),
 
 					excludes: []*regexp.Regexp{
@@ -1479,7 +1483,7 @@ func (r *tester) finalizeScenario(ctx context.Context, scenario *scenarioTest, o
 	var err error
 	scenario.dataStreams, err = r.buildDataStreamScenarios(ctx, opts.dsType, opts.dsDataset, opts.policy.Namespace, scenario.policyTemplate, opts.config)
 	if err != nil {
-		return err
+		return r.enrichWithAgentDiagnostics(ctx, scenario, err)
 	}
 
 	dataStreamNames := make([]string, len(scenario.dataStreams))
@@ -1490,7 +1494,7 @@ func (r *tester) finalizeScenario(ctx context.Context, scenario *scenarioTest, o
 
 	for i := range scenario.dataStreams {
 		if err := r.verifyDataStream(ctx, opts.config, opts.service, &scenario.dataStreams[i]); err != nil {
-			return err
+			return r.enrichWithAgentDiagnostics(ctx, scenario, err)
 		}
 	}
 
@@ -2751,23 +2755,10 @@ func (r *tester) checkAgentLogs(dump []stack.DumpResult, startTesting time.Time,
 func (r *tester) anyErrorMessages(logsFilePath string, startTime time.Time, errorPatterns []logsRegexp) error {
 	var multiErr multierror.Error
 	processLog := func(log stack.LogLine) error {
-		for _, pattern := range errorPatterns {
-			if !pattern.includes.MatchString(log.Message) {
-				continue
-			}
-			isExcluded := false
-			for _, excludes := range pattern.excludes {
-				if excludes.MatchString(log.Message) {
-					isExcluded = true
-					break
-				}
-			}
-			if isExcluded {
-				continue
-			}
-
-			multiErr = append(multiErr, fmt.Errorf("found error %q", log.Message))
+		if !matchLogPatterns(log, errorPatterns) {
+			return nil
 		}
+		multiErr = append(multiErr, fmt.Errorf("found error %q", log.FormatError()))
 		return nil
 	}
 	err := stack.ParseLogs(stack.ParseLogsOptions{

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -808,6 +808,7 @@ func isSyntheticSourceModeEnabled(ctx context.Context, api *elasticsearch.API, d
 	syntheticsIndexModes := []string{
 		"logs", // Replaced in 8.15.0 with "logsdb", see https://github.com/elastic/elasticsearch/pull/111054
 		"logsdb",
+		"logsdb_columnar",
 		"time_series",
 	}
 	if slices.Contains(syntheticsIndexModes, results.Template.Settings.Index.Mode) {

--- a/internal/testrunner/runners/system/tester_test.go
+++ b/internal/testrunner/runners/system/tester_test.go
@@ -7,6 +7,8 @@ package system
 import (
 	"fmt"
 	"maps"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -19,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-package/internal/common"
+	"github.com/elastic/elastic-package/internal/elasticsearch"
 	estest "github.com/elastic/elastic-package/internal/elasticsearch/test"
 	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/packages"
@@ -442,6 +445,37 @@ func TestIsSyntheticSourceModeEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSyntheticSourceModeEnabledLogsDBColumnar(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		if req.Method == http.MethodGet && req.URL.Path == "/" {
+			_, _ = w.Write([]byte(`{"version":{"number":"9.5.0-SNAPSHOT"}}`))
+			return
+		}
+		if req.Method != http.MethodPost || req.URL.Path != "/_index_template/_simulate_index/logs-example.default-12345simulated" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{
+			"template": {
+				"settings": {
+					"index": {
+						"mode": "logsdb_columnar"
+					}
+				}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client, err := elasticsearch.NewClient(elasticsearch.OptionWithAddress(server.URL))
+	require.NoError(t, err)
+
+	enabled, err := isSyntheticSourceModeEnabled(t.Context(), client.API, "logs-example.default-12345")
+	require.NoError(t, err)
+	assert.True(t, enabled)
+}
+
 func TestSearchDataStreams(t *testing.T) {
 	const pattern = "*-foo.bar-default"
 

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -237,6 +237,8 @@ The following settings are available per profile:
   kibana that support it. Defaults to true.
 * `stack.logsdb_enabled` can be set to true to activate the feature flag in Elasticsearch that
   enables logs index mode in all data streams that support it. Defaults to false.
+* `stack.logsdb_columnar_enabled` can be set to true to activate LogsDB Columnar support in
+  Elasticsearch for logs data streams. Defaults to false.
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -246,11 +246,13 @@ The following settings are available per profile:
   and package fields declared with `doc_values: false`). It also strips explicit
   `subobjects` mapping parameters from all logs `@package` templates in the package
   (including sibling streams not under test), which columnar mode rejects (the mode
-  already disables subobjects). Global `logs@custom` is never modified, so other
-  installed packages (for example `elastic_agent`) are unaffected. Metrics-only
-  packages skip this path. These overrides are a test-only workaround:
-  `logsdb_columnar` reconstructs `_source` from doc values, and ECS / package
-  mappings still need a product solution for this mode.
+  already disables subobjects). For input packages, datasets are taken from policy
+  template defaults and system test `data_stream.dataset` overrides. Global
+  `logs@custom` is never modified, so other installed packages (for example
+  `elastic_agent`) are unaffected. Metrics-only packages skip this path. These
+  overrides are a test-only workaround: `logsdb_columnar` reconstructs `_source`
+  from doc values, and ECS / package mappings still need a product solution for
+  this mode.
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -244,8 +244,9 @@ The following settings are available per profile:
   with `index.mode: logsdb_columnar` and forces `doc_values: true` on fields that would
   otherwise fail under columnar mode (including ECS `event.original` and package fields
   declared with `doc_values: false`). It also strips explicit `subobjects` mapping
-  parameters from `@package` templates, which columnar mode rejects (the mode already
-  disables subobjects). These overrides are a test-only workaround: `logsdb_columnar`
+  parameters from all logs `@package` templates in the package (including sibling
+  streams not under test), which columnar mode rejects (the mode already disables
+  subobjects). These overrides are a test-only workaround: `logsdb_columnar`
   reconstructs `_source` from doc values, and ECS / package mappings still need a
   product solution for this mode.
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -239,12 +239,13 @@ The following settings are available per profile:
   enables logs index mode in all data streams that support it. Defaults to false.
 * `stack.logsdb_columnar_enabled` can be set to true to activate LogsDB Columnar support in
   Elasticsearch for logs data streams. Defaults to false.
-  When system tests run with `--logsdb-columnar`, elastic-package configures dataset
-  `@custom` component templates after package install with `index.mode: logsdb_columnar`
-  and forces `doc_values: true` on fields that would otherwise fail under columnar mode
-  (including ECS `event.original` and package fields declared with `doc_values: false`).
-  That override is a test-only workaround: `logsdb_columnar` reconstructs `_source`
-  from doc values, and ECS still needs a product solution for this mode.
+  When this profile setting is true, or when system tests run with `--logsdb-columnar`,
+  elastic-package configures dataset `@custom` component templates after package install
+  with `index.mode: logsdb_columnar` and forces `doc_values: true` on fields that would
+  otherwise fail under columnar mode (including ECS `event.original` and package fields
+  declared with `doc_values: false`). That override is a test-only workaround:
+  `logsdb_columnar` reconstructs `_source` from doc values, and ECS still needs a product
+  solution for this mode.
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -243,9 +243,11 @@ The following settings are available per profile:
   elastic-package configures dataset `@custom` component templates after package install
   with `index.mode: logsdb_columnar` and forces `doc_values: true` on fields that would
   otherwise fail under columnar mode (including ECS `event.original` and package fields
-  declared with `doc_values: false`). That override is a test-only workaround:
-  `logsdb_columnar` reconstructs `_source` from doc values, and ECS still needs a product
-  solution for this mode.
+  declared with `doc_values: false`). It also strips explicit `subobjects` mapping
+  parameters from `@package` templates, which columnar mode rejects (the mode already
+  disables subobjects). These overrides are a test-only workaround: `logsdb_columnar`
+  reconstructs `_source` from doc values, and ECS / package mappings still need a
+  product solution for this mode.
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -240,15 +240,17 @@ The following settings are available per profile:
 * `stack.logsdb_columnar_enabled` can be set to true to activate LogsDB Columnar support in
   Elasticsearch for logs data streams. Defaults to false.
   When this profile setting is true, or when system tests run with `--logsdb-columnar`,
-  elastic-package configures dataset `@custom` component templates after package install
-  with `index.mode: logsdb_columnar` and forces `doc_values: true` on fields that would
-  otherwise fail under columnar mode (including ECS `event.original` and package fields
-  declared with `doc_values: false`). It also strips explicit `subobjects` mapping
-  parameters from all logs `@package` templates in the package (including sibling
-  streams not under test), which columnar mode rejects (the mode already disables
-  subobjects). These overrides are a test-only workaround: `logsdb_columnar`
-  reconstructs `_source` from doc values, and ECS / package mappings still need a
-  product solution for this mode.
+  elastic-package configures each selected logs dataset `@custom` component template
+  after package install with `index.mode: logsdb_columnar` and forces `doc_values: true`
+  on fields that would otherwise fail under columnar mode (including ECS `event.original`
+  and package fields declared with `doc_values: false`). It also strips explicit
+  `subobjects` mapping parameters from all logs `@package` templates in the package
+  (including sibling streams not under test), which columnar mode rejects (the mode
+  already disables subobjects). Global `logs@custom` is never modified, so other
+  installed packages (for example `elastic_agent`) are unaffected. Metrics-only
+  packages skip this path. These overrides are a test-only workaround:
+  `logsdb_columnar` reconstructs `_source` from doc values, and ECS / package
+  mappings still need a product solution for this mode.
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -239,6 +239,12 @@ The following settings are available per profile:
   enables logs index mode in all data streams that support it. Defaults to false.
 * `stack.logsdb_columnar_enabled` can be set to true to activate LogsDB Columnar support in
   Elasticsearch for logs data streams. Defaults to false.
+  When system tests run with `--logsdb-columnar`, elastic-package configures dataset
+  `@custom` component templates after package install with `index.mode: logsdb_columnar`
+  and forces `doc_values: true` on fields that would otherwise fail under columnar mode
+  (including ECS `event.original` and package fields declared with `doc_values: false`).
+  That override is a test-only workaround: `logsdb_columnar` reconstructs `_source`
+  from doc values, and ECS still needs a product solution for this mode.
 * `stack.logstash_enabled` can be set to true to start Logstash and configure it as the
   default output for tests using elastic-package. Supported only by the compose provider.
   Defaults to false.


### PR DESCRIPTION
## Summary

Adds opt-in LogsDB Columnar support to `elastic-package` system tests so integration teams can validate data streams against `logsdb_columnar` semantics on supported snapshot stacks.

Closes #3700.

Assisted-by: Cursor (gpt-5.5 for planning, gpt-5.3-codex-high for implementation)

## What changed

- Added new stack profile setting: `stack.logsdb_columnar_enabled`.
- Updated stack rendering to configure Elasticsearch when enabled on supported versions:
  - `cluster.logsdb_columnar.enabled: true`
  - `-Des.columnar_index_mode_feature_flag_enabled=true`
- Added new system-test flag: `elastic-package test system --logsdb-columnar`.
- Updated system runner to:
  - check ES create-index capability `columnar_index_modes`
  - apply `index.mode: logsdb_columnar` via scoped logs `@custom` templates before package install
  - restore/delete prior template state on teardown
- Added nested-field detection and skip behavior for incompatible logs streams under columnar mode.
- Treated `logsdb_columnar` as synthetic-source-like in system test validation.
- Normalized dotted live mapping keys before comparison so columnar mappings validate against nested simulated index-template mappings.
- Added test coverage for stack rendering, template lifecycle, skip behavior, and synthetic mode detection.

## Behavior and compatibility

- No behavior change unless users opt in.
- Columnar mode is gated by ES capability checks and stack version checks.
- Setup/no-provision/tear-down flows preserve template state across phases.

## Usage examples

### 1) Start stack with columnar enabled

```bash
elastic-package stack up -d -v --version 9.5.0-SNAPSHOT \
  -U stack.logsdb_columnar_enabled=true
```

### 2) Run system tests in columnar mode for a package

```bash
elastic-package -C /path/to/integrations/packages/apache \
  test system -v --data-streams access --logsdb-columnar
```

### 3) Setup/tests/teardown split flow in columnar mode

```bash
elastic-package test system --setup --config-file <config.yml> --logsdb-columnar
elastic-package test system --no-provision --logsdb-columnar
elastic-package test system --tear-down --logsdb-columnar
```

## Validation performed

- `go test ./internal/stack/... ./internal/testrunner/runners/system/... ./internal/elasticsearch/... ./cmd/...`
- `make build format lint licenser gomod update`
- Manual proof on `9.5.0-SNAPSHOT` for direct `logsdb_columnar` index creation + indexing.
- End-to-end `apache/access` system test with `--logsdb-columnar` passing with scoped template lifecycle logs.