### PR TITLE
internal/testrunner/runners/pipeline: add OTel validation for otelcol inputs

### DIFF
--- a/internal/testrunner/runners/pipeline/tester.go
+++ b/internal/testrunner/runners/pipeline/tester.go
@@ -206,11 +206,7 @@ func (r *tester) run(ctx context.Context) ([]testrunner.TestResult, error) {
 	}
 
 	if len(expectedDatasets) == 0 {
-		expectedDataset := dsManifest.Dataset
-		if expectedDataset == "" {
-			expectedDataset = pkgManifest.Name + "." + r.testFolder.DataStream
-		}
-		expectedDatasets = []string{expectedDataset}
+		expectedDatasets = defaultExpectedDatasets(pkgManifest.Name, r.testFolder.DataStream, dsManifest)
 	}
 
 	results := make([]testrunner.TestResult, 0)
@@ -222,6 +218,7 @@ func (r *tester) run(ctx context.Context) ([]testrunner.TestResult, error) {
 		fields.WithExpectedDatasets(expectedDatasets),
 		fields.WithEnabledImportAllECSSChema(true),
 		fields.WithSchemaURLs(r.schemaURLs),
+		fields.WithOTelValidation(isOTelCollectorInput(dsManifest)),
 	}
 	result, err := r.runTestCase(ctx, r.testCaseFile, dataStreamRoot, dsManifest.Type, entryPipeline, validatorOptions)
 	if err != nil {
@@ -580,4 +577,29 @@ func checkErrorMessage(event json.RawMessage) error {
 	default:
 		return fmt.Errorf("unexpected pipeline error (unexpected error.message type %T): %[1]v", m)
 	}
+}
+
+// defaultExpectedDatasets returns the expected dataset values when no reroute
+// processors override them. For otelcol inputs, both the base dataset and the
+// agent-appended .otel variant are expected.
+func defaultExpectedDatasets(pkgName, dataStream string, dsManifest *packages.DataStreamManifest) []string {
+	ds := dsManifest.Dataset
+	if ds == "" {
+		ds = pkgName + "." + dataStream
+	}
+	datasets := []string{ds}
+	if isOTelCollectorInput(dsManifest) {
+		datasets = append(datasets, ds+".otel")
+	}
+	return datasets
+}
+
+// isOTelCollectorInput returns true if the data stream manifest declares an otelcol input.
+func isOTelCollectorInput(dsManifest *packages.DataStreamManifest) bool {
+	for _, s := range dsManifest.Streams {
+		if s.Input == "otelcol" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/testrunner/runners/pipeline/tester.go
+++ b/internal/testrunner/runners/pipeline/tester.go
@@ -596,10 +596,7 @@ func defaultExpectedDatasets(pkgName, dataStream string, dsManifest *packages.Da
 
 // isOTelCollectorInput returns true if the data stream manifest declares an otelcol input.
 func isOTelCollectorInput(dsManifest *packages.DataStreamManifest) bool {
-	for _, s := range dsManifest.Streams {
-		if s.Input == "otelcol" {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(dsManifest.Streams, func(s packages.Stream) bool {
+		return s.Input == "otelcol"
+	})
 }

--- a/internal/testrunner/runners/pipeline/tester_test.go
+++ b/internal/testrunner/runners/pipeline/tester_test.go
@@ -1,0 +1,143 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elastic-package/internal/packages"
+)
+
+func TestDefaultExpectedDatasets(t *testing.T) {
+	cases := []struct {
+		title      string
+		pkgName    string
+		dataStream string
+		manifest   *packages.DataStreamManifest
+		expected   []string
+	}{
+		{
+			title:      "non-otelcol: uses package.datastream as dataset",
+			pkgName:    "nginx",
+			dataStream: "access",
+			manifest: &packages.DataStreamManifest{
+				Streams: []packages.Stream{{Input: "logfile"}},
+			},
+			expected: []string{"nginx.access"},
+		},
+		{
+			title:      "non-otelcol: explicit dataset in manifest",
+			pkgName:    "nginx",
+			dataStream: "access",
+			manifest: &packages.DataStreamManifest{
+				Dataset: "custom_dataset",
+				Streams: []packages.Stream{{Input: "logfile"}},
+			},
+			expected: []string{"custom_dataset"},
+		},
+		{
+			title:      "otelcol: base and .otel suffix",
+			pkgName:    "claude_code",
+			dataStream: "events",
+			manifest: &packages.DataStreamManifest{
+				Streams: []packages.Stream{{Input: "otelcol"}},
+			},
+			expected: []string{"claude_code.events", "claude_code.events.otel"},
+		},
+		{
+			title:      "otelcol: explicit dataset in manifest with .otel suffix",
+			pkgName:    "mypackage",
+			dataStream: "logs",
+			manifest: &packages.DataStreamManifest{
+				Dataset: "custom",
+				Streams: []packages.Stream{{Input: "otelcol"}},
+			},
+			expected: []string{"custom", "custom.otel"},
+		},
+		{
+			title:      "otelcol among other inputs: .otel suffix added",
+			pkgName:    "mypackage",
+			dataStream: "events",
+			manifest: &packages.DataStreamManifest{
+				Streams: []packages.Stream{
+					{Input: "logfile"},
+					{Input: "otelcol"},
+				},
+			},
+			expected: []string{"mypackage.events", "mypackage.events.otel"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			got := defaultExpectedDatasets(c.pkgName, c.dataStream, c.manifest)
+			assert.Equal(t, c.expected, got)
+		})
+	}
+}
+
+func TestIsOTelCollectorInput(t *testing.T) {
+	cases := []struct {
+		title    string
+		manifest *packages.DataStreamManifest
+		expected bool
+	}{
+		{
+			title: "no streams",
+			manifest: &packages.DataStreamManifest{
+				Streams: nil,
+			},
+			expected: false,
+		},
+		{
+			title: "logfile input only",
+			manifest: &packages.DataStreamManifest{
+				Streams: []packages.Stream{
+					{Input: "logfile"},
+				},
+			},
+			expected: false,
+		},
+		{
+			title: "multiple non-otelcol inputs",
+			manifest: &packages.DataStreamManifest{
+				Streams: []packages.Stream{
+					{Input: "logfile"},
+					{Input: "httpjson"},
+					{Input: "cel"},
+				},
+			},
+			expected: false,
+		},
+		{
+			title: "otelcol input only",
+			manifest: &packages.DataStreamManifest{
+				Streams: []packages.Stream{
+					{Input: "otelcol"},
+				},
+			},
+			expected: true,
+		},
+		{
+			title: "otelcol among other inputs",
+			manifest: &packages.DataStreamManifest{
+				Streams: []packages.Stream{
+					{Input: "logfile"},
+					{Input: "otelcol"},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			got := isOTelCollectorInput(c.manifest)
+			assert.Equal(t, c.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
Enable OTel field validation mode and accept the .otel dataset suffix in pipeline tests for packages that declare an otelcol input stream. This mirrors the behaviour already present in the system test runner.

Extract defaultExpectedDatasets and isOTelCollectorInput as testable helpers and add table-driven unit tests for both.

> [!NOTE]
> Tested with the elastic/integrations#19765 addition with its pipeline tests unskipped: confirmed working.

Fixes #3711 