### PR TITLE
Rename ingest-fp team reference to Streams

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,7 +13,7 @@ metadata:
 
 spec:
   type: tool
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   lifecycle: production
 
@@ -30,7 +30,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -58,7 +58,7 @@ spec:
       teams:
         ecosystem:
           access_level: MANAGE_BUILD_AND_READ
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         observablt-ci:
           access_level: MANAGE_BUILD_AND_READ
@@ -90,7 +90,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -118,7 +118,7 @@ spec:
       teams:
         ecosystem:
           access_level: MANAGE_BUILD_AND_READ
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
@@ -136,7 +136,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -164,7 +164,7 @@ spec:
           cronline: "00 1 * * *"
           message: Daily Cloud cleanup
       teams:
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         observablt-ci:
           access_level: MANAGE_BUILD_AND_READ
@@ -184,7 +184,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -217,7 +217,7 @@ spec:
           env:
             SERVERLESS_PROJECT: observability
       teams:
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         observablt-ci:
           access_level: MANAGE_BUILD_AND_READ

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -223,3 +223,4 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
+

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,7 +13,7 @@ metadata:
 
 spec:
   type: tool
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   lifecycle: production
 
@@ -30,7 +30,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -58,7 +58,7 @@ spec:
       teams:
         ecosystem:
           access_level: MANAGE_BUILD_AND_READ
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         observablt-ci:
           access_level: MANAGE_BUILD_AND_READ
@@ -90,7 +90,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -118,7 +118,7 @@ spec:
       teams:
         ecosystem:
           access_level: MANAGE_BUILD_AND_READ
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
@@ -136,7 +136,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -164,7 +164,7 @@ spec:
           cronline: "00 1 * * *"
           message: Daily Cloud cleanup
       teams:
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         observablt-ci:
           access_level: MANAGE_BUILD_AND_READ
@@ -184,7 +184,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -217,10 +217,9 @@ spec:
           env:
             SERVERLESS_PROJECT: observability
       teams:
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         observablt-ci:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
-


### PR DESCRIPTION
This catches up catalog-info.yaml to the GitHub team's actual current name — the team was renamed from `ingest-fp` to `Streams`.