### PR TITLE
Retry transient connection errors in HTTP retry policy

### DIFF
--- a/internal/retry/http.go
+++ b/internal/retry/http.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"net/url"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -87,9 +87,13 @@ func checkRetry(ctx context.Context, resp *http.Response, err error) (bool, erro
 			return false, nil
 		}
 
-		var urlError *url.Error
-		if errors.As(err, &urlError) {
-			// URL is invalid, not recoverable.
+		// http.Client.Do wraps every error it returns in *url.Error, including
+		// transient transport failures such as EOF or connection reset that are
+		// worth retrying, so the wrapper itself says nothing about recoverability.
+		// Inspect the underlying error for the genuinely unrecoverable causes.
+
+		if strings.Contains(err.Error(), "unsupported protocol scheme") {
+			// Malformed request URL, not recoverable.
 			return false, nil
 		}
 
@@ -111,7 +115,9 @@ func checkRetry(ctx context.Context, resp *http.Response, err error) (bool, erro
 			return false, nil
 		}
 
-		// Consider other errors as recoverable and retry.
+		// Consider other errors, including connection-level failures such as
+		// EOF (e.g. a reused keep-alive connection closed by the server) or
+		// connection reset, as recoverable and retry.
 		return true, nil
 	}
 

--- a/internal/retry/http.go
+++ b/internal/retry/http.go
@@ -11,7 +11,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -92,9 +94,26 @@ func checkRetry(ctx context.Context, resp *http.Response, err error) (bool, erro
 		// worth retrying, so the wrapper itself says nothing about recoverability.
 		// Inspect the underlying error for the genuinely unrecoverable causes.
 
-		if strings.Contains(err.Error(), "unsupported protocol scheme") {
-			// Malformed request URL, not recoverable.
+		if errors.Is(err, http.ErrSchemeMismatch) {
+			// Server returned HTTP to an HTTPS client — a configuration error.
 			return false, nil
+		}
+
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			// Go's stdlib does not export a typed error for unsupported protocol
+			// scheme, so match on the inner error string only (not the full
+			// url.Error string which embeds the URL and could produce false matches).
+			if strings.Contains(urlErr.Err.Error(), "unsupported protocol scheme") {
+				return false, nil
+			}
+
+			// Permanent DNS failure (NXDOMAIN). IsNotFound distinguishes it from
+			// transient resolver hiccups, which should still be retried.
+			var dnsErr *net.DNSError
+			if errors.As(urlErr.Err, &dnsErr) && dnsErr.IsNotFound {
+				return false, nil
+			}
 		}
 
 		var certVerificationError *tls.CertificateVerificationError

--- a/internal/retry/http.go
+++ b/internal/retry/http.go
@@ -104,7 +104,7 @@ func checkRetry(ctx context.Context, resp *http.Response, err error) (bool, erro
 			// Go's stdlib does not export a typed error for unsupported protocol
 			// scheme, so match on the inner error string only (not the full
 			// url.Error string which embeds the URL and could produce false matches).
-			if strings.Contains(urlErr.Err.Error(), "unsupported protocol scheme") {
+			if urlErr.Err != nil && strings.Contains(urlErr.Err.Error(), "unsupported protocol scheme") {
 				return false, nil
 			}
 

--- a/internal/retry/http_transport_errors_test.go
+++ b/internal/retry/http_transport_errors_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -20,6 +21,23 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// transientDNSError simulates a DNS failure that is NOT a permanent NXDOMAIN,
+// e.g. a transient resolver timeout.
+func transientDNSError(host string) error {
+	return &url.Error{Op: "Get", URL: "https://" + host + "/", Err: &net.DNSError{
+		Name:       host,
+		IsNotFound: false, // transient, not NXDOMAIN
+	}}
+}
+
+// permanentDNSError simulates a permanent NXDOMAIN failure.
+func permanentDNSError(host string) error {
+	return &url.Error{Op: "Get", URL: "https://" + host + "/", Err: &net.DNSError{
+		Name:       host,
+		IsNotFound: true,
+	}}
+}
 
 // TestCheckRetryTransientConnectionErrors feeds checkRetry the error shapes
 // http.Client.Do produces for transport-level failures, which are always
@@ -34,6 +52,7 @@ func TestCheckRetryTransientConnectionErrors(t *testing.T) {
 		{"unexpected EOF", &url.Error{Op: "Post", URL: "https://127.0.0.1:5601/api/fleet/package_policies", Err: io.ErrUnexpectedEOF}},
 		{"connection reset by peer", &url.Error{Op: "Get", URL: "https://127.0.0.1:5601/api/status", Err: syscall.ECONNRESET}},
 		{"connection refused", &url.Error{Op: "Get", URL: "https://127.0.0.1:5601/api/status", Err: syscall.ECONNREFUSED}},
+		{"transient DNS failure (not NXDOMAIN)", transientDNSError("kibana.example.internal")},
 	}
 
 	for _, c := range cases {
@@ -58,6 +77,8 @@ func TestCheckRetryUnrecoverableTransportErrors(t *testing.T) {
 		{"invalid certificate", &url.Error{Op: "Get", URL: "https://example.com", Err: &x509.CertificateInvalidError{Reason: x509.Expired}}},
 		{"unsupported protocol scheme", &url.Error{Op: "Get", URL: "ftp://example.com", Err: errors.New(`unsupported protocol scheme "ftp"`)}},
 		{"too many redirects", &url.Error{Op: "Get", URL: "http://example.com", Err: errTooManyRedirects}},
+		{"permanent DNS failure (NXDOMAIN)", permanentDNSError("does-not-exist.example.com")},
+		{"HTTP response to HTTPS client", fmt.Errorf("tls handshake: %w", http.ErrSchemeMismatch)},
 	}
 
 	for _, c := range cases {

--- a/internal/retry/http_transport_errors_test.go
+++ b/internal/retry/http_transport_errors_test.go
@@ -1,0 +1,147 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package retry
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"sync/atomic"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckRetryTransientConnectionErrors feeds checkRetry the error shapes
+// http.Client.Do produces for transport-level failures, which are always
+// wrapped in *url.Error. Transient connection errors must be retried.
+// Regression test for https://github.com/elastic/elastic-package/issues/3887.
+func TestCheckRetryTransientConnectionErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"EOF (stale keep-alive close)", &url.Error{Op: "Post", URL: "https://127.0.0.1:5601/api/fleet/agent_policies", Err: io.EOF}},
+		{"unexpected EOF", &url.Error{Op: "Post", URL: "https://127.0.0.1:5601/api/fleet/package_policies", Err: io.ErrUnexpectedEOF}},
+		{"connection reset by peer", &url.Error{Op: "Get", URL: "https://127.0.0.1:5601/api/status", Err: syscall.ECONNRESET}},
+		{"connection refused", &url.Error{Op: "Get", URL: "https://127.0.0.1:5601/api/status", Err: syscall.ECONNREFUSED}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			shouldRetry, err := checkRetry(context.Background(), nil, c.err)
+			assert.NoError(t, err)
+			assert.True(t, shouldRetry, "%s should be retried", c.name)
+		})
+	}
+}
+
+// TestCheckRetryUnrecoverableTransportErrors ensures the unrecoverable causes
+// are still not retried when wrapped in *url.Error, as http.Client.Do returns
+// them.
+func TestCheckRetryUnrecoverableTransportErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"certificate verification", &url.Error{Op: "Get", URL: "https://example.com", Err: &tls.CertificateVerificationError{Err: errors.New("bad cert")}}},
+		{"unknown authority", &url.Error{Op: "Get", URL: "https://example.com", Err: x509.UnknownAuthorityError{}}},
+		{"invalid certificate", &url.Error{Op: "Get", URL: "https://example.com", Err: &x509.CertificateInvalidError{Reason: x509.Expired}}},
+		{"unsupported protocol scheme", &url.Error{Op: "Get", URL: "ftp://example.com", Err: errors.New(`unsupported protocol scheme "ftp"`)}},
+		{"too many redirects", &url.Error{Op: "Get", URL: "http://example.com", Err: errTooManyRedirects}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			shouldRetry, err := checkRetry(context.Background(), nil, c.err)
+			assert.NoError(t, err)
+			assert.False(t, shouldRetry, "%s should not be retried", c.name)
+		})
+	}
+}
+
+// flakyConnectionServer accepts TCP connections and closes the first
+// failures of them without writing a response — the observable behavior of a
+// server-side keep-alive close race — and serves a minimal HTTP 200 response
+// afterwards. It returns the address and a counter of accepted connections.
+func flakyConnectionServer(t *testing.T, failures int32) (addr string, attempts *atomic.Int32) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	attempts = &atomic.Int32{}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			n := attempts.Add(1)
+			buf := make([]byte, 1024)
+			_, _ = conn.Read(buf)
+			if n <= failures {
+				// Close without responding: the client sees EOF.
+				conn.Close()
+				continue
+			}
+			_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"))
+			conn.Close()
+		}
+	}()
+
+	return ln.Addr().String(), attempts
+}
+
+// TestConnectionErrorsRetriedEndToEnd reproduces the failure mode of
+// https://github.com/elastic/elastic-package/issues/3887 end to end: a server
+// that closes the connection without responding must be retried, and the
+// request must succeed once the server recovers.
+func TestConnectionErrorsRetriedEndToEnd(t *testing.T) {
+	addr, attempts := flakyConnectionServer(t, 2)
+
+	client := WrapHTTPClient(&http.Client{}, HTTPOptions{
+		RetryMax:     5,
+		retryWaitMin: fastRetryWaitMin,
+		retryWaitMax: fastRetryWaitMax,
+	})
+
+	resp, err := client.Post("http://"+addr+"/api/fleet/agent_policies", "application/json", nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(3), attempts.Load(), "expected 2 failed attempts plus 1 success")
+}
+
+// TestConnectionErrorsRetriesExhausted verifies that a persistently failing
+// connection gives up after RetryMax retries and surfaces the underlying
+// error.
+func TestConnectionErrorsRetriesExhausted(t *testing.T) {
+	addr, attempts := flakyConnectionServer(t, int32(^uint32(0)>>1)) // always fail
+
+	client := WrapHTTPClient(&http.Client{}, HTTPOptions{
+		RetryMax:     2,
+		retryWaitMin: fastRetryWaitMin,
+		retryWaitMax: fastRetryWaitMax,
+	})
+
+	resp, err := client.Post("http://"+addr+"/api/fleet/agent_policies", "application/json", nil)
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, io.EOF), "expected EOF, got: %v", err)
+	assert.Equal(t, int32(3), attempts.Load(), "expected initial attempt plus RetryMax retries")
+}

--- a/internal/retry/http_transport_errors_test.go
+++ b/internal/retry/http_transport_errors_test.go
@@ -89,10 +89,10 @@ func TestCheckRetryUnrecoverableTransportErrors(t *testing.T) {
 	}
 }
 
-// flakyConnectionServer accepts TCP connections and closes the first
-// failures of them without writing a response — the observable behavior of a
-// server-side keep-alive close race — and serves a minimal HTTP 200 response
-// afterwards. It returns the address and a counter of accepted connections.
+// flakyConnectionServer accepts TCP connections and closes the first N without
+// responding — the observable behavior of a server-side keep-alive close race —
+// then serves a minimal HTTP 200 response for all subsequent connections.
+// It returns the listener address and an atomic counter of accepted connections.
 func flakyConnectionServer(t *testing.T, failures int32) (addr string, attempts *atomic.Int32) {
 	t.Helper()
 

--- a/internal/retry/http_transport_errors_test.go
+++ b/internal/retry/http_transport_errors_test.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 	"net/url"
 	"sync/atomic"
-	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,8 +49,8 @@ func TestCheckRetryTransientConnectionErrors(t *testing.T) {
 	}{
 		{"EOF (stale keep-alive close)", &url.Error{Op: "Post", URL: "https://127.0.0.1:5601/api/fleet/agent_policies", Err: io.EOF}},
 		{"unexpected EOF", &url.Error{Op: "Post", URL: "https://127.0.0.1:5601/api/fleet/package_policies", Err: io.ErrUnexpectedEOF}},
-		{"connection reset by peer", &url.Error{Op: "Get", URL: "https://127.0.0.1:5601/api/status", Err: syscall.ECONNRESET}},
-		{"connection refused", &url.Error{Op: "Get", URL: "https://127.0.0.1:5601/api/status", Err: syscall.ECONNREFUSED}},
+		{"connection reset by peer", &url.Error{Op: "Get", URL: "https://127.0.0.1:5601/api/status", Err: errors.New("connection reset by peer")}},
+		{"connection refused", &url.Error{Op: "Get", URL: "https://127.0.0.1:5601/api/status", Err: errors.New("connection refused")}},
 		{"transient DNS failure (not NXDOMAIN)", transientDNSError("kibana.example.internal")},
 	}
 


### PR DESCRIPTION
```
Retry transient connection errors in HTTP retry policy

The checkRetry function treated every *url.Error as an unrecoverable
invalid-URL error, which disabled retries for all connection-level
failures. Since http.Client.Do wraps every transport-level error in
*url.Error — including transient ones like EOF (from a keep-alive
connection the server already closed) or connection reset — this
effectively disabled retries for any connection error and made the
tls/x509 certificate checks below unreachable dead code.

Fix by inspecting the underlying error instead of the wrapper.
Keep genuinely unrecoverable causes non-retryable (unsupported
protocol scheme, certificate errors, redirect loops), and retry
everything else (EOF, connection reset, refused, etc.).

Fixes #3887

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
```

Closes #3887
