### PR TITLE
System test runner: re-attempt tests that fail during setup phase

### DIFF
--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -483,6 +483,7 @@ func getTestRunnerSystemCommand() *cobra.Command {
 	cmd.Flags().Bool(cobraext.TearDownFlagName, false, cobraext.TearDownFlagDescription)
 	cmd.Flags().Bool(cobraext.NoProvisionFlagName, false, cobraext.NoProvisionFlagDescription)
 	cmd.Flags().String(cobraext.AgentVersionFlagName, "", cobraext.AgentVersionFlagDescription)
+	cmd.Flags().Int(cobraext.SetupReattemptsFlagName, 1, cobraext.SetupReattemptsFlagDescription)
 
 	cmd.MarkFlagsMutuallyExclusive(cobraext.SetupFlagName, cobraext.TearDownFlagName, cobraext.NoProvisionFlagName)
 	cmd.MarkFlagsRequiredTogether(cobraext.ConfigFileFlagName, cobraext.SetupFlagName)
@@ -546,6 +547,11 @@ func testRunnerSystemCommandAction(cmd *cobra.Command, args []string) error {
 	deferCleanup, err := cmd.Flags().GetDuration(cobraext.DeferCleanupFlagName)
 	if err != nil {
 		return cobraext.FlagParsingError(err, cobraext.DeferCleanupFlagName)
+	}
+
+	setupReattempts, err := cmd.Flags().GetInt(cobraext.SetupReattemptsFlagName)
+	if err != nil {
+		return cobraext.FlagParsingError(err, cobraext.SetupReattemptsFlagName)
 	}
 
 	variantFlag, err := cmd.Flags().GetString(cobraext.VariantFlagName)
@@ -677,6 +683,7 @@ func testRunnerSystemCommandAction(cmd *cobra.Command, args []string) error {
 		FailOnMissingTests:     failOnMissing,
 		GenerateTestResult:     generateTestResult,
 		DeferCleanup:           deferCleanup,
+		SetupReattempts:        setupReattempts,
 		GlobalTestConfig:       globalTestConfig.System,
 		WithCoverage:           testCoverage,
 		CoverageType:           testCoverageFormat,

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -17,8 +17,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cobraext"
-	"github.com/elastic/elastic-package/internal/environment"
 	"github.com/elastic/elastic-package/internal/common"
+	"github.com/elastic/elastic-package/internal/environment"
 	"github.com/elastic/elastic-package/internal/files"
 	"github.com/elastic/elastic-package/internal/install"
 	"github.com/elastic/elastic-package/internal/logger"

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -11,11 +11,13 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-package/internal/cobraext"
+	"github.com/elastic/elastic-package/internal/environment"
 	"github.com/elastic/elastic-package/internal/common"
 	"github.com/elastic/elastic-package/internal/files"
 	"github.com/elastic/elastic-package/internal/install"
@@ -483,7 +485,7 @@ func getTestRunnerSystemCommand() *cobra.Command {
 	cmd.Flags().Bool(cobraext.TearDownFlagName, false, cobraext.TearDownFlagDescription)
 	cmd.Flags().Bool(cobraext.NoProvisionFlagName, false, cobraext.NoProvisionFlagDescription)
 	cmd.Flags().String(cobraext.AgentVersionFlagName, "", cobraext.AgentVersionFlagDescription)
-	cmd.Flags().Int(cobraext.SetupReattemptsFlagName, 1, cobraext.SetupReattemptsFlagDescription)
+	cmd.Flags().Int(cobraext.SetupReattemptsFlagName, 0, cobraext.SetupReattemptsFlagDescription)
 
 	cmd.MarkFlagsMutuallyExclusive(cobraext.SetupFlagName, cobraext.TearDownFlagName, cobraext.NoProvisionFlagName)
 	cmd.MarkFlagsRequiredTogether(cobraext.ConfigFileFlagName, cobraext.SetupFlagName)
@@ -552,6 +554,19 @@ func testRunnerSystemCommandAction(cmd *cobra.Command, args []string) error {
 	setupReattempts, err := cmd.Flags().GetInt(cobraext.SetupReattemptsFlagName)
 	if err != nil {
 		return cobraext.FlagParsingError(err, cobraext.SetupReattemptsFlagName)
+	}
+	if !cmd.Flags().Changed(cobraext.SetupReattemptsFlagName) {
+		if v, ok := os.LookupEnv(environment.WithElasticPackagePrefix("TEST_SETUP_REATTEMPTS")); ok {
+			n, err := strconv.Atoi(v)
+			if err != nil {
+				return fmt.Errorf("invalid value for %s env var: %w", environment.WithElasticPackagePrefix("TEST_SETUP_REATTEMPTS"), err)
+			}
+			setupReattempts = n
+		}
+	}
+	const maxSetupReattempts = 5
+	if setupReattempts < 0 || setupReattempts > maxSetupReattempts {
+		return fmt.Errorf("--%s must be between 0 and %d, got %d", cobraext.SetupReattemptsFlagName, maxSetupReattempts, setupReattempts)
 	}
 
 	variantFlag, err := cmd.Flags().GetString(cobraext.VariantFlagName)

--- a/docs/howto/system_testing.md
+++ b/docs/howto/system_testing.md
@@ -989,6 +989,28 @@ A sample workflow would look like:
 - Run `elastic-package stack up -d -v`
 - Navigate to the package folder in integrations and run `elastic-package test system -v`
 
+### Re-attempting tests that fail during the setup phase
+
+Failures during the setup phase of a system test (policy creation, agent
+enrollment and assignment, service container startup) are usually caused by
+transient issues in the environment, such as a dropped connection to Kibana or
+a container terminated by the CI runner, and not by problems in the package
+under test.
+
+To reduce the noise caused by these failures, when a system test fails during
+the setup phase, its resources are torn down and the failing test is
+re-attempted from scratch, once by default. The number of re-attempts can be
+adjusted with the `--setup-reattempts` flag, and re-attempts can be disabled
+with `--setup-reattempts=0`.
+
+Failures during data validation (missing documents, field or mapping problems,
+unexpected hit counts) are real test signal and are never re-attempted.
+
+A test that passes only after being re-attempted is still reported as passed,
+but it is annotated as flaky: the failures of the previous attempts are
+reported in a `<flakyFailure>` element in the xUnit report, so the instability
+of the environment remains visible in aggregate.
+
 ### Running system tests without cleanup (technical preview)
 
 By default, `elastic-package test system` command always performs these steps to run tests for a given package:

--- a/docs/howto/system_testing.md
+++ b/docs/howto/system_testing.md
@@ -999,17 +999,20 @@ under test.
 
 To reduce the noise caused by these failures, when a system test fails during
 the setup phase, its resources are torn down and the failing test is
-re-attempted from scratch, once by default. The number of re-attempts can be
-adjusted with the `--setup-reattempts` flag, and re-attempts can be disabled
-with `--setup-reattempts=0`.
+re-attempted from scratch. Setup re-attempts are disabled by default; enable
+them with `--setup-reattempts=N` (maximum 5). For example:
+
+```sh
+elastic-package test system -v --setup-reattempts 1
+```
 
 Failures during data validation (missing documents, field or mapping problems,
 unexpected hit counts) are real test signal and are never re-attempted.
 
-A test that passes only after being re-attempted is still reported as passed,
-but it is annotated as flaky: the failures of the previous attempts are
-reported in a `<flakyFailure>` element in the xUnit report, so the instability
-of the environment remains visible in aggregate.
+A test that passes only after being re-attempted is still reported as passed.
+The failures of the previous attempts are recorded in a `<flakyFailure>`
+element in the xUnit report, so the instability of the environment remains
+visible in aggregate even though the build does not fail.
 
 ### Running system tests without cleanup (technical preview)
 

--- a/internal/cobraext/flags.go
+++ b/internal/cobraext/flags.go
@@ -298,6 +298,9 @@ const (
 	SetupFlagName        = "setup"
 	SetupFlagDescription = "trigger just the setup phase of testing"
 
+	SetupReattemptsFlagName        = "setup-reattempts"
+	SetupReattemptsFlagDescription = "number of times a test that fails during the setup phase is re-attempted from scratch, set to 0 to disable re-attempts"
+
 	TearDownFlagName        = "tear-down"
 	TearDownFlagDescription = "trigger just the tear-down phase of testing"
 

--- a/internal/cobraext/flags.go
+++ b/internal/cobraext/flags.go
@@ -299,7 +299,7 @@ const (
 	SetupFlagDescription = "trigger just the setup phase of testing"
 
 	SetupReattemptsFlagName        = "setup-reattempts"
-	SetupReattemptsFlagDescription = "number of times a test that fails during the setup phase is re-attempted from scratch, set to 0 to disable re-attempts"
+	SetupReattemptsFlagDescription = "number of times a test that fails during the setup phase is re-attempted from scratch (0 disables re-attempts, max 5); can also be set via ELASTIC_PACKAGE_TEST_SETUP_REATTEMPTS env var"
 
 	TearDownFlagName        = "tear-down"
 	TearDownFlagDescription = "trigger just the tear-down phase of testing"

--- a/internal/testrunner/reporters/formats/human.go
+++ b/internal/testrunner/reporters/formats/human.go
@@ -58,6 +58,8 @@ func reportHumanFormat(results []testrunner.TestResult) (string, error) {
 			result = fmt.Sprintf("FAIL: %s", r.FailureMsg)
 		} else if r.Skipped != nil {
 			result = fmt.Sprintf("SKIPPED: %s", r.Skipped.String())
+		} else if r.FlakyMsg != "" {
+			result = fmt.Sprintf("PASS (flaky: %s)", r.FlakyMsg)
 		} else {
 			result = "PASS"
 		}

--- a/internal/testrunner/reporters/formats/human.go
+++ b/internal/testrunner/reporters/formats/human.go
@@ -58,8 +58,6 @@ func reportHumanFormat(results []testrunner.TestResult) (string, error) {
 			result = fmt.Sprintf("FAIL: %s", r.FailureMsg)
 		} else if r.Skipped != nil {
 			result = fmt.Sprintf("SKIPPED: %s", r.Skipped.String())
-		} else if r.FlakyMsg != "" {
-			result = fmt.Sprintf("PASS (flaky: %s)", r.FlakyMsg)
 		} else {
 			result = "PASS"
 		}

--- a/internal/testrunner/reporters/formats/json.go
+++ b/internal/testrunner/reporters/formats/json.go
@@ -28,6 +28,11 @@ type jsonResult struct {
 	Result         string `json:"result"`
 	TimeElapsed    string `json:"time_elapsed"`
 	FailureDetails string `json:"failure_details,omitempty"`
+
+	// FlakyDetails describes the failures of previous attempts of a test
+	// that eventually passed. The result is still reported as PASS; this
+	// mirrors the flakyFailure element of the xUnit format.
+	FlakyDetails string `json:"flaky_details,omitempty"`
 }
 
 func reportJSONFormat(results []testrunner.TestResult) (string, error) {
@@ -47,6 +52,10 @@ func reportJSONFormat(results []testrunner.TestResult) (string, error) {
 
 		if r.FailureMsg != "" {
 			jsonResult.FailureDetails = fmt.Sprintf("%s/%s %s:\n%s\n", r.Package, r.DataStream, r.Name, r.FailureDetails)
+		}
+
+		if r.FlakyMsg != "" {
+			jsonResult.FlakyDetails = r.FlakyMsg
 		}
 
 		var result string

--- a/internal/testrunner/reporters/formats/json.go
+++ b/internal/testrunner/reporters/formats/json.go
@@ -56,8 +56,6 @@ func reportJSONFormat(results []testrunner.TestResult) (string, error) {
 			result = fmt.Sprintf("FAIL: %s", r.FailureMsg)
 		} else if r.Skipped != nil {
 			result = fmt.Sprintf("SKIPPED: %s", r.Skipped)
-		} else if r.FlakyMsg != "" {
-			result = fmt.Sprintf("PASS (flaky: %s)", r.FlakyMsg)
 		} else {
 			result = "PASS"
 		}

--- a/internal/testrunner/reporters/formats/json.go
+++ b/internal/testrunner/reporters/formats/json.go
@@ -56,6 +56,8 @@ func reportJSONFormat(results []testrunner.TestResult) (string, error) {
 			result = fmt.Sprintf("FAIL: %s", r.FailureMsg)
 		} else if r.Skipped != nil {
 			result = fmt.Sprintf("SKIPPED: %s", r.Skipped)
+		} else if r.FlakyMsg != "" {
+			result = fmt.Sprintf("PASS (flaky: %s)", r.FlakyMsg)
 		} else {
 			result = "PASS"
 		}

--- a/internal/testrunner/reporters/formats/json_test.go
+++ b/internal/testrunner/reporters/formats/json_test.go
@@ -1,0 +1,51 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package formats
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-package/internal/testrunner"
+)
+
+func TestReportJSONFormatFlaky(t *testing.T) {
+	results := []testrunner.TestResult{
+		{
+			Name:        "default",
+			Package:     "network_traffic",
+			DataStream:  "dns",
+			TestType:    "system",
+			TimeElapsed: 5 * time.Second,
+			FlakyMsg:    "attempt 1 of 2 failed during setup: service is unhealthy",
+		},
+		{
+			Name:       "other",
+			Package:    "network_traffic",
+			DataStream: "http",
+			TestType:   "system",
+		},
+	}
+
+	report, err := reportJSONFormat(results)
+	require.NoError(t, err)
+
+	var parsed []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(report), &parsed))
+	require.Len(t, parsed, 2)
+
+	// The flaky test is still reported as a plain PASS, with the previous
+	// failures available in a separate field, mirroring the xUnit format.
+	assert.Equal(t, "PASS", parsed[0]["result"])
+	assert.Equal(t, "attempt 1 of 2 failed during setup: service is unhealthy", parsed[0]["flaky_details"])
+
+	// A stable pass carries no flaky details at all.
+	assert.Equal(t, "PASS", parsed[1]["result"])
+	assert.NotContains(t, parsed[1], "flaky_details")
+}

--- a/internal/testrunner/reporters/formats/xunit.go
+++ b/internal/testrunner/reporters/formats/xunit.go
@@ -41,12 +41,19 @@ type testCase struct {
 	ClassName     string  `xml:"classname,attr"`
 	TimeInSeconds float64 `xml:"time,attr"`
 
-	Error   string   `xml:"error,omitempty"`
-	Failure string   `xml:"failure,omitempty"`
-	Skipped *skipped `xml:"skipped,omitempty"`
+	Error        string        `xml:"error,omitempty"`
+	Failure      string        `xml:"failure,omitempty"`
+	Skipped      *skipped      `xml:"skipped,omitempty"`
+	FlakyFailure *flakyFailure `xml:"flakyFailure,omitempty"`
 }
 
 type skipped struct {
+	Message string `xml:"message,attr"`
+}
+
+// flakyFailure reports a failure of a previous attempt of a test that
+// eventually passed, following the schema used by Maven Surefire.
+type flakyFailure struct {
 	Message string `xml:"message,attr"`
 }
 
@@ -102,6 +109,10 @@ func reportXUnitFormat(results []testrunner.TestResult) (string, error) {
 
 		if r.Skipped != nil {
 			c.Skipped = &skipped{r.Skipped.String()}
+		}
+
+		if r.FlakyMsg != "" {
+			c.FlakyFailure = &flakyFailure{Message: r.FlakyMsg}
 		}
 
 		numTests++

--- a/internal/testrunner/reporters/formats/xunit_test.go
+++ b/internal/testrunner/reporters/formats/xunit_test.go
@@ -1,0 +1,42 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package formats
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-package/internal/testrunner"
+)
+
+func TestReportXUnitFormatFlaky(t *testing.T) {
+	results := []testrunner.TestResult{
+		{
+			Name:        "default",
+			Package:     "network_traffic",
+			DataStream:  "dns",
+			TestType:    "system",
+			TimeElapsed: 5 * time.Second,
+			FlakyMsg:    "attempt 1 of 2 failed during setup: service is unhealthy",
+		},
+		{
+			Name:       "other",
+			Package:    "network_traffic",
+			DataStream: "http",
+			TestType:   "system",
+		},
+	}
+
+	report, err := reportXUnitFormat(results)
+	require.NoError(t, err)
+
+	assert.Contains(t, report, `<flakyFailure message="attempt 1 of 2 failed during setup: service is unhealthy"`)
+	// The flaky test is still reported as passed, not as failed or errored.
+	assert.NotContains(t, report, "failures=")
+	assert.NotContains(t, report, "errors=")
+}

--- a/internal/testrunner/runners/system/reattempt_test.go
+++ b/internal/testrunner/runners/system/reattempt_test.go
@@ -1,0 +1,184 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package system
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-package/internal/testrunner"
+)
+
+// attemptOutcome describes what a single test attempt should produce in the
+// stub used by these tests.
+type attemptOutcome struct {
+	result testrunner.TestResult
+	runErr error
+	tdErr  error
+}
+
+func stubAttempts(t *testing.T, outcomes []attemptOutcome, calls *int) func() ([]testrunner.TestResult, error, error) {
+	t.Helper()
+	return func() ([]testrunner.TestResult, error, error) {
+		require.Less(t, *calls, len(outcomes), "more attempts than expected")
+		outcome := outcomes[*calls]
+		*calls++
+		return []testrunner.TestResult{outcome.result}, outcome.runErr, outcome.tdErr
+	}
+}
+
+func TestRunWithSetupReattempts(t *testing.T) {
+	setupErr := errSetupFailed{err: errors.New("service is unhealthy: container exited with code 143")}
+	setupResult := testrunner.TestResult{Name: "test", ErrorMsg: setupErr.Error()}
+	passResult := testrunner.TestResult{Name: "test"}
+	failedResult := testrunner.TestResult{Name: "test", FailureMsg: "could not find the expected hits"}
+
+	cases := []struct {
+		title           string
+		reattempts      int
+		outcomes        []attemptOutcome
+		expectedCalls   int
+		expectedErr     string
+		expectedFlaky   bool
+		expectedResults func(t *testing.T, results []testrunner.TestResult)
+	}{
+		{
+			title:         "pass on first attempt",
+			reattempts:    1,
+			outcomes:      []attemptOutcome{{result: passResult}},
+			expectedCalls: 1,
+		},
+		{
+			title:      "setup failure then pass is marked flaky",
+			reattempts: 1,
+			outcomes: []attemptOutcome{
+				{result: setupResult, runErr: setupErr},
+				{result: passResult},
+			},
+			expectedCalls: 2,
+			expectedFlaky: true,
+		},
+		{
+			title:      "setup failures until attempts are exhausted",
+			reattempts: 2,
+			outcomes: []attemptOutcome{
+				{result: setupResult, runErr: setupErr},
+				{result: setupResult, runErr: setupErr},
+				{result: setupResult, runErr: setupErr},
+			},
+			expectedCalls: 3,
+			expectedResults: func(t *testing.T, results []testrunner.TestResult) {
+				// The last failure is reported as an error entry, without
+				// aborting the run, and it is not marked as flaky.
+				require.Len(t, results, 1)
+				assert.NotEmpty(t, results[0].ErrorMsg)
+				assert.Empty(t, results[0].FlakyMsg)
+			},
+		},
+		{
+			title:      "validation failure is never re-attempted",
+			reattempts: 3,
+			outcomes: []attemptOutcome{
+				{result: failedResult},
+			},
+			expectedCalls: 1,
+		},
+		{
+			title:      "re-attempts disabled",
+			reattempts: 0,
+			outcomes: []attemptOutcome{
+				{result: setupResult, runErr: setupErr},
+			},
+			expectedCalls: 1,
+		},
+		{
+			title:      "hard errors are returned without re-attempt",
+			reattempts: 3,
+			outcomes: []attemptOutcome{
+				{result: passResult, runErr: errors.New("cannot load config")},
+			},
+			expectedCalls: 1,
+			expectedErr:   "cannot load config",
+		},
+		{
+			title:      "no re-attempt if teardown of the failed attempt failed",
+			reattempts: 3,
+			outcomes: []attemptOutcome{
+				{result: setupResult, runErr: setupErr, tdErr: errors.New("could not remove policy")},
+			},
+			expectedCalls: 1,
+			expectedErr:   "failed to tear down runner",
+		},
+		{
+			title:      "teardown failure after passing test is returned",
+			reattempts: 1,
+			outcomes: []attemptOutcome{
+				{result: passResult, tdErr: errors.New("could not remove policy")},
+			},
+			expectedCalls: 1,
+			expectedErr:   "failed to tear down runner",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			var calls int
+			results, err := runWithSetupReattempts(context.Background(), c.reattempts, stubAttempts(t, c.outcomes, &calls))
+
+			assert.Equal(t, c.expectedCalls, calls)
+			if c.expectedErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), c.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if c.expectedResults != nil {
+				c.expectedResults(t, results)
+				return
+			}
+
+			require.Len(t, results, 1)
+			if c.expectedFlaky {
+				assert.NotEmpty(t, results[0].FlakyMsg, "test passing after re-attempts should be marked as flaky")
+			} else {
+				assert.Empty(t, results[0].FlakyMsg)
+			}
+		})
+	}
+}
+
+func TestRunWithSetupReattemptsCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	setupErr := errSetupFailed{err: errors.New("context deadline exceeded")}
+	var calls int
+	attempt := func() ([]testrunner.TestResult, error, error) {
+		calls++
+		cancel() // The context is cancelled while the attempt runs.
+		return []testrunner.TestResult{{Name: "test", ErrorMsg: setupErr.Error()}}, setupErr, nil
+	}
+
+	results, err := runWithSetupReattempts(ctx, 3, attempt)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, calls, "cancelled context should not be re-attempted")
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].FlakyMsg)
+}
+
+func TestErrSetupFailedWrapping(t *testing.T) {
+	cause := errors.New("service is unhealthy")
+	err := fmt.Errorf("attempt failed: %w", errSetupFailed{err: cause})
+
+	var setupErr errSetupFailed
+	require.ErrorAs(t, err, &setupErr)
+	assert.ErrorIs(t, err, cause)
+	assert.Equal(t, cause, setupErr.Unwrap())
+}

--- a/internal/testrunner/runners/system/reattempt_test.go
+++ b/internal/testrunner/runners/system/reattempt_test.go
@@ -106,12 +106,12 @@ func TestRunWithSetupReattempts(t *testing.T) {
 			expectedErr:   "field mismatch",
 		},
 		{
-			// ErrTestCaseFailed from prepareScenario (service exit, no hits found)
-			// is a setup-phase environment failure and must be re-attempted.
-			title:      "prepareScenario ErrTestCaseFailed (service exit) is re-attempted",
+			// Service exit during verifyDataStream is a plain error wrapped as
+			// errSetupFailed (not ErrTestCaseFailed) so it is re-attempted.
+			title:      "service exit during setup is re-attempted",
 			reattempts: 1,
 			outcomes: []attemptOutcome{
-				{result: setupResult, runErr: errSetupFailed{err: testrunner.ErrTestCaseFailed{Reason: "the test service svc unexpectedly exited with code 143"}}},
+				{result: setupResult, runErr: errSetupFailed{err: fmt.Errorf("the test service svc unexpectedly exited with code 143")}},
 				{result: passResult},
 			},
 			expectedCalls: 2,
@@ -135,7 +135,9 @@ func TestRunWithSetupReattempts(t *testing.T) {
 			expectedErr:   "cannot load config",
 		},
 		{
-			title:      "context cancellation from runTest is returned directly without re-attempt",
+			// context.Canceled as a plain (non-errSetupFailed) hard error is
+			// returned immediately without re-attempt.
+			title:      "hard context.Canceled error is returned without re-attempt",
 			reattempts: 3,
 			outcomes: []attemptOutcome{
 				{result: setupResult, runErr: context.Canceled},

--- a/internal/testrunner/runners/system/reattempt_test.go
+++ b/internal/testrunner/runners/system/reattempt_test.go
@@ -83,12 +83,39 @@ func TestRunWithSetupReattempts(t *testing.T) {
 			},
 		},
 		{
-			title:      "validation failure is never re-attempted",
+			// validateTestScenario failures surface as FailureMsg in the result
+			// (nil runErr), not as errSetupFailed, so they are never re-attempted.
+			title:      "validateTestScenario failure (FailureMsg set, nil error) is never re-attempted",
 			reattempts: 3,
 			outcomes: []attemptOutcome{
 				{result: failedResult},
 			},
 			expectedCalls: 1,
+		},
+		{
+			// A bare ErrTestCaseFailed Go error (not wrapped in errSetupFailed) is
+			// treated as a hard error and returned immediately without re-attempt.
+			// validateTestScenario never produces this shape (it uses result.WithError
+			// which returns nil), but the boundary is explicit here for safety.
+			title:      "bare ErrTestCaseFailed Go error is a hard error, not re-attempted",
+			reattempts: 3,
+			outcomes: []attemptOutcome{
+				{result: failedResult, runErr: testrunner.ErrTestCaseFailed{Reason: "field mismatch"}},
+			},
+			expectedCalls: 1,
+			expectedErr:   "field mismatch",
+		},
+		{
+			// ErrTestCaseFailed from prepareScenario (service exit, no hits found)
+			// is a setup-phase environment failure and must be re-attempted.
+			title:      "prepareScenario ErrTestCaseFailed (service exit) is re-attempted",
+			reattempts: 1,
+			outcomes: []attemptOutcome{
+				{result: setupResult, runErr: errSetupFailed{err: testrunner.ErrTestCaseFailed{Reason: "the test service svc unexpectedly exited with code 143"}}},
+				{result: passResult},
+			},
+			expectedCalls: 2,
+			expectedFlaky: true,
 		},
 		{
 			title:      "re-attempts disabled",

--- a/internal/testrunner/runners/system/reattempt_test.go
+++ b/internal/testrunner/runners/system/reattempt_test.go
@@ -108,6 +108,15 @@ func TestRunWithSetupReattempts(t *testing.T) {
 			expectedErr:   "cannot load config",
 		},
 		{
+			title:      "context cancellation from runTest is returned directly without re-attempt",
+			reattempts: 3,
+			outcomes: []attemptOutcome{
+				{result: setupResult, runErr: context.Canceled},
+			},
+			expectedCalls: 1,
+			expectedErr:   "context canceled",
+		},
+		{
 			title:      "no re-attempt if teardown of the failed attempt failed",
 			reattempts: 3,
 			outcomes: []attemptOutcome{

--- a/internal/testrunner/runners/system/reattempt_test.go
+++ b/internal/testrunner/runners/system/reattempt_test.go
@@ -106,12 +106,12 @@ func TestRunWithSetupReattempts(t *testing.T) {
 			expectedErr:   "field mismatch",
 		},
 		{
-			// Service exit during verifyDataStream is a plain error wrapped as
-			// errSetupFailed (not ErrTestCaseFailed) so it is re-attempted.
+			// Service exit during verifyDataStream is classified by runTest as
+			// errSetupFailed (see setupReattemptError) so it is re-attempted.
 			title:      "service exit during setup is re-attempted",
 			reattempts: 1,
 			outcomes: []attemptOutcome{
-				{result: setupResult, runErr: errSetupFailed{err: fmt.Errorf("the test service svc unexpectedly exited with code 143")}},
+				{result: setupResult, runErr: errSetupFailed{err: errServiceExited{err: testrunner.ErrTestCaseFailed{Reason: "the test service svc unexpectedly exited with code 143"}}}},
 				{result: passResult},
 			},
 			expectedCalls: 2,
@@ -219,4 +219,50 @@ func TestErrSetupFailedWrapping(t *testing.T) {
 	require.ErrorAs(t, err, &setupErr)
 	assert.ErrorIs(t, err, cause)
 	assert.Equal(t, cause, setupErr.Unwrap())
+}
+
+func TestSetupReattemptError(t *testing.T) {
+	serviceExited := errServiceExited{err: testrunner.ErrTestCaseFailed{Reason: "the test service failing unexpectedly exited with code 1"}}
+
+	cases := []struct {
+		title       string
+		err         error
+		reattempted bool
+	}{
+		{"environment error", errors.New("service is unhealthy: container exited with code 143"), true},
+		{"wrapped environment error", fmt.Errorf("can't check enrolled agents: %w", context.DeadlineExceeded), true},
+		{"service exited", serviceExited, true},
+		{"wrapped service exited", fmt.Errorf("finalize: %w", serviceExited), true},
+		{"no hits found", testrunner.ErrTestCaseFailed{Reason: "could not find the expected hits in logs-foo data stream"}, false},
+		{"wrapped test case failure", fmt.Errorf("finalize: %w", testrunner.ErrTestCaseFailed{Reason: "no data streams matching logs-foo-* appeared"}), false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			err := setupReattemptError(c.err)
+			if !c.reattempted {
+				assert.NoError(t, err, "test signal must not be re-attempted")
+				return
+			}
+			var setupErr errSetupFailed
+			require.ErrorAs(t, err, &setupErr, "environment failures must be marked for re-attempt")
+			assert.Equal(t, c.err, setupErr.Unwrap())
+		})
+	}
+}
+
+// TestServiceExitedReportedAsFailure guards the reporting contract checked by
+// the docker_failing_test_service false-positive test: a service exiting
+// unexpectedly is still a test case failure (xUnit <failure>) with the same
+// message as before, even though it is now re-attemptable.
+func TestServiceExitedReportedAsFailure(t *testing.T) {
+	err := errServiceExited{err: testrunner.ErrTestCaseFailed{Reason: "the test service failing unexpectedly exited with code 1"}}
+
+	result := testrunner.NewResultComposer(testrunner.TestResult{Name: "fail"})
+	results, resultErr := result.WithError(err)
+	require.NoError(t, resultErr)
+	require.Len(t, results, 1)
+
+	assert.Equal(t, "test case failed: the test service failing unexpectedly exited with code 1", results[0].FailureMsg)
+	assert.Empty(t, results[0].ErrorMsg)
 }

--- a/internal/testrunner/runners/system/runner.go
+++ b/internal/testrunner/runners/system/runner.go
@@ -41,6 +41,7 @@ type runner struct {
 	globalTestConfig   testrunner.GlobalRunnerTestConfig
 	failOnMissingTests bool
 	deferCleanup       time.Duration
+	setupReattempts    int
 	generateTestResult bool
 	withCoverage       bool
 	coverageType       string
@@ -83,6 +84,7 @@ type SystemTestRunnerOptions struct {
 	FailOnMissingTests     bool
 	GenerateTestResult     bool
 	DeferCleanup           time.Duration
+	SetupReattempts        int
 	WithCoverage           bool
 	CoverageType           string
 	RequiredInputsResolver requiredinputs.Resolver
@@ -105,6 +107,7 @@ func NewSystemTestRunner(options SystemTestRunnerOptions) *runner {
 		failOnMissingTests:     options.FailOnMissingTests,
 		generateTestResult:     options.GenerateTestResult,
 		deferCleanup:           options.DeferCleanup,
+		setupReattempts:        options.SetupReattempts,
 		globalTestConfig:       options.GlobalTestConfig,
 		withCoverage:           options.WithCoverage,
 		coverageType:           options.CoverageType,
@@ -270,6 +273,7 @@ func (r *runner) GetTests(ctx context.Context) ([]testrunner.Tester, error) {
 					ServiceVariant:       variant,
 					GenerateTestResult:   r.generateTestResult,
 					DeferCleanup:         r.deferCleanup,
+					SetupReattempts:      r.setupReattempts,
 					RunSetup:             r.runSetup,
 					RunTestsOnly:         r.runTestsOnly,
 					RunTearDown:          r.runTearDown,

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -216,9 +216,10 @@ type tester struct {
 
 	fieldValidationMethod fieldValidationMethod
 
-	deferCleanup   time.Duration
-	serviceVariant string
-	configFileName string
+	deferCleanup    time.Duration
+	serviceVariant  string
+	configFileName  string
+	setupReattempts int
 
 	runSetup     bool
 	runTearDown  bool
@@ -273,6 +274,11 @@ type SystemTesterOptions struct {
 	WithCoverage     bool
 	CoverageType     string
 
+	// SetupReattempts is the number of times a test is re-attempted, from
+	// scratch, if it fails during the setup phase. Failures during data
+	// validation are never re-attempted.
+	SetupReattempts int
+
 	RunSetup     bool
 	RunTearDown  bool
 	RunTestsOnly bool
@@ -291,6 +297,7 @@ func NewSystemTester(options SystemTesterOptions) (*tester, error) {
 		deferCleanup:               options.DeferCleanup,
 		serviceVariant:             options.ServiceVariant,
 		configFileName:             options.ConfigFileName,
+		setupReattempts:            max(0, options.SetupReattempts),
 		runSetup:                   options.RunSetup,
 		runTestsOnly:               options.RunTestsOnly,
 		runTearDown:                options.RunTearDown,
@@ -733,30 +740,90 @@ func (r *tester) run(ctx context.Context, stackConfig stack.Config) (results []t
 	return results, nil
 }
 
+// errSetupFailed marks failures that happen while preparing the test scenario
+// (policy creation, agent enrollment and assignment, service startup), before
+// any data validation takes place. These failures are usually caused by
+// transient issues in the environment, so tests failing this way can be
+// re-attempted.
+type errSetupFailed struct {
+	err error
+}
+
+func (e errSetupFailed) Error() string {
+	return fmt.Sprintf("test setup failed: %v", e.err)
+}
+
+func (e errSetupFailed) Unwrap() error {
+	return e.err
+}
+
 func (r *tester) runTestPerVariant(ctx context.Context, stackConfig stack.Config, result *testrunner.ResultComposer, cfgFile, variantName string) ([]testrunner.TestResult, error) {
-	svcInfo, err := r.createServiceInfo()
-	if err != nil {
-		return result.WithError(err)
-	}
+	attempt := func() (partial []testrunner.TestResult, runErr, tdErr error) {
+		svcInfo, err := r.createServiceInfo()
+		if err != nil {
+			partial, err := result.WithError(err)
+			return partial, err, nil
+		}
 
-	configFile := filepath.Join(r.testFolder.Path, cfgFile)
-	testConfig, err := newConfig(configFile, svcInfo, variantName)
-	if err != nil {
-		return nil, fmt.Errorf("unable to load system test case file '%s': %w", configFile, err)
-	}
-	logger.Debugf("Using config: %q", testConfig.Name())
+		configFile := filepath.Join(r.testFolder.Path, cfgFile)
+		testConfig, err := newConfig(configFile, svcInfo, variantName)
+		if err != nil {
+			return nil, fmt.Errorf("unable to load system test case file '%s': %w", configFile, err), nil
+		}
+		logger.Debugf("Using config: %q", testConfig.Name())
 
-	partial, err := r.runTest(ctx, testConfig, stackConfig, svcInfo)
+		partial, err = r.runTest(ctx, testConfig, stackConfig, svcInfo)
 
-	skipDeferCleanup := len(partial) > 0 && partial[0].Skipped != nil
-	tdErr := r.tearDownTest(ctx, skipDeferCleanup)
-	if err != nil {
-		return partial, err
+		skipDeferCleanup := len(partial) > 0 && partial[0].Skipped != nil
+		return partial, err, r.tearDownTest(ctx, skipDeferCleanup)
 	}
-	if tdErr != nil {
-		return partial, fmt.Errorf("failed to tear down runner: %w", tdErr)
+	return runWithSetupReattempts(ctx, r.setupReattempts, attempt)
+}
+
+// runWithSetupReattempts runs a test attempt and, if it fails during the setup
+// phase, tears it down and re-attempts it from scratch up to the given number
+// of re-attempts. A test that eventually passes is annotated as flaky, so the
+// instability remains visible even if it doesn't fail the run anymore.
+func runWithSetupReattempts(ctx context.Context, reattempts int, attempt func() (partial []testrunner.TestResult, runErr, tdErr error)) ([]testrunner.TestResult, error) {
+	maxAttempts := 1 + reattempts
+	var setupFailures []string
+	for attemptNum := 1; ; attemptNum++ {
+		partial, err, tdErr := attempt()
+
+		var setupErr errSetupFailed
+		if errors.As(err, &setupErr) {
+			// Setup failures are already reported as part of the test results,
+			// they are not returned as hard errors to the caller.
+			err = nil
+
+			// Re-attempt the test from scratch, but only if the failure didn't
+			// come from a cancellation and the previous attempt could be torn
+			// down, so the new attempt starts from a clean environment.
+			if attemptNum < maxAttempts && ctx.Err() == nil && tdErr == nil {
+				failure := fmt.Sprintf("attempt %d of %d failed during setup: %v", attemptNum, maxAttempts, setupErr.Unwrap())
+				setupFailures = append(setupFailures, failure)
+				logger.Warnf("re-attempting test (%s)", failure)
+				continue
+			}
+		}
+		if err != nil {
+			return partial, err
+		}
+		if tdErr != nil {
+			return partial, fmt.Errorf("failed to tear down runner: %w", tdErr)
+		}
+
+		// If the test finally passed after failing setup in previous attempts,
+		// keep the flakiness visible in the results.
+		if len(setupFailures) > 0 && len(partial) > 0 && testPassed(partial[0]) {
+			partial[0].FlakyMsg = strings.Join(setupFailures, "; ")
+		}
+		return partial, nil
 	}
-	return partial, nil
+}
+
+func testPassed(result testrunner.TestResult) bool {
+	return result.ErrorMsg == "" && result.FailureMsg == "" && result.Skipped == nil
 }
 
 func isSyntheticSourceModeEnabled(ctx context.Context, api *elasticsearch.API, dataStreamName string) (bool, error) {
@@ -2120,7 +2187,16 @@ func (r *tester) runTest(ctx context.Context, config *testConfig, stackConfig st
 		}
 		// report all other errors as error entries in the xUnit file
 		results, _ := result.WithError(err)
-		return results, nil
+
+		// Test case failures (e.g. expected documents did not arrive) are
+		// real test signal, never re-attempted. Any other error during the
+		// preparation of the scenario is considered an environment issue and
+		// returned as a sentinel error so the caller can re-attempt the test.
+		var tcf testrunner.ErrTestCaseFailed
+		if errors.As(err, &tcf) {
+			return results, nil
+		}
+		return results, errSetupFailed{err: err}
 	}
 
 	if dump, ok := os.LookupEnv(dumpScenarioDocsEnv); ok && dump != "" {

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -1247,7 +1247,7 @@ func (r *tester) verifyDataStream(ctx context.Context, config *testConfig, servi
 			return err
 		}
 		if exited && code > 0 {
-			return testrunner.ErrTestCaseFailed{Reason: fmt.Sprintf("the test service %s unexpectedly exited with code %d", config.Service, code)}
+			return fmt.Errorf("the test service %s unexpectedly exited with code %d", config.Service, code)
 		}
 	}
 
@@ -2188,15 +2188,18 @@ func (r *tester) runTest(ctx context.Context, config *testConfig, stackConfig st
 		// report all other errors as error entries in the xUnit file
 		results, _ := result.WithError(err)
 
-		// All errors from prepareScenario are environment issues and should be
-		// re-attempted. Note: ErrTestCaseFailed can reach here from
-		// verifyDataStream (service exited non-zero) or waitForDocs (no hits
-		// within the timeout), both of which are setup-phase events.
+		// ErrTestCaseFailed from prepareScenario (e.g. waitForDocs timeout:
+		// no hits, assert.hit_count/min_count/fields_present not satisfied;
+		// or no data streams discovered) is real test signal that should not
+		// be re-attempted. The service-exit case that used to return
+		// ErrTestCaseFailed was changed to a plain error above so it goes
+		// through errSetupFailed and is retried as an environment failure.
 		// validateTestScenario failures are never returned as Go errors — they
 		// are captured in result.FailureMsg via result.WithError — so there is
-		// no validation signal to guard against here.
-		if ctx.Err() != nil {
-			return results, ctx.Err()
+		// no risk of retrying real validation failures here.
+		var tcf testrunner.ErrTestCaseFailed
+		if errors.As(err, &tcf) {
+			return results, nil
 		}
 		return results, errSetupFailed{err: err}
 	}

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -2196,6 +2196,9 @@ func (r *tester) runTest(ctx context.Context, config *testConfig, stackConfig st
 		if errors.As(err, &tcf) {
 			return results, nil
 		}
+		if ctx.Err() != nil {
+			return results, ctx.Err()
+		}
 		return results, errSetupFailed{err: err}
 	}
 

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -696,9 +696,10 @@ func (r *tester) newResult(name string) *testrunner.ResultComposer {
 func (r *tester) run(ctx context.Context, stackConfig stack.Config) (results []testrunner.TestResult, err error) {
 	result := r.newResult("(init)")
 
-	startTesting := time.Now()
-
-	results, err = r.runTestPerVariant(ctx, stackConfig, result, r.configFileName, r.serviceVariant)
+	// startTesting is the start of the last attempt of the test, so the agent
+	// logs check below doesn't consider logs from previous failed attempts.
+	var startTesting time.Time
+	results, startTesting, err = r.runTestPerVariant(ctx, stackConfig, result, r.configFileName, r.serviceVariant)
 	if err != nil {
 		return results, err
 	}
@@ -757,8 +758,15 @@ func (e errSetupFailed) Unwrap() error {
 	return e.err
 }
 
-func (r *tester) runTestPerVariant(ctx context.Context, stackConfig stack.Config, result *testrunner.ResultComposer, cfgFile, variantName string) ([]testrunner.TestResult, error) {
+// runTestPerVariant runs the test for the given config file and variant,
+// re-attempting it if it fails during setup. It also returns the time when the
+// last attempt started, so callers only inspect logs produced by that attempt
+// and not by previous, already torn down, failed attempts.
+func (r *tester) runTestPerVariant(ctx context.Context, stackConfig stack.Config, result *testrunner.ResultComposer, cfgFile, variantName string) ([]testrunner.TestResult, time.Time, error) {
+	var startTesting time.Time
 	attempt := func() (partial []testrunner.TestResult, runErr, tdErr error) {
+		startTesting = time.Now()
+
 		svcInfo, err := r.createServiceInfo()
 		if err != nil {
 			partial, err := result.WithError(err)
@@ -777,7 +785,8 @@ func (r *tester) runTestPerVariant(ctx context.Context, stackConfig stack.Config
 		skipDeferCleanup := len(partial) > 0 && partial[0].Skipped != nil
 		return partial, err, r.tearDownTest(ctx, skipDeferCleanup)
 	}
-	return runWithSetupReattempts(ctx, r.setupReattempts, attempt)
+	results, err := runWithSetupReattempts(ctx, r.setupReattempts, attempt)
+	return results, startTesting, err
 }
 
 // runWithSetupReattempts runs a test attempt and, if it fails during the setup

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -2188,14 +2188,13 @@ func (r *tester) runTest(ctx context.Context, config *testConfig, stackConfig st
 		// report all other errors as error entries in the xUnit file
 		results, _ := result.WithError(err)
 
-		// Test case failures (e.g. expected documents did not arrive) are
-		// real test signal, never re-attempted. Any other error during the
-		// preparation of the scenario is considered an environment issue and
-		// returned as a sentinel error so the caller can re-attempt the test.
-		var tcf testrunner.ErrTestCaseFailed
-		if errors.As(err, &tcf) {
-			return results, nil
-		}
+		// All errors from prepareScenario are environment issues and should be
+		// re-attempted. Note: ErrTestCaseFailed can reach here from
+		// verifyDataStream (service exited non-zero) or waitForDocs (no hits
+		// within the timeout), both of which are setup-phase events.
+		// validateTestScenario failures are never returned as Go errors — they
+		// are captured in result.FailureMsg via result.WithError — so there is
+		// no validation signal to guard against here.
 		if ctx.Err() != nil {
 			return results, ctx.Err()
 		}

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -758,6 +758,46 @@ func (e errSetupFailed) Unwrap() error {
 	return e.err
 }
 
+// errServiceExited marks a test service that exited with a non-zero code
+// while waiting for data. It unwraps to an ErrTestCaseFailed so it keeps
+// being reported as a test case failure, as it has always been, but it is
+// classified as a setup-phase environment failure for re-attempt purposes.
+type errServiceExited struct {
+	err testrunner.ErrTestCaseFailed
+}
+
+func (e errServiceExited) Error() string {
+	return e.err.Error()
+}
+
+func (e errServiceExited) Unwrap() error {
+	return e.err
+}
+
+// setupReattemptError classifies an error returned by prepareScenario. It
+// returns errSetupFailed when the test can be re-attempted, and nil when the
+// error is real test signal that must only be reported in the results.
+//
+// ErrTestCaseFailed from prepareScenario (e.g. waitForDocs timeout: no hits,
+// assert.hit_count/min_count/fields_present not satisfied; or no data streams
+// discovered) is never re-attempted. The only exception is the test service
+// exiting unexpectedly (errServiceExited), which is an environment failure.
+//
+// validateTestScenario failures are never returned as Go errors, they are
+// captured in result.FailureMsg via result.WithError, so there is no risk of
+// re-attempting real validation failures here.
+func setupReattemptError(err error) error {
+	var svcExited errServiceExited
+	if errors.As(err, &svcExited) {
+		return errSetupFailed{err: err}
+	}
+	var tcf testrunner.ErrTestCaseFailed
+	if errors.As(err, &tcf) {
+		return nil
+	}
+	return errSetupFailed{err: err}
+}
+
 // runTestPerVariant runs the test for the given config file and variant,
 // re-attempting it if it fails during setup. It also returns the time when the
 // last attempt started, so callers only inspect logs produced by that attempt
@@ -1256,7 +1296,7 @@ func (r *tester) verifyDataStream(ctx context.Context, config *testConfig, servi
 			return err
 		}
 		if exited && code > 0 {
-			return fmt.Errorf("the test service %s unexpectedly exited with code %d", config.Service, code)
+			return errServiceExited{err: testrunner.ErrTestCaseFailed{Reason: fmt.Sprintf("the test service %s unexpectedly exited with code %d", config.Service, code)}}
 		}
 	}
 
@@ -2194,23 +2234,11 @@ func (r *tester) runTest(ctx context.Context, config *testConfig, stackConfig st
 		if errors.As(err, &pathErr) && pathErr.Op == "fork/exec" && pathErr.Path == "/usr/bin/docker" {
 			return result.WithError(err)
 		}
-		// report all other errors as error entries in the xUnit file
+		// Report all other errors as failure or error entries in the xUnit
+		// file, exactly as before, and let the caller know whether the test
+		// can be re-attempted.
 		results, _ := result.WithError(err)
-
-		// ErrTestCaseFailed from prepareScenario (e.g. waitForDocs timeout:
-		// no hits, assert.hit_count/min_count/fields_present not satisfied;
-		// or no data streams discovered) is real test signal that should not
-		// be re-attempted. The service-exit case that used to return
-		// ErrTestCaseFailed was changed to a plain error above so it goes
-		// through errSetupFailed and is retried as an environment failure.
-		// validateTestScenario failures are never returned as Go errors — they
-		// are captured in result.FailureMsg via result.WithError — so there is
-		// no risk of retrying real validation failures here.
-		var tcf testrunner.ErrTestCaseFailed
-		if errors.As(err, &tcf) {
-			return results, nil
-		}
-		return results, errSetupFailed{err: err}
+		return results, setupReattemptError(err)
 	}
 
 	if dump, ok := os.LookupEnv(dumpScenarioDocsEnv); ok && dump != "" {

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -117,6 +117,11 @@ type TestResult struct {
 	// to an unexpected runtime error in the test execution.
 	ErrorMsg string
 
+	// If the test passed only after being re-attempted, description of the
+	// failures observed in previous attempts. The test is reported as
+	// passed, but flagged as flaky in reports that support it.
+	FlakyMsg string
+
 	// If the test was skipped, the reason it was skipped and a link for more
 	// details.
 	Skipped *SkipConfig


### PR DESCRIPTION
```
System test runner: re-attempt tests that fail during the setup phase

When a system test fails during setup (policy creation, agent enrollment
and assignment, service container startup), the cause is usually a
transient environment issue such as a dropped connection to Kibana, a
container killed by the CI runner, or a slow Fleet response, not a
problem in the package under test. Today these failures are terminal:
the build fails, a flaky-test issue is auto-filed, and a human triages
what turns out to be infrastructure noise.

Add an opt-in setup re-attempt to the system test runner. When
prepareScenario fails with an environment error, the attempt is torn
down and the single failing test config is re-attempted from scratch,
with a fresh service run ID and config, up to the configured number of
times.

Scope, deliberately strict:

- Setup-phase environment errors only. Failures reported as
  ErrTestCaseFailed from prepareScenario (no documents within the
  wait-for-data timeout, assert.hit_count / min_count / fields_present
  not satisfied, no data streams discovered) are real test signal and
  are never re-attempted. Data validation in validateTestScenario never
  surfaces as a Go error, so it cannot trigger a re-attempt either.
- The one exception is the test service exiting with a non-zero code
  while waiting for documents. It is marked with errServiceExited so it
  is re-attempted as an environment failure, while still unwrapping to
  ErrTestCaseFailed so it keeps being reported as a test case failure
  (xUnit <failure>) with the same message as before. The
  docker_failing_test_service false-positive test guards this.
- Each attempt is fully torn down before the next one starts. No
  re-attempt happens if the context was cancelled or if the teardown of
  the failed attempt returned an error.
- Context cancellation during setup is captured in the result as on
  main, so the <error> entry is preserved and post-processing continues
  without re-attempting.
- The agent logs check after the run uses the start time of the last
  attempt, so logs from torn-down attempts are not scanned.
- The --setup, --no-provision and --tear-down workflows are unchanged.

Configuration:

- --setup-reattempts N on `elastic-package test system`, default 0
  (disabled), maximum 5.
- ELASTIC_PACKAGE_TEST_SETUP_REATTEMPTS env var as an alternative, so CI
  can enable it without changing scripts. The flag takes precedence.

Reporting:

- Tests passing only after a re-attempt are reported as a plain PASS in
  the human and JSON formats, keeping the result values standard for
  Buildkite and the flaky-test automation.
- The failures of the previous attempts are kept for aggregation in a
  new FlakyMsg field on TestResult, emitted as a <flakyFailure> element
  in xUnit and a flaky_details field in JSON.
- Tests exhausting all attempts are reported exactly as a single failed
  attempt is today.

Also adds unit tests for the re-attempt policy, the error
classification and the reporters, and a section in the system testing
HOWTO.

Closes #3888

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
```

Closes #3888