### PR TITLE
fix: enable skipUploadPackageValidation in default Kibana config

### DIFF
--- a/docs/howto/install_package.md
+++ b/docs/howto/install_package.md
@@ -26,7 +26,7 @@ From Kibana 8.7.0 version, `elastic-package install` is able to install packages
     - build the package
     - upload the zip file built to Kibana.
 
-The stack started by `elastic-package stack up` automatically sets `xpack.fleet.internal.allowRegistryPackageUploads: true` in Kibana, which enables the upload API without requiring an Enterprise license. When using an external Kibana instance, add this setting to your Kibana configuration manually.
+The stack started by `elastic-package stack up` automatically sets `xpack.fleet.internal.allowRegistryPackageUploads: true` in Kibana, which allows uploading packages even when the package name already exists in the Elastic Package Registry (EPR). When using an external Kibana instance, add this setting to your Kibana configuration manually.
 
 Example of using `--zip` parameter:
 ```shell

--- a/docs/howto/install_package.md
+++ b/docs/howto/install_package.md
@@ -26,6 +26,8 @@ From Kibana 8.7.0 version, `elastic-package install` is able to install packages
     - build the package
     - upload the zip file built to Kibana.
 
+The stack started by `elastic-package stack up` automatically sets `xpack.fleet.internal.allowRegistryPackageUploads: true` in Kibana, which enables the upload API without requiring an Enterprise license. When using an external Kibana instance, add this setting to your Kibana configuration manually.
+
 Example of using `--zip` parameter:
 ```shell
  $ elastic-package stack up -v -d

--- a/docs/howto/install_package.md
+++ b/docs/howto/install_package.md
@@ -26,7 +26,23 @@ From Kibana 8.7.0 version, `elastic-package install` is able to install packages
     - build the package
     - upload the zip file built to Kibana.
 
-The stack started by `elastic-package stack up` automatically sets `xpack.fleet.internal.allowRegistryPackageUploads: true` in Kibana, which allows uploading packages even when the package name already exists in the Elastic Package Registry (EPR). When using an external Kibana instance, add this setting to your Kibana configuration manually.
+Starting with Kibana 9.6.0, `elastic-package stack up` automatically sets `xpack.fleet.internal.allowRegistryPackageUploads: true` in the generated Kibana configuration. This allows uploading packages even when the package name already exists in the Elastic Package Registry (EPR), which is required for local development of published integrations.
+
+<!-- TODO: extend version gate to 8.19, 9.4, and 9.5 once elastic/kibana#286094 is backported and released in those branches. -->
+
+When using a stack version that does not yet include the setting (< 9.6.0), you can apply it manually via your elastic-package profile until the backport is released:
+
+```bash
+echo 'xpack.fleet.internal.allowRegistryPackageUploads: true' >> ~/.elastic-package/profiles/default/kibana.dev.yml
+```
+
+Restart the stack with `elastic-package stack up` for the change to take effect. See [Custom Kibana Configuration](./custom_kibana_config.md) for more details on profile-level overrides.
+
+When using an external Kibana instance (>= 9.6.0), add this setting to your Kibana configuration manually:
+
+```yaml
+xpack.fleet.internal.allowRegistryPackageUploads: true
+```
 
 Example of using `--zip` parameter:
 ```shell

--- a/docs/howto/install_package.md
+++ b/docs/howto/install_package.md
@@ -36,7 +36,13 @@ When using a stack version that does not yet include the setting (< 9.6.0), you 
 echo 'xpack.fleet.internal.allowRegistryPackageUploads: true' >> ~/.elastic-package/profiles/default/kibana.dev.yml
 ```
 
-Restart the stack with `elastic-package stack up` for the change to take effect. See [Custom Kibana Configuration](./custom_kibana_config.md) for more details on profile-level overrides.
+Restart the stack for the change to take effect:
+
+```bash
+elastic-package stack down && elastic-package stack up -d
+```
+
+See [Custom Kibana Configuration](./custom_kibana_config.md) for more details on profile-level overrides.
 
 When using an external Kibana instance (>= 9.6.0), add this setting to your Kibana configuration manually:
 

--- a/docs/howto/install_package.md
+++ b/docs/howto/install_package.md
@@ -26,14 +26,14 @@ From Kibana 8.7.0 version, `elastic-package install` is able to install packages
     - build the package
     - upload the zip file built to Kibana.
 
-Starting with Kibana 9.6.0, `elastic-package stack up` automatically sets `xpack.fleet.internal.allowRegistryPackageUploads: true` in the generated Kibana configuration. This allows uploading packages even when the package name already exists in the Elastic Package Registry (EPR), which is required for local development of published integrations.
+Starting with Kibana 9.6.0, `elastic-package stack up` automatically sets `xpack.fleet.internal.skipUploadPackageValidation: true` in the generated Kibana configuration. This allows uploading packages even when the package name already exists in the Elastic Package Registry (EPR), which is required for local development of published integrations.
 
 <!-- TODO: extend version gate to 8.19, 9.4, and 9.5 once elastic/kibana#286094 is backported and released in those branches. -->
 
 When using a stack version that does not yet include the setting (< 9.6.0), you can apply it manually via your elastic-package profile until the backport is released:
 
 ```bash
-echo 'xpack.fleet.internal.allowRegistryPackageUploads: true' >> ~/.elastic-package/profiles/default/kibana.dev.yml
+echo 'xpack.fleet.internal.skipUploadPackageValidation: true' >> ~/.elastic-package/profiles/default/kibana.dev.yml
 ```
 
 Restart the stack for the change to take effect:
@@ -47,7 +47,7 @@ See [Custom Kibana Configuration](./custom_kibana_config.md) for more details on
 When using an external Kibana instance (>= 9.6.0), add this setting to your Kibana configuration manually:
 
 ```yaml
-xpack.fleet.internal.allowRegistryPackageUploads: true
+xpack.fleet.internal.skipUploadPackageValidation: true
 ```
 
 Example of using `--zip` parameter:

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -193,4 +193,7 @@ xpack.fleet.outputs:
 xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
 {{- end }}
 
+{{/* TODO: extend to 8.19, 9.4, and 9.5 once elastic/kibana#286094 is backported and released in those branches */}}
+{{- if not (semverLessThan $version "9.6.0-SNAPSHOT") }}
 xpack.fleet.internal.allowRegistryPackageUploads: true
+{{- end }}

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -195,5 +195,5 @@ xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
 
 {{/* TODO: extend to 8.19, 9.4, and 9.5 once elastic/kibana#286094 is backported and released in those branches */}}
 {{- if not (semverLessThan $version "9.6.0-SNAPSHOT") }}
-xpack.fleet.internal.allowRegistryPackageUploads: true
+xpack.fleet.internal.skipUploadPackageValidation: true
 {{- end }}

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -192,3 +192,5 @@ xpack.fleet.outputs:
 {{- if eq $version "9.0.0-SNAPSHOT" }}
 xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
 {{- end }}
+
+xpack.fleet.internal.allowRegistryPackageUploads: true

--- a/internal/stack/kibana_upload_flag_test.go
+++ b/internal/stack/kibana_upload_flag_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/elastic/elastic-package/internal/profile"
 )
 
-func TestskipUploadPackageValidationGating(t *testing.T) {
+func TestSkipUploadPackageValidationGating(t *testing.T) {
 	cases := []struct {
 		version string
 		want    bool

--- a/internal/stack/kibana_upload_flag_test.go
+++ b/internal/stack/kibana_upload_flag_test.go
@@ -1,0 +1,89 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package stack
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/elastic/elastic-package/internal/install"
+	"github.com/elastic/elastic-package/internal/profile"
+)
+
+func TestAllowRegistryPackageUploadsGating(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		// Should NOT have the flag (backport not yet landed in these versions)
+		{"8.0.0", false},
+		{"8.7.0", false},
+		{"8.18.0", false},
+		{"8.19.0", false},
+		{"8.19.21", false},
+		{"8.19.21-SNAPSHOT", false},
+		{"9.0.0", false},
+		{"9.4.0", false},
+		{"9.4.6", false},
+		{"9.4.6-SNAPSHOT", false},
+		{"9.5.0", false},
+		{"9.5.2", false},
+		// Should have the flag (9.6 main — elastic/kibana#286094 merged here; backport follow-up pending)
+		{"9.6.0-SNAPSHOT", true},
+		{"9.6.0", true},
+		{"9.6.1", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("version_%s", tc.version), func(t *testing.T) {
+			elasticPackagePath := t.TempDir()
+			profilesPath := filepath.Join(elasticPackagePath, "profiles")
+			t.Setenv("ELASTIC_PACKAGE_DATA_HOME", elasticPackagePath)
+
+			err := profile.CreateProfile(profile.Options{
+				ProfilesDirPath: profilesPath,
+				Name:            "test",
+			})
+			if err != nil {
+				t.Fatalf("create profile: %v", err)
+			}
+
+			p, err := profile.LoadProfile("test")
+			if err != nil {
+				t.Fatalf("load profile: %v", err)
+			}
+
+			appConfig, err := install.Configuration()
+			if err != nil {
+				t.Fatalf("load config: %v", err)
+			}
+
+			if err := applyResources(p, appConfig, tc.version, tc.version); err != nil {
+				t.Fatalf("applyResources: %v", err)
+			}
+
+			d, err := os.ReadFile(p.Path(ProfileStackPath, KibanaConfigFile))
+			if err != nil {
+				t.Fatalf("read kibana.yml: %v", err)
+			}
+
+			got := strings.Contains(string(d), "allowRegistryPackageUploads")
+			if got != tc.want {
+				lines := strings.Split(string(d), "\n")
+				tail := lines
+				if len(lines) > 20 {
+					tail = lines[len(lines)-20:]
+				}
+				t.Errorf("version %s: allowRegistryPackageUploads present=%v, want=%v\n\n--- kibana.yml tail ---\n%s",
+					tc.version, got, tc.want, strings.Join(tail, "\n"))
+			} else {
+				t.Logf("version %s: allowRegistryPackageUploads present=%v ✓", tc.version, got)
+			}
+		})
+	}
+}

--- a/internal/stack/kibana_upload_flag_test.go
+++ b/internal/stack/kibana_upload_flag_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/elastic/elastic-package/internal/profile"
 )
 
-func TestAllowRegistryPackageUploadsGating(t *testing.T) {
+func TestskipUploadPackageValidationGating(t *testing.T) {
 	cases := []struct {
 		version string
 		want    bool
@@ -72,17 +72,17 @@ func TestAllowRegistryPackageUploadsGating(t *testing.T) {
 				t.Fatalf("read kibana.yml: %v", err)
 			}
 
-			got := strings.Contains(string(d), "allowRegistryPackageUploads")
+			got := strings.Contains(string(d), "skipUploadPackageValidation")
 			if got != tc.want {
 				lines := strings.Split(string(d), "\n")
 				tail := lines
 				if len(lines) > 20 {
 					tail = lines[len(lines)-20:]
 				}
-				t.Errorf("version %s: allowRegistryPackageUploads present=%v, want=%v\n\n--- kibana.yml tail ---\n%s",
+				t.Errorf("version %s: skipUploadPackageValidation present=%v, want=%v\n\n--- kibana.yml tail ---\n%s",
 					tc.version, got, tc.want, strings.Join(tail, "\n"))
 			} else {
-				t.Logf("version %s: allowRegistryPackageUploads present=%v ✓", tc.version, got)
+				t.Logf("version %s: skipUploadPackageValidation present=%v ✓", tc.version, got)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Set `xpack.fleet.internal.skipUploadPackageValidation: true` in the Kibana configuration generated by `elastic-package stack up`, gated to versions where the config key exists.

elastic/kibana#286094 introduces a Fleet config flag `xpack.fleet.internal.skipUploadPackageValidation ` (default `false`) that blocks uploading a package whose name already exists in the Elastic Package Registry (EPR). This breaks the `elastic-package install` upload flow for any integration that has been published to the registry.

## Version gating

The flag is only set for Kibana **>= 9.6.0-SNAPSHOT** (where elastic/kibana#286094 is merged). Older versions do not have this config key and Kibana would fail to start if an unknown key is present.

Backports of elastic/kibana#286094 to 8.19, 9.4, and 9.5 are pending. The template and test both carry a TODO to extend the gate to those branches once the backports land in a released patch.

**Workaround for < 9.6.0**: users can add the setting to their elastic-package profile manually:

```bash
echo 'xpack.fleet.internal.skipUploadPackageValidation: true' >> ~/.elastic-package/profiles/default/kibana.dev.yml
elastic-package stack down && elastic-package stack up -d
```

The profile content is appended to the generated `kibana.yml`, so Kibana picks it up as if it were part of the base config.

## Changes

- **`internal/stack/_static/kibana.yml.tmpl`** — adds the flag gated to `>= 9.6.0-SNAPSHOT`, with a TODO comment referencing the pending backports.
- **`internal/stack/kibana_upload_flag_test.go`** — new test covering version boundaries: verifies the flag is absent for 8.x, 9.4, 9.5 and present for 9.6.0-SNAPSHOT and above.
- **`docs/howto/install_package.md`** — documents the version boundary, the profile-level workaround for older versions, and how to apply the setting on an external Kibana instance.

## Test plan

- [ ] Confirm `~/.elastic-package/profiles/default/stack/kibana.yml` contains `xpack.fleet.internal.skipUploadPackageValidation: true` when running `elastic-package stack up --version 9.6.0-SNAPSHOT`
- [ ] Confirm the flag is absent in the generated `kibana.yml` for versions < 9.6.0 (e.g. `9.5.2`, `9.4.6`)
- [ ] Apply the workaround on a < 9.6.0 stack via `kibana.dev.yml` and confirm `elastic-package install` succeeds on a package already published in EPR
- [ ] Run `go test ./internal/stack/ -run TestSkipUploadPackageValidationGating`