### PR TITLE
[CI] Reorder release step to run in parallel with tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,7 +39,7 @@ steps:
     agents:
       provider: "gcp"
     plugins:
-      # required to create Github releases
+      # required to create GitHub releases
       - elastic/vault-github-token#v0.1.0:
 
   - group: ":go: Run Unit tests"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,6 +31,17 @@ steps:
       cpu: "8"
       memory: "4G"
 
+  - label: ":github: Release"
+    key: "release"
+    if: |
+      build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
+    command: ".buildkite/scripts/release.sh"
+    agents:
+      provider: "gcp"
+    plugins:
+      # required to create Github releases
+      - elastic/vault-github-token#v0.1.0:
+
   - group: ":go: Run Unit tests"
     key: unit-tests
     steps:
@@ -116,14 +127,3 @@ steps:
           report-skipped: true
           always-annotate: true
           run-in-docker: false
-
-  - label: ":github: Release"
-    key: "release"
-    if: |
-      build.tag =~ /^v[0-9]+[.][0-9]+[.][0-9]+$$/
-    command: ".buildkite/scripts/release.sh"
-    agents:
-      provider: "gcp"
-    plugins:
-      # required to create Github releases
-      - elastic/vault-github-token#v0.1.0:


### PR DESCRIPTION
## Summary

The Buildkite release step was positioned at the end of the pipeline, after all test steps, and relied on `wait: continue_on_failure: true` barriers to ensure it would always be reached even when tests failed.

This PR moves the release step to the beginning of the pipeline so it runs in parallel with the test steps, making it independent of their outcome by design rather than by barrier configuration. As a side effect, running the release step in parallel with the tests reduces the overall build time.

## Proposed commit

```
[CI] Reorder release step

Previously, the release step was running at the end of the pipeline after
all test steps finished (with failure or success), relying on
`continue_on_failure: true` barriers to always reach it. This change
moves the release step to the beginning so it runs in parallel with
the test steps, independently of their outcome.
```

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).