### PR TITLE
Retry on search_phase_execution_exception "all shards failed"

### DIFF
--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -836,6 +836,21 @@ func (h hits) size() int {
 	return len(h.Source)
 }
 
+// hasTransientRootCause reports whether the error body contains a root cause
+// that indicates a transient shard condition safe to retry. Currently this
+// covers the case where Elasticsearch internally computes a negative minDoc
+// value (illegal_argument_exception with "minDoc must be >= 0") during index
+// shard initialization.
+func hasTransientRootCause(errBody elasticsearch.ErrorBody) bool {
+	for _, rc := range errBody.Error.RootCause {
+		if rc.Type == "illegal_argument_exception" &&
+			strings.Contains(rc.Reason, "minDoc must be") {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *tester) getDocs(ctx context.Context, dataStream string) (*hits, error) {
 	resp, err := r.esAPI.Search(
 		r.esAPI.Search.WithContext(ctx),
@@ -864,7 +879,8 @@ func (r *tester) getDocs(ctx context.Context, dataStream string) (*hits, error) 
 			var errBody elasticsearch.ErrorBody
 			if json.Unmarshal(bodyBytes, &errBody) == nil &&
 				errBody.Error.Type == "search_phase_execution_exception" &&
-				errBody.Error.Reason == "all shards failed" {
+				errBody.Error.Reason == "all shards failed" &&
+				hasTransientRootCause(errBody) {
 				// Transient shard failure during index creation, retry.
 				logger.Debugf("Transient shard failure while searching %s, retrying: %s", dataStream, string(bodyBytes))
 				return &hits{}, nil

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -856,7 +856,17 @@ func (r *tester) getDocs(ctx context.Context, dataStream string) (*hits, error) 
 		return &hits{}, nil
 	}
 	if resp.IsError() {
-		return nil, fmt.Errorf("failed to search docs for data stream %s: %s", dataStream, resp.String())
+		body := resp.String()
+		if resp.StatusCode == http.StatusBadRequest {
+			var errBody elasticsearch.ErrorBody
+			if err := json.Unmarshal([]byte(body), &errBody); err == nil {
+				if errBody.Error.Type == "search_phase_execution_exception" && errBody.Error.Reason == "all shards failed" {
+					// Transient shard failure during index creation, retry.
+					return &hits{}, nil
+				}
+			}
+		}
+		return nil, fmt.Errorf("failed to search docs for data stream %s: %s", dataStream, body)
 	}
 
 	var results FieldsQueryResult

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"net/http"
 	"os"
@@ -856,18 +857,21 @@ func (r *tester) getDocs(ctx context.Context, dataStream string) (*hits, error) 
 		return &hits{}, nil
 	}
 	if resp.IsError() {
-		body := resp.String()
+		// Read raw bytes instead of resp.String(): resp.String() prepends "[STATUS_CODE STATUS_TEXT] "
+		// to the body, making json.Unmarshal fail on the prefixed string.
+		bodyBytes, _ := io.ReadAll(resp.Body)
 		if resp.StatusCode == http.StatusBadRequest {
 			var errBody elasticsearch.ErrorBody
-			if err := json.Unmarshal([]byte(body), &errBody); err == nil {
-				if errBody.Error.Type == "search_phase_execution_exception" && errBody.Error.Reason == "all shards failed" {
-					// Transient shard failure during index creation, retry.
-					logger.Debugf("Transient shard failure while searching %s, retrying: %s", dataStream, body)
-					return &hits{}, nil
-				}
+			if json.Unmarshal(bodyBytes, &errBody) == nil &&
+				errBody.Error.Type == "search_phase_execution_exception" &&
+				errBody.Error.Reason == "all shards failed" {
+				// Transient shard failure during index creation, retry.
+				logger.Debugf("Transient shard failure while searching %s, retrying: %s", dataStream, string(bodyBytes))
+				return &hits{}, nil
 			}
 		}
-		return nil, fmt.Errorf("failed to search docs for data stream %s: %s", dataStream, body)
+		return nil, fmt.Errorf("failed to search docs for data stream %s: [%d %s] %s",
+			dataStream, resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes))
 	}
 
 	var results FieldsQueryResult

--- a/internal/testrunner/runners/system/tester.go
+++ b/internal/testrunner/runners/system/tester.go
@@ -862,6 +862,7 @@ func (r *tester) getDocs(ctx context.Context, dataStream string) (*hits, error) 
 			if err := json.Unmarshal([]byte(body), &errBody); err == nil {
 				if errBody.Error.Type == "search_phase_execution_exception" && errBody.Error.Reason == "all shards failed" {
 					// Transient shard failure during index creation, retry.
+					logger.Debugf("Transient shard failure while searching %s, retrying: %s", dataStream, body)
 					return &hits{}, nil
 				}
 			}


### PR DESCRIPTION
## What does this PR do?

When `getDocs` queries a data stream and Elasticsearch responds with a
`400 Bad Request` containing a `search_phase_execution_exception` with
reason `all shards failed`, the error is transient — it can happen during
index creation before all shards are fully initialised (see
`minDoc must be >= 0 but got minDoc=-N` in the root cause). Previously
this caused `waitForDocs` to abort immediately with an error, making
system tests report a flaky failure.

This change treats that specific 400 as a retryable condition (returning
empty hits) so `waitForDocs` keeps polling until the timeout, consistent
with the existing handling of `no_shard_available_action_exception` on 503.

The response body is decoded into the existing `elasticsearch.ErrorBody`
struct to match on `error.type` and `error.reason` precisely, rather than
relying on substring matching.

### Error example

```
failed to search docs for data stream logs-system_test_assert_conditions.test-27777:
[400 Bad Request] {
  "error": {
    "root_cause": [{"type": "illegal_argument_exception", "reason": "minDoc must be >= 0 but got minDoc=-438"}],
    "type": "search_phase_execution_exception",
    "reason": "all shards failed",
    "phase": "query",
    "grouped": true,
    "failed_shards": [{
      "shard": 0,
      "index": ".ds-logs-system_test_assert_conditions.test-27777-2026.09.09-000001",
      "node": "u5lu04-ARUuWYWPBiiUmLA",
      "reason": {"type": "illegal_argument_exception", "reason": "minDoc must be >= 0 but got minDoc=-438"}
    }],
    "caused_by": {"type": "illegal_argument_exception", "reason": "minDoc must be >= 0 but got minDoc=-438"}
  },
  "status": 400
}
```

Observed in: https://buildkite.com/elastic/elastic-package/builds/8597

## Proposed commit

```
Retry on search_phase_execution_exception "all shards failed"

When Elasticsearch returns a 400 with a search_phase_execution_exception
("all shards failed") during getDocs, treat it as a transient failure and
return empty hits so waitForDocs keeps retrying instead of aborting.
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).