### PR TITLE
lint(gocritic): enable exitAfterDefer check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
       disable-all: true
       enabled-checks:
         - appendAssign
+        - exitAfterDefer
         - offBy1
 
         # Enabled for the custom rules below.

--- a/internal/registry/gpgkey/fetch/main.go
+++ b/internal/registry/gpgkey/fetch/main.go
@@ -67,11 +67,12 @@ func fetchKey(url string) ([]byte, string) {
 	if err != nil {
 		log.Fatalf("GET %s: %v", url, err)
 	}
-	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close() // log.Fatalf exits the process; defer would not run.
 		log.Fatalf("GET %s: unexpected status %d", url, resp.StatusCode)
 	}
 	data, err := io.ReadAll(resp.Body)
+	resp.Body.Close() // both log.Fatalf (exit) and normal return are below; defer would not run.
 	if err != nil {
 		log.Fatalf("reading response body: %v", err)
 	}

--- a/internal/registry/gpgkey/fetch/main.go
+++ b/internal/registry/gpgkey/fetch/main.go
@@ -35,7 +35,10 @@ func main() {
 	oldFingerprint := readCurrentFingerprint(keyFileName)
 
 	log.Printf("Fetching key from %s ...", upstreamKeyURL)
-	keyBytes, newFingerprint := fetchKey(upstreamKeyURL)
+	keyBytes, newFingerprint, err := fetchKey(upstreamKeyURL)
+	if err != nil {
+		log.Fatalf("fetching key: %v", err)
+	}
 
 	if err := os.WriteFile(keyFileName, keyBytes, 0o644); err != nil {
 		log.Fatalf("writing %s: %v", keyFileName, err)
@@ -62,31 +65,34 @@ func main() {
 
 // fetchKey downloads the armored GPG key from url, validates it parses as an
 // OpenPGP public key, and returns the raw bytes and its fingerprint.
-func fetchKey(url string) ([]byte, string) {
+func fetchKey(url string) ([]byte, string, error) {
 	resp, err := http.Get(url) //nolint:noctx
 	if err != nil {
-		log.Fatalf("GET %s: %v", url, err)
+		return nil, "", fmt.Errorf("GET %s: %w", url, err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close() // log.Fatalf exits the process; defer would not run.
-		log.Fatalf("GET %s: unexpected status %d", url, resp.StatusCode)
+		return nil, "", fmt.Errorf("GET %s: unexpected status %d", url, resp.StatusCode)
 	}
 	data, err := io.ReadAll(resp.Body)
-	resp.Body.Close() // both log.Fatalf (exit) and normal return are below; defer would not run.
 	if err != nil {
-		log.Fatalf("reading response body: %v", err)
+		return nil, "", fmt.Errorf("reading response body: %w", err)
 	}
-	return data, mustFingerprint(data)
+	fp, err := fingerprint(data)
+	if err != nil {
+		return nil, "", err
+	}
+	return data, fp, nil
 }
 
-// mustFingerprint parses keyBytes as an armored OpenPGP public key and returns
-// the primary key fingerprint. Calls log.Fatal on any parse error.
-func mustFingerprint(keyBytes []byte) string {
+// fingerprint parses keyBytes as an armored OpenPGP public key and returns
+// the primary key fingerprint.
+func fingerprint(keyBytes []byte) (string, error) {
 	key, err := crypto.NewKeyFromArmored(string(keyBytes))
 	if err != nil {
-		log.Fatalf("parsing GPG key: %v", err)
+		return "", fmt.Errorf("parsing GPG key: %w", err)
 	}
-	return strings.ToUpper(key.GetFingerprint())
+	return strings.ToUpper(key.GetFingerprint()), nil
 }
 
 // readCurrentFingerprint returns the fingerprint of the key currently stored

--- a/tools/readme/main.go
+++ b/tools/readme/main.go
@@ -99,8 +99,10 @@ func generateReadme(readmeTmpl *template.Template, cmdsDoc string) {
 	// process, so a deferred close would never run.
 	r := readmeVars{cmdsDoc}
 	if err := readmeTmpl.Execute(readme, r); err != nil {
-		readme.Close()
+		_ = readme.Close()
 		log.Fatalf("Writing README file %s failed: %v", readmePath, err)
 	}
-	readme.Close()
+	if err := readme.Close(); err != nil {
+		log.Fatalf("Closing README file %s failed: %v", readmePath, err)
+	}
 }

--- a/tools/readme/main.go
+++ b/tools/readme/main.go
@@ -95,8 +95,8 @@ func generateReadme(readmeTmpl *template.Template, cmdsDoc string) {
 	if err != nil {
 		log.Fatalf("Opening README file %s failed: %v", readmePath, err)
 	}
-	// Close readme explicitly instead of using defer: log.Fatalf exits the
-	// process, so a deferred close would never run.
+	// Close readme explicitly (no defer) because this function may call log.Fatalf,
+	// which exits the process and skips deferred calls.
 	r := readmeVars{cmdsDoc}
 	if err := readmeTmpl.Execute(readme, r); err != nil {
 		_ = readme.Close()

--- a/tools/readme/main.go
+++ b/tools/readme/main.go
@@ -95,10 +95,12 @@ func generateReadme(readmeTmpl *template.Template, cmdsDoc string) {
 	if err != nil {
 		log.Fatalf("Opening README file %s failed: %v", readmePath, err)
 	}
-	defer readme.Close()
-
+	// Close readme explicitly instead of using defer: log.Fatalf exits the
+	// process, so a deferred close would never run.
 	r := readmeVars{cmdsDoc}
 	if err := readmeTmpl.Execute(readme, r); err != nil {
+		readme.Close()
 		log.Fatalf("Writing README file %s failed: %v", readmePath, err)
 	}
+	readme.Close()
 }

--- a/tools/readme/main.go
+++ b/tools/readme/main.go
@@ -99,7 +99,7 @@ func generateReadme(readmeTmpl *template.Template, cmdsDoc string) (err error) {
 	}
 	defer func() {
 		if cerr := readme.Close(); cerr != nil && err == nil {
-			err = cerr
+			err = fmt.Errorf("closing README file %s: %w", readmePath, cerr)
 		}
 	}()
 

--- a/tools/readme/main.go
+++ b/tools/readme/main.go
@@ -104,7 +104,7 @@ func generateReadme(readmeTmpl *template.Template, cmdsDoc string) (err error) {
 	}()
 
 	r := readmeVars{cmdsDoc}
-	if err := readmeTmpl.Execute(readme, r); err != nil {
+	if err = readmeTmpl.Execute(readme, r); err != nil {
 		return fmt.Errorf("writing README file %s: %w", readmePath, err)
 	}
 	return nil

--- a/tools/readme/main.go
+++ b/tools/readme/main.go
@@ -22,7 +22,9 @@ func main() {
 	commandsDoc := generateCommandsDoc(commandTemplate, subCommandTemplate)
 
 	readmeTemplate := loadReadmeTemplate()
-	generateReadme(readmeTemplate, commandsDoc.String())
+	if err := generateReadme(readmeTemplate, commandsDoc.String()); err != nil {
+		log.Fatalf("generating README: %v", err)
+	}
 
 	fmt.Println("README.md successfully written")
 }
@@ -85,24 +87,25 @@ func loadReadmeTemplate() *template.Template {
 	return readmeTmpl
 }
 
-func generateReadme(readmeTmpl *template.Template, cmdsDoc string) {
+func generateReadme(readmeTmpl *template.Template, cmdsDoc string) (err error) {
 	readmePath, err := filepath.Abs("../../README.md")
 	if err != nil {
-		log.Fatalf("Creating README absolute file path failed: %v", err)
+		return fmt.Errorf("creating README absolute file path: %w", err)
 	}
 
-	readme, err := os.OpenFile(readmePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	readme, err := os.OpenFile(readmePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
-		log.Fatalf("Opening README file %s failed: %v", readmePath, err)
+		return fmt.Errorf("opening README file %s: %w", readmePath, err)
 	}
-	// Close readme explicitly (no defer) because this function may call log.Fatalf,
-	// which exits the process and skips deferred calls.
+	defer func() {
+		if cerr := readme.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
 	r := readmeVars{cmdsDoc}
 	if err := readmeTmpl.Execute(readme, r); err != nil {
-		_ = readme.Close()
-		log.Fatalf("Writing README file %s failed: %v", readmePath, err)
+		return fmt.Errorf("writing README file %s: %w", readmePath, err)
 	}
-	if err := readme.Close(); err != nil {
-		log.Fatalf("Closing README file %s failed: %v", readmePath, err)
-	}
+	return nil
 }

--- a/tools/readme/main.go
+++ b/tools/readme/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -98,9 +99,11 @@ func generateReadme(readmeTmpl *template.Template, cmdsDoc string) (err error) {
 		return fmt.Errorf("opening README file %s: %w", readmePath, err)
 	}
 	defer func() {
-		if cerr := readme.Close(); cerr != nil && err == nil {
-			err = fmt.Errorf("closing README file %s: %w", readmePath, cerr)
+		cerr := readme.Close()
+		if cerr != nil {
+			cerr = fmt.Errorf("closing README file %s: %w", readmePath, cerr)
 		}
+		err = errors.Join(err, cerr)
 	}()
 
 	r := readmeVars{cmdsDoc}


### PR DESCRIPTION
## Summary

Enable the \`exitAfterDefer\` gocritic check, which detects \`defer\` calls that will never execute because the enclosing function exits via \`log.Fatalf\` (which calls \`os.Exit\` internally). This is part of the gradual tightening of the golangci-lint configuration tracked in #3443.

## Changes

- \`.golangci.yml\`: add \`exitAfterDefer\` to the enabled gocritic checks.
- \`internal/registry/gpgkey/fetch/main.go\`: refactor \`fetchKey\` and \`fingerprint\`
  to return errors instead of calling \`log.Fatalf\`, restoring idiomatic \`defer\`
  for response body cleanup.
- \`tools/readme/main.go\`: refactor \`generateReadme\` to return an error instead of
  calling \`log.Fatalf\`, using a named return with a custom defer to propagate
  \`Close\` errors (with path context) on the success path.

## Proposed commit

\`\`\`
lint(gocritic): enable exitAfterDefer check

Enable the exitAfterDefer gocritic check, which detects deferred calls
that will never execute because the enclosing function exits via
log.Fatalf (which calls os.Exit internally).

Fix the two flagged sites by refactoring fetchKey, fingerprint, and
generateReadme to return errors instead of calling log.Fatalf, restoring
idiomatic defer usage for resource cleanup.
\`\`\`

## Related issues

- Part of #3443 (Gradually stricter configuration for golangci-lint)

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).