### PR TITLE
modify pipeline-tag: fix to tag on_failure processors as well

### DIFF
--- a/internal/modify/pipelinetag/pipelinetag.go
+++ b/internal/modify/pipelinetag/pipelinetag.go
@@ -61,13 +61,15 @@ func run(pkg *fleetpkg.Package) error {
 func processPipeline(pipeline *fleetpkg.Pipeline) error {
 	seen := map[string]*processorNode{}
 
-	for _, proc := range pipeline.Processors {
-		node := processorNode{
-			Processor: proc,
-		}
+	for _, procs := range [][]*fleetpkg.Processor{pipeline.Processors, pipeline.OnFailure} {
+		for _, proc := range procs {
+			node := processorNode{
+				Processor: proc,
+			}
 
-		if err := processTag(pipeline, &node, seen); err != nil {
-			return err
+			if err := processTag(pipeline, &node, seen); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/modify/pipelinetag/pipelinetag_test.go
+++ b/internal/modify/pipelinetag/pipelinetag_test.go
@@ -55,4 +55,7 @@ func Test_GenerateTags(t *testing.T) {
 	assertProcessorTag(t, &pipeline, "$.processors[0].set.tag", "set_sample_field_71a88542")
 	assertProcessorTag(t, &pipeline, "$.processors[1].set.tag", "valid_tag")
 	assertProcessorTag(t, &pipeline, "$.processors[1].set.on_failure[0].set.tag", "set_sample_field_a7a6e0d7")
+
+	// Processors in the pipeline-level on_failure block must be tagged too.
+	assertProcessorTag(t, &pipeline, "$.on_failure[0].set.tag", "set_error_message_57a6b93c")
 }


### PR DESCRIPTION
Proposed commit message:

```
modify pipeline-tag: fix to tag on_failure processors as well (#)

processPipeline only walked pipeline.Processors, so processors in the
pipeline's top-level on_failure block never received generated tags.
```