### PR TITLE
Allow blueprint type packages

### DIFF
--- a/cmd/create_package_test.go
+++ b/cmd/create_package_test.go
@@ -95,6 +95,35 @@ func TestCreatePackageDescriptorFromAnswers_InputWithSubobjects(t *testing.T) {
 	assert.Nil(t, descriptor.Manifest.Elasticsearch)
 }
 
+func TestCreatePackageDescriptorFromAnswers_Blueprint(t *testing.T) {
+	answers := newPackageAnswers{
+		Type:                "blueprint",
+		Name:                "my_blueprint",
+		Version:             "0.0.1",
+		SourceLicense:       licenses.Elastic20,
+		Title:               "my_blueprint",
+		Description:         "This is a new package.",
+		Categories:          []string{"custom"},
+		KibanaVersion:       tui.DefaultKibanaVersionConditionValue(),
+		ElasticSubscription: "basic",
+		GithubOwner:         "elastic/integrations",
+		OwnerType:           "elastic",
+		DataStreamType:      "logs",
+		Subobjects:          false,
+	}
+
+	descriptor := createPackageDescriptorFromAnswers(answers)
+
+	assert.Equal(t, "blueprint", descriptor.Manifest.Type)
+	assert.Equal(t, "my_blueprint", descriptor.Manifest.Name)
+	assert.Equal(t, "0.0.1", descriptor.Manifest.Version)
+	assert.Equal(t, licenses.Elastic20, descriptor.Manifest.Source.License)
+	// Blueprint packages have no data streams and no Elasticsearch overrides,
+	// even if the wizard collected default data-stream answers.
+	assert.Empty(t, descriptor.InputDataStreamType)
+	assert.Nil(t, descriptor.Manifest.Elasticsearch)
+}
+
 func TestCreatePackageDescriptorFromAnswers_NoLicense(t *testing.T) {
 	answers := newPackageAnswers{
 		Type:                "integration",
@@ -116,7 +145,7 @@ func TestCreatePackageDescriptorFromAnswers_NoLicense(t *testing.T) {
 }
 
 func TestAllowedPackageTypes(t *testing.T) {
-	valid := []string{"input", "integration", "content"}
+	valid := []string{"input", "integration", "content", "blueprint"}
 	for _, v := range valid {
 		assert.Contains(t, packages.AllowedPackageTypes, v, "expected %q to be in AllowedPackageTypes", v)
 	}

--- a/internal/cobraext/flags.go
+++ b/internal/cobraext/flags.go
@@ -119,7 +119,7 @@ const (
 	CreatePackageNameFlagDescription = "set to create an empty package with the given name in a non-interactive way"
 
 	CreatePackageTypeFlagName        = "type"
-	CreatePackageTypeFlagDescription = "set to 'input', 'integration' or 'content' to create an empty package of the given type in a non-interactive way"
+	CreatePackageTypeFlagDescription = "set to 'input', 'integration', 'content' or 'blueprint' to create an empty package of the given type in a non-interactive way"
 
 	CreateDataStreamNameFlagName        = "name"
 	CreateDataStreamNameFlagDescription = "set to create a data stream with the given name in a non-interactive way"

--- a/internal/packages/archetype/_static/blueprint-sample.cloudformation.json
+++ b/internal/packages/archetype/_static/blueprint-sample.cloudformation.json
@@ -1,0 +1,30 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Sample canonical base blueprint. Replace with the real IaC template for this provider/trust-model/scope.",
+  "Parameters": {
+    "ElasticResourceId": {
+      "Type": "String",
+      "Description": "Elastic resource ID used to construct trust conditions."
+    }
+  },
+  "Resources": {
+    "ElasticFederatedIdentityRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "RoleName": { "Fn::Sub": "ElasticFederatedIdentity-${AWS::StackName}" },
+        "Path": "/",
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": []
+        },
+        "ManagedPolicyArns": []
+      }
+    }
+  },
+  "Outputs": {
+    "RoleArn": {
+      "Description": "ARN of the Elastic Federated Identity role.",
+      "Value": { "Fn::GetAtt": ["ElasticFederatedIdentityRole", "Arn"] }
+    }
+  }
+}

--- a/internal/packages/archetype/_static/package-manifest.yml.tmpl
+++ b/internal/packages/archetype/_static/package-manifest.yml.tmpl
@@ -8,9 +8,11 @@ source:
 {[ end ]}
 description: "{[.Manifest.Description]}"
 type: {[.Manifest.Type]}
+{[- if ne .Manifest.Type "blueprint" ]}
 categories:{[range $category := .Manifest.Categories]}
   - {[$category]}
 {[- end]}
+{[- end ]}
 conditions:
   kibana:
     version: "{[.Manifest.Conditions.Kibana.Version]}"
@@ -20,6 +22,7 @@ conditions:
 discovery:
   fields: []
 {[- end ]}
+{[- if ne .Manifest.Type "blueprint" ]}
 screenshots:
   - src: /img/sample-screenshot.png
     title: Sample screenshot
@@ -30,6 +33,7 @@ icons:
     title: Sample logo
     size: 32x32
     type: image/svg+xml
+{[- end ]}
 {[- if (or (eq .Manifest.Type "integration") (eq .Manifest.Type "input")) ]}
 policy_templates:
 {[- if eq .Manifest.Type "integration" ]}

--- a/internal/packages/archetype/package.go
+++ b/internal/packages/archetype/package.go
@@ -54,10 +54,13 @@ func createPackageInDir(packageDescriptor PackageDescriptor, cwd string) error {
 		return fmt.Errorf("can't render package README: %w", err)
 	}
 
-	logger.Debugf("Write docs readme template to _dev")
-	err = renderResourceFile(packageDocsReadme, &packageDescriptor, filepath.Join(baseDir, "_dev", "build", "docs", "README.md"))
-	if err != nil {
-		return fmt.Errorf("can't render package README in _dev: %w", err)
+	// Blueprint packages do not allow a `_dev` directory in package-spec.
+	if packageDescriptor.Manifest.Type != "blueprint" {
+		logger.Debugf("Write docs readme template to _dev")
+		err = renderResourceFile(packageDocsReadme, &packageDescriptor, filepath.Join(baseDir, "_dev", "build", "docs", "README.md"))
+		if err != nil {
+			return fmt.Errorf("can't render package README in _dev: %w", err)
+		}
 	}
 
 	if license := packageDescriptor.Manifest.Source.License; license != "" {
@@ -68,20 +71,23 @@ func createPackageInDir(packageDescriptor PackageDescriptor, cwd string) error {
 		}
 	}
 
-	logger.Debugf("Write sample icon")
-	err = writeRawResourceFile(packageImgSampleIcon, filepath.Join(baseDir, "img", "sample-logo.svg"))
-	if err != nil {
-		return fmt.Errorf("can't render sample icon: %w", err)
-	}
+	// Blueprint packages do not ship Kibana assets or package icons.
+	if packageDescriptor.Manifest.Type != "blueprint" {
+		logger.Debugf("Write sample icon")
+		err = writeRawResourceFile(packageImgSampleIcon, filepath.Join(baseDir, "img", "sample-logo.svg"))
+		if err != nil {
+			return fmt.Errorf("can't render sample icon: %w", err)
+		}
 
-	logger.Debugf("Write sample screenshot")
-	decodedSampleScreenshot, err := decodeBase64Resource(packageImgSampleScreenshot)
-	if err != nil {
-		return fmt.Errorf("can't decode sample screenshot: %w", err)
-	}
-	err = writeRawResourceFile(decodedSampleScreenshot, filepath.Join(baseDir, "img", "sample-screenshot.png"))
-	if err != nil {
-		return fmt.Errorf("can't render sample screenshot: %w", err)
+		logger.Debugf("Write sample screenshot")
+		decodedSampleScreenshot, err := decodeBase64Resource(packageImgSampleScreenshot)
+		if err != nil {
+			return fmt.Errorf("can't decode sample screenshot: %w", err)
+		}
+		err = writeRawResourceFile(decodedSampleScreenshot, filepath.Join(baseDir, "img", "sample-screenshot.png"))
+		if err != nil {
+			return fmt.Errorf("can't render sample screenshot: %w", err)
+		}
 	}
 
 	if packageDescriptor.Manifest.Type == "integration" {
@@ -104,6 +110,14 @@ func createPackageInDir(packageDescriptor PackageDescriptor, cwd string) error {
 		err = renderResourceFile(inputAgentConfigTemplate, &packageDescriptor, filepath.Join(baseDir, "agent", "input", "input.yml.hbs"))
 		if err != nil {
 			return fmt.Errorf("can't render agent stream: %w", err)
+		}
+	}
+
+	if packageDescriptor.Manifest.Type == "blueprint" {
+		logger.Debugf("Write sample blueprint")
+		err = writeRawResourceFile(blueprintSampleCloudFormation, filepath.Join(baseDir, "blueprints", "aws", "federated-identity", "account.cloudformation.json"))
+		if err != nil {
+			return fmt.Errorf("can't render sample blueprint: %w", err)
 		}
 	}
 

--- a/internal/packages/archetype/package_test.go
+++ b/internal/packages/archetype/package_test.go
@@ -35,6 +35,48 @@ func TestPackage(t *testing.T) {
 		pd := createPackageDescriptorForTest("content", "^8.16.0")
 		createAndCheckPackage(t, pd, true)
 	})
+	t.Run("blueprint-package", func(t *testing.T) {
+		pd := createPackageDescriptorForTest("blueprint", "^8.0.0")
+		createAndCheckBlueprintPackage(t, pd)
+	})
+}
+
+// createAndCheckBlueprintPackage verifies blueprint scaffolding and package-root
+// detection. Full package-spec validation is skipped until package-spec publishes
+// the blueprint type (elastic/package-spec#1209).
+func createAndCheckBlueprintPackage(t *testing.T, pd PackageDescriptor) {
+	t.Helper()
+
+	repositoryRoot, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+	defer repositoryRoot.Close()
+
+	packagesDir := filepath.Join(repositoryRoot.Name(), "packages")
+	err = createPackageInDir(pd, packagesDir)
+	require.NoError(t, err)
+
+	packageRoot := filepath.Join(packagesDir, pd.Manifest.Name)
+	root, err := packages.FindPackageRootFrom(packageRoot)
+	require.NoError(t, err)
+	assert.Equal(t, packageRoot, root)
+
+	manifest, err := packages.ReadPackageManifestFromPackageRoot(packageRoot)
+	require.NoError(t, err)
+	assert.Equal(t, "blueprint", manifest.Type)
+	assert.Empty(t, manifest.Categories)
+
+	manifestBytes, err := os.ReadFile(filepath.Join(packageRoot, packages.PackageManifestFile))
+	require.NoError(t, err)
+	assert.NotContains(t, string(manifestBytes), "icons:")
+	assert.NotContains(t, string(manifestBytes), "screenshots:")
+	assert.NotContains(t, string(manifestBytes), "categories:")
+
+	_, err = os.Stat(filepath.Join(packageRoot, "blueprints", "aws", "federated-identity", "account.cloudformation.json"))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(packageRoot, "img"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(filepath.Join(packageRoot, "_dev"))
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func createAndCheckPackage(t *testing.T, pd PackageDescriptor, valid bool) {

--- a/internal/packages/archetype/resources.go
+++ b/internal/packages/archetype/resources.go
@@ -23,6 +23,9 @@ var fieldsBaseTemplate string
 //go:embed _static/package-validation.yml.tmpl
 var validationBaseTemplate string
 
+//go:embed _static/blueprint-sample.cloudformation.json
+var blueprintSampleCloudFormation []byte
+
 // Images (logo and screenshot)
 
 //go:embed _static/sampleIcon.svg

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -40,8 +40,9 @@ const (
 	dataStreamTypeTraces     = "traces"
 )
 
-// AllowedPackageTypes lists the valid package types accepted by the create wizard.
-var AllowedPackageTypes = []string{"input", "integration", "content"}
+// AllowedPackageTypes lists the valid package types accepted by package root
+// detection and the create wizard.
+var AllowedPackageTypes = []string{"input", "integration", "content", "blueprint"}
 
 // AllowedDataStreamTypes lists the data stream types accepted by the create wizard.
 var AllowedDataStreamTypes = []string{"logs", "metrics"}

--- a/internal/packages/packages_test.go
+++ b/internal/packages/packages_test.go
@@ -6,6 +6,7 @@ package packages
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -382,4 +383,62 @@ latest:
 			}
 		})
 	}
+}
+
+func TestFindPackageRootFrom_AllowedPackageTypes(t *testing.T) {
+	for _, pkgType := range AllowedPackageTypes {
+		t.Run(pkgType, func(t *testing.T) {
+			packageDir := t.TempDir()
+			manifest := fmt.Sprintf(`format_version: 3.6.6
+name: test_%s_pkg
+title: Test %s Package
+description: Test package for FindPackageRootFrom.
+version: 0.0.1
+type: %s
+owner:
+  github: elastic/integrations
+  type: elastic
+`, pkgType, pkgType, pkgType)
+			err := os.WriteFile(filepath.Join(packageDir, PackageManifestFile), []byte(manifest), 0o644)
+			require.NoError(t, err)
+
+			root, err := FindPackageRootFrom(packageDir)
+			require.NoError(t, err)
+			assert.Equal(t, packageDir, root)
+		})
+	}
+
+	t.Run("unknown type is not a package root", func(t *testing.T) {
+		packageDir := t.TempDir()
+		manifest := `format_version: 3.6.6
+name: test_unknown_pkg
+title: Test Unknown Package
+description: Should not be recognized as a package root.
+version: 0.0.1
+type: unknown
+owner:
+  github: elastic/integrations
+  type: elastic
+`
+		err := os.WriteFile(filepath.Join(packageDir, PackageManifestFile), []byte(manifest), 0o644)
+		require.NoError(t, err)
+
+		_, err = FindPackageRootFrom(packageDir)
+		require.ErrorIs(t, err, ErrPackageRootNotFound)
+	})
+}
+
+func TestAllowedPackageTypesIncludesBlueprint(t *testing.T) {
+	assert.Contains(t, AllowedPackageTypes, "blueprint")
+}
+
+func TestFindPackageRootFrom_BlueprintFixture(t *testing.T) {
+	packageRoot := filepath.Join("testdata", "blueprint")
+	root, err := FindPackageRootFrom(packageRoot)
+	require.NoError(t, err)
+	assert.Equal(t, packageRoot, root)
+
+	manifest, err := ReadPackageManifestFromPackageRoot(root)
+	require.NoError(t, err)
+	assert.Equal(t, "blueprint", manifest.Type)
 }

--- a/internal/packages/testdata/blueprint/LICENSE.txt
+++ b/internal/packages/testdata/blueprint/LICENSE.txt
@@ -1,0 +1,93 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/internal/packages/testdata/blueprint/blueprints/aws/federated-identity/account.cloudformation.json
+++ b/internal/packages/testdata/blueprint/blueprints/aws/federated-identity/account.cloudformation.json
@@ -1,0 +1,37 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Sample canonical base blueprint. Replace with the real IaC template for this provider/trust-model/scope.",
+    "Parameters": {
+        "ElasticResourceId": {
+            "Type": "String",
+            "Description": "Elastic resource ID used to construct trust conditions."
+        }
+    },
+    "Resources": {
+        "ElasticFederatedIdentityRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "RoleName": {
+                    "Fn::Sub": "ElasticFederatedIdentity-${AWS::StackName}"
+                },
+                "Path": "/",
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": []
+                },
+                "ManagedPolicyArns": []
+            }
+        }
+    },
+    "Outputs": {
+        "RoleArn": {
+            "Description": "ARN of the Elastic Federated Identity role.",
+            "Value": {
+                "Fn::GetAtt": [
+                    "ElasticFederatedIdentityRole",
+                    "Arn"
+                ]
+            }
+        }
+    }
+}

--- a/internal/packages/testdata/blueprint/changelog.yml
+++ b/internal/packages/testdata/blueprint/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: Initial draft of the package
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 # FIXME Replace with the real PR link

--- a/internal/packages/testdata/blueprint/docs/README.md
+++ b/internal/packages/testdata/blueprint/docs/README.md
@@ -1,0 +1,3 @@
+# Blueprint
+
+Minimal test package for the `blueprint` package type, which hosts canonical IaC base blueprints under `blueprints/<provider>/<trust-model>/<scope>.<format>.<ext>`.

--- a/internal/packages/testdata/blueprint/manifest.yml
+++ b/internal/packages/testdata/blueprint/manifest.yml
@@ -1,0 +1,16 @@
+format_version: 3.6.6
+name: blueprint
+title: Blueprint
+description: Minimal blueprint package fixture for elastic-package package-root detection and scaffolding.
+version: 0.0.1
+type: blueprint
+source:
+  license: "Elastic-2.0"
+conditions:
+  kibana:
+    version: "^8.0.0"
+  elastic:
+    subscription: basic
+owner:
+  github: elastic/integrations
+  type: elastic

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -499,7 +499,7 @@ func PackageHasDataStreams(manifest *packages.PackageManifest) (bool, error) {
 	switch manifest.Type {
 	case "integration":
 		return true, nil
-	case "input", "content":
+	case "input", "content", "blueprint":
 		return false, nil
 	default:
 		return false, fmt.Errorf("unexpected package type %q", manifest.Type)

--- a/internal/testrunner/testrunner_test.go
+++ b/internal/testrunner/testrunner_test.go
@@ -1,0 +1,40 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package testrunner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-package/internal/packages"
+)
+
+func TestPackageHasDataStreams(t *testing.T) {
+	cases := []struct {
+		packageType string
+		expected    bool
+	}{
+		{"integration", true},
+		{"input", false},
+		{"content", false},
+		{"blueprint", false},
+	}
+	for _, c := range cases {
+		t.Run(c.packageType, func(t *testing.T) {
+			manifest := &packages.PackageManifest{Type: c.packageType}
+			hasDataStreams, err := PackageHasDataStreams(manifest)
+			require.NoError(t, err)
+			assert.Equal(t, c.expected, hasDataStreams)
+		})
+	}
+
+	t.Run("unknown type", func(t *testing.T) {
+		manifest := &packages.PackageManifest{Type: "unknown"}
+		_, err := PackageHasDataStreams(manifest)
+		require.Error(t, err)
+	})
+}

--- a/pr-description.md
+++ b/pr-description.md
@@ -1,0 +1,27 @@
+## Summary
+
+- Add `"blueprint"` to `AllowedPackageTypes` so package-root detection recognizes blueprint packages. This unblocks `format`, `lint`, `build`, and `check` from failing early with `package root not found`.
+- Teach `elastic-package create package` to scaffold blueprint packages (wizard + `--type blueprint`): sample IaC under `blueprints/`, and omit `img/`, `_dev/`, categories, icons, and screenshots to match the upcoming package-spec layout.
+- Treat `blueprint` like other non-data-stream package types in `PackageHasDataStreams`.
+- Add unit/archetype coverage and a minimal fixture under `internal/packages/testdata/blueprint`.
+
+Closes #3827
+
+Relates to elastic/package-spec#1209 (blueprint package type / dynamic IaC).
+
+## Context
+
+A new `blueprint` package type is being introduced in package-spec for canonical IaC base templates. Without recognizing that type in `AllowedPackageTypes`, every core command fails before doing real work. This is also a prerequisite for the integrations repo publish pipeline once blueprint packages start landing there.
+
+## Test plan
+
+- [x] `go test ./internal/packages/ ./internal/packages/archetype/ ./cmd/ -run 'TestAllowedPackageTypes|TestFindPackageRoot|TestPackage|TestCreatePackage'`
+- [x] `elastic-package create package --type blueprint --name <tmp>` creates a valid-looking package root (manifest type `blueprint`, `blueprints/` present, no `img/`/`_dev`)
+- [x] `elastic-package format -C internal/packages/testdata/blueprint` succeeds
+- [x] `make build format lint licenser gomod` (with `CGO_ENABLED=0` for `make update` if needed in local env)
+- [ ] Confirm `lint` / `build` / `check` succeed against the fixture after bumping to a package-spec release that includes the `blueprint` type (currently blocked on package-spec#1209; verified locally against that PR tip via a temporary replace)
+
+## Follow-ups
+
+- Bump `github.com/elastic/package-spec/v3` once the blueprint type ships, then re-run `lint`/`build`/`check` on the fixture (and optionally move/add a package under `test/packages/` for CI coverage).
+- Decide whether baseline semantic validation (changelog link, version integrity, etc.) should be wired for `blueprint` before GA.


### PR DESCRIPTION
## Summary

- Add `"blueprint"` to `AllowedPackageTypes` so package-root detection recognizes blueprint packages. This unblocks `format`, `lint`, `build`, and `check` from failing early with `package root not found`.
- Teach `elastic-package create package` to scaffold blueprint packages (wizard + `--type blueprint`): sample IaC under `blueprints/`, and omit `img/`, `_dev/`, categories, icons, and screenshots to match the upcoming package-spec layout.
- Treat `blueprint` like other non-data-stream package types in `PackageHasDataStreams`.
- Add unit/archetype coverage and a minimal fixture under `internal/packages/testdata/blueprint`.

Closes #3827

Relates to elastic/package-spec#1209 (blueprint package type / dynamic IaC).

## Context

A new `blueprint` package type is being introduced in package-spec for canonical IaC base templates. Without recognizing that type in `AllowedPackageTypes`, every core command fails before doing real work. This is also a prerequisite for the integrations repo publish pipeline once blueprint packages start landing there.

## Test plan

- [x] `go test ./internal/packages/ ./internal/packages/archetype/ ./cmd/ -run 'TestAllowedPackageTypes|TestFindPackageRoot|TestPackage|TestCreatePackage'`
- [x] `elastic-package create package --type blueprint --name <tmp>` creates a valid-looking package root (manifest type `blueprint`, `blueprints/` present, no `img/`/`_dev`)
- [x] `elastic-package format -C internal/packages/testdata/blueprint` succeeds
- [x] `make build format lint licenser gomod` (with `CGO_ENABLED=0` for `make update` if needed in local env)
- [ ] Confirm `lint` / `build` / `check` succeed against the fixture after bumping to a package-spec release that includes the `blueprint` type (currently blocked on package-spec#1209; verified locally against that PR tip via a temporary replace)

## Follow-ups

- Bump `github.com/elastic/package-spec/v3` once the blueprint type ships, then re-run `lint`/`build`/`check` on the fixture (and optionally move/add a package under `test/packages/` for CI coverage).
- Decide whether baseline semantic validation (changelog link, version integrity, etc.) should be wired for `blueprint` before GA.
