### PR TITLE
Always run Docker Compose with --progress plain

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,7 +933,8 @@ There are available some environment variables that could be used to change some
 - Related to `docker-compose` / `docker compose` commands:
     - `ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT`: If set to `true`, it disables the progress output from `docker compose`/`docker-compose` commands.
         - For versions v2 `< 2.19.0`, it sets `--ansi never` flag.
-        - For versions v2 `>= 2.19.0`, it sets `--progress plain` flag and `--quiet-pull` for `up` sub-command`.
+        - For all versions, it sets `--quiet-pull` for `up` sub-command.
+        - `--progress plain` is always set for versions v2 `>= 2.19.0`, regardless of this variable: Compose is run without a terminal on its standard output, and recent versions fail to render interactive progress there.
 
 
 - Related to global `elastic-package` settings:

--- a/README.md
+++ b/README.md
@@ -931,10 +931,10 @@ There are available some environment variables that could be used to change some
 `elastic-package` settings:
 
 - Related to `docker-compose` / `docker compose` commands:
-    - `ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT`: If set to `true`, it disables the progress output from `docker compose`/`docker-compose` commands.
+    - `ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT`: If set to `true`, it reduces the output from `docker compose`/`docker-compose` commands further.
         - For versions v2 `< 2.19.0`, it sets `--ansi never` flag.
         - For all versions, it sets `--quiet-pull` for `up` sub-command.
-        - `--progress plain` is always set for versions v2 `>= 2.19.0`, regardless of this variable: Compose is run without a terminal on its standard output, and recent versions fail to render interactive progress there.
+        - Independently of this variable, `--progress plain` is always set for versions v2 `>= 2.19.0`: Compose is run without a terminal on its standard output, and recent versions fail to render interactive progress there.
 
 
 - Related to global `elastic-package` settings:

--- a/README.md
+++ b/README.md
@@ -934,7 +934,7 @@ There are available some environment variables that could be used to change some
     - `ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT`: If set to `true`, it reduces the output from `docker compose`/`docker-compose` commands further.
         - For versions v2 `< 2.19.0`, it sets `--ansi never` flag.
         - For all versions, it sets `--quiet-pull` for `up` sub-command.
-        - Independently of this variable, `--progress plain` is always set for versions v2 `>= 2.19.0`: Compose is run without a terminal on its standard output, and recent versions fail to render interactive progress there.
+        - Independently of this variable, `--progress plain` is always set for versions `>= 2.19.0` (including v5): Compose is run without a terminal on its standard output, and recent versions fail to render interactive progress there.
 
 
 - Related to global `elastic-package` settings:

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -206,20 +206,38 @@ func NewProject(name string, paths ...string) (*Project, error) {
 	}
 	logger.Tracef("Determined Docker Compose version: %v", ver)
 
+	// Compose is never given a terminal to draw on: on Unix it runs under a pseudo-terminal
+	// so that its messages can be captured, but stdout is discarded unless in debug mode.
+	// Recent versions decide to render interactive progress from stderr being a terminal
+	// and then require stdout to be one as well, failing every build with "failed to get
+	// console: provided file is not a console" (observed with Docker Compose v5.5.1, see
+	// https://github.com/docker/compose/issues/13363). Plain progress is also what ends up
+	// in logs and error messages, so it is the right default and not only a CI setting.
+	c.progressOutput = composeProgressOutput(c.composeVersion)
+
 	v, ok = os.LookupEnv(DisableVerboseOutputComposeEnv)
 	if ok && strings.ToLower(v) != "false" {
 		if c.composeVersion.LessThan(semver.MustParse("2.19.0")) {
+			// --progress does not exist yet; --ansi never is the closest thing.
 			c.disableANSI = true
-		} else {
-			// --ansi never looks is ignored by "docker compose" and latest versions of "docker-compose"
-			// adding --progress plain is a similar result as --ansi never
-			// if set to "--progress quiet", there is no output at all from docker compose commands
-			c.progressOutput = defaultComposeProgressOutput
 		}
 		c.disablePullProgressInformation = true
 	}
 
 	return &c, nil
+}
+
+// composeProgressOutput is the value for the --progress flag, or empty for versions that
+// do not have the flag.
+//
+// The flag was added in Docker Compose 2.19.0. "plain" is the only mode that works with
+// stdout that is not a terminal; "quiet" would also work but produces no output at all,
+// which loses the messages that are reported back on errors.
+func composeProgressOutput(composeVersion *semver.Version) string {
+	if composeVersion.LessThan(semver.MustParse("2.19.0")) {
+		return ""
+	}
+	return defaultComposeProgressOutput
 }
 
 // Up brings up a Docker Compose project.

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -206,18 +206,19 @@ func NewProject(name string, paths ...string) (*Project, error) {
 	}
 	logger.Tracef("Determined Docker Compose version: %v", ver)
 
-	// Compose is never given a terminal to draw on: on Unix it runs under a pseudo-terminal
-	// so that its messages can be captured, but stdout is discarded unless in debug mode.
-	// Docker Compose v5.5.1 decides to render interactive progress from stderr being a
-	// terminal and then requires stdout to be one as well, failing every build with "failed
-	// to get console: provided file is not a console" (docker/compose#14182, fixed upstream
-	// after v5.5.1 by docker/compose#14194). Plain progress is also what ends up in logs and
-	// error messages, so it is the right default and not only a CI setting.
-	c.progressOutput = composeProgressOutput(c.composeVersion)
+	// Compose does not get a terminal on stdout: it is discarded unless in debug mode. On
+	// Unix it does get one on stderr, the pseudo-terminal that runDockerComposeCmd uses to
+	// capture its messages. Docker Compose v5.5.1 decides to render interactive progress
+	// from stderr being a terminal and then requires stdout to be one as well, failing
+	// every build with "failed to get console: provided file is not a console"
+	// (docker/compose#14182, fixed upstream after v5.5.1 by docker/compose#14194). Plain
+	// progress is also what ends up in logs and error messages, so it is the right default
+	// and not only a CI setting.
+	c.progressOutput = composeProgressOutput(ver)
 
 	v, ok = os.LookupEnv(DisableVerboseOutputComposeEnv)
 	if ok && strings.ToLower(v) != "false" {
-		if c.composeVersion.LessThan(semver.MustParse("2.19.0")) {
+		if ver.LessThan(semver.MustParse("2.19.0")) {
 			// --progress does not exist yet; --ansi never is the closest thing.
 			c.disableANSI = true
 		}

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -208,11 +208,11 @@ func NewProject(name string, paths ...string) (*Project, error) {
 
 	// Compose is never given a terminal to draw on: on Unix it runs under a pseudo-terminal
 	// so that its messages can be captured, but stdout is discarded unless in debug mode.
-	// Recent versions decide to render interactive progress from stderr being a terminal
-	// and then require stdout to be one as well, failing every build with "failed to get
-	// console: provided file is not a console" (observed with Docker Compose v5.5.1, see
-	// https://github.com/docker/compose/issues/13363). Plain progress is also what ends up
-	// in logs and error messages, so it is the right default and not only a CI setting.
+	// Docker Compose v5.5.1 decides to render interactive progress from stderr being a
+	// terminal and then requires stdout to be one as well, failing every build with "failed
+	// to get console: provided file is not a console" (docker/compose#14182, fixed upstream
+	// after v5.5.1 by docker/compose#14194). Plain progress is also what ends up in logs and
+	// error messages, so it is the right default and not only a CI setting.
 	c.progressOutput = composeProgressOutput(c.composeVersion)
 
 	v, ok = os.LookupEnv(DisableVerboseOutputComposeEnv)

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -7,6 +7,7 @@ package compose
 import (
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -28,6 +29,27 @@ func TestIntOrStringYaml(t *testing.T) {
 			err := yaml.Unmarshal([]byte(c.yaml), &n)
 			require.NoError(t, err)
 			assert.Equal(t, c.expected, int(n))
+		})
+	}
+}
+
+func TestComposeProgressOutput(t *testing.T) {
+	cases := []struct {
+		version  string
+		expected string
+	}{
+		// --progress does not exist before 2.19.0.
+		{"2.18.1", ""},
+		{"2.19.0", "plain"},
+		{"2.40.0", "plain"},
+		// Bake-based builds require a console when they believe they have one; plain
+		// progress is what keeps them working under our pseudo-terminal.
+		{"5.5.1", "plain"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.version, func(t *testing.T) {
+			assert.Equal(t, c.expected, composeProgressOutput(semver.MustParse(c.version)))
 		})
 	}
 }

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -322,7 +322,7 @@ There are available some environment variables that could be used to change some
     - `ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT`: If set to `true`, it reduces the output from `docker compose`/`docker-compose` commands further.
         - For versions v2 `< 2.19.0`, it sets `--ansi never` flag.
         - For all versions, it sets `--quiet-pull` for `up` sub-command.
-        - Independently of this variable, `--progress plain` is always set for versions v2 `>= 2.19.0`: Compose is run without a terminal on its standard output, and recent versions fail to render interactive progress there.
+        - Independently of this variable, `--progress plain` is always set for versions `>= 2.19.0` (including v5): Compose is run without a terminal on its standard output, and recent versions fail to render interactive progress there.
 
 
 - Related to global `elastic-package` settings:

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -321,7 +321,8 @@ There are available some environment variables that could be used to change some
 - Related to `docker-compose` / `docker compose` commands:
     - `ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT`: If set to `true`, it disables the progress output from `docker compose`/`docker-compose` commands.
         - For versions v2 `< 2.19.0`, it sets `--ansi never` flag.
-        - For versions v2 `>= 2.19.0`, it sets `--progress plain` flag and `--quiet-pull` for `up` sub-command`.
+        - For all versions, it sets `--quiet-pull` for `up` sub-command.
+        - `--progress plain` is always set for versions v2 `>= 2.19.0`, regardless of this variable: Compose is run without a terminal on its standard output, and recent versions fail to render interactive progress there.
 
 
 - Related to global `elastic-package` settings:

--- a/tools/readme/readme.md.tmpl
+++ b/tools/readme/readme.md.tmpl
@@ -319,10 +319,10 @@ There are available some environment variables that could be used to change some
 `elastic-package` settings:
 
 - Related to `docker-compose` / `docker compose` commands:
-    - `ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT`: If set to `true`, it disables the progress output from `docker compose`/`docker-compose` commands.
+    - `ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT`: If set to `true`, it reduces the output from `docker compose`/`docker-compose` commands further.
         - For versions v2 `< 2.19.0`, it sets `--ansi never` flag.
         - For all versions, it sets `--quiet-pull` for `up` sub-command.
-        - `--progress plain` is always set for versions v2 `>= 2.19.0`, regardless of this variable: Compose is run without a terminal on its standard output, and recent versions fail to render interactive progress there.
+        - Independently of this variable, `--progress plain` is always set for versions v2 `>= 2.19.0`: Compose is run without a terminal on its standard output, and recent versions fail to render interactive progress there.
 
 
 - Related to global `elastic-package` settings:


### PR DESCRIPTION
## What

Always pass `--progress plain` to Docker Compose (≥ 2.19.0, where the flag exists), instead of only when `ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT` is set.

Note: drafted with :robot: Cursor/Fable 5.1, under my supervision.

## Why

With Docker Compose v5.5.1 (current Docker Desktop), `elastic-package stack up` fails on macOS and Linux before starting anything:

```
Error: booting up the stack failed: building docker images failed: running command failed:
running Docker Compose build command failed: exit status 1:
failed to get console: provided file is not a console
```

It fails the same way from an interactive terminal and from a script. The only thing that makes it work today is setting `ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT=true`, which CI does and users do not.

The cause is how compose is run. `runDockerComposeCmd` on Unix starts it under a pseudo-terminal (`creack/pty`) so that its messages can be captured, while `cmd.Stdout` is `io.Discard` (or `os.Stdout` in debug mode). So compose sees a terminal on **stderr** and a pipe on **stdout**. Recent compose decides to render interactive progress because stderr is a terminal, then hands stdout to BuildKit's console renderer, which refuses a non-terminal. Isolated with a one-service compose file:

| stdin | stdout | stderr | `docker compose build` |
|---|---|---|---|
| pipe | pipe | pipe | ok, plain progress |
| tty | pipe | **tty** | **`failed to get console`** |
| pipe | pipe | **tty** | **`failed to get console`** |
| tty | pipe | pipe | ok |
| pipe | tty | pipe | ok |
| tty | pipe | tty, with `--progress plain` | ok |

Upstream this is a regression in Compose v5.5.1 (v5.5.0 is fine, bisected with the release binaries), reported as docker/compose#14182 and fixed today by docker/compose#14194, which is not in a release yet. Their diagnosis is the same: the progress mode is resolved against stderr, the display is written to stdout. Docker Desktop 4.90.0 ships v5.5.1, so every macOS and Linux user who updated Docker Desktop in the last few days is affected as soon as compose has something to build — `stack up` always does, for the package registry image — until the next Desktop release picks up the fix. Windows is not affected: `runDockerComposeCmd` does not use a pseudo-terminal there, so compose sees pipes everywhere and picks plain progress on its own. Only `build` is affected; `pull`, `up`, `ps` and `down` work in the same layout.

Whatever compose does about it, elastic-package's wiring is the failing row by construction, so the fix belongs here too, and it covers every compose invocation: they all go through `compose.Project` (stack, serverless local services, the compose/custom-agent/terraform service deployers, the agent deployer). `internal/docker` runs `docker` directly with pipes and is not affected.

Plain progress is also the right default on its own terms: compose's output is only ever seen through the captured stderr — in debug output and in the error message reported when a command fails — where the interactive renderer's escape sequences are noise. This is what the CI setting has been producing all along.

## Changes

- `NewProject` sets `progressOutput` for every compose ≥ 2.19.0, via a small `composeProgressOutput(version)` so it can be unit-tested. The environment variable keeps its other effects: `--ansi never` on compose < 2.19.0, and `--quiet-pull` on `up`.
- `TestComposeProgressOutput` covers the version boundary (2.18.1, 2.19.0, 2.40.0, 5.5.1).
- README (and its template) describe the new behaviour under the environment variable's entry.

## Verified

A build of this branch, no environment variable set, from a shell without a terminal:

```
$ /tmp/ep stack up -d --version 9.4.3
…
Done
$ elastic-package stack status
│ elastic-agent    │ 9.4.3   │ running (healthy) │
│ elasticsearch    │ 9.4.3   │ running (healthy) │
│ fleet-server     │ 9.4.3   │ running (healthy) │
│ kibana           │ 9.4.3   │ running (healthy) │
│ package-registry │ latest  │ running (healthy) │
```

The released v0.125.1 fails at the build step on the same machine. `make lint`, `make gomod` and `go test ./internal/compose/` are clean.
