### PR TITLE
Add install scripts for macOS, Linux, and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ irm https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/insta
 ```
 
 The PowerShell script defaults to `%LOCALAPPDATA%\Programs\elastic-package` and adds that directory to
-your user `PATH` automatically. It supports `amd64`, `arm64`, and `386` architectures.
+your user `PATH` automatically. It supports `amd64`, `arm64`, and `386` architectures, and requires
+PowerShell 5.1 or later (included with Windows 10 and later).
 Both scripts skip the download if the installed version is already up to date.
 
 ### Manual download

--- a/README.md
+++ b/README.md
@@ -33,10 +33,22 @@ curl -fsSL https://raw.githubusercontent.com/elastic/elastic-package/main/script
 The script supports macOS (darwin) and Linux on `amd64`, `arm64`, and `386` architectures.
 On macOS it automatically removes the quarantine attribute so the binary can run without Gatekeeper warnings.
 
+To install a specific version, pass `--version`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.sh | bash -s -- --version 0.125.0
+```
+
 On **Windows**, use the PowerShell script instead:
 
 ```powershell
 irm https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.ps1 | iex
+```
+
+To install a specific version on Windows:
+
+```powershell
+& ([scriptblock]::Create((irm 'https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.ps1'))) -Version 0.125.0
 ```
 
 To install to a custom directory on Windows:

--- a/README.md
+++ b/README.md
@@ -14,11 +14,34 @@ explore the builder tools.
 
 ## Getting started
 
-Download latest release from the [Releases](https://github.com/elastic/elastic-package/releases/latest) page.
+### Install with a script (recommended)
+
+The quickest way to install or update `elastic-package` is with the install script. It automatically detects
+your operating system and architecture, downloads the latest release, and installs the binary to `/usr/local/bin`
+(override with the `INSTALL_DIR` environment variable):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.sh | bash
+```
+
+To install to a custom directory (no `sudo` required):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.sh | INSTALL_DIR=$HOME/.local/bin bash
+```
+
+The script supports macOS (darwin) and Linux on `amd64`, `arm64`, and `386` architectures.
+On macOS it automatically removes the quarantine attribute so the binary can run without Gatekeeper warnings.
+
+### Manual download
+
+Download the latest release directly from the [Releases](https://github.com/elastic/elastic-package/releases/latest) page.
 
 On macOS, use `xattr -r -d com.apple.quarantine elastic-package` after downloading to allow the binary to run.
 
-Alternatively, you may use `go install` but you will not be able to use the `elastic-package version` command or check updates.
+### Install with Go
+
+You may also use `go install`, but you will not be able to use the `elastic-package version` command or check for updates.
 
 ```bash
 go install github.com/elastic/elastic-package@latest

--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@ curl -fsSL https://raw.githubusercontent.com/elastic/elastic-package/main/script
 The script supports macOS (darwin) and Linux on `amd64`, `arm64`, and `386` architectures.
 On macOS it automatically removes the quarantine attribute so the binary can run without Gatekeeper warnings.
 
+On **Windows**, use the PowerShell script instead:
+
+```powershell
+irm https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.ps1 | iex
+```
+
+To install to a custom directory on Windows:
+
+```powershell
+$env:INSTALL_DIR = "$env:USERPROFILE\.local\bin"
+irm https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.ps1 | iex
+```
+
+The PowerShell script defaults to `%LOCALAPPDATA%\Programs\elastic-package` and adds that directory to
+your user `PATH` automatically. It supports `amd64`, `arm64`, and `386` architectures.
+Both scripts skip the download if the installed version is already up to date.
+
 ### Manual download
 
 Download the latest release directly from the [Releases](https://github.com/elastic/elastic-package/releases/latest) page.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,102 @@
+#Requires -Version 5.1
+# Install the latest release of elastic-package for Windows.
+# Usage (PowerShell):
+#   irm https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.ps1 | iex
+#
+# To install to a custom directory, set INSTALL_DIR before piping:
+#   $env:INSTALL_DIR = "$env:USERPROFILE\.local\bin"
+#   irm https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.ps1 | iex
+
+$ErrorActionPreference = 'Stop'
+
+$Repo       = 'elastic/elastic-package'
+$InstallDir = if ($env:INSTALL_DIR) { $env:INSTALL_DIR } else { "$env:LOCALAPPDATA\Programs\elastic-package" }
+
+# Detect true OS architecture.
+# $env:PROCESSOR_ARCHITEW6432 is only set when running a 32-bit process on a 64-bit OS,
+# and in that case it holds the real OS arch — so check it first.
+$OsArch = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
+$Arch = switch ($OsArch) {
+    'AMD64' { 'amd64' }
+    'ARM64' { 'arm64' }
+    'x86'   { '386' }
+    default {
+        Write-Error "Unsupported architecture: $OsArch. Please download manually from https://github.com/$Repo/releases/latest"
+        exit 1
+    }
+}
+
+# Fetch latest release version from GitHub API
+Write-Host "Fetching latest elastic-package release..."
+$Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -UseBasicParsing
+$Version = $Release.tag_name -replace '^v', ''
+
+if (-not $Version) {
+    Write-Error "Failed to determine the latest release version."
+    exit 1
+}
+
+# Check currently installed version, skip if already up to date
+$CurrentVersion = ''
+$ExistingBinary = Join-Path $InstallDir 'elastic-package.exe'
+if (Test-Path $ExistingBinary) {
+    try {
+        $VersionOutput = & $ExistingBinary version 2>$null
+        $Match = [regex]::Match($VersionOutput, '\d+\.\d+\.\d+')
+        if ($Match.Success) { $CurrentVersion = $Match.Value }
+    } catch {}
+}
+
+if ($CurrentVersion -eq $Version) {
+    Write-Host "elastic-package v$Version is already installed and up to date."
+    exit 0
+}
+
+if ($CurrentVersion) {
+    Write-Host "Upgrading elastic-package v$CurrentVersion -> v$Version (windows/$Arch)..."
+} else {
+    Write-Host "Installing elastic-package v$Version (windows/$Arch)..."
+}
+
+$Filename = "elastic-package_${Version}_windows_${Arch}.zip"
+$Url      = "https://github.com/$Repo/releases/download/v$Version/$Filename"
+
+$TmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Path $TmpDir | Out-Null
+
+try {
+    $ZipPath = Join-Path $TmpDir $Filename
+    Invoke-WebRequest -Uri $Url -OutFile $ZipPath -UseBasicParsing
+    Expand-Archive -Path $ZipPath -DestinationPath $TmpDir -Force
+
+    $Binary = Join-Path $TmpDir 'elastic-package.exe'
+    if (-not (Test-Path $Binary)) {
+        Write-Error "Extraction failed: elastic-package.exe not found in archive."
+        exit 1
+    }
+
+    # Ensure install directory exists
+    if (-not (Test-Path $InstallDir)) {
+        Write-Host "Creating install directory $InstallDir..."
+        New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    }
+
+    Copy-Item -Path $Binary -Destination $InstallDir -Force
+
+    # Add install directory to the user PATH if not already present
+    $UserPath = [System.Environment]::GetEnvironmentVariable('PATH', 'User')
+    if ($UserPath -notlike "*$InstallDir*") {
+        [System.Environment]::SetEnvironmentVariable('PATH', "$UserPath;$InstallDir", 'User')
+        Write-Host "Added $InstallDir to your PATH (restart your shell for this to take effect)."
+    }
+
+    Write-Host ""
+    Write-Host "elastic-package v$Version installed to $InstallDir\elastic-package.exe"
+    Write-Host ""
+
+    # Verify — update PATH for the current session so the check works immediately
+    $env:PATH = "$env:PATH;$InstallDir"
+    & (Join-Path $InstallDir 'elastic-package.exe') version
+} finally {
+    Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -65,7 +65,7 @@ if ($CurrentVersion -eq $Version) {
 }
 
 if ($CurrentVersion) {
-    Write-Host "Upgrading elastic-package v$CurrentVersion -> v$Version (windows/$Arch)..."
+    Write-Host "Updating elastic-package v$CurrentVersion -> v$Version (windows/$Arch)..."
 } else {
     Write-Host "Installing elastic-package v$Version (windows/$Arch)..."
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -70,15 +70,36 @@ if ($CurrentVersion) {
     Write-Host "Installing elastic-package v$Version (windows/$Arch)..."
 }
 
-$Filename = "elastic-package_${Version}_windows_${Arch}.zip"
-$Url      = "https://github.com/$Repo/releases/download/v$Version/$Filename"
+$Filename      = "elastic-package_${Version}_windows_${Arch}.zip"
+$Url           = "https://github.com/$Repo/releases/download/v$Version/$Filename"
+$ChecksumsUrl  = "https://github.com/$Repo/releases/download/v$Version/elastic-package_${Version}_checksums.txt"
 
+# %TEMP%\<random> is user-private temp space
 $TmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
 New-Item -ItemType Directory -Path $TmpDir | Out-Null
 
 try {
-    $ZipPath = Join-Path $TmpDir $Filename
-    Invoke-WebRequest -Uri $Url -OutFile $ZipPath -UseBasicParsing
+    $ZipPath      = Join-Path $TmpDir $Filename
+    $ChecksumsFile = Join-Path $TmpDir 'checksums.txt'
+
+    Invoke-WebRequest -Uri $Url          -OutFile $ZipPath       -UseBasicParsing
+    Invoke-WebRequest -Uri $ChecksumsUrl -OutFile $ChecksumsFile  -UseBasicParsing
+
+    # Verify SHA-256 checksum against the release checksums file
+    $ChecksumLine = Get-Content $ChecksumsFile | Where-Object { $_ -match "  $([regex]::Escape($Filename))$" }
+    if (-not $ChecksumLine) {
+        Write-Error "Checksum not found for $Filename in checksums file."
+        exit 1
+    }
+    $ExpectedHash = ($ChecksumLine -split '\s+')[0]
+    $ActualHash   = (Get-FileHash -Path $ZipPath -Algorithm SHA256).Hash
+
+    if ($ActualHash.ToLower() -ne $ExpectedHash.ToLower()) {
+        Write-Error "Checksum verification failed for $Filename.`nExpected: $ExpectedHash`nGot:      $ActualHash"
+        exit 1
+    }
+    Write-Host "Checksum verified."
+
     Expand-Archive -Path $ZipPath -DestinationPath $TmpDir -Force
 
     $Binary = Join-Path $TmpDir 'elastic-package.exe'
@@ -95,10 +116,13 @@ try {
 
     Copy-Item -Path $Binary -Destination $InstallDir -Force
 
-    # Add install directory to the user PATH if not already present
-    $UserPath = [System.Environment]::GetEnvironmentVariable('PATH', 'User')
-    if ($UserPath -notlike "*$InstallDir*") {
-        [System.Environment]::SetEnvironmentVariable('PATH', "$UserPath;$InstallDir", 'User')
+    # Add install directory to the user PATH if not already present.
+    # Split on ';' for exact matching — avoids wildcard misfires from -like/*notlike*.
+    $UserPath     = [System.Environment]::GetEnvironmentVariable('PATH', 'User')
+    $PathEntries  = if ($UserPath) { $UserPath.Split(';') } else { @() }
+    if ($PathEntries -notcontains $InstallDir) {
+        $NewPath = if ($UserPath) { "$UserPath;$InstallDir" } else { $InstallDir }
+        [System.Environment]::SetEnvironmentVariable('PATH', $NewPath, 'User')
         Write-Host "Added $InstallDir to your PATH (restart your shell for this to take effect)."
     }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,16 +1,26 @@
 #Requires -Version 5.1
-# Install the latest release of elastic-package for Windows.
+# Install a release of elastic-package for Windows.
 # Usage (PowerShell):
 #   irm https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.ps1 | iex
+#
+# To install a specific version:
+#   & ([scriptblock]::Create((irm 'https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.ps1'))) -Version 0.125.0
 #
 # To install to a custom directory, set INSTALL_DIR before piping:
 #   $env:INSTALL_DIR = "$env:USERPROFILE\.local\bin"
 #   irm https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.ps1 | iex
 
+param(
+    [string]$Version = ''
+)
+
 $ErrorActionPreference = 'Stop'
 
 $Repo       = 'elastic/elastic-package'
 $InstallDir = if ($env:INSTALL_DIR) { $env:INSTALL_DIR } else { "$env:LOCALAPPDATA\Programs\elastic-package" }
+
+# Strip leading 'v' from version if provided (accept both v0.125.0 and 0.125.0)
+if ($Version) { $Version = $Version -replace '^v', '' }
 
 # Detect true OS architecture.
 # $env:PROCESSOR_ARCHITEW6432 is only set when running a 32-bit process on a 64-bit OS,
@@ -26,17 +36,19 @@ $Arch = switch ($OsArch) {
     }
 }
 
-# Fetch latest release version from GitHub API
-Write-Host "Fetching latest elastic-package release..."
-$Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -UseBasicParsing
-$Version = $Release.tag_name -replace '^v', ''
-
+# Resolve target version: use -Version argument or fetch latest
 if (-not $Version) {
-    Write-Error "Failed to determine the latest release version."
-    exit 1
+    Write-Host "Fetching latest elastic-package release..."
+    $Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -UseBasicParsing
+    $Version = $Release.tag_name -replace '^v', ''
+
+    if (-not $Version) {
+        Write-Error "Failed to determine the latest release version."
+        exit 1
+    }
 }
 
-# Check currently installed version, skip if already up to date
+# Check currently installed version, skip if already at the target version
 $CurrentVersion = ''
 $ExistingBinary = Join-Path $InstallDir 'elastic-package.exe'
 if (Test-Path $ExistingBinary) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -36,11 +36,18 @@ $Arch = switch ($OsArch) {
     }
 }
 
-# Resolve target version: use -Version argument or fetch latest
+# Resolve target version: use -Version argument or follow the GitHub
+# /releases/latest redirect (avoids JSON parsing and API rate limits).
 if (-not $Version) {
     Write-Host "Fetching latest elastic-package release..."
-    $Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -UseBasicParsing
-    $Version = $Release.tag_name -replace '^v', ''
+    $LatestResponse = Invoke-WebRequest -Uri "https://github.com/$Repo/releases/latest" -UseBasicParsing
+    # PS 5.1 (HttpWebResponse) exposes ResponseUri; PS 7 (HttpResponseMessage) uses RequestMessage.RequestUri
+    $FinalUri = if ($LatestResponse.BaseResponse -is [System.Net.HttpWebResponse]) {
+        $LatestResponse.BaseResponse.ResponseUri
+    } else {
+        $LatestResponse.BaseResponse.RequestMessage.RequestUri
+    }
+    $Version = $FinalUri.Segments[-1] -replace '^v', ''
 
     if (-not $Version) {
         Write-Error "Failed to determine the latest release version."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -64,14 +64,16 @@ case "$ARCH" in
     ;;
 esac
 
-# Resolve target version: use requested version or fetch latest
+# Resolve target version: use requested version or follow the GitHub
+# /releases/latest redirect (avoids JSON parsing and API rate limits).
 if [ -n "$REQUESTED_VERSION" ]; then
   VERSION="$REQUESTED_VERSION"
 else
   echo "Fetching latest elastic-package release..."
-  VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-    | grep '"tag_name"' \
-    | sed 's/.*"tag_name": *"v\([^"]*\)".*/\1/')
+  LATEST_URL=$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+    "https://github.com/${REPO}/releases/latest")
+  VERSION="${LATEST_URL##*/}"
+  VERSION="${VERSION#v}"
 
   if [ -z "$VERSION" ]; then
     echo "Failed to determine the latest release version." >&2

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -107,12 +107,37 @@ fi
 
 FILENAME="elastic-package_${VERSION}_${OS}_${ARCH}.tar.gz"
 URL="https://github.com/${REPO}/releases/download/v${VERSION}/${FILENAME}"
+CHECKSUMS_URL="https://github.com/${REPO}/releases/download/v${VERSION}/elastic-package_${VERSION}_checksums.txt"
 
+# mktemp -d creates a 0700 directory — only the current user can read it
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-# Download and extract
-curl -fsSL "$URL" | tar -xz -C "$TMP_DIR"
+# Download archive to disk (needed for checksum verification before extraction)
+ARCHIVE="${TMP_DIR}/${FILENAME}"
+curl -fsSL "$URL" -o "$ARCHIVE"
+
+# Verify checksum against the release checksums file
+CHECKSUMS_FILE="${TMP_DIR}/checksums.txt"
+curl -fsSL "$CHECKSUMS_URL" -o "$CHECKSUMS_FILE"
+
+EXPECTED_HASH=$(grep "  ${FILENAME}$" "$CHECKSUMS_FILE" | awk '{print $1}')
+if [ -z "$EXPECTED_HASH" ]; then
+  echo "Checksum not found for ${FILENAME} in checksums file." >&2
+  exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  echo "${EXPECTED_HASH}  ${ARCHIVE}" | sha256sum -c - >/dev/null
+elif command -v shasum >/dev/null 2>&1; then
+  echo "${EXPECTED_HASH}  ${ARCHIVE}" | shasum -a 256 -c - >/dev/null
+else
+  echo "Warning: cannot verify checksum (neither sha256sum nor shasum found)." >&2
+fi
+echo "Checksum verified."
+
+# Extract archive
+tar -xz -C "$TMP_DIR" -f "$ARCHIVE"
 
 BINARY="${TMP_DIR}/elastic-package"
 
@@ -126,10 +151,10 @@ if [ "$OS" = "darwin" ]; then
   xattr -r -d com.apple.quarantine "$BINARY" 2>/dev/null || true
 fi
 
-# Ensure the install directory exists
+# Ensure the install directory exists; fall back to sudo if the parent is root-owned
 if [ ! -d "$INSTALL_DIR" ]; then
   echo "Creating install directory ${INSTALL_DIR}..."
-  mkdir -p "$INSTALL_DIR"
+  mkdir -p "$INSTALL_DIR" 2>/dev/null || sudo mkdir -p "$INSTALL_DIR"
 fi
 
 # Install the binary

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -56,16 +56,7 @@ ARCH="$(uname -m)"
 case "$ARCH" in
   x86_64)        ARCH="amd64" ;;
   aarch64|arm64) ARCH="arm64" ;;
-  i386|i686)
-    # darwin/386 was never released; only map 386 on Linux
-    if [ "$OS" = "linux" ]; then
-      ARCH="386"
-    else
-      echo "32-bit macOS is not supported." >&2
-      echo "Please download the binary manually from https://github.com/${REPO}/releases/latest" >&2
-      exit 1
-    fi
-    ;;
+  i386|i686) ARCH="386" ;;
   *)
     echo "Unsupported architecture: $ARCH" >&2
     echo "Please download the binary manually from https://github.com/${REPO}/releases/latest" >&2

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -56,7 +56,7 @@ ARCH="$(uname -m)"
 case "$ARCH" in
   x86_64)        ARCH="amd64" ;;
   aarch64|arm64) ARCH="arm64" ;;
-  i386|i686) ARCH="386" ;;
+  i386|i686)     ARCH="386" ;;
   *)
     echo "Unsupported architecture: $ARCH" >&2
     echo "Please download the binary manually from https://github.com/${REPO}/releases/latest" >&2
@@ -79,9 +79,13 @@ else
   fi
 fi
 
-# Check currently installed version, skip if already at the target version
+# Check currently installed version, skip if already at the target version.
+# Prefer the binary in INSTALL_DIR (matches install.ps1), then fall back to PATH.
 CURRENT_VERSION=""
-if command -v elastic-package >/dev/null 2>&1; then
+EXISTING_BINARY="${INSTALL_DIR}/elastic-package"
+if [ -x "$EXISTING_BINARY" ]; then
+  CURRENT_VERSION=$("$EXISTING_BINARY" version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+elif command -v elastic-package >/dev/null 2>&1; then
   CURRENT_VERSION=$(elastic-package version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
 fi
 
@@ -120,12 +124,13 @@ fi
 
 if command -v sha256sum >/dev/null 2>&1; then
   echo "${EXPECTED_HASH}  ${ARCHIVE}" | sha256sum -c - >/dev/null
+  echo "Checksum verified."
 elif command -v shasum >/dev/null 2>&1; then
   echo "${EXPECTED_HASH}  ${ARCHIVE}" | shasum -a 256 -c - >/dev/null
+  echo "Checksum verified."
 else
   echo "Warning: cannot verify checksum (neither sha256sum nor shasum found)." >&2
 fi
-echo "Checksum verified."
 
 # Extract archive
 tar -xz -C "$TMP_DIR" -f "$ARCHIVE"
@@ -136,6 +141,8 @@ if [ ! -f "$BINARY" ]; then
   echo "Extraction failed: elastic-package binary not found in archive." >&2
   exit 1
 fi
+
+chmod +x "$BINARY"
 
 # Remove quarantine attribute on macOS to allow the binary to run
 if [ "$OS" = "darwin" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# Install the latest release of elastic-package for the current platform.
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.sh | bash
+#   INSTALL_DIR=$HOME/.local/bin bash install.sh
+
+set -euo pipefail
+
+REPO="elastic/elastic-package"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+# Detect OS
+OS="$(uname -s)"
+case "$OS" in
+  Darwin) OS="darwin" ;;
+  Linux)  OS="linux" ;;
+  MINGW*|MSYS*|CYGWIN*)
+    echo "Windows is not supported by this install script." >&2
+    echo "Please download the binary manually from https://github.com/${REPO}/releases/latest" >&2
+    exit 1
+    ;;
+  *)
+    echo "Unsupported operating system: $OS" >&2
+    echo "Please download the binary manually from https://github.com/${REPO}/releases/latest" >&2
+    exit 1
+    ;;
+esac
+
+# Detect architecture
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64)        ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  i386|i686)
+    # darwin/386 was never released; only map 386 on Linux
+    if [ "$OS" = "linux" ]; then
+      ARCH="386"
+    else
+      echo "32-bit macOS is not supported." >&2
+      echo "Please download the binary manually from https://github.com/${REPO}/releases/latest" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "Unsupported architecture: $ARCH" >&2
+    echo "Please download the binary manually from https://github.com/${REPO}/releases/latest" >&2
+    exit 1
+    ;;
+esac
+
+# Resolve latest release version
+echo "Fetching latest elastic-package release..."
+VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+  | grep '"tag_name"' \
+  | sed 's/.*"tag_name": *"v\([^"]*\)".*/\1/')
+
+if [ -z "$VERSION" ]; then
+  echo "Failed to determine the latest release version." >&2
+  exit 1
+fi
+
+# Check currently installed version, skip if already up to date
+CURRENT_VERSION=""
+if command -v elastic-package >/dev/null 2>&1; then
+  CURRENT_VERSION=$(elastic-package version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+fi
+
+if [ -n "$CURRENT_VERSION" ] && [ "$CURRENT_VERSION" = "$VERSION" ]; then
+  echo "elastic-package v${VERSION} is already installed and up to date."
+  exit 0
+fi
+
+if [ -n "$CURRENT_VERSION" ]; then
+  echo "Upgrading elastic-package v${CURRENT_VERSION} -> v${VERSION} (${OS}/${ARCH})..."
+else
+  echo "Installing elastic-package v${VERSION} (${OS}/${ARCH})..."
+fi
+
+FILENAME="elastic-package_${VERSION}_${OS}_${ARCH}.tar.gz"
+URL="https://github.com/${REPO}/releases/download/v${VERSION}/${FILENAME}"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Download and extract
+curl -fsSL "$URL" | tar -xz -C "$TMP_DIR"
+
+BINARY="${TMP_DIR}/elastic-package"
+
+if [ ! -f "$BINARY" ]; then
+  echo "Extraction failed: elastic-package binary not found in archive." >&2
+  exit 1
+fi
+
+# Remove quarantine attribute on macOS to allow the binary to run
+if [ "$OS" = "darwin" ]; then
+  xattr -r -d com.apple.quarantine "$BINARY" 2>/dev/null || true
+fi
+
+# Ensure the install directory exists
+if [ ! -d "$INSTALL_DIR" ]; then
+  echo "Creating install directory ${INSTALL_DIR}..."
+  mkdir -p "$INSTALL_DIR"
+fi
+
+# Install the binary
+if [ -w "$INSTALL_DIR" ]; then
+  mv "$BINARY" "${INSTALL_DIR}/elastic-package"
+else
+  echo "Installing to ${INSTALL_DIR} requires elevated privileges..."
+  sudo mv "$BINARY" "${INSTALL_DIR}/elastic-package"
+fi
+
+echo ""
+echo "elastic-package v${VERSION} installed to ${INSTALL_DIR}/elastic-package"
+echo ""
+
+# Verify installation
+if command -v elastic-package >/dev/null 2>&1; then
+  elastic-package version
+else
+  echo "Make sure ${INSTALL_DIR} is in your PATH."
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,13 +1,37 @@
 #!/bin/bash
-# Install the latest release of elastic-package for the current platform.
+# Install a release of elastic-package for the current platform.
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.sh | bash -s -- --version 0.125.0
 #   INSTALL_DIR=$HOME/.local/bin bash install.sh
 
 set -euo pipefail
 
 REPO="elastic/elastic-package"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+# Parse arguments
+REQUESTED_VERSION=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version|-v)
+      REQUESTED_VERSION="${2:-}"
+      if [ -z "$REQUESTED_VERSION" ]; then
+        echo "Error: --version requires a value." >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Usage: install.sh [--version <version>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Strip leading 'v' from version if provided (accept both v0.125.0 and 0.125.0)
+REQUESTED_VERSION="${REQUESTED_VERSION#v}"
 
 # Detect OS
 OS="$(uname -s)"
@@ -49,18 +73,22 @@ case "$ARCH" in
     ;;
 esac
 
-# Resolve latest release version
-echo "Fetching latest elastic-package release..."
-VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-  | grep '"tag_name"' \
-  | sed 's/.*"tag_name": *"v\([^"]*\)".*/\1/')
+# Resolve target version: use requested version or fetch latest
+if [ -n "$REQUESTED_VERSION" ]; then
+  VERSION="$REQUESTED_VERSION"
+else
+  echo "Fetching latest elastic-package release..."
+  VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep '"tag_name"' \
+    | sed 's/.*"tag_name": *"v\([^"]*\)".*/\1/')
 
-if [ -z "$VERSION" ]; then
-  echo "Failed to determine the latest release version." >&2
-  exit 1
+  if [ -z "$VERSION" ]; then
+    echo "Failed to determine the latest release version." >&2
+    exit 1
+  fi
 fi
 
-# Check currently installed version, skip if already up to date
+# Check currently installed version, skip if already at the target version
 CURRENT_VERSION=""
 if command -v elastic-package >/dev/null 2>&1; then
   CURRENT_VERSION=$(elastic-package version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -97,7 +97,7 @@ if [ -n "$CURRENT_VERSION" ] && [ "$CURRENT_VERSION" = "$VERSION" ]; then
 fi
 
 if [ -n "$CURRENT_VERSION" ]; then
-  echo "Upgrading elastic-package v${CURRENT_VERSION} -> v${VERSION} (${OS}/${ARCH})..."
+  echo "Updating elastic-package v${CURRENT_VERSION} -> v${VERSION} (${OS}/${ARCH})..."
 else
   echo "Installing elastic-package v${VERSION} (${OS}/${ARCH})..."
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,8 +15,9 @@ case "$OS" in
   Darwin) OS="darwin" ;;
   Linux)  OS="linux" ;;
   MINGW*|MSYS*|CYGWIN*)
-    echo "Windows is not supported by this install script." >&2
-    echo "Please download the binary manually from https://github.com/${REPO}/releases/latest" >&2
+    echo "Windows is not supported by this script." >&2
+    echo "Use the PowerShell script instead:" >&2
+    echo "  irm https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.ps1 | iex" >&2
     exit 1
     ;;
   *)

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -59,7 +59,8 @@ irm https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/insta
 ```
 
 The PowerShell script defaults to `%LOCALAPPDATA%\Programs\elastic-package` and adds that directory to
-your user `PATH` automatically. It supports `amd64`, `arm64`, and `386` architectures.
+your user `PATH` automatically. It supports `amd64`, `arm64`, and `386` architectures, and requires
+PowerShell 5.1 or later (included with Windows 10 and later).
 Both scripts skip the download if the installed version is already up to date.
 
 ### Manual download

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -33,10 +33,22 @@ curl -fsSL https://raw.githubusercontent.com/elastic/elastic-package/main/script
 The script supports macOS (darwin) and Linux on `amd64`, `arm64`, and `386` architectures.
 On macOS it automatically removes the quarantine attribute so the binary can run without Gatekeeper warnings.
 
+To install a specific version, pass `--version`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.sh | bash -s -- --version 0.125.0
+```
+
 On **Windows**, use the PowerShell script instead:
 
 ```powershell
 irm https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.ps1 | iex
+```
+
+To install a specific version on Windows:
+
+```powershell
+& ([scriptblock]::Create((irm 'https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.ps1'))) -Version 0.125.0
 ```
 
 To install to a custom directory on Windows:

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -14,11 +14,34 @@ explore the builder tools.
 
 ## Getting started
 
-Download latest release from the [Releases](https://github.com/elastic/elastic-package/releases/latest) page.
+### Install with a script (recommended)
+
+The quickest way to install or update `elastic-package` is with the install script. It automatically detects
+your operating system and architecture, downloads the latest release, and installs the binary to `/usr/local/bin`
+(override with the `INSTALL_DIR` environment variable):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.sh | bash
+```
+
+To install to a custom directory (no `sudo` required):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.sh | INSTALL_DIR=$HOME/.local/bin bash
+```
+
+The script supports macOS (darwin) and Linux on `amd64`, `arm64`, and `386` architectures.
+On macOS it automatically removes the quarantine attribute so the binary can run without Gatekeeper warnings.
+
+### Manual download
+
+Download the latest release directly from the [Releases](https://github.com/elastic/elastic-package/releases/latest) page.
 
 On macOS, use `xattr -r -d com.apple.quarantine elastic-package` after downloading to allow the binary to run.
 
-Alternatively, you may use `go install` but you will not be able to use the `elastic-package version` command or check updates.
+### Install with Go
+
+You may also use `go install`, but you will not be able to use the `elastic-package version` command or check for updates.
 
 ```bash
 go install github.com/elastic/elastic-package@latest

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -33,6 +33,23 @@ curl -fsSL https://raw.githubusercontent.com/elastic/elastic-package/main/script
 The script supports macOS (darwin) and Linux on `amd64`, `arm64`, and `386` architectures.
 On macOS it automatically removes the quarantine attribute so the binary can run without Gatekeeper warnings.
 
+On **Windows**, use the PowerShell script instead:
+
+```powershell
+irm https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.ps1 | iex
+```
+
+To install to a custom directory on Windows:
+
+```powershell
+$env:INSTALL_DIR = "$env:USERPROFILE\.local\bin"
+irm https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.ps1 | iex
+```
+
+The PowerShell script defaults to `%LOCALAPPDATA%\Programs\elastic-package` and adds that directory to
+your user `PATH` automatically. It supports `amd64`, `arm64`, and `386` architectures.
+Both scripts skip the download if the installed version is already up to date.
+
 ### Manual download
 
 Download the latest release directly from the [Releases](https://github.com/elastic/elastic-package/releases/latest) page.


### PR DESCRIPTION
## Problem

Installing or updating `elastic-package` requires manually navigating to the Releases page, picking the right binary for your OS and architecture, downloading, extracting, removing the macOS quarantine attribute, and moving the binary into `$PATH`. This is tedious to repeat on every release.

## Solution

Two scripts that handle the full install/update flow in one command:

**macOS / Linux**
```bash
curl -fsSL https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.sh | bash
```

**Windows (PowerShell)**
```powershell
irm https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/install.ps1 | iex
```

Both scripts:
- Auto-detect OS and architecture
- Fetch the latest release (or a pinned version via `--version` / `-Version`)
- Verify the SHA-256 checksum against the release checksums file before extracting
- Skip the download if the installed version already matches the target
- Show an upgrade message when replacing an older version
- Create the install directory if it doesn't exist

Platform-specific behaviour:
- **macOS**: removes the quarantine attribute automatically
- **Windows**: adds the install directory to the user `PATH` permanently; defaults to `%LOCALAPPDATA%\Programs\elastic-package` (no admin required)

The README Getting started section is updated to lead with the script install method.

## Reviewer notes

- The bash script saves the archive to disk before extraction (rather than piping `curl | tar`) so the checksum can be verified first; the temp directory is `0700` and cleaned on exit.
- `sudo` is only invoked for `mkdir` and `mv` when the unprivileged attempt fails — not proactively.
- The PowerShell PATH dedup uses `Split(';') -notcontains` rather than `-notlike` to avoid bracket characters in the path being interpreted as wildcards.
- Windows is deliberately out of scope for `install.sh`; the error message points to `install.ps1`.
