### PR TITLE
chore: update dependabot configuration to include cooldown settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
         patterns:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
+    cooldown:
+      default-days: 3
+      exclude:
+        - github.com/elastic/package-spec/v3
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Added a default cooldown of 3 days for dependency updates, excluding the package 'github.com/elastic/package-spec/v3' from this cooldown.