### PR TITLE
Pre-fetch enrollment token for all agent deployers

### DIFF
--- a/internal/agentdeployer/agent.go
+++ b/internal/agentdeployer/agent.go
@@ -287,19 +287,14 @@ func (d *DockerComposeAgentDeployer) installDockerCompose(ctx context.Context, a
 	if err != nil {
 		return "", fmt.Errorf("failed to load config from profile: %w", err)
 	}
-	enrollmentToken := ""
-	if config.ElasticsearchAPIKey != "" {
-		// TODO: Review if this is the correct place to get the enrollment token.
-		kibanaClient, err := stack.NewKibanaClientFromProfile(d.profile)
-		if err != nil {
-			return "", fmt.Errorf("failed to create kibana client: %w", err)
-		}
-		enrollmentToken, err = kibanaClient.GetEnrollmentTokenForPolicyID(ctx, agentInfo.Policy.ID)
-		if err != nil {
-			return "", fmt.Errorf("failed to get enrollment token for policy %q: %w", agentInfo.Policy.Name, err)
-		}
+	kibanaClient, err := stack.NewKibanaClientFromProfile(d.profile)
+	if err != nil {
+		return "", fmt.Errorf("failed to create kibana client: %w", err)
 	}
-
+	enrollmentToken, err := kibanaClient.GetEnrollmentTokenForPolicyID(ctx, agentInfo.Policy.ID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get enrollment token for policy %q: %w", agentInfo.Policy.Name, err)
+	}
 	// TODO: Include these settings more explicitly in `config`.
 	fleetURL := "https://fleet-server:8220"
 	kibanaHost := "https://kibana:5601"

--- a/internal/agentdeployer/kubernetes.go
+++ b/internal/agentdeployer/kubernetes.go
@@ -199,19 +199,14 @@ func getElasticAgentYAML(ctx context.Context, profile *profile.Profile, agentInf
 		stackVersion = version
 	}
 
-	enrollmentToken := ""
-	if config.ElasticsearchAPIKey != "" {
-		// TODO: Review if this is the correct place to get the enrollment token.
-		kibanaClient, err := stack.NewKibanaClientFromProfile(profile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create kibana client: %w", err)
-		}
-		enrollmentToken, err = kibanaClient.GetEnrollmentTokenForPolicyID(ctx, agentInfo.Policy.ID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get enrollment token for policy %q: %w", agentInfo.Policy.Name, err)
-		}
+	kibanaClient, err := stack.NewKibanaClientFromProfile(profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kibana client: %w", err)
 	}
-
+	enrollmentToken, err := kibanaClient.GetEnrollmentTokenForPolicyID(ctx, agentInfo.Policy.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get enrollment token for policy %q: %w", agentInfo.Policy.Name, err)
+	}
 	// default to stack version if no override is provided
 	agentVersion := stackVersion
 	if overrideAgentVersion != "" {


### PR DESCRIPTION
## Summary

Previously, `elastic-package` only pre-fetched the Fleet enrollment token from Kibana when `config.ElasticsearchAPIKey` was set (i.e. the serverless/environment provider). For the DockerCompose and Kubernetes providers, the agent container was left to retrieve it itself via `FLEET_TOKEN_POLICY_NAME`, which triggers a broad `/api/fleet/enrollment_api_keys` query inside the container with a ~90s context deadline.

Under sustained CI load (many sequential test runs), Kibana can fail to respond within that window, causing each agent container to wait the full ~90s before falling back to fleet-server enrollment — contributing to flaky and slow CI runs.

## Changes

This PR removes the `if config.ElasticsearchAPIKey != ""` guard in both deployers and unconditionally pre-fetches the enrollment token using the policy-scoped kuery (`active:true and policy_id:<ID>`) before the container starts. The token is then passed directly as `FLEET_ENROLLMENT_TOKEN`, bypassing the in-container Kibana fetch entirely.

**Files changed:**
- `internal/agentdeployer/agent.go` — DockerCompose deployer
- `internal/agentdeployer/kubernetes.go` — Kubernetes deployer

## Proposed commit

```
Pre-fetch enrollment token for all agent deployers

The enrollment token was previously only pre-fetched by elastic-package
when config.ElasticsearchAPIKey was set (i.e. the environment provider).
For the compose and Kubernetes providers the container was left to fetch
it from Kibana itself via FLEET_TOKEN_POLICY_NAME, which requires a broad
/api/fleet/enrollment_api_keys query inside the container with a ~90s
context deadline.

Under sustained CI load (many sequential test runs), Kibana can fail to
respond within that window, causing every agent container to wait the
full ~90s before falling back to fleet-server enrollment.

Pre-fetch the token unconditionally using the policy-scoped kuery
(active:true and policy_id:<ID>) so FLEET_ENROLLMENT_TOKEN is always
passed directly to the container, bypassing the in-container Kibana
fetch entirely.
```

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).