### PR TITLE
feat: add env var override for skipUploadPackageValidation Kibana flag

### DIFF
--- a/docs/howto/install_package.md
+++ b/docs/howto/install_package.md
@@ -28,7 +28,7 @@ From Kibana 8.7.0 version, `elastic-package install` is able to install packages
 
 Starting with Kibana 9.6.0, `elastic-package stack up` automatically sets `xpack.fleet.internal.skipUploadPackageValidation: true` in the generated Kibana configuration. This allows uploading packages even when the package name already exists in the Elastic Package Registry (EPR), which is required for local development of published integrations.
 
-The setting is also available for the backport branches (elastic/kibana#287670, #287671, #287672) once the patch containing the fix is used: `>= 8.19.10`, `>= 9.4.7`, and `>= 9.5.3`. To activate it, set `ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true` — this enables the flag only for those specific patch versions and above within each branch, so it is safe to set in a shared CI environment:
+The setting is also available for the backport branches (elastic/kibana#287670, #287671, #287672) for ongoing CI snapshot builds: `>= 8.19.22-SNAPSHOT`, `>= 9.4.7-SNAPSHOT`, and `>= 9.5.3-SNAPSHOT`. To activate it, set `ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true` — this enables the flag only for those specific snapshot versions and above within each branch, so it is safe to set in a shared CI environment:
 
 ```bash
 export ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true

--- a/docs/howto/install_package.md
+++ b/docs/howto/install_package.md
@@ -28,14 +28,14 @@ From Kibana 8.7.0 version, `elastic-package install` is able to install packages
 
 Starting with Kibana 9.6.0, `elastic-package stack up` automatically sets `xpack.fleet.internal.skipUploadPackageValidation: true` in the generated Kibana configuration. This allows uploading packages even when the package name already exists in the Elastic Package Registry (EPR), which is required for local development of published integrations.
 
-The setting is also available for the backport branches (8.19.x, 9.4.x, 9.5.x) via the environment variable `ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION`. When set to `true`, the flag is injected automatically for those branch ranges. Versions outside the known backport ranges are unaffected, so setting the variable in a shared CI environment is safe.
+The setting is also available for the backport branches (elastic/kibana#287670, #287671, #287672) once the patch containing the fix is used: `>= 8.19.10`, `>= 9.4.7`, and `>= 9.5.3`. To activate it, set `ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true` — this enables the flag only for those specific patch versions and above within each branch, so it is safe to set in a shared CI environment:
 
 ```bash
 export ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true
 elastic-package stack up -d
 ```
 
-When using a stack version that does not include the setting and the env var is not applicable, you can apply it manually via your elastic-package profile:
+When using a stack version that does not yet include the setting, you can apply it manually via your elastic-package profile:
 
 ```bash
 echo 'xpack.fleet.internal.skipUploadPackageValidation: true' >> ~/.elastic-package/profiles/default/kibana.dev.yml

--- a/docs/howto/install_package.md
+++ b/docs/howto/install_package.md
@@ -28,9 +28,14 @@ From Kibana 8.7.0 version, `elastic-package install` is able to install packages
 
 Starting with Kibana 9.6.0, `elastic-package stack up` automatically sets `xpack.fleet.internal.skipUploadPackageValidation: true` in the generated Kibana configuration. This allows uploading packages even when the package name already exists in the Elastic Package Registry (EPR), which is required for local development of published integrations.
 
-<!-- TODO: extend version gate to 8.19, 9.4, and 9.5 once elastic/kibana#286094 is backported and released in those branches. -->
+The setting is also available for the backport branches (8.19.x, 9.4.x, 9.5.x) via the environment variable `ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION`. When set to `true`, the flag is injected automatically for those branch ranges. Versions outside the known backport ranges are unaffected, so setting the variable in a shared CI environment is safe.
 
-When using a stack version that does not yet include the setting (< 9.6.0), you can apply it manually via your elastic-package profile until the backport is released:
+```bash
+export ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true
+elastic-package stack up -d
+```
+
+When using a stack version that does not include the setting and the env var is not applicable, you can apply it manually via your elastic-package profile:
 
 ```bash
 echo 'xpack.fleet.internal.skipUploadPackageValidation: true' >> ~/.elastic-package/profiles/default/kibana.dev.yml

--- a/docs/howto/install_package.md
+++ b/docs/howto/install_package.md
@@ -28,7 +28,7 @@ From Kibana 8.7.0 version, `elastic-package install` is able to install packages
 
 Starting with Kibana 9.6.0, `elastic-package stack up` automatically sets `xpack.fleet.internal.skipUploadPackageValidation: true` in the generated Kibana configuration. This allows uploading packages even when the package name already exists in the Elastic Package Registry (EPR), which is required for local development of published integrations.
 
-The setting is also available for the backport branches (elastic/kibana#287670, #287671, #287672) for ongoing CI snapshot builds: `>= 8.19.22-SNAPSHOT`, `>= 9.4.7-SNAPSHOT`, and `>= 9.5.3-SNAPSHOT`. To activate it, set `ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true` — this enables the flag only for those specific snapshot versions and above within each branch, so it is safe to set in a shared CI environment:
+The setting is also available for the backport branches (elastic/kibana#287670, #287671, #287672) for ongoing CI snapshot builds: `>= 8.19.22-SNAPSHOT`, `>= 9.4.7-SNAPSHOT`, and `>= 9.5.4-SNAPSHOT`. To activate it, set `ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true` — this enables the flag only for those specific snapshot versions and above within each branch, so it is safe to set in a shared CI environment:
 
 ```bash
 export ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true

--- a/docs/howto/install_package.md
+++ b/docs/howto/install_package.md
@@ -28,7 +28,7 @@ From Kibana 8.7.0 version, `elastic-package install` is able to install packages
 
 Starting with Kibana 9.6.0, `elastic-package stack up` automatically sets `xpack.fleet.internal.skipUploadPackageValidation: true` in the generated Kibana configuration. This allows uploading packages even when the package name already exists in the Elastic Package Registry (EPR), which is required for local development of published integrations.
 
-The setting is also available for the backport branches (elastic/kibana#287670, #287671, #287672) for ongoing CI snapshot builds: `>= 8.19.22-SNAPSHOT`, `>= 9.4.7-SNAPSHOT`, and `>= 9.5.4-SNAPSHOT`. To activate it, set `ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true` — this enables the flag only for those specific snapshot versions and above within each branch, so it is safe to set in a shared CI environment:
+The setting is also available for the backport branches (elastic/kibana#287670, elastic/kibana#287671, elastic/kibana#287672) for ongoing CI snapshot builds: `>= 8.19.22-SNAPSHOT`, `>= 9.4.7-SNAPSHOT`, and `>= 9.5.4-SNAPSHOT`. To activate it, set `ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true` — this enables the flag only for those specific snapshot versions and above within each branch, so it is safe to set in a shared CI environment:
 
 ```bash
 export ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -193,7 +193,14 @@ xpack.fleet.outputs:
 xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
 {{- end }}
 
-{{/* Present on 9.6.0-SNAPSHOT+ (elastic/kibana#286094). For backport branches (8.19, 9.4, 9.5) set ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true. */}}
-{{- if or (not (semverLessThan $version "9.6.0-SNAPSHOT")) (eq (fact "skip_upload_package_validation") "true") }}
+{{/* elastic/kibana#286094: merged in 9.6.0-SNAPSHOT; backported to 8.19.10-SNAPSHOT (#287670), 9.4.7-SNAPSHOT (#287671), 9.5.3-SNAPSHOT (#287672).
+     Backport branches also require ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true so CI controls when activation occurs. */}}
+{{- $skipUpload := eq (fact "skip_upload_package_validation") "true" }}
+{{- if or
+    (not (semverLessThan $version "9.6.0-SNAPSHOT"))
+    (and $skipUpload (not (semverLessThan $version "8.19.10-SNAPSHOT")) (semverLessThan $version "9.0.0"))
+    (and $skipUpload (not (semverLessThan $version "9.4.7-SNAPSHOT")) (semverLessThan $version "9.5.0"))
+    (and $skipUpload (not (semverLessThan $version "9.5.3-SNAPSHOT")) (semverLessThan $version "9.6.0-SNAPSHOT"))
+}}
 xpack.fleet.internal.skipUploadPackageValidation: true
 {{- end }}

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -193,7 +193,7 @@ xpack.fleet.outputs:
 xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
 {{- end }}
 
-{{/* TODO: extend to 8.19, 9.4, and 9.5 once elastic/kibana#286094 is backported and released in those branches */}}
-{{- if not (semverLessThan $version "9.6.0-SNAPSHOT") }}
+{{/* Present on 9.6.0-SNAPSHOT+ (elastic/kibana#286094). For backport branches (8.19, 9.4, 9.5) set ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true. */}}
+{{- if or (not (semverLessThan $version "9.6.0-SNAPSHOT")) (eq (fact "skip_upload_package_validation") "true") }}
 xpack.fleet.internal.skipUploadPackageValidation: true
 {{- end }}

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -198,8 +198,8 @@ xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
 {{- $skipUpload := eq (fact "skip_upload_package_validation") "true" }}
 {{- if or
     (not (semverLessThan $version "9.6.0-SNAPSHOT"))
-    (and $skipUpload (not (semverLessThan $version "8.19.10-SNAPSHOT")) (semverLessThan $version "9.0.0"))
-    (and $skipUpload (not (semverLessThan $version "9.4.7-SNAPSHOT")) (semverLessThan $version "9.5.0"))
+    (and $skipUpload (not (semverLessThan $version "8.19.10-SNAPSHOT")) (semverLessThan $version "9.0.0-SNAPSHOT"))
+    (and $skipUpload (not (semverLessThan $version "9.4.7-SNAPSHOT")) (semverLessThan $version "9.5.0-SNAPSHOT"))
     (and $skipUpload (not (semverLessThan $version "9.5.3-SNAPSHOT")) (semverLessThan $version "9.6.0-SNAPSHOT"))
 }}
 xpack.fleet.internal.skipUploadPackageValidation: true

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -193,7 +193,7 @@ xpack.fleet.outputs:
 xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
 {{- end }}
 
-{{/* elastic/kibana#286094: merged in 9.6.0-SNAPSHOT; backported to 8.19.22-SNAPSHOT (#287670), 9.4.7-SNAPSHOT (#287671), 9.5.4-SNAPSHOT (#287672).
+{{/* elastic/kibana#286094: merged in 9.6.0-SNAPSHOT; backported to 8.19.22-SNAPSHOT (elastic/kibana#287670), 9.4.7-SNAPSHOT (elastic/kibana#287671), 9.5.4-SNAPSHOT (elastic/kibana#287672).
      Backport branches also require ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true so CI controls when activation occurs. */}}
 {{- $skipUpload := eq (fact "skip_upload_package_validation") "true" }}
 {{- if or

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -193,12 +193,12 @@ xpack.fleet.outputs:
 xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
 {{- end }}
 
-{{/* elastic/kibana#286094: merged in 9.6.0-SNAPSHOT; backported to 8.19.10-SNAPSHOT (#287670), 9.4.7-SNAPSHOT (#287671), 9.5.3-SNAPSHOT (#287672).
+{{/* elastic/kibana#286094: merged in 9.6.0-SNAPSHOT; backported to 8.19.22-SNAPSHOT (#287670), 9.4.7-SNAPSHOT (#287671), 9.5.3-SNAPSHOT (#287672).
      Backport branches also require ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true so CI controls when activation occurs. */}}
 {{- $skipUpload := eq (fact "skip_upload_package_validation") "true" }}
 {{- if or
     (not (semverLessThan $version "9.6.0-SNAPSHOT"))
-    (and $skipUpload (not (semverLessThan $version "8.19.10-SNAPSHOT")) (semverLessThan $version "9.0.0-SNAPSHOT"))
+    (and $skipUpload (not (semverLessThan $version "8.19.22-SNAPSHOT")) (semverLessThan $version "9.0.0-SNAPSHOT"))
     (and $skipUpload (not (semverLessThan $version "9.4.7-SNAPSHOT")) (semverLessThan $version "9.5.0-SNAPSHOT"))
     (and $skipUpload (not (semverLessThan $version "9.5.3-SNAPSHOT")) (semverLessThan $version "9.6.0-SNAPSHOT"))
 }}

--- a/internal/stack/_static/kibana.yml.tmpl
+++ b/internal/stack/_static/kibana.yml.tmpl
@@ -193,14 +193,14 @@ xpack.fleet.outputs:
 xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
 {{- end }}
 
-{{/* elastic/kibana#286094: merged in 9.6.0-SNAPSHOT; backported to 8.19.22-SNAPSHOT (#287670), 9.4.7-SNAPSHOT (#287671), 9.5.3-SNAPSHOT (#287672).
+{{/* elastic/kibana#286094: merged in 9.6.0-SNAPSHOT; backported to 8.19.22-SNAPSHOT (#287670), 9.4.7-SNAPSHOT (#287671), 9.5.4-SNAPSHOT (#287672).
      Backport branches also require ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true so CI controls when activation occurs. */}}
 {{- $skipUpload := eq (fact "skip_upload_package_validation") "true" }}
 {{- if or
     (not (semverLessThan $version "9.6.0-SNAPSHOT"))
     (and $skipUpload (not (semverLessThan $version "8.19.22-SNAPSHOT")) (semverLessThan $version "9.0.0-SNAPSHOT"))
     (and $skipUpload (not (semverLessThan $version "9.4.7-SNAPSHOT")) (semverLessThan $version "9.5.0-SNAPSHOT"))
-    (and $skipUpload (not (semverLessThan $version "9.5.3-SNAPSHOT")) (semverLessThan $version "9.6.0-SNAPSHOT"))
+    (and $skipUpload (not (semverLessThan $version "9.5.4-SNAPSHOT")) (semverLessThan $version "9.6.0-SNAPSHOT"))
 }}
 xpack.fleet.internal.skipUploadPackageValidation: true
 {{- end }}

--- a/internal/stack/kibana_upload_flag_test.go
+++ b/internal/stack/kibana_upload_flag_test.go
@@ -70,14 +70,14 @@ func TestSkipUploadPackageValidationBackportEnvVar(t *testing.T) {
 		{"9.0.0", false},
 		{"9.0.0-SNAPSHOT", false},
 		{"9.3.0", false},
-		// 8.19.x: patches before the backport (elastic/kibana#287670)
+		// 8.19.x: already-released patches (backport present but env var not needed for past releases)
 		{"8.19.0", false},
 		{"8.19.9", false},
-		{"8.19.9-SNAPSHOT", false},
-		// 8.19.x: backport patch and later
-		{"8.19.10-SNAPSHOT", true},
-		{"8.19.10", true},
-		{"8.19.21", true},
+		{"8.19.10-SNAPSHOT", false},
+		{"8.19.10", false},
+		{"8.19.21", false},
+		// 8.19.x: current and future snapshots — env var activates the flag
+		{"8.19.22-SNAPSHOT", true},
 		// 9.4.x: patches before the backport (elastic/kibana#287671)
 		{"9.4.0", false},
 		{"9.4.6", false},

--- a/internal/stack/kibana_upload_flag_test.go
+++ b/internal/stack/kibana_upload_flag_test.go
@@ -85,14 +85,15 @@ func TestSkipUploadPackageValidationBackportEnvVar(t *testing.T) {
 		// 9.4.x: backport patch and later
 		{"9.4.7-SNAPSHOT", true},
 		{"9.4.7", true},
-		// 9.5.x: patches before the backport (elastic/kibana#287672)
+		// 9.5.x: already-released patches and 9.5.3 (RC cut without the fix)
 		{"9.5.0", false},
 		{"9.5.0-SNAPSHOT", false},
 		{"9.5.2", false},
 		{"9.5.2-SNAPSHOT", false},
+		{"9.5.3-SNAPSHOT", false},
+		{"9.5.3", false},
 		// 9.5.x: backport patch and later
-		{"9.5.3-SNAPSHOT", true},
-		{"9.5.3", true},
+		{"9.5.4-SNAPSHOT", true},
 		// 9.6.0-SNAPSHOT+ enabled by version gate regardless of env var
 		{"9.6.0-SNAPSHOT", true},
 		{"9.6.0", true},

--- a/internal/stack/kibana_upload_flag_test.go
+++ b/internal/stack/kibana_upload_flag_test.go
@@ -33,7 +33,7 @@ func TestSkipUploadPackageValidationGating(t *testing.T) {
 		{"9.4.6-SNAPSHOT", false},
 		{"9.5.0", false},
 		{"9.5.2", false},
-		// Should have the flag (9.6 main — elastic/kibana#286094 merged here; backport follow-up pending)
+		// Should have the flag (9.6 main — elastic/kibana#286094 merged here)
 		{"9.6.0-SNAPSHOT", true},
 		{"9.6.0", true},
 		{"9.6.1", true},
@@ -83,6 +83,71 @@ func TestSkipUploadPackageValidationGating(t *testing.T) {
 					tc.version, got, tc.want, strings.Join(tail, "\n"))
 			} else {
 				t.Logf("version %s: skipUploadPackageValidation present=%v ✓", tc.version, got)
+			}
+		})
+	}
+}
+
+// TestSkipUploadPackageValidationEnvOverride verifies that setting
+// ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true injects the flag
+// even for versions that predate 9.6.0-SNAPSHOT (backport branches).
+func TestSkipUploadPackageValidationEnvOverride(t *testing.T) {
+	t.Setenv(KibanaSkipUploadPackageValidationEnvVar, "true")
+
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		// Backport target branches — flag forced on via env var
+		{"8.19.0", true},
+		{"8.19.21", true},
+		{"9.4.0", true},
+		{"9.4.6", true},
+		{"9.5.0", true},
+		{"9.5.2", true},
+		// Already covered by the version gate, still true
+		{"9.6.0-SNAPSHOT", true},
+		{"9.6.0", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("version_%s", tc.version), func(t *testing.T) {
+			elasticPackagePath := t.TempDir()
+			profilesPath := filepath.Join(elasticPackagePath, "profiles")
+			t.Setenv("ELASTIC_PACKAGE_DATA_HOME", elasticPackagePath)
+
+			err := profile.CreateProfile(profile.Options{
+				ProfilesDirPath: profilesPath,
+				Name:            "test",
+			})
+			if err != nil {
+				t.Fatalf("create profile: %v", err)
+			}
+
+			p, err := profile.LoadProfile("test")
+			if err != nil {
+				t.Fatalf("load profile: %v", err)
+			}
+
+			appConfig, err := install.Configuration()
+			if err != nil {
+				t.Fatalf("load config: %v", err)
+			}
+
+			if err := applyResources(p, appConfig, tc.version, tc.version); err != nil {
+				t.Fatalf("applyResources: %v", err)
+			}
+
+			d, err := os.ReadFile(p.Path(ProfileStackPath, KibanaConfigFile))
+			if err != nil {
+				t.Fatalf("read kibana.yml: %v", err)
+			}
+
+			got := strings.Contains(string(d), "skipUploadPackageValidation")
+			if got != tc.want {
+				t.Errorf("version %s (env override): skipUploadPackageValidation present=%v, want=%v", tc.version, got, tc.want)
+			} else {
+				t.Logf("version %s (env override): skipUploadPackageValidation present=%v ✓", tc.version, got)
 			}
 		})
 	}

--- a/internal/stack/kibana_upload_flag_test.go
+++ b/internal/stack/kibana_upload_flag_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestSkipUploadPackageValidationGating(t *testing.T) {
+	t.Setenv(KibanaSkipUploadPackageValidationEnvVar, "")
 	cases := []struct {
 		version string
 		want    bool

--- a/internal/stack/kibana_upload_flag_test.go
+++ b/internal/stack/kibana_upload_flag_test.go
@@ -15,26 +15,29 @@ import (
 	"github.com/elastic/elastic-package/internal/profile"
 )
 
+// TestSkipUploadPackageValidationGating verifies the version-only gate (no env var).
+// Only 9.6.0-SNAPSHOT+ is enabled unconditionally; backport branches require the env var.
 func TestSkipUploadPackageValidationGating(t *testing.T) {
 	t.Setenv(KibanaSkipUploadPackageValidationEnvVar, "")
+
 	cases := []struct {
 		version string
 		want    bool
 	}{
-		// Should NOT have the flag (backport not yet landed in these versions)
+		// 8.x — never enabled without env var
 		{"8.0.0", false},
-		{"8.7.0", false},
 		{"8.18.0", false},
 		{"8.19.0", false},
+		{"8.19.9", false},
+		{"8.19.10-SNAPSHOT", false},
 		{"8.19.21", false},
-		{"8.19.21-SNAPSHOT", false},
+		// 9.x pre-backport branches — never enabled without env var
 		{"9.0.0", false},
 		{"9.4.0", false},
-		{"9.4.6", false},
-		{"9.4.6-SNAPSHOT", false},
+		{"9.4.7-SNAPSHOT", false},
 		{"9.5.0", false},
-		{"9.5.2", false},
-		// Should have the flag (9.6 main — elastic/kibana#286094 merged here)
+		{"9.5.3-SNAPSHOT", false},
+		// 9.6.0-SNAPSHOT+ — always enabled (elastic/kibana#286094 merged on main)
 		{"9.6.0-SNAPSHOT", true},
 		{"9.6.0", true},
 		{"9.6.1", true},
@@ -42,46 +45,9 @@ func TestSkipUploadPackageValidationGating(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("version_%s", tc.version), func(t *testing.T) {
-			elasticPackagePath := t.TempDir()
-			profilesPath := filepath.Join(elasticPackagePath, "profiles")
-			t.Setenv("ELASTIC_PACKAGE_DATA_HOME", elasticPackagePath)
-
-			err := profile.CreateProfile(profile.Options{
-				ProfilesDirPath: profilesPath,
-				Name:            "test",
-			})
-			if err != nil {
-				t.Fatalf("create profile: %v", err)
-			}
-
-			p, err := profile.LoadProfile("test")
-			if err != nil {
-				t.Fatalf("load profile: %v", err)
-			}
-
-			appConfig, err := install.Configuration()
-			if err != nil {
-				t.Fatalf("load config: %v", err)
-			}
-
-			if err := applyResources(p, appConfig, tc.version, tc.version); err != nil {
-				t.Fatalf("applyResources: %v", err)
-			}
-
-			d, err := os.ReadFile(p.Path(ProfileStackPath, KibanaConfigFile))
-			if err != nil {
-				t.Fatalf("read kibana.yml: %v", err)
-			}
-
-			got := strings.Contains(string(d), "skipUploadPackageValidation")
+			got := renderAndCheck(t, tc.version)
 			if got != tc.want {
-				lines := strings.Split(string(d), "\n")
-				tail := lines
-				if len(lines) > 20 {
-					tail = lines[len(lines)-20:]
-				}
-				t.Errorf("version %s: skipUploadPackageValidation present=%v, want=%v\n\n--- kibana.yml tail ---\n%s",
-					tc.version, got, tc.want, strings.Join(tail, "\n"))
+				t.Errorf("version %s: skipUploadPackageValidation present=%v, want=%v", tc.version, got, tc.want)
 			} else {
 				t.Logf("version %s: skipUploadPackageValidation present=%v ✓", tc.version, got)
 			}
@@ -89,74 +55,82 @@ func TestSkipUploadPackageValidationGating(t *testing.T) {
 	}
 }
 
-// TestSkipUploadPackageValidationEnvOverride verifies template rendering when
-// ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true. It does not assert
-// Kibana compatibility — that depends on the backport being present in the version.
-// The env var only activates for backport branch ranges (8.19.x, 9.4.x, 9.5.x);
-// versions outside those ranges are unaffected even when the env var is set.
-func TestSkipUploadPackageValidationEnvOverride(t *testing.T) {
+// TestSkipUploadPackageValidationBackportEnvVar verifies that setting
+// ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true enables the flag
+// for backport patches at or above the known minimum, and not for patches below it.
+func TestSkipUploadPackageValidationBackportEnvVar(t *testing.T) {
 	t.Setenv(KibanaSkipUploadPackageValidationEnvVar, "true")
 
 	cases := []struct {
 		version string
 		want    bool
 	}{
-		// Outside backport range — env var must NOT apply
-		{"8.0.0", false},
+		// Entirely outside the backport branches — env var has no effect
 		{"8.18.0", false},
 		{"9.0.0", false},
 		{"9.3.0", false},
-		// Backport target branches — env var activates the flag
-		{"8.19.0", true},
+		// 8.19.x: patches before the backport (elastic/kibana#287670)
+		{"8.19.0", false},
+		{"8.19.9", false},
+		{"8.19.9-SNAPSHOT", false},
+		// 8.19.x: backport patch and later
+		{"8.19.10-SNAPSHOT", true},
+		{"8.19.10", true},
 		{"8.19.21", true},
-		{"9.4.0", true},
-		{"9.4.6", true},
-		{"9.5.0", true},
-		{"9.5.2", true},
-		// Version gate takes over from here regardless of env var
+		// 9.4.x: patches before the backport (elastic/kibana#287671)
+		{"9.4.0", false},
+		{"9.4.6", false},
+		{"9.4.6-SNAPSHOT", false},
+		// 9.4.x: backport patch and later
+		{"9.4.7-SNAPSHOT", true},
+		{"9.4.7", true},
+		// 9.5.x: patches before the backport (elastic/kibana#287672)
+		{"9.5.0", false},
+		{"9.5.2", false},
+		{"9.5.2-SNAPSHOT", false},
+		// 9.5.x: backport patch and later
+		{"9.5.3-SNAPSHOT", true},
+		{"9.5.3", true},
+		// 9.6.0-SNAPSHOT+ enabled by version gate regardless of env var
 		{"9.6.0-SNAPSHOT", true},
 		{"9.6.0", true},
 	}
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("version_%s", tc.version), func(t *testing.T) {
-			elasticPackagePath := t.TempDir()
-			profilesPath := filepath.Join(elasticPackagePath, "profiles")
-			t.Setenv("ELASTIC_PACKAGE_DATA_HOME", elasticPackagePath)
-
-			err := profile.CreateProfile(profile.Options{
-				ProfilesDirPath: profilesPath,
-				Name:            "test",
-			})
-			if err != nil {
-				t.Fatalf("create profile: %v", err)
-			}
-
-			p, err := profile.LoadProfile("test")
-			if err != nil {
-				t.Fatalf("load profile: %v", err)
-			}
-
-			appConfig, err := install.Configuration()
-			if err != nil {
-				t.Fatalf("load config: %v", err)
-			}
-
-			if err := applyResources(p, appConfig, tc.version, tc.version); err != nil {
-				t.Fatalf("applyResources: %v", err)
-			}
-
-			d, err := os.ReadFile(p.Path(ProfileStackPath, KibanaConfigFile))
-			if err != nil {
-				t.Fatalf("read kibana.yml: %v", err)
-			}
-
-			got := strings.Contains(string(d), "skipUploadPackageValidation")
+			got := renderAndCheck(t, tc.version)
 			if got != tc.want {
-				t.Errorf("version %s (env override): skipUploadPackageValidation present=%v, want=%v", tc.version, got, tc.want)
+				t.Errorf("version %s (env=true): skipUploadPackageValidation present=%v, want=%v", tc.version, got, tc.want)
 			} else {
-				t.Logf("version %s (env override): skipUploadPackageValidation present=%v ✓", tc.version, got)
+				t.Logf("version %s (env=true): skipUploadPackageValidation present=%v ✓", tc.version, got)
 			}
 		})
 	}
+}
+
+func renderAndCheck(t *testing.T, version string) bool {
+	t.Helper()
+	elasticPackagePath := t.TempDir()
+	profilesPath := filepath.Join(elasticPackagePath, "profiles")
+	t.Setenv("ELASTIC_PACKAGE_DATA_HOME", elasticPackagePath)
+
+	if err := profile.CreateProfile(profile.Options{ProfilesDirPath: profilesPath, Name: "test"}); err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+	p, err := profile.LoadProfile("test")
+	if err != nil {
+		t.Fatalf("load profile: %v", err)
+	}
+	appConfig, err := install.Configuration()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if err := applyResources(p, appConfig, version, version); err != nil {
+		t.Fatalf("applyResources: %v", err)
+	}
+	d, err := os.ReadFile(p.Path(ProfileStackPath, KibanaConfigFile))
+	if err != nil {
+		t.Fatalf("read kibana.yml: %v", err)
+	}
+	return strings.Contains(string(d), "skipUploadPackageValidation")
 }

--- a/internal/stack/kibana_upload_flag_test.go
+++ b/internal/stack/kibana_upload_flag_test.go
@@ -89,9 +89,11 @@ func TestSkipUploadPackageValidationGating(t *testing.T) {
 	}
 }
 
-// TestSkipUploadPackageValidationEnvOverride verifies that setting
-// ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true injects the flag
-// even for versions that predate 9.6.0-SNAPSHOT (backport branches).
+// TestSkipUploadPackageValidationEnvOverride verifies template rendering when
+// ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true. It does not assert
+// Kibana compatibility — that depends on the backport being present in the version.
+// The env var only activates for backport branch ranges (8.19.x, 9.4.x, 9.5.x);
+// versions outside those ranges are unaffected even when the env var is set.
 func TestSkipUploadPackageValidationEnvOverride(t *testing.T) {
 	t.Setenv(KibanaSkipUploadPackageValidationEnvVar, "true")
 
@@ -99,14 +101,19 @@ func TestSkipUploadPackageValidationEnvOverride(t *testing.T) {
 		version string
 		want    bool
 	}{
-		// Backport target branches — flag forced on via env var
+		// Outside backport range — env var must NOT apply
+		{"8.0.0", false},
+		{"8.18.0", false},
+		{"9.0.0", false},
+		{"9.3.0", false},
+		// Backport target branches — env var activates the flag
 		{"8.19.0", true},
 		{"8.19.21", true},
 		{"9.4.0", true},
 		{"9.4.6", true},
 		{"9.5.0", true},
 		{"9.5.2", true},
-		// Already covered by the version gate, still true
+		// Version gate takes over from here regardless of env var
 		{"9.6.0-SNAPSHOT", true},
 		{"9.6.0", true},
 	}

--- a/internal/stack/kibana_upload_flag_test.go
+++ b/internal/stack/kibana_upload_flag_test.go
@@ -68,6 +68,7 @@ func TestSkipUploadPackageValidationBackportEnvVar(t *testing.T) {
 		// Entirely outside the backport branches — env var has no effect
 		{"8.18.0", false},
 		{"9.0.0", false},
+		{"9.0.0-SNAPSHOT", false},
 		{"9.3.0", false},
 		// 8.19.x: patches before the backport (elastic/kibana#287670)
 		{"8.19.0", false},
@@ -86,6 +87,7 @@ func TestSkipUploadPackageValidationBackportEnvVar(t *testing.T) {
 		{"9.4.7", true},
 		// 9.5.x: patches before the backport (elastic/kibana#287672)
 		{"9.5.0", false},
+		{"9.5.0-SNAPSHOT", false},
 		{"9.5.2", false},
 		{"9.5.2-SNAPSHOT", false},
 		// 9.5.x: backport patch and later

--- a/internal/stack/resources.go
+++ b/internal/stack/resources.go
@@ -82,8 +82,8 @@ const (
 
 var (
 	// KibanaSkipUploadPackageValidationEnvVar enables xpack.fleet.internal.skipUploadPackageValidation
-	// for Kibana versions that have the backport of elastic/kibana#286094 but are below 9.6.0-SNAPSHOT.
-	// Set to "true" in CI when targeting 8.19, 9.4, or 9.5 stacks with the backport applied.
+	// for backport branches (8.19.x, 9.4.x, 9.5.x) that have elastic/kibana#286094 but are below
+	// 9.6.0-SNAPSHOT. Set to "true" in CI for those branches; the flag is ignored for other versions.
 	KibanaSkipUploadPackageValidationEnvVar = environment.WithElasticPackagePrefix("KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION")
 )
 
@@ -219,7 +219,7 @@ func applyResources(profile *profile.Profile, appConfig *install.ApplicationConf
 		"elastic_subscription":                        elasticSubscriptionProfile,
 		"fleet_auto_install_task_interval":            profile.Config(configFleetAutoInstallTaskInterval, "10m"),
 		"fleet_auto_install_content_packages_enabled": profile.Config(configFleetAutoInstallContentPackagesEnabled, "false"),
-		"skip_upload_package_validation":              os.Getenv(KibanaSkipUploadPackageValidationEnvVar),
+		"skip_upload_package_validation":              skipUploadPackageValidationFact(stackVersion),
 	})
 
 	if err := os.MkdirAll(stackDir, 0755); err != nil {
@@ -319,4 +319,27 @@ func semverLessThan(a, b string) (bool, error) {
 // Typically used for fixing yaml configs.
 func indent(input string, indent string) string {
 	return strings.ReplaceAll(input, "\n", "\n"+indent)
+}
+
+// skipUploadPackageValidationFact returns "true" when the env var override is set and the stack
+// version falls in a known backport branch (8.19.x or 9.4.x/9.5.x). Versions outside those ranges
+// are unaffected even when the env var is present, preventing accidental injection into unsupported stacks.
+func skipUploadPackageValidationFact(stackVersion string) string {
+	if os.Getenv(KibanaSkipUploadPackageValidationEnvVar) != "true" {
+		return ""
+	}
+	v, err := semver.NewVersion(stackVersion)
+	if err != nil {
+		return ""
+	}
+	backport819Min := semver.MustParse("8.19.0")
+	backport819Max := semver.MustParse("9.0.0")
+	backport9xMin := semver.MustParse("9.4.0")
+	backport9xMax := semver.MustParse("9.6.0-SNAPSHOT")
+	in8x := !v.LessThan(backport819Min) && v.LessThan(backport819Max)
+	in9x := !v.LessThan(backport9xMin) && v.LessThan(backport9xMax)
+	if in8x || in9x {
+		return "true"
+	}
+	return ""
 }

--- a/internal/stack/resources.go
+++ b/internal/stack/resources.go
@@ -81,9 +81,10 @@ const (
 )
 
 var (
-	// KibanaSkipUploadPackageValidationEnvVar enables xpack.fleet.internal.skipUploadPackageValidation
-	// for backport branches (8.19.x, 9.4.x, 9.5.x) that have elastic/kibana#286094 but are below
-	// 9.6.0-SNAPSHOT. Set to "true" in CI for those branches; the flag is ignored for other versions.
+	// KibanaSkipUploadPackageValidationEnvVar activates xpack.fleet.internal.skipUploadPackageValidation
+	// for the backport branches. Set to "true" in CI once the backport is confirmed present in the
+	// snapshot under test. The version gates (8.19.10-SNAPSHOT, 9.4.7-SNAPSHOT, 9.5.3-SNAPSHOT) ensure
+	// the flag is only injected into patches that actually contain the fix.
 	KibanaSkipUploadPackageValidationEnvVar = environment.WithElasticPackagePrefix("KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION")
 )
 
@@ -219,7 +220,7 @@ func applyResources(profile *profile.Profile, appConfig *install.ApplicationConf
 		"elastic_subscription":                        elasticSubscriptionProfile,
 		"fleet_auto_install_task_interval":            profile.Config(configFleetAutoInstallTaskInterval, "10m"),
 		"fleet_auto_install_content_packages_enabled": profile.Config(configFleetAutoInstallContentPackagesEnabled, "false"),
-		"skip_upload_package_validation":              skipUploadPackageValidationFact(stackVersion),
+		"skip_upload_package_validation":              os.Getenv(KibanaSkipUploadPackageValidationEnvVar),
 	})
 
 	if err := os.MkdirAll(stackDir, 0755); err != nil {
@@ -321,25 +322,3 @@ func indent(input string, indent string) string {
 	return strings.ReplaceAll(input, "\n", "\n"+indent)
 }
 
-// skipUploadPackageValidationFact returns "true" when the env var override is set and the stack
-// version falls in a known backport branch (8.19.x or 9.4.x/9.5.x). Versions outside those ranges
-// are unaffected even when the env var is present, preventing accidental injection into unsupported stacks.
-func skipUploadPackageValidationFact(stackVersion string) string {
-	if os.Getenv(KibanaSkipUploadPackageValidationEnvVar) != "true" {
-		return ""
-	}
-	v, err := semver.NewVersion(stackVersion)
-	if err != nil {
-		return ""
-	}
-	backport819Min := semver.MustParse("8.19.0")
-	backport819Max := semver.MustParse("9.0.0")
-	backport9xMin := semver.MustParse("9.4.0")
-	backport9xMax := semver.MustParse("9.6.0-SNAPSHOT")
-	in8x := !v.LessThan(backport819Min) && v.LessThan(backport819Max)
-	in9x := !v.LessThan(backport9xMin) && v.LessThan(backport9xMax)
-	if in8x || in9x {
-		return "true"
-	}
-	return ""
-}

--- a/internal/stack/resources.go
+++ b/internal/stack/resources.go
@@ -83,8 +83,8 @@ const (
 var (
 	// KibanaSkipUploadPackageValidationEnvVar activates xpack.fleet.internal.skipUploadPackageValidation
 	// for the backport branches. Set to "true" in CI once the backport is confirmed present in the
-	// snapshot under test. The version gates (8.19.10-SNAPSHOT, 9.4.7-SNAPSHOT, 9.5.3-SNAPSHOT) ensure
-	// the flag is only injected into patches that actually contain the fix.
+	// snapshot under test. The version gates (8.19.22-SNAPSHOT, 9.4.7-SNAPSHOT, 9.5.4-SNAPSHOT) ensure
+	// the flag is only injected into snapshots that actually contain the fix.
 	KibanaSkipUploadPackageValidationEnvVar = environment.WithElasticPackagePrefix("KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION")
 )
 

--- a/internal/stack/resources.go
+++ b/internal/stack/resources.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/elastic/go-resource"
 
+	"github.com/elastic/elastic-package/internal/environment"
 	"github.com/elastic/elastic-package/internal/install"
 	"github.com/elastic/elastic-package/internal/profile"
 )
@@ -77,6 +78,13 @@ const (
 	configElasticSubscription                    = "stack.elastic_subscription"
 	configFleetAutoInstallTaskInterval           = "stack.fleet_auto_install_task_interval"
 	configFleetAutoInstallContentPackagesEnabled = "stack.fleet_auto_install_content_packages_enabled"
+)
+
+var (
+	// KibanaSkipUploadPackageValidationEnvVar enables xpack.fleet.internal.skipUploadPackageValidation
+	// for Kibana versions that have the backport of elastic/kibana#286094 but are below 9.6.0-SNAPSHOT.
+	// Set to "true" in CI when targeting 8.19, 9.4, or 9.5 stacks with the backport applied.
+	KibanaSkipUploadPackageValidationEnvVar = environment.WithElasticPackagePrefix("KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION")
 )
 
 var (
@@ -211,6 +219,7 @@ func applyResources(profile *profile.Profile, appConfig *install.ApplicationConf
 		"elastic_subscription":                        elasticSubscriptionProfile,
 		"fleet_auto_install_task_interval":            profile.Config(configFleetAutoInstallTaskInterval, "10m"),
 		"fleet_auto_install_content_packages_enabled": profile.Config(configFleetAutoInstallContentPackagesEnabled, "false"),
+		"skip_upload_package_validation":              os.Getenv(KibanaSkipUploadPackageValidationEnvVar),
 	})
 
 	if err := os.MkdirAll(stackDir, 0755); err != nil {

--- a/internal/stack/resources.go
+++ b/internal/stack/resources.go
@@ -321,4 +321,3 @@ func semverLessThan(a, b string) (bool, error) {
 func indent(input string, indent string) string {
 	return strings.ReplaceAll(input, "\n", "\n"+indent)
 }
-


### PR DESCRIPTION
## Summary

Adds `ELASTIC_PACKAGE_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true` to force-enable `xpack.fleet.internal.skipUploadPackageValidation: true` in the generated Kibana config for `9.6.0-SNAPSHOT` onwards and backported branches detail below.

The flag is auto-injected for `>= 9.6.0-SNAPSHOT` (elastic/kibana#286094, merged on main). Once each lands, CI can activate the flag by setting the env var; the version ranges in the template ensure it is only injected into ongoing CI snapshot builds that actually contain the backport.

| Branch | Range | Kibana PR |
|--------|-------|-----------|
| 8.19.x | `[8.19.22-SNAPSHOT, 9.0.0-SNAPSHOT)` | elastic/kibana#287670 |
| 9.4.x  | `[9.4.7-SNAPSHOT, 9.5.0-SNAPSHOT)`   | elastic/kibana#287671 |
| 9.5.x  | `[9.5.4-SNAPSHOT, 9.6.0-SNAPSHOT)`   | elastic/kibana#287672 |

Lower bounds reflect the current CI snapshot for each branch (already-released builds are excluded). Upper bounds use SNAPSHOT forms so that prerelease versions of the next minor (e.g. `9.0.0-SNAPSHOT`, `9.5.0-SNAPSHOT`) are not inadvertently included. Setting the env var for a version outside these ranges has no effect, so it is safe to set in a shared CI environment.

## Changes

- `internal/stack/_static/kibana.yml.tmpl` — adds version-scoped conditions for the env var override: the flag is emitted when `$skipUpload` is true and the stack version falls within one of the three backport ranges above. Upper bounds are in SNAPSHOT form to exclude prerelease versions of adjacent minors.
- `internal/stack/resources.go` — exports `KibanaSkipUploadPackageValidationEnvVar` and passes its value as the `skip_upload_package_validation` template fact.
- `internal/stack/kibana_upload_flag_test.go` — covers three scenarios: version gate only (`>= 9.6.0-SNAPSHOT`), env var with a matching backport snapshot (enabled), and env var with a pre-backport or out-of-range version (disabled). Includes SNAPSHOT boundary cases for all range edges.
- `docs/howto/install_package.md` — documents the env var, the minimum snapshot versions per branch, and the manual `kibana.dev.yml` workaround for versions not yet covered.

## Related

- #3879 — initial version gate for 9.6.0-SNAPSHOT
- elastic/kibana#286094 — original PR
- elastic/kibana#287670 — backport to 8.19
- elastic/kibana#287671 — backport to 9.4
- elastic/kibana#287672 — backport to 9.5