### PR TITLE
internal/kibana/agents.go: Fix agent version policy ID matching

### DIFF
--- a/internal/kibana/agents.go
+++ b/internal/kibana/agents.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/elastic/elastic-package/internal/logger"
@@ -148,7 +149,7 @@ func (c *Client) waitUntilPolicyAssigned(ctx context.Context, a Agent, p Policy)
 		logger.Debugf("Agent %s (Host: %s): Policy ID %s LogLevel: %s Status: %s",
 			agent.ID, agent.LocalMetadata.Host.Name, agent.PolicyID, agent.LocalMetadata.Elastic.Agent.LogLevel, agent.Status)
 
-		if agent.PolicyID == p.ID && agent.PolicyRevision >= p.Revision {
+		if assignedPolicyIDMatches(agent.PolicyID, p.ID) && agent.PolicyRevision >= p.Revision {
 			logger.Debugf("Policy revision assigned to the agent (ID: %s)...", a.ID)
 			break
 		}
@@ -165,6 +166,10 @@ func (c *Client) waitUntilPolicyAssigned(ctx context.Context, a Agent, p Policy)
 
 	}
 	return nil
+}
+
+func assignedPolicyIDMatches(agentPolicyID, policyID string) bool {
+	return agentPolicyID == policyID || strings.HasPrefix(agentPolicyID, policyID+"#")
 }
 
 func (c *Client) getAgent(ctx context.Context, agentID string) (*Agent, error) {

--- a/internal/kibana/agents_test.go
+++ b/internal/kibana/agents_test.go
@@ -1,0 +1,55 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kibana
+
+import "testing"
+
+func TestAssignedPolicyIDMatches(t *testing.T) {
+	tests := []struct {
+		name          string
+		agentPolicyID string
+		policyID      string
+		want          bool
+	}{
+		{
+			name:          "exact policy ID",
+			agentPolicyID: "19957920-e8d8-4f12-a6e0-2e3f7cff1e6e",
+			policyID:      "19957920-e8d8-4f12-a6e0-2e3f7cff1e6e",
+			want:          true,
+		},
+		{
+			name:          "version-specific policy ID",
+			agentPolicyID: "19957920-e8d8-4f12-a6e0-2e3f7cff1e6e#9.5",
+			policyID:      "19957920-e8d8-4f12-a6e0-2e3f7cff1e6e",
+			want:          true,
+		},
+		{
+			name:          "different policy ID",
+			agentPolicyID: "different-policy-id",
+			policyID:      "19957920-e8d8-4f12-a6e0-2e3f7cff1e6e",
+			want:          false,
+		},
+		{
+			name:          "same prefix without version separator",
+			agentPolicyID: "19957920-e8d8-4f12-a6e0-2e3f7cff1e6e-extra",
+			policyID:      "19957920-e8d8-4f12-a6e0-2e3f7cff1e6e",
+			want:          false,
+		},
+		{
+			name:          "version separator on different policy ID",
+			agentPolicyID: "19957920-e8d8-4f12-a6e0-2e3f7cff1e6ef#9.5",
+			policyID:      "19957920-e8d8-4f12-a6e0-2e3f7cff1e6e",
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := assignedPolicyIDMatches(tt.agentPolicyID, tt.policyID); got != tt.want {
+				t.Fatalf("assignedPolicyIDMatches(%q, %q) = %v, want %v", tt.agentPolicyID, tt.policyID, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Accept Fleet version-specific policy IDs like `<policy-id>#9.5` when waiting for agent policy assignment. This prevents package tests from timing out after Fleet applies a versioned policy for packages with agent version conditions.

Fixes elastic/elastic-package#3728

Related docs: https://github.com/elastic/integrations/blob/main/docs/extend/agent-version-conditions.md