### PR TITLE
internal/testrunner/script: add stack_constraint condition for version-gated tests

### DIFF
--- a/docs/howto/script_testing.md
+++ b/docs/howto/script_testing.md
@@ -86,6 +86,7 @@ a stack, starting agents and services and validating results.
 - `LATEST_EPR_VERSION`: the version of the latest EPR-available version
 - `CURRENT_VERSION`: the current version of the package
 - `PREVIOUS_VERSION`: the previous version of the package
+- `STACK_VERSION`: the version of the running stack (e.g. `9.5.0-SNAPSHOT`), set when `--external-stack` is used
 - `DATA_STREAM`: the name of the data stream
 - `DATA_STREAM_ROOT`: the path to the root of the data stream
 - `ECS_BASE_SCHEMA_URL`: the ECS base schema URL
@@ -112,6 +113,14 @@ test for changes that are back-ports.
 The `has_previous_release` condition indicates whether there is a previous version
 in the changelog file.
 
+The `stack_constraint:<constraint>` condition checks whether the running stack
+version satisfies a [semver constraint](https://github.com/Masterminds/semver#checking-version-constraints).
+Pre-release suffixes (e.g. `-SNAPSHOT`) are stripped before checking, so a
+`9.5.0-SNAPSHOT` stack satisfies `>=9.5.0`. When no stack version is available
+(e.g. the stack has not been started), the condition evaluates to false. This is
+useful for skipping tests that depend on features introduced in a specific stack
+version.
+
 The `env:<VAR>` condition is true when the named environment variable is set and
 non-empty. For example, `[!env:LATEST_EPR_VERSION] skip` skips when there is no
 EPR release for the package.
@@ -123,6 +132,8 @@ As an example, a basic system test could be expressed as follows.
 ```
 # Only run the test if --external-stack=true.
 [!external_stack] skip 'Skipping external stack test.'
+# Only run the test if the stack is >= 9.5.0.
+[!stack_constraint:>=9.5.0] skip 'requires stack >= 9.5.0'
 # Only run the test if the jq executable is in $PATH. This is needed for a test below.
 [!exec:jq] skip 'Skipping test requiring absent jq command'
 

--- a/internal/testrunner/script/script.go
+++ b/internal/testrunner/script/script.go
@@ -32,6 +32,7 @@ import (
 	"github.com/elastic/elastic-package/internal/configuration/locations"
 	"github.com/elastic/elastic-package/internal/elasticsearch/ingest"
 	"github.com/elastic/elastic-package/internal/install"
+	"github.com/elastic/elastic-package/internal/kibana"
 	"github.com/elastic/elastic-package/internal/packages"
 	"github.com/elastic/elastic-package/internal/packages/changelog"
 	"github.com/elastic/elastic-package/internal/profile"
@@ -110,6 +111,11 @@ func Run(dst *[]testrunner.TestResult, w io.Writer, opt Options) error {
 	if err != nil {
 		return err
 	}
+
+	var stackVersion string
+	if opt.ExternalStack {
+		stackVersion = resolveStackVersion(prof)
+	}
 	loc, err := locations.NewLocationManager()
 	if err != nil {
 		return err
@@ -178,10 +184,13 @@ func Run(dst *[]testrunner.TestResult, w io.Writer, opt Options) error {
 	if pkgInfo.prevVersion != "" {
 		baseEnv["PREVIOUS_VERSION"] = pkgInfo.prevVersion
 	}
+	if stackVersion != "" {
+		baseEnv["STACK_VERSION"] = stackVersion
+	}
 
 	var n int
 	for _, d := range pkgInfo.dirs {
-		ran, err := runScriptTestsForDir(ctx, t, d, pkgInfo, workdirRoot, baseEnv, scriptCmds, isLatestVersion, opt)
+		ran, err := runScriptTestsForDir(ctx, t, d, pkgInfo, workdirRoot, baseEnv, scriptCmds, isLatestVersion, stackVersion, opt)
 		if err != nil {
 			return err
 		}
@@ -193,6 +202,24 @@ func Run(dst *[]testrunner.TestResult, w io.Writer, opt Options) error {
 		t.Log("[no test files]")
 	}
 	return nil
+}
+
+// resolveStackVersion queries the running stack for its version. Returns the
+// version string (e.g. "9.5.0-SNAPSHOT") or empty string if unavailable.
+func resolveStackVersion(prof *profile.Profile) string {
+	cfg, err := stack.LoadConfig(prof)
+	if err != nil {
+		return ""
+	}
+	kib, err := stack.NewKibanaClientFromProfile(prof, kibana.CertificateAuthority(cfg.CACertFile))
+	if err != nil {
+		return ""
+	}
+	vi, err := kib.Version()
+	if err != nil {
+		return ""
+	}
+	return vi.Version()
 }
 
 // packageInfo is the complete result of script test resolution: which directories to run,
@@ -265,7 +292,7 @@ func resolvePackageInfo(opt Options) (packageInfo, error) {
 }
 
 // buildScriptCondition returns the testscript condition evaluator for the given run context.
-func buildScriptCondition(opt Options, scriptEnv map[string]string, breakingChange, isLatestVersion bool, prevVersion string) func(string) (bool, error) {
+func buildScriptCondition(opt Options, scriptEnv map[string]string, breakingChange, isLatestVersion bool, prevVersion, stackVersion string) func(string) (bool, error) {
 	return func(cond string) (bool, error) {
 		switch {
 		case cond == "external_stack":
@@ -276,6 +303,8 @@ func buildScriptCondition(opt Options, scriptEnv map[string]string, breakingChan
 			return isLatestVersion, nil
 		case cond == "has_previous_release":
 			return prevVersion != "", nil
+		case strings.HasPrefix(cond, "stack_constraint:"):
+			return checkStackConstraint(stackVersion, cond[len("stack_constraint:"):])
 		case strings.HasPrefix(cond, "env:"):
 			_, ok := scriptEnv[cond[len("env:"):]]
 			return ok, nil
@@ -283,6 +312,28 @@ func buildScriptCondition(opt Options, scriptEnv map[string]string, breakingChan
 			return false, fmt.Errorf("unknown condition: %s", cond)
 		}
 	}
+}
+
+// checkStackConstraint checks whether the running stack version satisfies a
+// semver constraint string (e.g. ">=9.5.0", ">=9.5.0,<10.0.0"). Returns false
+// when the stack version is unknown. Pre-release suffixes (e.g. -SNAPSHOT) are
+// stripped from the version before checking so that snapshots satisfy release
+// constraints.
+func checkStackConstraint(stackVersion, constraint string) (bool, error) {
+	if stackVersion == "" {
+		return false, nil
+	}
+	c, err := semver.NewConstraint(constraint)
+	if err != nil {
+		return false, fmt.Errorf("invalid stack_constraint %q: %w", constraint, err)
+	}
+	// Strip pre-release so that e.g. 9.5.0-SNAPSHOT satisfies >=9.5.0.
+	v, err := semver.NewVersion(stackVersion)
+	if err != nil {
+		return false, fmt.Errorf("parsing stack version %q: %w", stackVersion, err)
+	}
+	release := semver.New(v.Major(), v.Minor(), v.Patch(), "", "")
+	return c.Check(release), nil
 }
 
 // scriptTestCommands returns the map of custom testscript commands.
@@ -323,7 +374,7 @@ func scriptTestCommands() map[string]func(ts *testscript.TestScript, neg bool, a
 
 // runScriptTestsForDir runs the script tests for a single data stream directory d.
 // It returns true when test files were found and executed.
-func runScriptTestsForDir(ctx context.Context, t *T, d string, pkgInfo packageInfo, workdirRoot string, baseEnv map[string]string, scriptCmds map[string]func(*testscript.TestScript, bool, []string), isLatestVersion bool, opt Options) (bool, error) {
+func runScriptTestsForDir(ctx context.Context, t *T, d string, pkgInfo packageInfo, workdirRoot string, baseEnv map[string]string, scriptCmds map[string]func(*testscript.TestScript, bool, []string), isLatestVersion bool, stackVersion string, opt Options) (bool, error) {
 	t.dataStream = d
 	scripts := d
 	var dsRoot string
@@ -363,7 +414,7 @@ func runScriptTestsForDir(ctx context.Context, t *T, d string, pkgInfo packageIn
 			e.Values[registryPackageRootsTag{}] = t.registryPackageRoots
 			return nil
 		},
-		Condition: buildScriptCondition(opt, scriptEnv, pkgInfo.breakingChange, isLatestVersion, pkgInfo.prevVersion),
+		Condition: buildScriptCondition(opt, scriptEnv, pkgInfo.breakingChange, isLatestVersion, pkgInfo.prevVersion, stackVersion),
 	}
 	// This is not the ideal approach. What I would like would
 	// be to pass this into the testscript, but that is a bunch

--- a/internal/testrunner/script/script_test.go
+++ b/internal/testrunner/script/script_test.go
@@ -41,3 +41,34 @@ func TestRevisionsFromRegistry_propagatesRegistryClientError(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "creating package registry client")
 }
+
+func TestCheckStackConstraint(t *testing.T) {
+	tests := []struct {
+		name       string
+		version    string
+		constraint string
+		want       bool
+		wantErr    string
+	}{
+		{name: "empty version returns false", version: "", constraint: ">=9.5.0", want: false},
+		{name: "release satisfies >=", version: "9.5.0", constraint: ">=9.5.0", want: true},
+		{name: "snapshot satisfies >=", version: "9.5.0-SNAPSHOT", constraint: ">=9.5.0", want: true},
+		{name: "older version fails >=", version: "9.4.3", constraint: ">=9.5.0", want: false},
+		{name: "older snapshot fails >=", version: "9.4.3-SNAPSHOT", constraint: ">=9.5.0", want: false},
+		{name: "range constraint", version: "9.5.1", constraint: ">=9.5.0,<10.0.0", want: true},
+		{name: "outside range", version: "10.0.0", constraint: ">=9.5.0,<10.0.0", want: false},
+		{name: "invalid constraint", version: "9.5.0", constraint: "not-valid", wantErr: "invalid stack_constraint"},
+		{name: "invalid version", version: "bad", constraint: ">=9.5.0", wantErr: "parsing stack version"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := checkStackConstraint(tt.version, tt.constraint)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got, "checkStackConstraint(%q, %q)", tt.version, tt.constraint)
+		})
+	}
+}


### PR DESCRIPTION
Add a testscript condition that checks whether the running stack version satisfies a semver constraint. This allows script tests to skip when the stack is too old (or too new) for the feature under test.

Usage: [!stack_constraint:>=9.5.0] skip 'requires stack >= 9.5.0'

Pre-release suffixes (e.g. -SNAPSHOT) are stripped before checking so that snapshots satisfy release constraints. The stack version is also exposed as the STACK_VERSION environment variable.