### PR TITLE
Policy tests: normalize suffixed OTel extension IDs in auth.authenticator

### DIFF
--- a/internal/testrunner/runners/policy/policy.go
+++ b/internal/testrunner/runners/policy/policy.go
@@ -355,7 +355,13 @@ func applyNormalization(node any, idMapping map[string]string) {
 			}
 			return
 		}
-		for _, v := range n {
+		for k, v := range n {
+			if s, ok := v.(string); ok {
+				if newRef, ok := idMapping[s]; ok {
+					n[k] = newRef
+					continue
+				}
+			}
 			applyNormalization(v, idMapping)
 		}
 	case []any:

--- a/internal/testrunner/runners/policy/policy.go
+++ b/internal/testrunner/runners/policy/policy.go
@@ -356,27 +356,28 @@ func applyNormalization(node any, idMapping map[string]string) {
 			return
 		}
 		for k, v := range n {
-			if s, ok := v.(string); ok {
-				if newRef, ok := idMapping[s]; ok {
-					n[k] = newRef
-					continue
-				}
-			}
-			applyNormalization(v, idMapping)
+			n[k] = replaceOrRecurse(v, idMapping)
 		}
 	case []any:
 		for i, elem := range n {
-			if s, ok := elem.(string); ok {
-				if newRef, ok := idMapping[s]; ok {
-					n[i] = newRef
-				}
-			} else {
-				applyNormalization(elem, idMapping)
-			}
+			n[i] = replaceOrRecurse(elem, idMapping)
 		}
 	default:
 		// strings, numbers, etc. — no change
 	}
+}
+
+// replaceOrRecurse returns v's canonical replacement if v is a string found in idMapping;
+// otherwise it recurses into v (for maps/slices) and returns v unchanged.
+func replaceOrRecurse(v any, idMapping map[string]string) any {
+	if s, ok := v.(string); ok {
+		if newRef, ok := idMapping[s]; ok {
+			return newRef
+		}
+		return v
+	}
+	applyNormalization(v, idMapping)
+	return v
 }
 
 func cleanPolicyMap(policyMap common.MapStr, entries []policyEntryFilter) (common.MapStr, error) {

--- a/internal/testrunner/runners/policy/policy_test.go
+++ b/internal/testrunner/runners/policy/policy_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/elastic-package/internal/common"
 )
@@ -317,6 +318,78 @@ service:
 		assert.Contains(t, string(out), "- apikeyauth/componentid-0")
 		assert.Contains(t, string(out), "authenticator: apikeyauth/componentid-0")
 		assert.Contains(t, string(out), "traces/componentid-0")
+	})
+
+	t.Run("does not mix up references when there are two distinct apikeyauth extensions", func(t *testing.T) {
+		policy := `
+extensions:
+  apikeyauth/otelcol-receiverA-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa-otelcol-elasticapm_input_otel-receiverA-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:
+    api_key: key-for-a
+  apikeyauth/otelcol-receiverB-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb-otelcol-elasticapm_input_otel-receiverB-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb:
+    api_key: key-for-b
+receivers:
+  elasticapmintakereceiver/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:
+    endpoint: localhost:8200
+    auth:
+      authenticator: apikeyauth/otelcol-receiverA-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa-otelcol-elasticapm_input_otel-receiverA-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+  elasticapmintakereceiver/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb:
+    endpoint: localhost:8201
+    auth:
+      authenticator: apikeyauth/otelcol-receiverB-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb-otelcol-elasticapm_input_otel-receiverB-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+service:
+  extensions:
+    - apikeyauth/otelcol-receiverA-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa-otelcol-elasticapm_input_otel-receiverA-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+    - apikeyauth/otelcol-receiverB-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb-otelcol-elasticapm_input_otel-receiverB-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+`
+		out, err := normalizePolicyToCanonical([]byte(policy))
+		require.NoError(t, err)
+		t.Log(string(out))
+
+		var root map[string]any
+		require.NoError(t, yaml.Unmarshal(out, &root))
+
+		extensions, ok := root["extensions"].(map[string]any)
+		require.True(t, ok, "extensions should be a map")
+
+		// Identify each extension's canonical id by its distinguishing api_key,
+		// since buildSectionMapping's sort order is value-based and not fixed here.
+		var idForA, idForB string
+		for key, val := range extensions {
+			body, ok := val.(map[string]any)
+			require.True(t, ok)
+			switch body["api_key"] {
+			case "key-for-a":
+				idForA = key
+			case "key-for-b":
+				idForB = key
+			}
+		}
+		require.NotEmpty(t, idForA, "extension for receiver A should have been found")
+		require.NotEmpty(t, idForB, "extension for receiver B should have been found")
+		assert.NotEqual(t, idForA, idForB, "the two extensions must normalize to distinct component ids")
+
+		receivers, ok := root["receivers"].(map[string]any)
+		require.True(t, ok, "receivers should be a map")
+
+		var authForA, authForB string
+		for _, val := range receivers {
+			body, ok := val.(map[string]any)
+			require.True(t, ok)
+			auth, ok := body["auth"].(map[string]any)
+			require.True(t, ok)
+			authenticator, _ := auth["authenticator"].(string)
+			switch body["endpoint"] {
+			case "localhost:8200":
+				authForA = authenticator
+			case "localhost:8201":
+				authForB = authenticator
+			}
+		}
+		require.NotEmpty(t, authForA, "receiver A's authenticator should have been found")
+		require.NotEmpty(t, authForB, "receiver B's authenticator should have been found")
+
+		assert.Equal(t, idForA, authForA, "receiver A's authenticator must reference extension A's canonical id, not extension B's")
+		assert.Equal(t, idForB, authForB, "receiver B's authenticator must reference extension B's canonical id, not extension A's")
 	})
 }
 

--- a/internal/testrunner/runners/policy/policy_test.go
+++ b/internal/testrunner/runners/policy/policy_test.go
@@ -251,6 +251,73 @@ exporters:
 		assert.NoError(t, err)
 		assert.Equal(t, string(outA), string(outB), "equivalent policies with different key order should normalize to same YAML")
 	})
+
+	// Reproduces https://github.com/elastic/elastic-package/issues/3630:
+	// Fleet (since https://github.com/elastic/kibana/pull/270771) suffixes extension keys
+	// for cross-stream uniqueness, and references those extensions from service.extensions[]
+	// and from auth.authenticator inside receiver bodies.
+	t.Run("normalizes suffixed extension id referenced from service.extensions", func(t *testing.T) {
+		policy := `
+extensions:
+  apikeyauth/otelcol-elasticapmintakereceiver-2ad3f316-95ec-4749-955d-bb680ccb3a6f-otelcol-elasticapm_input_otel-elasticapmintakereceiver-2ad3f316-95ec-4749-955d-bb680ccb3a6f:
+    api_key: abc
+service:
+  extensions:
+    - apikeyauth/otelcol-elasticapmintakereceiver-2ad3f316-95ec-4749-955d-bb680ccb3a6f-otelcol-elasticapm_input_otel-elasticapmintakereceiver-2ad3f316-95ec-4749-955d-bb680ccb3a6f
+`
+		out, err := normalizePolicyToCanonical([]byte(policy))
+		assert.NoError(t, err)
+		t.Log(string(out))
+		assert.Contains(t, string(out), "apikeyauth/componentid-0")
+		assert.Contains(t, string(out), "- apikeyauth/componentid-0")
+	})
+
+	t.Run("normalizes suffixed extension id referenced from auth.authenticator", func(t *testing.T) {
+		policy := `
+extensions:
+  apikeyauth/otelcol-elasticapmintakereceiver-2ad3f316-95ec-4749-955d-bb680ccb3a6f-otelcol-elasticapm_input_otel-elasticapmintakereceiver-2ad3f316-95ec-4749-955d-bb680ccb3a6f:
+    api_key: abc
+receivers:
+  elasticapmintakereceiver/2ad3f316-95ec-4749-955d-bb680ccb3a6f:
+    endpoint: localhost:8200
+    auth:
+      authenticator: apikeyauth/otelcol-elasticapmintakereceiver-2ad3f316-95ec-4749-955d-bb680ccb3a6f-otelcol-elasticapm_input_otel-elasticapmintakereceiver-2ad3f316-95ec-4749-955d-bb680ccb3a6f
+`
+		out, err := normalizePolicyToCanonical([]byte(policy))
+		assert.NoError(t, err)
+		t.Log(string(out))
+		assert.Contains(t, string(out), "apikeyauth/componentid-0")
+		assert.Contains(t, string(out), "elasticapmintakereceiver/componentid-0")
+		assert.Contains(t, string(out), "authenticator: apikeyauth/componentid-0")
+	})
+
+	t.Run("normalizes suffixed extension id referenced from both service.extensions and auth.authenticator", func(t *testing.T) {
+		policy := `
+extensions:
+  apikeyauth/otelcol-elasticapmintakereceiver-2ad3f316-95ec-4749-955d-bb680ccb3a6f-otelcol-elasticapm_input_otel-elasticapmintakereceiver-2ad3f316-95ec-4749-955d-bb680ccb3a6f:
+    api_key: abc
+receivers:
+  elasticapmintakereceiver/2ad3f316-95ec-4749-955d-bb680ccb3a6f:
+    endpoint: localhost:8200
+    auth:
+      authenticator: apikeyauth/otelcol-elasticapmintakereceiver-2ad3f316-95ec-4749-955d-bb680ccb3a6f-otelcol-elasticapm_input_otel-elasticapmintakereceiver-2ad3f316-95ec-4749-955d-bb680ccb3a6f
+service:
+  extensions:
+    - apikeyauth/otelcol-elasticapmintakereceiver-2ad3f316-95ec-4749-955d-bb680ccb3a6f-otelcol-elasticapm_input_otel-elasticapmintakereceiver-2ad3f316-95ec-4749-955d-bb680ccb3a6f
+  pipelines:
+    traces/custom:
+      receivers:
+        - elasticapmintakereceiver/2ad3f316-95ec-4749-955d-bb680ccb3a6f
+`
+		out, err := normalizePolicyToCanonical([]byte(policy))
+		assert.NoError(t, err)
+		t.Log(string(out))
+		assert.Contains(t, string(out), "apikeyauth/componentid-0")
+		assert.Contains(t, string(out), "elasticapmintakereceiver/componentid-0")
+		assert.Contains(t, string(out), "- apikeyauth/componentid-0")
+		assert.Contains(t, string(out), "authenticator: apikeyauth/componentid-0")
+		assert.Contains(t, string(out), "traces/componentid-0")
+	})
 }
 
 func TestComparePolicies(t *testing.T) {


### PR DESCRIPTION
### TL;DR

Fixes elastic-package#3630. Fleet now suffixes OTel extension IDs (e.g. `apikeyauth` → `apikeyauth/otelcol-<uuid>`) and references them from `auth.authenticator` inside receiver bodies. `normalizePolicyToCanonical` already normalized these suffixed IDs when they appeared as map keys or array elements, but not as plain scalar string values — so `auth.authenticator` never got rewritten to the deterministic `componentid-N` form, breaking policy test comparisons against static `.expected` files.

### What changed

- Since [elastic/kibana#270771](https://github.com/elastic/kibana/pull/270771), Fleet's per-stream OTel config generator suffixes extension keys for cross-stream uniqueness and correctly suffixes the references to those extensions in both `service.extensions[]` and `auth.authenticator`.
- Verified `service.extensions[]` was already normalized correctly (array elements were already checked against the ID mapping) — the real gap was `auth.authenticator`, a scalar string value nested in receiver bodies, which fell through untouched.
- Extended `applyNormalization`'s generic map-value walk to also replace scalar string values found in the component ID mapping, mirroring the existing array-element logic — no field-name special-casing, so it also covers any future scalar reference field.
- Deduplicated the map/slice branches into a shared `replaceOrRecurse` helper.
- Added test coverage reproducing the issue's exact scenario (`service.extensions`, `auth.authenticator`, and both together), plus a test asserting two distinct `apikeyauth` extensions normalize to distinct, correctly-paired IDs without cross-wiring.

### Testing

- `go test ./internal/testrunner/runners/policy/...` — all tests pass, including new subtests reproducing the issue.
- `go test ./internal/testrunner/runners/policy/... -race -count=5` — no races, consistent output across repeated runs.
- `go vet ./internal/testrunner/runners/policy/...` — clean.

### Related issues

Closes #3630

### Proposed commit

```
Policy tests: normalize suffixed OTel extension IDs in auth.authenticator

applyNormalization only rewrote OTel component ID references found in
map keys and array elements, so auth.authenticator values (a plain
scalar string inside receiver bodies) were left with Fleet's dynamic
suffix, breaking policy test comparisons after elastic/kibana#270771.
Extend the generic map-value walk to also replace string values found
in idMapping.

Policy tests: extract replaceOrRecurse helper in applyNormalization

Deduplicate the map and slice branches of applyNormalization, which
both implemented the same "replace if in idMapping, else recurse"
idiom, into a shared replaceOrRecurse helper.

Add policy test for multi-extension ID normalization
```

---

> This PR was generated with the assistance of [Claude Code](https://claude.com/claude-code) (claude-sonnet-5).