### PR TITLE
[Serverless] add Kibana config override for package upload validation

### DIFF
--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -18,6 +18,8 @@ env:
   ELASTIC_PACKAGE_SERVERLESS_PIPELINE_TEST_DISABLE_COMPARE_RESULTS: "true"
   # Enable/Disable the usage of wolfi images for Elastic Agent
   ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI: "${ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI:-false}"
+  # Required to install packages via API even if they are already present in EPR (only available in QA)
+  ELASTIC_PACKAGE_SERVERLESS_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION: "true"
 
 
 steps:

--- a/README.md
+++ b/README.md
@@ -956,6 +956,8 @@ There are available some environment variables that could be used to change some
 
 - Related to tests:
     - `ELASTIC_PACKAGE_SERVERLESS_PIPELINE_TEST_DISABLE_COMPARE_RESULTS`: If set to `true`, the results from pipeline tests are not compared to avoid errors from GeoIP.
+    - `ELASTIC_PACKAGE_SERVERLESS_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION`: If set to `true`, the Kibana config `xpack.fleet.internal.skipUploadPackageValidation` is included
+      when creating a Serverless project. This allows installing packages via API even if they are already present in EPR. Only available in QA environments.
     - `ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI`: If set to `true`, the Elastic Agent image used for running agents will be using the Ubuntu docker images
       (e.g. `docker.elastic.co/elastic-agent/elastic-agent-complete`). If set to `false`, the Elastic Agent image used for the running agents will be based on the wolfi
       images (e.g. `docker.elastic.co/elastic-agent/elastic-agent-wolfi`). Default: `false`.

--- a/docs/howto/use_existing_stack.md
+++ b/docs/howto/use_existing_stack.md
@@ -80,6 +80,17 @@ You can have multiple stacks configured, with different providers, if you use
 profiles. You can read more about them in the [README](https://github.com/elastic/elastic-package/blob/main/README.md#elastic-package-profiles-1).
 
 
+### Package already exists in the package registry
+
+If you encounter an error like the following when installing a package:
+
+```
+can't install the package: there was an apply error: installation failed: can't install the package: could not zip-install package; API status code = 400; response body = {"statusCode":400,"error":"Bad Request","message":"Cannot upload a package whose name already exists in the package registry or as a bundled package: <package_name>"}
+```
+
+This happens because the package is already present in EPR and the stack does not allow overriding it by default.
+To fix this, the Kibana configuration `xpack.fleet.internal.skipUploadPackageValidation` must be set to `true` in the target stack.
+
 ### Example: Using elastic-package with Kibana development environment
 
 One of the use cases of the environment provider is to be able to use

--- a/docs/howto/use_serverless_stack.md
+++ b/docs/howto/use_serverless_stack.md
@@ -66,6 +66,23 @@ pipeline tests should not be compared. This can be achieved by setting the follo
 export ELASTIC_PACKAGE_SERVERLESS_PIPELINE_TEST_DISABLE_COMPARE_RESULTS=true
 ```
 
+### Package already exists in the package registry
+
+If you encounter an error like the following when installing a package:
+
+```
+can't install the package: there was an apply error: installation failed: can't install the package: could not zip-install package; API status code = 400; response body = {"statusCode":400,"error":"Bad Request","message":"Cannot upload a package whose name already exists in the package registry or as a bundled package: <package_name>"}
+```
+
+This happens because the package is already present in EPR and the Serverless project does not allow overriding it by default.
+To fix this, set the following environment variable before creating the Serverless project:
+
+```shell
+export ELASTIC_PACKAGE_SERVERLESS_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true
+```
+
+> **Note:** This setting is only available in QA environments.
+
 ### How to use an existing `Serverless` project
 
 In case you want to test your packages using an already existing Serverless project, it could be used

--- a/internal/serverless/client.go
+++ b/internal/serverless/client.go
@@ -161,7 +161,7 @@ func (c *Client) CreateProject(ctx context.Context, name, region, projectType st
 	}
 	// Required to install packages via API even if they are already present in EPR (only available in QA).
 	if os.Getenv(kibanaSkipUploadPackageValidationEnv) == "true" {
-		logger.Debug("Adding skipUploadPackageValidation kibana config")
+		logger.Debug("Adding xpack.fleet.internal.skipUploadPackageValidation kibana config")
 		reqBody.Overrides = &createProjectOverrides{
 			Kibana: createProjectKibanaOverride{
 				Config: map[string]any{

--- a/internal/serverless/client.go
+++ b/internal/serverless/client.go
@@ -143,25 +143,33 @@ func (c *Client) doRequest(request *http.Request) (int, []byte, error) {
 }
 
 func (c *Client) CreateProject(ctx context.Context, name, region, projectType string) (*Project, error) {
-	ReqBody := struct {
-		Name      string `json:"name"`
-		RegionID  string `json:"region_id"`
-		Overrides struct {
-			Kibana struct {
-				Config map[string]any `json:"config"`
-			} `json:"kibana"`
-		} `json:"overrides"`
-	}{
+	type createProjectKibanaOverride struct {
+		Config map[string]any `json:"config"`
+	}
+	type createProjectOverrides struct {
+		Kibana createProjectKibanaOverride `json:"kibana"`
+	}
+	type createProjectRequest struct {
+		Name      string                  `json:"name"`
+		RegionID  string                  `json:"region_id"`
+		Overrides *createProjectOverrides `json:"overrides,omitempty"`
+	}
+
+	reqBody := createProjectRequest{
 		Name:     name,
 		RegionID: region,
 	}
 	// Required to install packages via API even if they are already present in EPR (only available in QA).
 	if os.Getenv(kibanaSkipUploadPackageValidationEnv) == "true" {
-		ReqBody.Overrides.Kibana.Config = map[string]any{
-			"xpack.fleet.internal.skipUploadPackageValidation": true,
+		reqBody.Overrides = &createProjectOverrides{
+			Kibana: createProjectKibanaOverride{
+				Config: map[string]any{
+					"xpack.fleet.internal.skipUploadPackageValidation": true,
+				},
+			},
 		}
 	}
-	p, err := json.Marshal(ReqBody)
+	p, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/serverless/client.go
+++ b/internal/serverless/client.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/elastic/elastic-package/internal/environment"
 	"github.com/elastic/elastic-package/internal/logger"
 )
 
@@ -36,6 +37,8 @@ type ClientOption func(*Client)
 var (
 	elasticCloudAPIKeyEnv   = "EC_API_KEY"
 	elasticCloudEndpointEnv = "EC_HOST"
+
+	kibanaSkipUploadPackageValidationEnv = environment.WithElasticPackagePrefix("SERVERLESS_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION")
 
 	ErrProjectNotExist = errors.New("project does not exist")
 )
@@ -141,11 +144,22 @@ func (c *Client) doRequest(request *http.Request) (int, []byte, error) {
 
 func (c *Client) CreateProject(ctx context.Context, name, region, projectType string) (*Project, error) {
 	ReqBody := struct {
-		Name     string `json:"name"`
-		RegionID string `json:"region_id"`
+		Name      string `json:"name"`
+		RegionID  string `json:"region_id"`
+		Overrides struct {
+			Kibana struct {
+				Config map[string]any `json:"config"`
+			} `json:"kibana"`
+		} `json:"overrides"`
 	}{
 		Name:     name,
 		RegionID: region,
+	}
+	// Required to install packages via API even if they are already present in EPR (only available in QA).
+	if os.Getenv(kibanaSkipUploadPackageValidationEnv) == "true" {
+		ReqBody.Overrides.Kibana.Config = map[string]any{
+			"xpack.fleet.internal.skipUploadPackageValidation": true,
+		}
 	}
 	p, err := json.Marshal(ReqBody)
 	if err != nil {

--- a/internal/serverless/client.go
+++ b/internal/serverless/client.go
@@ -161,6 +161,7 @@ func (c *Client) CreateProject(ctx context.Context, name, region, projectType st
 	}
 	// Required to install packages via API even if they are already present in EPR (only available in QA).
 	if os.Getenv(kibanaSkipUploadPackageValidationEnv) == "true" {
+		logger.Debug("Adding skipUploadPackageValidation kibana config")
 		reqBody.Overrides = &createProjectOverrides{
 			Kibana: createProjectKibanaOverride{
 				Config: map[string]any{

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -344,6 +344,8 @@ There are available some environment variables that could be used to change some
 
 - Related to tests:
     - `ELASTIC_PACKAGE_SERVERLESS_PIPELINE_TEST_DISABLE_COMPARE_RESULTS`: If set to `true`, the results from pipeline tests are not compared to avoid errors from GeoIP.
+    - `ELASTIC_PACKAGE_SERVERLESS_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION`: If set to `true`, the Kibana config `xpack.fleet.internal.skipUploadPackageValidation` is included
+      when creating a Serverless project. This allows installing packages via API even if they are already present in EPR. Only available in QA environments.
     - `ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI`: If set to `true`, the Elastic Agent image used for running agents will be using the Ubuntu docker images
       (e.g. `docker.elastic.co/elastic-agent/elastic-agent-complete`). If set to `false`, the Elastic Agent image used for the running agents will be based on the wolfi
       images (e.g. `docker.elastic.co/elastic-agent/elastic-agent-wolfi`). Default: `false`.


### PR DESCRIPTION
Relates https://github.com/elastic/elastic-package/pull/3910


## Summary

When creating a Serverless project, the `CreateProject` request now conditionally includes a Kibana configuration override to skip upload package validation. This is controlled by the `ELASTIC_PACKAGE_SERVERLESS_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION` environment variable and is enabled by default in the Buildkite serverless pipeline.

## Changes

- **`internal/serverless/client.go`**: Extended the `CreateProject` request body with an `overrides.kibana.config` block. The `xpack.fleet.internal.skipUploadPackageValidation: true` setting is conditionally included when `ELASTIC_PACKAGE_SERVERLESS_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION=true`, using the standard `environment.WithElasticPackagePrefix` helper for the env var name.

- **`.buildkite/pipeline.serverless.yml`**: Added `ELASTIC_PACKAGE_SERVERLESS_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION: "true"` to the global `env` block, alongside other QA-specific `ELASTIC_PACKAGE_*` settings.

## Why

The Kibana setting `xpack.fleet.internal.skipUploadPackageValidation` is required to install packages via the API even when they are already present in EPR. This configuration is only available in QA environments, so it is gated behind an environment variable rather than always applied.

Currently, the pipeline in charge of testing test packages with a Serverless project is failing with this error ([example buildkite build](https://buildkite.com/elastic/elastic-package-test-serverless/builds/934)):
```
Error: error running package asset tests: error running package asset tests: could not complete test run: can't install the package: there was an apply error: installation failed: can't install the package: could not zip-install package; API status code = 400; response body = {"statusCode":400,"error":"Bad Request","message":"Cannot upload a package whose name already exists in the package registry or as a bundled package: zipkin_input_otel"}
```

## Proposed commit

```
[serverless] add Kibana config override for package upload validation

When ELASTIC_PACKAGE_SERVERLESS_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION is
set to "true", the serverless project creation request includes a Kibana
config override to skip upload package validation. This is required to
install packages via API even if they are already present in EPR, and is
only available in QA environments. The env var is enabled by default in
the Buildkite serverless pipeline.

```

### Author's Checklist
- [x] Trigger Serverless pipeline and validate that installation runs successfully https://buildkite.com/elastic/elastic-package-test-serverless/builds/937
- [x] Update documentation.

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).