### PR TITLE
fix: prevent empty ILM heading and discover lifecycle.yml data streams

### DIFF
--- a/docs/howto/add_package_readme.md
+++ b/docs/howto/add_package_readme.md
@@ -124,9 +124,12 @@ List of placeholders that can be used in the Markdown templates:
       ```
     - Requirements:
         - It is needed to define a file with the links definitions. More information [in this section](#requirements)
-- `ilm [data_stream...]`: this placeholder renders ILM policies defined under
-  `data_stream/<name>/elasticsearch/ilm/`.
-    - Example of usage (all data streams with ILM policies):
+- `ilm [data_stream...]`: this placeholder renders ILM policies or lifecycle
+  configuration for each data stream. Two file locations are supported:
+    - `data_stream/<name>/elasticsearch/ilm/<policy>.json` — ILM policy file.
+    - `data_stream/<name>/lifecycle.yml` — DLM (Data Lifecycle Management)
+      configuration (takes precedence when both exist for the same data stream).
+    - Example of usage (all data streams):
       ```
       {{ ilm }}
       ```
@@ -134,10 +137,11 @@ List of placeholders that can be used in the Markdown templates:
       ```
       {{ ilm "metrics" }}
       ```
-    - When no data stream arguments are given, `elastic-package` discovers data streams
-      that have an `elasticsearch/ilm/` directory and documents each policy as a
+    - When no data stream arguments are given, `elastic-package` discovers all
+      data streams that have either an `elasticsearch/ilm/` directory or a
+      `lifecycle.yml` file, and documents one policy per data stream as a
       flattened key/value table.
-    - If there are no ILM policies to document (or discovery finds none), the placeholder
+    - If there are no policies to document (or discovery finds none), the placeholder
       renders as an empty string: no heading and no empty section are written.
     - Example of the rendered output when policies exist:
       ```

--- a/docs/howto/add_package_readme.md
+++ b/docs/howto/add_package_readme.md
@@ -143,7 +143,7 @@ List of placeholders that can be used in the Markdown templates:
       flattened key/value table.
     - If there are no policies to document (or discovery finds none), the placeholder
       renders as an empty string: no heading and no empty section are written.
-    - Example of the rendered output when policies exist:
+    - Example of the rendered output for an ILM policy (`elasticsearch/ilm/<policy>.json`):
       ```
       ### Data streams using ILM policies
 
@@ -153,6 +153,16 @@ List of placeholders that can be used in the Markdown templates:
       | policy.phases.delete.min_age | 30d |
       | policy.phases.hot.actions.rollover.max_age | 30d |
       ...
+      ```
+    - Example of the rendered output for a DLM `lifecycle.yml` (for example
+      `data_retention: "30d"`):
+      ```
+      ### Data streams using ILM policies
+
+      #### metrics Policy
+      | Key | Value |
+      |---|---|
+      | data_retention | 30d |
       ```
 - `transform`: this placeholder renders transforms defined under `elasticsearch/transform/`.
     - Example of usage:

--- a/docs/howto/add_package_readme.md
+++ b/docs/howto/add_package_readme.md
@@ -124,6 +124,39 @@ List of placeholders that can be used in the Markdown templates:
       ```
     - Requirements:
         - It is needed to define a file with the links definitions. More information [in this section](#requirements)
+- `ilm [data_stream...]`: this placeholder renders ILM policies defined under
+  `data_stream/<name>/elasticsearch/ilm/`.
+    - Example of usage (all data streams with ILM policies):
+      ```
+      {{ ilm }}
+      ```
+    - Example of usage (specific data streams):
+      ```
+      {{ ilm "metrics" }}
+      ```
+    - When no data stream arguments are given, `elastic-package` discovers data streams
+      that have an `elasticsearch/ilm/` directory and documents each policy as a
+      flattened key/value table.
+    - If there are no ILM policies to document (or discovery finds none), the placeholder
+      renders as an empty string: no heading and no empty section are written.
+    - Example of the rendered output when policies exist:
+      ```
+      ### Data streams using ILM policies
+
+      #### metrics Policy
+      | Key | Value |
+      |---|---|
+      | policy.phases.delete.min_age | 30d |
+      | policy.phases.hot.actions.rollover.max_age | 30d |
+      ...
+      ```
+- `transform`: this placeholder renders transforms defined under `elasticsearch/transform/`.
+    - Example of usage:
+      ```
+      {{ transform }}
+      ```
+    - If there are no transforms defined, the placeholder renders as an empty string
+      (no heading is written), same as `ilm`.
 
 ## Requirements
 

--- a/docs/howto/add_package_readme.md
+++ b/docs/howto/add_package_readme.md
@@ -125,22 +125,27 @@ List of placeholders that can be used in the Markdown templates:
     - Requirements:
         - It is needed to define a file with the links definitions. More information [in this section](#requirements)
 - `ilm [data_stream...]`: this placeholder renders ILM policies or lifecycle
-  configuration for each data stream. Two file locations are supported:
-    - `data_stream/<name>/elasticsearch/ilm/<policy>.json` — ILM policy file.
-    - `data_stream/<name>/lifecycle.yml` — DLM (Data Lifecycle Management)
-      configuration (takes precedence when both exist for the same data stream).
-    - Example of usage (all data streams):
+  configuration. Behavior depends on the package type:
+    - **Integration packages** — reads per-data-stream policy files:
+        - `data_stream/<name>/elasticsearch/ilm/<policy>.json` — ILM policy file.
+        - `data_stream/<name>/lifecycle.yml` — DLM (Data Lifecycle Management)
+          configuration (takes precedence when both exist for the same data stream).
+    - **Input packages** — reads a single package-root lifecycle file:
+        - `lifecycle.yml` at the package root (bare `{{ ilm }}` only; data stream
+          name arguments are not supported for input packages and skip this path).
+    - Example of usage (all data streams / input package root):
       ```
       {{ ilm }}
       ```
-    - Example of usage (specific data streams):
+    - Example of usage (specific data streams, integration packages only):
       ```
       {{ ilm "metrics" }}
       ```
-    - When no data stream arguments are given, `elastic-package` discovers all
-      data streams that have either an `elasticsearch/ilm/` directory or a
-      `lifecycle.yml` file, and documents one policy per data stream as a
-      flattened key/value table.
+    - When no data stream arguments are given, `elastic-package` reads the package
+      manifest type. For integration packages it discovers all data streams that
+      have either an `elasticsearch/ilm/` directory or a `lifecycle.yml` file, and
+      documents one policy per data stream as a flattened key/value table. For
+      input packages it renders the single root `lifecycle.yml`.
     - If there are no policies to document (or discovery finds none), the placeholder
       renders as an empty string: no heading and no empty section are written.
     - Example of the rendered output for an ILM policy (`elasticsearch/ilm/<policy>.json`):
@@ -160,6 +165,16 @@ List of placeholders that can be used in the Markdown templates:
       ### Data streams using ILM policies
 
       #### metrics Policy
+      | Key | Value |
+      |---|---|
+      | data_retention | 30d |
+      ```
+    - Example of the rendered output for an input package root `lifecycle.yml`
+      (for example `data_retention: "30d"`):
+      ```
+      ### Lifecycle policy
+
+      #### <package-name> Policy
       | Key | Value |
       |---|---|
       | data_retention | 30d |

--- a/docs/howto/migrate_integration_required_input_dependency.md
+++ b/docs/howto/migrate_integration_required_input_dependency.md
@@ -378,10 +378,6 @@ For integrations using `streams[].package`, generated READMEs may leave the **In
 This integration uses the [Prometheus input](https://www.elastic.co/docs/reference/integrations/prometheus_input) to collect metrics from the `/metrics` endpoint...
 ```
 
-### Empty ILM section in generated docs
-
-Packages without ILM policies may still get an empty **ILM Policies** section in built READMEs ([`internal/docs/ilm.go`](../../internal/docs/ilm.go) lacks the empty-check used for transforms). Cosmetic only; tracked separately from this migration.
-
 ## Known platform gaps and follow-up issues
 
 | Gap | Impact | Tracking |

--- a/internal/docs/ilm.go
+++ b/internal/docs/ilm.go
@@ -87,6 +87,9 @@ func getILMPolicyFilePath(packageRoot, dataStreamName string) (string, error) {
 	if err == nil {
 		return lifecyclePath, nil
 	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("checking lifecycle.yml for data stream %s: %w", dataStreamName, err)
+	}
 
 	// otherwise, look for something in an ilm directory
 	paths, err := filepath.Glob(filepath.Join(packageRoot, "data_stream", dataStreamName, "elasticsearch", "ilm", "*.json"))

--- a/internal/docs/ilm.go
+++ b/internal/docs/ilm.go
@@ -96,9 +96,6 @@ func getILMPolicyFilePath(packageRoot, dataStreamName string) (string, error) {
 }
 
 func renderILMPaths(packageRoot string, args []string) (string, error) {
-	// gather the list of data streams that have ILM policies defined
-	// if the list is empty, return ""
-	// if the list is not empty, format the list as a markdown list
 	var dataStreamNames []string
 	var err error
 	if len(args) > 0 {
@@ -109,6 +106,9 @@ func renderILMPaths(packageRoot string, args []string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("finding ILM paths failed: %w", err)
 		}
+	}
+	if len(dataStreamNames) == 0 {
+		return "", nil
 	}
 
 	var renderedDocs strings.Builder

--- a/internal/docs/ilm.go
+++ b/internal/docs/ilm.go
@@ -6,6 +6,7 @@ package docs
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +14,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/elastic/elastic-package/internal/packages"
 )
 
 // flattenNestedMap flattens a nested JSON-like structure (maps and slices) into
@@ -95,43 +98,74 @@ func getILMPolicyFilePath(packageRoot, dataStreamName string) (string, error) {
 	return paths[0], nil
 }
 
-func renderILMPaths(packageRoot string, args []string) (string, error) {
-	var dataStreamNames []string
-	var err error
-	if len(args) > 0 {
-		// filter the list of data streams to only include the data stream name in the args
-		dataStreamNames = append(dataStreamNames, args...)
-	} else {
-		dataStreamNames, err = findILMPaths(packageRoot)
-		if err != nil {
-			return "", fmt.Errorf("finding ILM paths failed: %w", err)
-		}
-	}
+func renderILMPolicySection(out *strings.Builder, title string, policyMap map[string]string) {
+	fmt.Fprintf(out, "\n#### %s Policy\n", title)
+	out.WriteString("| Key | Value |\n")
+	out.WriteString("|---|---|\n")
+	renderILMPolicyMap(out, policyMap)
+}
+
+// renderDataStreamILM renders ILM policies for named data streams (integration packages).
+func renderDataStreamILM(packageRoot string, dataStreamNames []string) (string, error) {
 	if len(dataStreamNames) == 0 {
 		return "", nil
 	}
-
-	var renderedDocs strings.Builder
-	renderedDocs.WriteString("\n### Data streams using ILM policies\n")
-	for _, dataStreamName := range dataStreamNames {
-		ilmPath, err := getILMPolicyFilePath(packageRoot, dataStreamName)
+	var out strings.Builder
+	out.WriteString("\n### Data streams using ILM policies\n")
+	for _, name := range dataStreamNames {
+		ilmPath, err := getILMPolicyFilePath(packageRoot, name)
 		if err != nil {
-			return "", fmt.Errorf("getting ILM policy file path for data stream %s failed: %w", dataStreamName, err)
+			return "", fmt.Errorf("getting ILM policy file path for data stream %s failed: %w", name, err)
 		}
-
-		// get the policy map from the ILM policy file
 		policyMap, err := getILMPolicyMap(ilmPath)
 		if err != nil {
 			return "", fmt.Errorf("getting ILM policy map for path %s failed: %w", ilmPath, err)
 		}
-		fmt.Fprintf(&renderedDocs, "\n#### %s Policy\n", dataStreamName)
-
-		// render the policy map as a markdown table
-		renderedDocs.WriteString("| Key | Value |\n")
-		renderedDocs.WriteString("|---|---|\n")
-		renderILMPolicyMap(&renderedDocs, policyMap)
+		renderILMPolicySection(&out, name, policyMap)
 	}
-	return renderedDocs.String(), nil
+	return out.String(), nil
+}
+
+// renderInputPackageILM renders the lifecycle policy at the package root (input packages).
+// Returns an empty string when no root lifecycle.yml exists.
+func renderInputPackageILM(packageRoot string) (string, error) {
+	p := filepath.Join(packageRoot, "lifecycle.yml")
+	policyMap, err := getILMPolicyMap(p)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", fmt.Errorf("getting ILM policy map for root lifecycle.yml failed: %w", err)
+	}
+	sectionName := "lifecycle"
+	if manifest, mErr := packages.ReadPackageManifestFromPackageRoot(packageRoot); mErr == nil && manifest.Name != "" {
+		sectionName = manifest.Name
+	}
+	var out strings.Builder
+	out.WriteString("\n### Data streams using ILM policies\n")
+	renderILMPolicySection(&out, sectionName, policyMap)
+	return out.String(), nil
+}
+
+// renderILMPaths is the entry point for the {{ ilm }} template function.
+// args are data stream names and only apply to integration packages; passing
+// them skips the input-package path entirely. Bare invocation checks for a
+// root lifecycle.yml (input packages) first, then discovers data streams.
+func renderILMPaths(packageRoot string, args []string) (string, error) {
+	if len(args) > 0 {
+		return renderDataStreamILM(packageRoot, args)
+	}
+
+	result, err := renderInputPackageILM(packageRoot)
+	if err != nil || result != "" {
+		return result, err
+	}
+
+	names, err := findILMPaths(packageRoot)
+	if err != nil {
+		return "", fmt.Errorf("finding ILM paths failed: %w", err)
+	}
+	return renderDataStreamILM(packageRoot, names)
 }
 
 // findILMPaths scans a given package path for data streams that have ILM policies

--- a/internal/docs/ilm.go
+++ b/internal/docs/ilm.go
@@ -153,9 +153,11 @@ func renderILMPaths(packageRoot string, args []string) (string, error) {
 		return renderDataStreamILM(packageRoot, args)
 	}
 
-	// Only input packages use a root lifecycle.yml; non-input packages and any
-	// package whose manifest is unreadable fall through to per-data-stream discovery.
-	if manifest, mErr := packages.ReadPackageManifestFromPackageRoot(packageRoot); mErr == nil && manifest.Type == "input" {
+	manifest, err := packages.ReadPackageManifestFromPackageRoot(packageRoot)
+	if err != nil {
+		return "", fmt.Errorf("reading package manifest failed: %w", err)
+	}
+	if manifest.Type == "input" {
 		return renderInputPackageILM(packageRoot, manifest.Name)
 	}
 

--- a/internal/docs/ilm.go
+++ b/internal/docs/ilm.go
@@ -135,22 +135,30 @@ func renderILMPaths(packageRoot string, args []string) (string, error) {
 }
 
 // findILMPaths scans a given package path for data streams that have ILM policies
-// and returns a list of all data stream names that have ILM policies defined.
+// or a lifecycle.yml file, and returns a sorted, deduplicated list of data stream names.
 func findILMPaths(packageRoot string) ([]string, error) {
-	// look for ilm/ from the packageRoot/data_stream/<data_stream_name>/elasticsearch/ilm/
-	// add the data_stream_name to the list
+	seen := make(map[string]struct{})
+
 	ilmPaths, err := filepath.Glob(filepath.Join(packageRoot, "data_stream", "*", "elasticsearch", "ilm"))
 	if err != nil {
 		return nil, fmt.Errorf("finding ILM paths failed: %w", err)
 	}
-
-	result := make([]string, 0, len(ilmPaths))
-
-	// return the list of globbed paths
 	for _, ilmPath := range ilmPaths {
-		// get the data_stream_name from the ilmPath
-		dataStreamName := filepath.Base(filepath.Dir(filepath.Dir(ilmPath)))
-		result = append(result, dataStreamName)
+		seen[filepath.Base(filepath.Dir(filepath.Dir(ilmPath)))] = struct{}{}
 	}
+
+	lifecyclePaths, err := filepath.Glob(filepath.Join(packageRoot, "data_stream", "*", "lifecycle.yml"))
+	if err != nil {
+		return nil, fmt.Errorf("finding lifecycle paths failed: %w", err)
+	}
+	for _, lifecyclePath := range lifecyclePaths {
+		seen[filepath.Base(filepath.Dir(lifecyclePath))] = struct{}{}
+	}
+
+	result := make([]string, 0, len(seen))
+	for name := range seen {
+		result = append(result, name)
+	}
+	sort.Strings(result)
 	return result, nil
 }

--- a/internal/docs/ilm.go
+++ b/internal/docs/ilm.go
@@ -128,7 +128,7 @@ func renderDataStreamILM(packageRoot string, dataStreamNames []string) (string, 
 
 // renderInputPackageILM renders the lifecycle policy at the package root (input packages).
 // Returns an empty string when no root lifecycle.yml exists.
-func renderInputPackageILM(packageRoot string) (string, error) {
+func renderInputPackageILM(packageRoot, packageName string) (string, error) {
 	p := filepath.Join(packageRoot, "lifecycle.yml")
 	policyMap, err := getILMPolicyMap(p)
 	if err != nil {
@@ -137,28 +137,26 @@ func renderInputPackageILM(packageRoot string) (string, error) {
 		}
 		return "", fmt.Errorf("getting ILM policy map for root lifecycle.yml failed: %w", err)
 	}
-	sectionName := "lifecycle"
-	if manifest, mErr := packages.ReadPackageManifestFromPackageRoot(packageRoot); mErr == nil && manifest.Name != "" {
-		sectionName = manifest.Name
-	}
 	var out strings.Builder
-	out.WriteString("\n### Data streams using ILM policies\n")
-	renderILMPolicySection(&out, sectionName, policyMap)
+	out.WriteString("\n### Lifecycle policy\n")
+	renderILMPolicySection(&out, packageName, policyMap)
 	return out.String(), nil
 }
 
 // renderILMPaths is the entry point for the {{ ilm }} template function.
 // args are data stream names and only apply to integration packages; passing
-// them skips the input-package path entirely. Bare invocation checks for a
-// root lifecycle.yml (input packages) first, then discovers data streams.
+// them skips the input-package path entirely. Bare invocation reads the
+// manifest type: input packages use the root lifecycle.yml; all other types
+// use per-data-stream discovery.
 func renderILMPaths(packageRoot string, args []string) (string, error) {
 	if len(args) > 0 {
 		return renderDataStreamILM(packageRoot, args)
 	}
 
-	result, err := renderInputPackageILM(packageRoot)
-	if err != nil || result != "" {
-		return result, err
+	// Only input packages use a root lifecycle.yml; non-input packages and any
+	// package whose manifest is unreadable fall through to per-data-stream discovery.
+	if manifest, mErr := packages.ReadPackageManifestFromPackageRoot(packageRoot); mErr == nil && manifest.Type == "input" {
+		return renderInputPackageILM(packageRoot, manifest.Name)
 	}
 
 	names, err := findILMPaths(packageRoot)

--- a/internal/docs/readme_test.go
+++ b/internal/docs/readme_test.go
@@ -474,6 +474,7 @@ Introduction to the package
 func TestRenderILMPathsLifecycleYMLDiscovered(t *testing.T) {
 	packageRoot := t.TempDir()
 
+	createManifestFile(t, packageRoot)
 	createILMFileYML(t, packageRoot, "mystream")
 
 	rendered, err := renderILMPaths(packageRoot, nil)
@@ -599,6 +600,7 @@ Input package lifecycle
 
 func TestRenderILMPathsEmpty(t *testing.T) {
 	packageRoot := t.TempDir()
+	createManifestFile(t, packageRoot) // bare {{ ilm }} requires a readable manifest
 
 	rendered, err := renderILMPaths(packageRoot, nil)
 	require.NoError(t, err)

--- a/internal/docs/readme_test.go
+++ b/internal/docs/readme_test.go
@@ -529,7 +529,7 @@ func TestRenderILMPathsRootLifecycleDiscovered(t *testing.T) {
 
 	rendered, err := renderILMPaths(packageRoot, nil)
 	require.NoError(t, err)
-	assert.Contains(t, rendered, "### Data streams using ILM policies")
+	assert.Contains(t, rendered, "### Lifecycle policy")
 	assert.Contains(t, rendered, "#### my_input_pkg Policy")
 	assert.Contains(t, rendered, "| data_retention | 30d |")
 }
@@ -559,7 +559,7 @@ Input package lifecycle
 Input package lifecycle
 
 
-### Data streams using ILM policies
+### Lifecycle policy
 
 #### my_input_pkg Policy
 | Key | Value |

--- a/internal/docs/readme_test.go
+++ b/internal/docs/readme_test.go
@@ -479,6 +479,45 @@ func TestRenderILMPathsLifecycleYMLDiscovered(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, rendered, "### Data streams using ILM policies")
 	assert.Contains(t, rendered, "#### mystream Policy")
+	assert.Contains(t, rendered, "| data_retention | 30d |")
+}
+
+func TestRenderReadmeWithLifecycleYML(t *testing.T) {
+	linksMap := newEmptyLinkMap()
+	urls := fields.NewSchemaURLs()
+	packageRoot := t.TempDir()
+
+	const tmpl = `# README
+Introduction to the package
+
+{{ ilm "mystream" }}
+`
+	const expected = `# README
+Introduction to the package
+
+
+### Data streams using ILM policies
+
+#### mystream Policy
+| Key | Value |
+|---|---|
+| data_retention | 30d |
+
+`
+
+	createManifestFile(t, packageRoot)
+	createBuildFile(t, packageRoot)
+	createReadmeTemplateFile(t, packageRoot, tmpl)
+	createILMFileYML(t, packageRoot, "mystream")
+
+	templatePath := filepath.Join(packageRoot, "_dev", "build", "docs", "README.md")
+	root, err := os.OpenRoot(packageRoot)
+	require.NoError(t, err)
+	t.Cleanup(func() { root.Close() })
+
+	rendered, err := renderReadme(root, "README.md", packageRoot, templatePath, linksMap, urls)
+	require.NoError(t, err)
+	assert.Equal(t, expected, string(rendered))
 }
 
 func TestRenderILMPathsEmpty(t *testing.T) {
@@ -532,7 +571,7 @@ Introduction to the package
 func TestRenderReadmeWithFields(t *testing.T) {
 	linksMap := newEmptyLinkMap()
 	urls := fields.NewSchemaURLs()
-	for i, c := range renderCases {
+	for _, c := range renderCases {
 		t.Run(c.title, func(t *testing.T) {
 			packageRoot := t.TempDir()
 			filename := filepath.Base(c.templatePath)
@@ -542,13 +581,8 @@ func TestRenderReadmeWithFields(t *testing.T) {
 			createBuildFile(t, packageRoot)
 			createReadmeTemplateFile(t, packageRoot, c.readmeTemplateContents)
 			createFieldsFile(t, packageRoot, c.dataStreamName, c.fieldsContents)
-			if i%2 == 0 {
-				createILMFileYML(t, packageRoot, c.dataStreamName)
-				createILMFileYML(t, packageRoot, "example2")
-			} else {
-				createILMFile(t, packageRoot, c.dataStreamName)
-				createILMFile(t, packageRoot, "example2")
-			}
+			createILMFile(t, packageRoot, c.dataStreamName)
+			createILMFile(t, packageRoot, "example2")
 			createTransformFile(t, packageRoot, c.transformName)
 
 			root, err := os.OpenRoot(packageRoot)
@@ -742,7 +776,8 @@ func createILMFile(t *testing.T, packageRoot, dataStreamName string) {
 	require.NoError(t, err)
 }
 
-// create ilm file as yaml
+// createILMFileYML creates a data stream lifecycle.yml following the package-spec:
+// only data_retention is defined (DLM, not an ILM policy).
 func createILMFileYML(t *testing.T, packageRoot, dataStreamName string) {
 	t.Helper()
 	if dataStreamName == "" {
@@ -753,19 +788,7 @@ func createILMFileYML(t *testing.T, packageRoot, dataStreamName string) {
 	err := os.MkdirAll(ilmFolder, 0755)
 	require.NoError(t, err)
 	ilmFile := filepath.Join(ilmFolder, "lifecycle.yml")
-	contents := `policy:
-  phases:
-    hot:
-      actions:
-        rollover:
-          max_age: "30d"
-          max_primary_shard_size: "50gb"
-    delete:
-      min_age: "30d"
-      actions:
-        delete: {}
-`
-	err = os.WriteFile(ilmFile, []byte(contents), 0644)
+	err = os.WriteFile(ilmFile, []byte("data_retention: \"30d\"\n"), 0644)
 	require.NoError(t, err)
 }
 

--- a/internal/docs/readme_test.go
+++ b/internal/docs/readme_test.go
@@ -534,6 +534,20 @@ func TestRenderILMPathsRootLifecycleDiscovered(t *testing.T) {
 	assert.Contains(t, rendered, "| data_retention | 30d |")
 }
 
+func TestRenderILMPathsIntegrationWithRootLifecycleIgnored(t *testing.T) {
+	packageRoot := t.TempDir()
+
+	createManifestFile(t, packageRoot) // type: integration
+	createRootLifecycleFile(t, packageRoot)
+	createILMFile(t, packageRoot, "mystream")
+
+	rendered, err := renderILMPaths(packageRoot, nil)
+	require.NoError(t, err)
+	assert.Contains(t, rendered, "### Data streams using ILM policies")
+	assert.Contains(t, rendered, "#### mystream Policy")
+	assert.NotContains(t, rendered, "### Lifecycle policy")
+}
+
 func TestRenderILMPathsRootLifecycleNotDiscoveredWhenArgsGiven(t *testing.T) {
 	packageRoot := t.TempDir()
 

--- a/internal/docs/readme_test.go
+++ b/internal/docs/readme_test.go
@@ -23,6 +23,7 @@ const (
 # README
 Introduction to the package
 `
+	lifecycleYMLContent = "data_retention: \"30d\"\n"
 )
 
 func readmeEventTemplateLine(eventTarget string) string {
@@ -520,6 +521,68 @@ Introduction to the package
 	assert.Equal(t, expected, string(rendered))
 }
 
+func TestRenderILMPathsRootLifecycleDiscovered(t *testing.T) {
+	packageRoot := t.TempDir()
+
+	createRootLifecycleFile(t, packageRoot)
+	createInputPackageManifestFile(t, packageRoot, "my_input_pkg")
+
+	rendered, err := renderILMPaths(packageRoot, nil)
+	require.NoError(t, err)
+	assert.Contains(t, rendered, "### Data streams using ILM policies")
+	assert.Contains(t, rendered, "#### my_input_pkg Policy")
+	assert.Contains(t, rendered, "| data_retention | 30d |")
+}
+
+func TestRenderILMPathsRootLifecycleNotDiscoveredWhenArgsGiven(t *testing.T) {
+	packageRoot := t.TempDir()
+
+	createRootLifecycleFile(t, packageRoot)
+
+	// Named form {{ ilm "ds" }} should not pick up the root lifecycle.yml.
+	rendered, err := renderILMPaths(packageRoot, []string{"ds"})
+	require.Error(t, err)
+	assert.Empty(t, rendered)
+}
+
+func TestRenderReadmeWithRootLifecycle(t *testing.T) {
+	linksMap := newEmptyLinkMap()
+	urls := fields.NewSchemaURLs()
+	packageRoot := t.TempDir()
+
+	const tmpl = `# README
+Input package lifecycle
+
+{{ ilm }}
+`
+	const expected = `# README
+Input package lifecycle
+
+
+### Data streams using ILM policies
+
+#### my_input_pkg Policy
+| Key | Value |
+|---|---|
+| data_retention | 30d |
+
+`
+
+	createInputPackageManifestFile(t, packageRoot, "my_input_pkg")
+	createBuildFile(t, packageRoot)
+	createReadmeTemplateFile(t, packageRoot, tmpl)
+	createRootLifecycleFile(t, packageRoot)
+
+	templatePath := filepath.Join(packageRoot, "_dev", "build", "docs", "README.md")
+	root, err := os.OpenRoot(packageRoot)
+	require.NoError(t, err)
+	t.Cleanup(func() { root.Close() })
+
+	rendered, err := renderReadme(root, "README.md", packageRoot, templatePath, linksMap, urls)
+	require.NoError(t, err)
+	assert.Equal(t, expected, string(rendered))
+}
+
 func TestRenderILMPathsEmpty(t *testing.T) {
 	packageRoot := t.TempDir()
 
@@ -692,6 +755,25 @@ version: 1.0.0
 	require.NoError(t, err)
 }
 
+func createInputPackageManifestFile(t *testing.T, packageRoot, packageName string) {
+	t.Helper()
+	manifest := fmt.Sprintf(`format_version: 2.10.0
+name: %s
+type: input
+version: 1.0.0
+`, packageName)
+	manifestFile := filepath.Join(packageRoot, packages.PackageManifestFile)
+	err := os.WriteFile(manifestFile, []byte(manifest), 0o644)
+	require.NoError(t, err)
+}
+
+func createRootLifecycleFile(t *testing.T, packageRoot string) {
+	t.Helper()
+	lifecycleFile := filepath.Join(packageRoot, "lifecycle.yml")
+	err := os.WriteFile(lifecycleFile, []byte(lifecycleYMLContent), 0o644)
+	require.NoError(t, err)
+}
+
 func createDataStreamFolder(t *testing.T, packageRoot, dataStreamName string) string {
 	t.Helper()
 	if dataStreamName == "" {
@@ -788,7 +870,7 @@ func createILMFileYML(t *testing.T, packageRoot, dataStreamName string) {
 	err := os.MkdirAll(ilmFolder, 0755)
 	require.NoError(t, err)
 	ilmFile := filepath.Join(ilmFolder, "lifecycle.yml")
-	err = os.WriteFile(ilmFile, []byte("data_retention: \"30d\"\n"), 0644)
+	err = os.WriteFile(ilmFile, []byte(lifecycleYMLContent), 0644)
 	require.NoError(t, err)
 }
 

--- a/internal/docs/readme_test.go
+++ b/internal/docs/readme_test.go
@@ -470,6 +470,17 @@ Introduction to the package
 	},
 }
 
+func TestRenderILMPathsLifecycleYMLDiscovered(t *testing.T) {
+	packageRoot := t.TempDir()
+
+	createILMFileYML(t, packageRoot, "mystream")
+
+	rendered, err := renderILMPaths(packageRoot, nil)
+	require.NoError(t, err)
+	assert.Contains(t, rendered, "### Data streams using ILM policies")
+	assert.Contains(t, rendered, "#### mystream Policy")
+}
+
 func TestRenderILMPathsEmpty(t *testing.T) {
 	packageRoot := t.TempDir()
 

--- a/internal/docs/readme_test.go
+++ b/internal/docs/readme_test.go
@@ -470,6 +470,54 @@ Introduction to the package
 	},
 }
 
+func TestRenderILMPathsEmpty(t *testing.T) {
+	packageRoot := t.TempDir()
+
+	rendered, err := renderILMPaths(packageRoot, nil)
+	require.NoError(t, err)
+	assert.Empty(t, rendered)
+
+	rendered, err = renderILMPaths(packageRoot, []string{})
+	require.NoError(t, err)
+	assert.Empty(t, rendered)
+}
+
+func TestRenderReadmeWithNoILMPolicies(t *testing.T) {
+	linksMap := newEmptyLinkMap()
+	urls := fields.NewSchemaURLs()
+	packageRoot := t.TempDir()
+
+	const template = `# README
+Introduction to the package
+{{ fields "example" }}
+
+{{ ilm }}
+`
+	const expectedFields = `**Exported fields**
+
+| Field | Description | Type |
+|---|---|---|
+| data_stream.type | Data stream type. | constant_keyword |
+`
+	createManifestFile(t, packageRoot)
+	createBuildFile(t, packageRoot)
+	createReadmeTemplateFile(t, packageRoot, template)
+	createFieldsFile(t, packageRoot, "example", `
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.`)
+
+	templatePath := filepath.Join(packageRoot, "_dev", "build", "docs", "README.md")
+	root, err := os.OpenRoot(packageRoot)
+	require.NoError(t, err)
+	t.Cleanup(func() { root.Close() })
+
+	rendered, err := renderReadme(root, "README.md", packageRoot, templatePath, linksMap, urls)
+	require.NoError(t, err)
+	assert.Contains(t, string(rendered), expectedFields)
+	assert.NotContains(t, string(rendered), "### Data streams using ILM policies")
+}
+
 func TestRenderReadmeWithFields(t *testing.T) {
 	linksMap := newEmptyLinkMap()
 	urls := fields.NewSchemaURLs()

--- a/internal/packages/archetype/_static/package-docs-readme.md.tmpl
+++ b/internal/packages/archetype/_static/package-docs-readme.md.tmpl
@@ -126,11 +126,12 @@ To include a sample event from `sample_event.json`, uncomment and use:
 {{/* {{ event "data_stream_name" }}  */}}
 
 {{/* Export ILM Policies
-     This accepts a list of data stream names as arguments and documents one ILM policy
+     This accepts a list of data stream names as arguments and documents one policy
      per data stream. If no arguments are provided, data streams are auto-discovered by
-     scanning for data_stream/<name>/elasticsearch/ilm/ directories.
+     scanning for data_stream/<name>/elasticsearch/ilm/ directories and
+     data_stream/<name>/lifecycle.yml files (lifecycle.yml takes precedence when both exist).
 
-     If there are no ILM Policies defined, this renders as an empty string (no heading).
+     If there are no policies defined, this renders as an empty string (no heading).
 */}}
 {{ ilm }}
 

--- a/internal/packages/archetype/_static/package-docs-readme.md.tmpl
+++ b/internal/packages/archetype/_static/package-docs-readme.md.tmpl
@@ -128,7 +128,7 @@ To include a sample event from `sample_event.json`, uncomment and use:
 {{/* Export ILM Policies
      This accepts a list of data stream names as arguments, and will export the ILM Policies
      for each given data stream name. If no arguments are provided, all ILM Policies found
-     under data_stream/*/elasticsearch/ilm/ will be exported.
+     under data_stream/<name>/elasticsearch/ilm/ will be exported.
 
      If there are no ILM Policies defined, this renders as an empty string (no heading).
 */}}

--- a/internal/packages/archetype/_static/package-docs-readme.md.tmpl
+++ b/internal/packages/archetype/_static/package-docs-readme.md.tmpl
@@ -126,9 +126,9 @@ To include a sample event from `sample_event.json`, uncomment and use:
 {{/* {{ event "data_stream_name" }}  */}}
 
 {{/* Export ILM Policies
-     This accepts a list of data stream names as arguments, and will export the ILM Policies
-     for each given data stream name. If no arguments are provided, all ILM Policies found
-     under data_stream/<name>/elasticsearch/ilm/ will be exported.
+     This accepts a list of data stream names as arguments and documents one ILM policy
+     per data stream. If no arguments are provided, data streams are auto-discovered by
+     scanning for data_stream/<name>/elasticsearch/ilm/ directories.
 
      If there are no ILM Policies defined, this renders as an empty string (no heading).
 */}}

--- a/internal/packages/archetype/_static/package-docs-readme.md.tmpl
+++ b/internal/packages/archetype/_static/package-docs-readme.md.tmpl
@@ -127,15 +127,15 @@ To include a sample event from `sample_event.json`, uncomment and use:
 
 {{/* Export ILM Policies
      This accepts a list of data stream names as arguments, and will export the ILM Policies
-     for each given data stream name. If no arguments are provided, all ILM Policies will be
-     exported.
+     for each given data stream name. If no arguments are provided, all ILM Policies found
+     under data_stream/*/elasticsearch/ilm/ will be exported.
 
-     If there are no ILM Policies defined, this will be an empty string.
+     If there are no ILM Policies defined, this renders as an empty string (no heading).
 */}}
 {{ ilm }}
 
 {{/* Export Transforms
      This will export the transforms used by this integration.
-     If there are no transforms defined, this will be an empty string.
+     If there are no transforms defined, this renders as an empty string (no heading).
 */}}
 {{ transform }}

--- a/test/packages/other/readme_ilm/_dev/build/build.yml
+++ b/test/packages/other/readme_ilm/_dev/build/build.yml
@@ -1,0 +1,3 @@
+dependencies:
+  ecs:
+    reference: git@8.1

--- a/test/packages/other/readme_ilm/_dev/build/docs/README.md
+++ b/test/packages/other/readme_ilm/_dev/build/docs/README.md
@@ -1,0 +1,3 @@
+# Readme ILM
+
+{{ ilm }}

--- a/test/packages/other/readme_ilm/changelog.yml
+++ b/test/packages/other/readme_ilm/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: Initial draft of the package
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1

--- a/test/packages/other/readme_ilm/data_stream/ilm_ds/agent/stream/stream.yml.hbs
+++ b/test/packages/other/readme_ilm/data_stream/ilm_ds/agent/stream/stream.yml.hbs
@@ -1,0 +1,5 @@
+paths:
+{{#each paths as |path i|}}
+  - {{path}}
+{{/each}}
+exclude_files: [".gz$"]

--- a/test/packages/other/readme_ilm/data_stream/ilm_ds/elasticsearch/ilm/default_policy.json
+++ b/test/packages/other/readme_ilm/data_stream/ilm_ds/elasticsearch/ilm/default_policy.json
@@ -1,0 +1,20 @@
+{
+  "policy": {
+    "phases": {
+      "hot": {
+        "actions": {
+          "rollover": {
+            "max_age": "30d",
+            "max_primary_shard_size": "50gb"
+          }
+        }
+      },
+      "delete": {
+        "min_age": "30d",
+        "actions": {
+          "delete": {}
+        }
+      }
+    }
+  }
+}

--- a/test/packages/other/readme_ilm/data_stream/ilm_ds/fields/base-fields.yml
+++ b/test/packages/other/readme_ilm/data_stream/ilm_ds/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.

--- a/test/packages/other/readme_ilm/data_stream/ilm_ds/manifest.yml
+++ b/test/packages/other/readme_ilm/data_stream/ilm_ds/manifest.yml
@@ -1,1 +1,13 @@
 title: "ILM DS"
+type: logs
+streams:
+  - input: logfile
+    title: ILM DS
+    description: Collect ILM DS logs
+    vars:
+      - name: paths
+        type: text
+        title: Paths
+        multi: true
+        default:
+          - /var/log/*.log

--- a/test/packages/other/readme_ilm/data_stream/ilm_ds/manifest.yml
+++ b/test/packages/other/readme_ilm/data_stream/ilm_ds/manifest.yml
@@ -1,0 +1,1 @@
+title: "ILM DS"

--- a/test/packages/other/readme_ilm/data_stream/lifecycle_ds/agent/stream/stream.yml.hbs
+++ b/test/packages/other/readme_ilm/data_stream/lifecycle_ds/agent/stream/stream.yml.hbs
@@ -1,0 +1,5 @@
+paths:
+{{#each paths as |path i|}}
+  - {{path}}
+{{/each}}
+exclude_files: [".gz$"]

--- a/test/packages/other/readme_ilm/data_stream/lifecycle_ds/fields/base-fields.yml
+++ b/test/packages/other/readme_ilm/data_stream/lifecycle_ds/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.

--- a/test/packages/other/readme_ilm/data_stream/lifecycle_ds/lifecycle.yml
+++ b/test/packages/other/readme_ilm/data_stream/lifecycle_ds/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/test/packages/other/readme_ilm/data_stream/lifecycle_ds/manifest.yml
+++ b/test/packages/other/readme_ilm/data_stream/lifecycle_ds/manifest.yml
@@ -1,1 +1,13 @@
 title: "Lifecycle DS"
+type: logs
+streams:
+  - input: logfile
+    title: Lifecycle DS
+    description: Collect Lifecycle DS logs
+    vars:
+      - name: paths
+        type: text
+        title: Paths
+        multi: true
+        default:
+          - /var/log/*.log

--- a/test/packages/other/readme_ilm/data_stream/lifecycle_ds/manifest.yml
+++ b/test/packages/other/readme_ilm/data_stream/lifecycle_ds/manifest.yml
@@ -1,0 +1,1 @@
+title: "Lifecycle DS"

--- a/test/packages/other/readme_ilm/docs/README.md
+++ b/test/packages/other/readme_ilm/docs/README.md
@@ -1,0 +1,17 @@
+# Readme ILM
+
+
+### Data streams using ILM policies
+
+#### ilm_ds Policy
+| Key | Value |
+|---|---|
+| policy.phases.delete.min_age | 30d |
+| policy.phases.hot.actions.rollover.max_age | 30d |
+| policy.phases.hot.actions.rollover.max_primary_shard_size | 50gb |
+
+#### lifecycle_ds Policy
+| Key | Value |
+|---|---|
+| data_retention | 30d |
+

--- a/test/packages/other/readme_ilm/docs/README.md
+++ b/test/packages/other/readme_ilm/docs/README.md
@@ -10,8 +10,3 @@
 | policy.phases.hot.actions.rollover.max_age | 30d |
 | policy.phases.hot.actions.rollover.max_primary_shard_size | 50gb |
 
-#### lifecycle_ds Policy
-| Key | Value |
-|---|---|
-| data_retention | 30d |
-

--- a/test/packages/other/readme_ilm/docs/README.md
+++ b/test/packages/other/readme_ilm/docs/README.md
@@ -10,3 +10,8 @@
 | policy.phases.hot.actions.rollover.max_age | 30d |
 | policy.phases.hot.actions.rollover.max_primary_shard_size | 50gb |
 
+#### lifecycle_ds Policy
+| Key | Value |
+|---|---|
+| data_retention | 30d |
+

--- a/test/packages/other/readme_ilm/manifest.yml
+++ b/test/packages/other/readme_ilm/manifest.yml
@@ -1,0 +1,18 @@
+format_version: 3.2.1
+name: readme_ilm
+title: "Readme ILM"
+version: 0.0.1
+source:
+  license: "Elastic-2.0"
+description: "Tests README rendering with ILM policies and lifecycle.yml data streams."
+type: integration
+categories:
+  - custom
+conditions:
+  kibana:
+    version: "^8.15.0"
+  elastic:
+    subscription: "basic"
+owner:
+  github: elastic/ecosystem
+  type: elastic

--- a/test/packages/other/readme_ilm_input/_dev/build/build.yml
+++ b/test/packages/other/readme_ilm_input/_dev/build/build.yml
@@ -1,0 +1,3 @@
+dependencies:
+  ecs:
+    reference: git@8.1

--- a/test/packages/other/readme_ilm_input/_dev/build/docs/README.md
+++ b/test/packages/other/readme_ilm_input/_dev/build/docs/README.md
@@ -1,0 +1,3 @@
+# Readme ILM Input
+
+{{ ilm }}

--- a/test/packages/other/readme_ilm_input/agent/input/input.yml.hbs
+++ b/test/packages/other/readme_ilm_input/agent/input/input.yml.hbs
@@ -1,0 +1,5 @@
+paths:
+{{#each paths as |path i|}}
+  - {{path}}
+{{/each}}
+exclude_files: [".gz$"]

--- a/test/packages/other/readme_ilm_input/changelog.yml
+++ b/test/packages/other/readme_ilm_input/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: Initial draft of the package
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1

--- a/test/packages/other/readme_ilm_input/docs/README.md
+++ b/test/packages/other/readme_ilm_input/docs/README.md
@@ -1,0 +1,10 @@
+# Readme ILM Input
+
+
+### Data streams using ILM policies
+
+#### readme_ilm_input Policy
+| Key | Value |
+|---|---|
+| data_retention | 30d |
+

--- a/test/packages/other/readme_ilm_input/docs/README.md
+++ b/test/packages/other/readme_ilm_input/docs/README.md
@@ -1,7 +1,7 @@
 # Readme ILM Input
 
 
-### Data streams using ILM policies
+### Lifecycle policy
 
 #### readme_ilm_input Policy
 | Key | Value |

--- a/test/packages/other/readme_ilm_input/fields/base-fields.yml
+++ b/test/packages/other/readme_ilm_input/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.

--- a/test/packages/other/readme_ilm_input/lifecycle.yml
+++ b/test/packages/other/readme_ilm_input/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/test/packages/other/readme_ilm_input/manifest.yml
+++ b/test/packages/other/readme_ilm_input/manifest.yml
@@ -1,0 +1,34 @@
+format_version: 3.2.1
+name: readme_ilm_input
+title: "Readme ILM Input"
+version: 0.0.1
+source:
+  license: "Elastic-2.0"
+description: "Tests README rendering with a root lifecycle.yml in an input package."
+type: input
+categories:
+  - custom
+conditions:
+  kibana:
+    version: "^8.15.0"
+  elastic:
+    subscription: "basic"
+policy_templates:
+  - name: readme_ilm_input
+    type: logs
+    title: Readme ILM Input
+    description: Test policy template for README ILM input package.
+    input: logfile
+    template_path: input.yml.hbs
+    vars:
+      - name: paths
+        type: text
+        title: Paths
+        multi: true
+        required: true
+        show_user: true
+        default:
+          - /var/log/*.log
+owner:
+  github: elastic/ecosystem
+  type: elastic


### PR DESCRIPTION
Resolve #3709

## Why

The `{{ ilm }}` README template helper had three bugs:

1. With no matching data streams it rendered an empty heading instead of an empty string.
2. `findILMPaths` only globbed `elasticsearch/ilm/` directories, so data streams using only `lifecycle.yml` (DLM) were never discovered by bare `{{ ilm }}`.
3. Input packages with a root `lifecycle.yml` were not supported at all.

## What

**Empty heading guard** — added an early-return when the resolved data stream list is empty, consistent with how `{{ transform }}` behaves.

**`lifecycle.yml` discovery** — `findILMPaths` now also globs `data_stream/*/lifecycle.yml`; a `seen` map deduplicates streams that have both files. Returns a sorted list for deterministic output.

**Input package support** — bare `{{ ilm }}` now checks for a root `lifecycle.yml` first (input packages), falls back to per-data-stream discovery (integration packages). Named args still bypass this and go straight to data-stream rendering.

Also adds documentation in the how-to guide and test coverage (unit tests + two new test packages: `readme_ilm` for integration packages, `readme_ilm_input` for input packages).