### PR TITLE
[dependabot] Group all dependencies from go.opentelemetry.io

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
         patterns:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
+      opentelemetry:
+        patterns:
+          - "go.opentelemetry.io/*"
     cooldown:
       default-days: 3
       exclude:


### PR DESCRIPTION
Apply the same dependabot configuration as in Elastic Package Registry repository to group dependencies from go.opentelemetry.io:

https://github.com/elastic/package-registry/blob/b41a65a4a866cecf87c06e9179de2c80f99a7e09/.github/dependabot.yml#L17-L19

This would group all these PRs in just one:

- https://github.com/elastic/elastic-package/pull/3813
- https://github.com/elastic/elastic-package/pull/3814
- https://github.com/elastic/elastic-package/pull/3815
- https://github.com/elastic/elastic-package/pull/3816