### PR TITLE
fix: avoid false positive in mapping validation for dynamic children of a nested ECS parent

### DIFF
--- a/internal/fields/mappings.go
+++ b/internal/fields/mappings.go
@@ -300,6 +300,24 @@ func isNumberTypeField(previewType, actualType string) bool {
 	return false
 }
 
+// mappingTypesWithDynamicChildren lists mapping types whose child mappings can be created
+// dynamically by Elasticsearch during document ingest, even when no child mapping is defined
+// in the index template (e.g. ECS nested fields like "email.attachments").
+// Add "object" here once the scope is extended to cover plain object parents.
+var mappingTypesWithDynamicChildren = []string{"nested"}
+
+// allowsDynamicChildMappings reports whether the preview mapping is a type that Elasticsearch
+// can populate with dynamically created child mappings, and that the actual mapping preserves
+// the same type.  When both conditions hold, the extra properties in the actual mapping should
+// be validated as dynamic fields rather than treated as an error.
+func allowsDynamicChildMappings(preview, actual map[string]any) bool {
+	previewType := mappingParameter("type", preview)
+	if !slices.Contains(mappingTypesWithDynamicChildren, previewType) {
+		return false
+	}
+	return previewType == mappingParameter("type", actual)
+}
+
 func (v *MappingValidator) validateMappingInECSSchema(currentPath string, definition map[string]any) multierror.Error {
 	found := FindElementDefinition(currentPath, v.Schema)
 	if found == nil {
@@ -457,8 +475,18 @@ func (v *MappingValidator) compareMappings(path string, couldBeParametersDefinit
 			}
 			return nil
 		} else if !isObject(preview) {
-			errs = append(errs, fmt.Errorf("undefined field mappings found in path: %q", path))
-			return errs.Unique()
+			if !allowsDynamicChildMappings(preview, actual) {
+				errs = append(errs, fmt.Errorf("undefined field mappings found in path: %q", path))
+				return errs.Unique()
+			}
+			// Elasticsearch created these child mappings dynamically while ingesting documents.
+			// Validate them the same way as any mapping not present in the preview.
+			dynamicErrors := v.validateMappingsNotInPreview(path, actual, dynamicTemplates)
+			errs = append(errs, dynamicErrors...)
+			if len(errs) > 0 {
+				return errs.Unique()
+			}
+			return nil
 		}
 		previewProperties, err := getMappingDefinitionsField("properties", preview)
 		if err != nil {

--- a/internal/fields/mappings_test.go
+++ b/internal/fields/mappings_test.go
@@ -748,8 +748,10 @@ func TestComparingMappings(t *testing.T) {
 			},
 			exceptionFields: []string{},
 			schema:          []FieldDefinition{},
+			// foo.bar is not defined in the schema and has no matching dynamic template,
+			// so it must be reported as undefined rather than silently accepted.
 			expectedErrors: []string{
-				`undefined field mappings found in path: "foo"`,
+				`field "foo.bar" is undefined: field definition not found`,
 			},
 		},
 		{
@@ -844,6 +846,208 @@ func TestComparingMappings(t *testing.T) {
 				// Should it be considered this error in "foa" "missing time_series_metric bar"?
 				// "fob" is failing because it does not have the expected value for the "time_series_metric" field
 				`field "fob" is undefined: field definition not found`,
+			},
+		},
+		{
+			// Reproducer for https://github.com/elastic/elastic-package/issues/3639:
+			// a package defines a nested ECS parent field and Elasticsearch dynamically
+			// adds child mappings while ingesting documents.  The children all exist in
+			// the ECS schema, so validation must pass.
+			title: "dynamic child mappings under a nested ECS parent defined in preview",
+			preview: map[string]any{
+				"email": map[string]any{
+					"properties": map[string]any{
+						"attachments": map[string]any{
+							"type": "nested",
+						},
+					},
+				},
+			},
+			actual: map[string]any{
+				"email": map[string]any{
+					"properties": map[string]any{
+						"attachments": map[string]any{
+							"type": "nested",
+							"properties": map[string]any{
+								"file": map[string]any{
+									"properties": map[string]any{
+										"size": map[string]any{
+											"type": "long",
+										},
+										"name": map[string]any{
+											"type": "keyword",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			schema: []FieldDefinition{
+				{
+					Name:     "email.attachments",
+					Type:     "nested",
+					External: "ecs",
+				},
+				{
+					Name:     "email.attachments.file.size",
+					Type:     "long",
+					External: "ecs",
+				},
+				{
+					Name:     "email.attachments.file.name",
+					Type:     "keyword",
+					External: "ecs",
+				},
+			},
+			exceptionFields: []string{},
+			expectedErrors:  []string{},
+		},
+		{
+			// Same as above but with one extra child that is NOT in ECS.
+			// Only the non-ECS child must be reported as undefined.
+			title: "dynamic child mappings under a nested ECS parent — mixed ECS and non-ECS children",
+			preview: map[string]any{
+				"email": map[string]any{
+					"properties": map[string]any{
+						"attachments": map[string]any{
+							"type": "nested",
+						},
+					},
+				},
+			},
+			actual: map[string]any{
+				"email": map[string]any{
+					"properties": map[string]any{
+						"attachments": map[string]any{
+							"type": "nested",
+							"properties": map[string]any{
+								"file": map[string]any{
+									"properties": map[string]any{
+										"name": map[string]any{
+											"type": "keyword",
+										},
+									},
+								},
+								"foo": map[string]any{
+									"type": "keyword",
+								},
+							},
+						},
+					},
+				},
+			},
+			schema: []FieldDefinition{
+				{
+					Name:     "email.attachments",
+					Type:     "nested",
+					External: "ecs",
+				},
+				{
+					Name:     "email.attachments.file.name",
+					Type:     "keyword",
+					External: "ecs",
+				},
+			},
+			exceptionFields: []string{},
+			expectedErrors: []string{
+				`field "email.attachments.foo" is undefined: field definition not found`,
+			},
+		},
+		{
+			// The children under the nested parent are not in ECS but they match a
+			// package-defined dynamic template, so validation must pass.
+			title: "dynamic child mappings under a nested parent matched by a dynamic template",
+			preview: map[string]any{
+				"threat": map[string]any{
+					"properties": map[string]any{
+						"enrichments": map[string]any{
+							"type": "nested",
+						},
+					},
+				},
+			},
+			actual: map[string]any{
+				"threat": map[string]any{
+					"properties": map[string]any{
+						"enrichments": map[string]any{
+							"type": "nested",
+							"properties": map[string]any{
+								"matched": map[string]any{
+									"properties": map[string]any{
+										"id": map[string]any{
+											"type": "keyword",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			dynamicTemplates: []map[string]any{
+				{
+					"threat_enrichments_keyword": map[string]any{
+						"path_match": "threat.enrichments.*",
+						"mapping": map[string]any{
+							"type": "keyword",
+						},
+					},
+				},
+			},
+			schema:          []FieldDefinition{},
+			exceptionFields: []string{},
+			expectedErrors:  []string{},
+		},
+		{
+			// Preview says nested but actual dropped the type (became a plain object).
+			// The type changed, so this should still be reported as an error.
+			title: "nested parent in preview becomes a plain object in actual (type drift)",
+			preview: map[string]any{
+				"foo": map[string]any{
+					"type": "nested",
+				},
+			},
+			actual: map[string]any{
+				"foo": map[string]any{
+					// "type" is absent: Elasticsearch reports object without type once it has properties
+					"properties": map[string]any{
+						"bar": map[string]any{
+							"type": "long",
+						},
+					},
+				},
+			},
+			schema:          []FieldDefinition{},
+			exceptionFields: []string{},
+			expectedErrors: []string{
+				`undefined field mappings found in path: "foo"`,
+			},
+		},
+		{
+			// A plain object parent in the preview (no dynamic:true) acquires properties
+			// in the actual mapping.  Scope of this fix is nested only; this case must
+			// continue to produce an error so the boundary is explicitly documented.
+			title: "object parent (not nested) with dynamic children is out of scope",
+			preview: map[string]any{
+				"foo": map[string]any{
+					"type": "object",
+				},
+			},
+			actual: map[string]any{
+				"foo": map[string]any{
+					"properties": map[string]any{
+						"bar": map[string]any{
+							"type": "keyword",
+						},
+					},
+				},
+			},
+			schema:          []FieldDefinition{},
+			exceptionFields: []string{},
+			expectedErrors: []string{
+				`undefined field mappings found in path: "foo"`,
 			},
 		},
 	}

--- a/test/packages/other/ecs_nested_fields/_dev/build/build.yml
+++ b/test/packages/other/ecs_nested_fields/_dev/build/build.yml
@@ -1,0 +1,4 @@
+dependencies:
+  ecs:
+    reference: git@v8.11.0
+    import_mappings: true

--- a/test/packages/other/ecs_nested_fields/_dev/deploy/docker/docker-compose.yml
+++ b/test/packages/other/ecs_nested_fields/_dev/deploy/docker/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '2.3'
+services:
+  ecs_nested_fields:
+    image: "alpine:3.16"
+    command: ["sh", "-c", "while true; do echo '{\"message\": \"hello\"}' >> ./logs/ecs_nested_fields.log; sleep 1; done"]
+    volumes:
+      - ${SERVICE_LOGS_DIR}:/logs

--- a/test/packages/other/ecs_nested_fields/changelog.yml
+++ b/test/packages/other/ecs_nested_fields/changelog.yml
@@ -1,0 +1,5 @@
+- version: "0.0.1"
+  changes:
+    - description: Initial test package for ECS nested fields mapping validation.
+      type: enhancement
+      link: https://github.com/elastic/elastic-package/issues/3639

--- a/test/packages/other/ecs_nested_fields/data_stream/logs/_dev/test/system/test-default-config.yml
+++ b/test/packages/other/ecs_nested_fields/data_stream/logs/_dev/test/system/test-default-config.yml
@@ -1,0 +1,6 @@
+vars: ~
+input: logfile
+data_stream:
+  vars:
+    paths:
+      - "{{SERVICE_LOGS_DIR}}/ecs_nested_fields.log"

--- a/test/packages/other/ecs_nested_fields/data_stream/logs/agent/stream/stream.yml.hbs
+++ b/test/packages/other/ecs_nested_fields/data_stream/logs/agent/stream/stream.yml.hbs
@@ -1,0 +1,5 @@
+paths:
+{{#each paths as |path i|}}
+  - {{path}}
+{{/each}}
+exclude_files: [".gz$"]

--- a/test/packages/other/ecs_nested_fields/data_stream/logs/elasticsearch/ingest_pipeline/default.yml
+++ b/test/packages/other/ecs_nested_fields/data_stream/logs/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,20 @@
+---
+description: Pipeline for ECS nested fields mapping validation test.
+processors:
+  - set:
+      field: email.attachments
+      value:
+        - file:
+            name: "report.pdf"
+            extension: "pdf"
+            mime_type: "application/pdf"
+            size: 52428
+            hash:
+              sha256: "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3"
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: "{{ _ingest.on_failure_message }}"

--- a/test/packages/other/ecs_nested_fields/data_stream/logs/fields/base-fields.yml
+++ b/test/packages/other/ecs_nested_fields/data_stream/logs/fields/base-fields.yml
@@ -1,0 +1,20 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.
+- name: input.type
+  type: keyword
+- name: log.file.path
+  type: keyword
+- name: log.offset
+  type: long
+- name: message
+  type: match_only_text

--- a/test/packages/other/ecs_nested_fields/data_stream/logs/fields/ecs.yml
+++ b/test/packages/other/ecs_nested_fields/data_stream/logs/fields/ecs.yml
@@ -1,0 +1,6 @@
+# Only the nested parent is declared here.  Child fields (e.g. email.attachments.file.name)
+# are intentionally omitted so that Elasticsearch creates them dynamically during ingest.
+# The mapping validator must accept those children when they are valid ECS fields.
+# See https://github.com/elastic/elastic-package/issues/3639.
+- name: email.attachments
+  external: ecs

--- a/test/packages/other/ecs_nested_fields/data_stream/logs/manifest.yml
+++ b/test/packages/other/ecs_nested_fields/data_stream/logs/manifest.yml
@@ -1,0 +1,13 @@
+title: ECS nested fields logs
+type: logs
+streams:
+  - input: logfile
+    title: Collect logs from file
+    description: Collecting sample logs
+    vars:
+      - name: paths
+        title: Paths
+        type: text
+        required: true
+        multi: true
+        show_user: true

--- a/test/packages/other/ecs_nested_fields/data_stream/logs/sample_event.json
+++ b/test/packages/other/ecs_nested_fields/data_stream/logs/sample_event.json
@@ -1,0 +1,84 @@
+{
+    "@timestamp": "2026-08-13T09:22:33.634Z",
+    "agent": {
+        "ephemeral_id": "714157b9-dbd7-42e3-b542-8bf12d54dfcf",
+        "id": "86c418aa-8eb9-4976-aaaf-40c30b6e3a3d",
+        "name": "elastic-agent-52093",
+        "type": "filebeat",
+        "version": "9.5.0"
+    },
+    "data_stream": {
+        "dataset": "ecs_nested_fields.logs",
+        "namespace": "38286",
+        "type": "logs"
+    },
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "elastic_agent": {
+        "id": "86c418aa-8eb9-4976-aaaf-40c30b6e3a3d",
+        "snapshot": false,
+        "version": "9.5.0"
+    },
+    "email": {
+        "attachments": [
+            {
+                "file.extension": [
+                    "pdf"
+                ],
+                "file.hash.sha256": [
+                    "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3"
+                ],
+                "file.mime_type": [
+                    "application/pdf"
+                ],
+                "file.name": [
+                    "report.pdf"
+                ],
+                "file.name.text": [
+                    "report.pdf"
+                ],
+                "file.size": [
+                    52428
+                ]
+            }
+        ]
+    },
+    "event": {
+        "agent_id_status": "verified",
+        "dataset": "ecs_nested_fields.logs",
+        "ingested": "2026-08-13T09:22:37Z"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "elastic-agent-52093",
+        "ip": [
+            "172.19.0.2",
+            "172.18.0.4"
+        ],
+        "mac": [
+            "B2-EA-83-BA-7F-1B",
+            "F2-0F-F2-02-9D-87"
+        ],
+        "name": "elastic-agent-52093",
+        "os": {
+            "family": "",
+            "kernel": "6.8.0-136-generic",
+            "name": "Wolfi",
+            "platform": "wolfi",
+            "type": "linux",
+            "version": "20230201"
+        }
+    },
+    "input": {
+        "type": "log"
+    },
+    "log": {
+        "file": {
+            "path": "/tmp/service_logs/ecs_nested_fields.log"
+        },
+        "offset": 0
+    },
+    "message": "{\"message\": \"hello\"}"
+}

--- a/test/packages/other/ecs_nested_fields/docs/README.md
+++ b/test/packages/other/ecs_nested_fields/docs/README.md
@@ -1,0 +1,8 @@
+# ECS nested fields mapping validation test
+
+Test package for https://github.com/elastic/elastic-package/issues/3639.
+
+It declares only the `email.attachments` ECS nested parent field.  During system tests,
+Elasticsearch dynamically maps child fields (e.g. `email.attachments.file.name`) when documents
+are indexed.  The mapping validator must accept these children when they are valid ECS fields,
+rather than failing at the parent path with a false-positive error.

--- a/test/packages/other/ecs_nested_fields/manifest.yml
+++ b/test/packages/other/ecs_nested_fields/manifest.yml
@@ -1,0 +1,27 @@
+format_version: 3.3.2
+name: ecs_nested_fields
+title: ECS nested fields mapping validation test
+version: 0.0.1
+description: >
+  Tests that dynamically created child mappings under an explicitly-defined ECS nested parent
+  field are accepted by the mapping validator when they are valid ECS fields.
+  Regression test for https://github.com/elastic/elastic-package/issues/3639.
+type: integration
+categories:
+  - custom
+conditions:
+  kibana:
+    version: "^8.13.0 || ^9.0.0"
+  elastic:
+    subscription: basic
+policy_templates:
+  - name: logs
+    title: ECS nested fields logs
+    description: Collect logs for ECS nested fields mapping validation test
+    inputs:
+      - type: logfile
+        title: Collect logs from file
+        description: Collecting sample logs
+owner:
+  github: elastic/integrations
+  type: elastic


### PR DESCRIPTION
## Summary

When a package declares an ECS `nested` field (e.g. `email.attachments`) and Elasticsearch dynamically creates child mappings during document ingest, the mapping validator was incorrectly raising a false positive:

```
undefined field mappings found in path: "email.attachments"
```

The preview (simulated index template) carries `{"type":"nested"}` with no `properties`, while the actual data stream mappings gain `properties` from dynamically ingested documents. The validator treated this as an undefined field at the parent level and never inspected the children individually.

This fix detects when a preview mapping has a type that Elasticsearch can populate with dynamically created children (currently `nested`) and the actual mapping preserves the same type. In that case the children are validated via the existing `validateMappingsNotInPreview` path — accepted if they match a dynamic template or the ECS schema, reported as errors otherwise.

Closes #3639

## Changes

- **`internal/fields/mappings.go`** — add `allowsDynamicChildMappings` helper and wire it into `compareMappings` inside the `else if !isObject(preview)` branch.
- **`internal/fields/mappings_test.go`** — add / update 6 test cases covering: ECS children pass, mixed ECS + non-ECS children (error on non-ECS only), dynamic-template match, type drift (error preserved), `object` parent out of scope.
- **`test/packages/other/ecs_nested_fields/`** — new e2e test package that reproduces the issue end-to-end: declares only `email.attachments` in `fields/ecs.yml`, ingest pipeline populates `file.{name,extension,mime_type,size,hash.sha256}` dynamically.

## Proposed commit message

```
fix: avoid false positive in mapping validation for dynamic children of a nested ECS parent

When a package declares an ECS `nested` field (e.g. `email.attachments`) without
declaring its children, and Elasticsearch creates those children dynamically during
ingest, the validator was reporting "undefined field mappings found in path" at the
parent level instead of inspecting the children individually.

Add `allowsDynamicChildMappings` to detect when the preview has a type that allows
dynamic children (`nested`) and the actual mapping preserves that type. Wire it into
`compareMappings` so those children are validated through `validateMappingsNotInPreview`
— accepted if they match a dynamic template or the ECS schema, errors otherwise.

```

## Testing

Verified on two stacks with both the released `v0.125.1` binary (reproduces the false positive) and the patched binary (passes):

| Stack | Binary | Result |
|-------|--------|--------|
| 9.5.0 | v0.125.1 | FAIL — `undefined field mappings found in path: "email.attachments"` |
| 9.5.0 | patched | PASS |
| 8.19.20-SNAPSHOT | v0.125.1 | FAIL |
| 8.19.20-SNAPSHOT | patched | PASS |

Also tested against `microsoft_exchange_online_message_trace` from the integrations repo with the child-field workaround removed — both `cel` and `logfile` test cases pass on both stacks.

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).